### PR TITLE
xslt mods for styling, disable network access when loading documents

### DIFF
--- a/includes/modules/import/odf/class-pb-odt.php
+++ b/includes/modules/import/odf/class-pb-odt.php
@@ -540,10 +540,8 @@ class Odt extends Import {
 		// trouble with simplexmlelement and elements with dashes
 		// (ODT's are ripe with dashes), so giving it to the DOM
 
-		$old_value = libxml_disable_entity_loader( true );
 		$xml = new \DOMDocument();
-		$xml->loadXML( $content, LIBXML_NOBLANKS | LIBXML_NOENT | LIBXML_XINCLUDE | LIBXML_NOERROR | LIBXML_NOWARNING );
-		libxml_disable_entity_loader( $old_value );
+		$xml->loadXML( $content, LIBXML_NOBLANKS | LIBXML_NOENT | LIBXML_NONET | LIBXML_XINCLUDE | LIBXML_NOERROR | LIBXML_NOWARNING );
 
 		return $xml;
 	}


### PR DESCRIPTION
Four things going on in this commit: 
1. xslt modifications to deal with styling (bold, italic, underline) that can be represented as an HTML entity.
2. xslt modifications to better detect the a difference between ordered and unordered lists
3. xslt modifications to drop support for 'track changes' in an ODT document.
4. changing how to protect against the loading of external entities (with LIBXML_NONET)

I will split them up into separate pull requests if need be.
