### PR TITLE
EPUB import authors, metadata pb_section_author

### DIFF
--- a/includes/modules/import/epub/class-pb-epub201.php
+++ b/includes/modules/import/epub/class-pb-epub201.php
@@ -31,9 +31,11 @@ class Epub201 extends Import {
 
 
 	/**
+	 * String for authors, contributors
+	 * 
 	 * @var string
 	 */
-	protected $rights;
+	protected $authors;
 
 	/**
 	 * If PressBooks generated the epub file
@@ -129,17 +131,17 @@ class Epub201 extends Import {
 
 			$val = (string) $val;
 
-			// Set rights
+			// Set authors
 			if ( 'creator' == $key && ! empty( $val ) ) {
-				$this->rights .= trim( $val ) . ', ';
-			} elseif ( 'rights' == $key && ! empty( $val ) ) {
-				$this->rights .= trim( $val ) . ', ';
+				$this->authors .= trim( $val ) . ', ';
+			} elseif ( 'contributor' == $key && ! empty( $val ) ) {
+				$this->authors .= trim( $val ) . ', ';
 			}
 
 		}
 
 		// Get rid of trailing comma
-		$this->rights = rtrim( $this->rights, ', ' );
+		$this->authors = rtrim( $this->authors, ', ' );
 	}
 
 
@@ -292,9 +294,8 @@ class Epub201 extends Import {
 
 		$pid = wp_insert_post( $new_post );
 
-		if ( $this->rights ) {
-			// TODO
-			// update_post_meta( $pid, 'pb_section_author', $this->rights );
+		if ( $this->authors ) {
+			update_post_meta( $pid, 'pb_section_author', $this->authors );
 		}
 
 		update_post_meta( $pid, 'pb_show_title', 'on' );


### PR DESCRIPTION
quick fix to bring in author information from EPUB metadata. Change in this commit to highlight is that it's now grabbing both dc:creator and dc:contributor (instead of dc:creator & dc:rights). If author information is all we're after, then dc:contributor is more suitable (if it's populated). Changes still permit more than one dc:creator and more than one dc:contributor — http://www.idpf.org/epub/20/spec/OPF_2.0_latest.htm#Section2.2.2 
