### PR TITLE
try/catch validate image based on mimetype

### DIFF
--- a/includes/pb-image.php
+++ b/includes/pb-image.php
@@ -72,8 +72,35 @@ function is_valid_image( $data, $filename, $is_stream = false ) {
 
 		$func = 'imagecreatefrom' . $format;
 		$image = @$func( $data );
+
 		if ( $image === false ) {
-			return false;
+
+			try { // for images that lie; hide behind an extension 
+				$resource = finfo_open( FILEINFO_MIME_TYPE );
+				$mime_type = finfo_file( $resource, $data );
+
+				switch ( $mime_type ) {
+
+					case 'image/gif':
+						$func = 'imagecreatefromgif';
+						break;
+					case 'image/png':
+						$func = 'imagecreatefrompng';
+						break;
+					case 'image/jpeg':
+						$func = 'imagecreatefromjpeg';
+						break;
+				};
+
+				$image = @$func( $data );
+
+				if ( $image === false ) {
+					throw new Exception( 'Image is corrupted' );
+				}
+			} catch ( Exception $exc ) {
+
+				return false;
+			}
 		}
 	}
 


### PR DESCRIPTION
During an import I've come across images with extensions that are different from their mimetype (ie. someimage.gif has a mimetype of image/png). This solves the problem of images not importing based on an incorrect extension and should be relatively harmless for other code that uses is_valid_image. Please confirm. 
