### PR TITLE
import checks for proper image extension

### DIFF
--- a/includes/modules/import/class-pb-import.php
+++ b/includes/modules/import/class-pb-import.php
@@ -163,7 +163,33 @@ abstract class Import {
 		return $_POST['chapters'][$id]['type'];
 	}
 
+	/**
+	 * Checks if the file extension matches its mimetype, returns a modified
+	 * filename if they don't match. 
+	 * 
+	 * @param string $path_to_file
+	 * @param string $filename
+	 * @return string - modified filename if the extension did not match the mimetype,
+	 * otherwise returns the filename that was passed to it
+	 */
+	protected function properImageExtension( $path_to_file, $filename ) {
+		$mimes = array (
+		    'jpg|jpeg|jpe' => 'image/jpeg',
+		    'gif' => 'image/gif',
+		    'png' => 'image/png',
+		);
 
+		// Attempt to determine the real file type of a file.
+		$validate = wp_check_filetype_and_ext( $path_to_file, $filename, $mimes );
+
+		// change filename to the extension that matches its mimetype
+		if ( $validate['proper_filename'] !== false ) {
+			return $validate['proper_filename'];
+		} else {
+			return $filename;
+		}
+	}
+	
 	/**
 	 * Tidy HTML
 	 *

--- a/includes/modules/import/epub/class-pb-epub201.php
+++ b/includes/modules/import/epub/class-pb-epub201.php
@@ -484,9 +484,18 @@ class Epub201 extends Import {
 		file_put_contents( $tmp_name, $image_content );
 
 		if ( ! \PressBooks\Image\is_valid_image( $tmp_name, $filename ) ) {
-			// Garbage, Don't import
-			$already_done[$img_location] = '';
-			return '';
+
+			try { // changing the file name so that extension matches the mime type
+				$filename = $this->properImageExtension( $tmp_name, $filename );
+
+				if ( ! \PressBooks\Image\is_valid_image( $tmp_name, $filename ) ) {
+					throw new \Exception( 'Image is corrupt, and file extension matches the mime type' );
+				}
+			} catch ( Exception $exc ) {
+				// Garbage, Don't import
+				$already_done[$img_location] = '';
+				return '';
+			}
 		}
 
 		$pid = media_handle_sideload( array( 'name' => $filename, 'tmp_name' => $tmp_name ), 0 );

--- a/includes/modules/import/wordpress/class-pb-wxr.php
+++ b/includes/modules/import/wordpress/class-pb-wxr.php
@@ -220,10 +220,19 @@ class Wxr extends Import {
 		}
 
 		if ( ! \PressBooks\Image\is_valid_image( $tmp_name, $filename ) ) {
-			// Garbage, don't import
-			$already_done[$remote_img_location] = '';
-			unlink( $tmp_name );
-			return '';
+
+			try { // changing the file name so that extension matches the mime type
+				$filename = $this->properImageExtension( $tmp_name, $filename );
+
+				if ( ! \PressBooks\Image\is_valid_image( $tmp_name, $filename ) ) {
+					throw new \Exception( 'Image is corrupt, and file extension matches the mime type' );
+				}
+			} catch ( Exception $exc ) {
+				// Garbage, don't import
+				$already_done[$remote_img_location] = '';
+				unlink( $tmp_name );
+				return '';
+			}
 		}
 
 		$pid = media_handle_sideload( array ( 'name' => $filename, 'tmp_name' => $tmp_name ), 0 );


### PR DESCRIPTION
isolated the image file type/mime type validation to the import module, using try/catch blocks in both WXR import and EPUB import. 
