### PR TITLE
use regex on import to clean up PB generated content

### DIFF
--- a/includes/modules/import/epub/class-pb-epub201.php
+++ b/includes/modules/import/epub/class-pb-epub201.php
@@ -346,8 +346,14 @@ class Epub201 extends Import {
 
 		// Remove auto-created <html> <body> and <!DOCTYPE> tags.
 		$html = preg_replace( '/^<!DOCTYPE.+?>/', '', str_replace( array( '<html>', '</html>', '<body>', '</body>' ), array( '', '', '', '' ), $html ) );
+        // Remove PB created div id (on EPUB201 Export) that will generate a princexml error on re-export 
+        // @see createPartsAndChapters() in export/epub/class-pb-epub201.php
+        $html = preg_replace('/(?:<div class="chapter" id="(.*)">)/isU', '<div class="chapter">', $html);
+        // Remove PB generated content that is superfluous in a WP/PB environment 
+        // @see createPartsAndChapters() in export/epub/class-pb-epub201.php
+        $html = preg_replace('/(?:<div class="chapter-title-wrap"[^>]*>)(.*)<\/div>/isU', '', $html);
 
-		$errors = libxml_get_errors(); // TODO: Handle errors gracefully
+       	$errors = libxml_get_errors(); // TODO: Handle errors gracefully
 		libxml_clear_errors();
 
 		return $html;


### PR DESCRIPTION
The export to epub creates two things that cause problems on epub import:
1. @see createPartsAndChapters() in export/epub/class-pb-epub201.php line 893. If this div is present again in an export, princexml will generate errors. I'm proposing to strip it out on import. 
2.  @see createPartsAndChapters() in export/epub/class-pb-epub201.php lines 894-896. The chapter number and title are repeated in the body of the html on import. This content is redundant. I'm proposing to strip it out on import. 
