### PR TITLE
adding custom post types to rss feed

### DIFF
--- a/hooks.php
+++ b/hooks.php
@@ -64,6 +64,7 @@ add_filter('upload_mimes', '\PressBooks\Media\addMimeTypes');
 
 add_action( 'init', '\PressBooks\PostType\register_post_types' );
 add_action( 'init', '\PressBooks\Taxonomy\register_taxonomies' );
+add_filter( 'request', '\PressBooks\PostType\add_post_types_rss' );
 
 // -------------------------------------------------------------------------------------------------------------------
 // Remove the "admin bar" from any public facing theme

--- a/includes/pb-postype.php
+++ b/includes/pb-postype.php
@@ -225,3 +225,32 @@ function register_post_types() {
 	);
 	register_post_type( 'custom-css', $args );
 }
+
+
+/**
+ * Add custom post types to RSS feed
+ * 
+ * @param array $args 
+ * 
+ * @return array $args
+ */
+function add_post_types_rss( $args ) {
+	$blog_public = get_option( 'blog_public' );
+	$num_posts = get_option( 'posts_per_rss' );
+
+	// only if book is public
+	if ( 1 == $blog_public ) {
+		if ( isset( $args['feed'] ) && ! isset( $args['post_type'] ) ) {
+			$args['post_type'] = array( 'front-matter', 'back-matter', 'chapter' );
+		}
+		// increase default posts per rss
+		if ( 10 == $num_posts ) {
+			update_option( 'posts_per_rss', 999 );
+		}
+	} elseif ( 0 == $blog_public ) {
+		if ( isset( $args['feed'] ) && ! isset( $args['post_type'] ) ) {
+			$args['post_type'] = array( 'post' );
+		}
+	}
+	return $args;
+}


### PR DESCRIPTION
Currently the RSS feed at http://yourdomain/yourbook/feed displays post types  that are 'posts' which is usually the out-of-the-box 'hello world' post. It is assumed that the RSS feed provides some meaningful functionality(?)...it certainly does for our use case. 

Adding custom post types to the rss feed is trivial, and I've taken into consideration that those with books marked as 'private' don't want their RSS feed to display the contents of their book.

For those books that are marked as public, the content of the book will be available via RSS.
