### PR TITLE
resolving inconsistent naming convention for chapter files

### DIFF
--- a/includes/modules/export/epub/class-pb-epub201.php
+++ b/includes/modules/export/epub/class-pb-epub201.php
@@ -1129,7 +1129,7 @@ class Epub201 extends Export {
 					$content,
 					'' );
 
-				$file_id = 'chapter-' . $id;
+				$file_id = 'chapter-' . sprintf( "%03s", $j );
 				$filename = "{$file_id}-{$slug}.html";
 
 				file_put_contents(
@@ -1144,7 +1144,7 @@ class Epub201 extends Export {
 
 				$has_chapters = true;
 
-				if ( $subclass !== 'numberless' ) ++$j;
+				++$j;
 			}
 
 			if ( $has_chapters && count( $book_contents['part'] ) > 1 ) {


### PR DESCRIPTION
line 1097 - The inconsistency between passing $j to `kneadHtml($var, $var, $j)` which then passes it to `fuzzyHrefMatch($var,$var,$j)` causes internal/relative links to generate the error 'referenced resource missing in the package' in epubcheck. Plus the links in an epub no longer work.

The name of link `<a href="chapter-001-chapter-214.html">`pointing to internal content must match the file name 'chapter-3873-chapter-214.html'. If the file name is created with $id (post id) and the internal link is created with $j, they will never match.

![screen shot 2014-02-19 at 11 45 49 am](https://f.cloud.github.com/assets/2048170/2210879/c9bba1b6-999e-11e3-8cdf-ae8553a886ad.png)

![screen shot 2014-02-19 at 11 48 59 am](https://f.cloud.github.com/assets/2048170/2210898/ee4db582-999e-11e3-92b0-d72b9f2e243e.png)

The argument for numberless chapters is sufficient at line 1121
