### PR TITLE
WXR import author, adding section author to metadata

### DIFF
--- a/includes/modules/import/wordpress/class-pb-wxr.php
+++ b/includes/modules/import/wordpress/class-pb-wxr.php
@@ -93,8 +93,13 @@ class Wxr extends Import {
 
 			$pid = wp_insert_post( $new_post );
 
-			// TODO
-			// update_post_meta( $pid, 'pb_section_author', $p['post_author'] );
+			$section_author = $this->searchForSectionAuthor( $p['postmeta'] );
+
+			if ( $section_author ) {
+				update_post_meta( $pid, 'pb_section_author', $section_author );
+			} else { // if above returns no results, take value from 'dc:creator' 
+				update_post_meta( $pid, 'pb_section_author', $p['post_author'] );
+			}
 
 			update_post_meta( $pid, 'pb_show_title', 'on' );
 			update_post_meta( $pid, 'pb_export', 'on' );
@@ -108,5 +113,24 @@ class Wxr extends Import {
 		return $this->revokeCurrentImport();
 	}
 
+	/**
+	 * Check for PB specific metadata, returns empty string if not found.
+	 * 
+	 * @param array $postmeta
+	 * @return string Author's name 
+	 */
+	protected function searchForSectionAuthor( array $postmeta ) {
+		if ( ! is_array( $postmeta ) || empty( $postmeta ) ) {
+			return '';
+		}
+		foreach ( $postmeta as $meta ) {
+			// prefer this value, if it's set
+			if ( 'pb_section_author' == $meta['key'] ) {
+				return $meta['value'];
+			}
+
+		}
+		return '';
+	}
 
 }


### PR DESCRIPTION
Updating the metadata value of pb_section_author in the imported chapter. Checks to see if the pb_section_author exists in the WXR import file, otherwise $p[post_author]/item->dc:creator is used.
