### PR TITLE
WXR import fix, images into media library

### DIFF
--- a/includes/modules/import/wordpress/class-pb-wxr.php
+++ b/includes/modules/import/wordpress/class-pb-wxr.php
@@ -67,6 +67,8 @@ class Wxr extends Import {
 		$chapter_parent = $this->getChapterParent();
 		$total = 0;
 
+		libxml_use_internal_errors( true );
+		
 		foreach ( $xml['posts'] as $p ) {
 
 			// Skip
@@ -74,17 +76,23 @@ class Wxr extends Import {
 			if ( ! isset( $match_ids[$p['post_id']] ) ) continue;
 
 			// Insert
-
 			$post_type = $this->determinePostType( $p['post_id'] );
 
-			// TODO: Import images
-			// TODO: Fix self-referencing URLs
+			// Load HTMl snippet into DOMDocument using UTF-8 hack
+			$utf8_hack = '<?xml version="1.0" encoding="UTF-8"?>';
+			$doc = new \DOMDocument();
+			$doc->loadHTML( $utf8_hack . $p['post_content'] );
 
-			$new_post = array(
-				'post_title' => wp_strip_all_tags( $p['post_title'] ),
-				'post_content' => $this->tidy( $p['post_content'] ),
-				'post_type' => $post_type,
-				'post_status' => 'draft',
+			// Download images, change image paths
+			$doc = $this->scrapeAndKneadImages( $doc );
+
+			$html = $doc->saveXML( $doc->documentElement );
+
+			$new_post = array (
+			    'post_title' => wp_strip_all_tags( $p['post_title'] ),
+			    'post_content' => $this->tidy( $html ),
+			    'post_type' => $post_type,
+			    'post_status' => 'draft',
 			);
 
 			if ( 'chapter' == $post_type ) {
@@ -107,6 +115,81 @@ class Wxr extends Import {
 		$_SESSION['pb_notices'][] = sprintf( __( 'Imported %s chapters.', 'pressbooks' ), $total );
 		return $this->revokeCurrentImport();
 	}
+	
+	/**
+	 * Parse HTML snippet, save all found <img> tags using media_handle_sideload(), return the HTML with changed <img> paths.
+	 *
+	 * @param \DOMDocument $doc
+	 *
+	 * @return \DOMDocument
+	 */
+	protected function scrapeAndKneadImages( \DOMDocument $doc ) {
 
+		$images = $doc->getElementsByTagName( 'img' );
+
+		foreach ( $images as $image ) {
+			// Fetch image, change src
+			$old_src = $image->getAttribute( 'src' );
+
+			$new_src = $this->fetchAndSaveUniqueImage( $old_src );
+
+			if ( $new_src ) {
+				// Replace with new image
+				$image->setAttribute( 'src', $new_src );
+			} else {
+				// Tag broken image
+				$image->setAttribute( 'src', "{$old_src}#fixme" );
+			}
+		}
+
+		return $doc;
+	}
+
+	/**
+	 * Load remote url of image into WP using media_handle_sideload()
+	 * Will return an empty string if something went wrong.
+	 *
+	 * @param string $url 
+	 *
+	 * @see media_handle_sideload
+	 *
+	 * @return string filename
+	 */
+	protected function fetchAndSaveUniqueImage( $url ) {
+
+		if ( ! filter_var( $url, FILTER_VALIDATE_URL ) ) {
+			return '';
+		}
+		$remote_img_location = $url;
+
+		// Cheap cache
+		static $already_done = array ( );
+		if ( isset( $already_done[$remote_img_location] ) ) {
+			return $already_done[$remote_img_location];
+		}
+
+		/* Process */
+
+		$filename = array_shift( explode( '?', basename( $url ) ) ); // Basename without query string
+		$filename = sanitize_file_name( urldecode( $filename ) );
+
+		if ( ! preg_match( '/\.(jpe?g|gif|png)$/i', $filename ) ) {
+			// Unsupported image type
+			$already_done[$remote_img_location] = '';
+			return '';
+		}
+
+
+		$tmp_name = $this->createTmpFile();
+
+		file_put_contents( $tmp_name, file_get_contents( $remote_img_location ) );
+
+		$pid = media_handle_sideload( array ( 'name' => $filename, 'tmp_name' => $tmp_name ), 0 );
+		$src = wp_get_attachment_url( $pid );
+		if ( ! $src ) $src = ''; // Change false to empty string
+		$already_done[$remote_img_location] = $src;
+
+		return $src;
+	}
 
 }


### PR DESCRIPTION
Straight forward import of images, modelled after what is being done with importing images from an EPUB. It will only pull in images from chapters that have been selected, and relies on 'src' being an absolute URL to an existing image. 
