### PR TITLE
quick fix for matching chapter_titles with nodeValues

### DIFF
--- a/includes/modules/import/ooxml/class-pb-docx.php
+++ b/includes/modules/import/ooxml/class-pb-docx.php
@@ -540,7 +540,7 @@ class Docx extends Import {
 		}
 
 		$currentTag = $node->tagName;
-		$currentValue = $node->nodeValue;
+		$currentValue = trim( $node->nodeValue );
 
 		if ( $chapter_name == $currentValue && $this->tag == $currentTag ) {
 			return $node;


### PR DESCRIPTION
Chapter titles @line 627 get stripped of white space at the beginning and end of a string, so too must the nodeValues in order for a string comparison to be successful @line 545
