### PR TITLE
re-instating workaround for PHP, XML custom entity shortcomings

### DIFF
--- a/includes/modules/import/odf/class-pb-odt.php
+++ b/includes/modules/import/odf/class-pb-odt.php
@@ -539,10 +539,11 @@ class Odt extends Import {
 
 		// trouble with simplexmlelement and elements with dashes
 		// (ODT's are ripe with dashes), so giving it to the DOM
-
+		$old_value = libxml_disable_entity_loader( true );
 		$xml = new \DOMDocument();
 		$xml->loadXML( $content, LIBXML_NOBLANKS | LIBXML_NOENT | LIBXML_NONET | LIBXML_XINCLUDE | LIBXML_NOERROR | LIBXML_NOWARNING );
-
+		libxml_disable_entity_loader( $old_value );
+		
 		return $xml;
 	}
 


### PR DESCRIPTION
as discussed...LIBXML_NOENT is perhaps not an adequate measure on its own to protect against local entity injection/expansion.
