### PR TITLE
fix inconsistent display for editor role

### DIFF
--- a/admin/pb-admin-laf.php
+++ b/admin/pb-admin-laf.php
@@ -143,7 +143,6 @@ function replace_book_admin_menu() {
 	$front_matter_types = $submenu['edit.php?post_type=front-matter'][15];
 	$back_matter_types = $submenu['edit.php?post_type=back-matter'][15];
 	unset( $submenu['edit.php?post_type=chapter'][10] );
-	unset( $submenu['edit.php?post_type=chapter'][15] );
 	
 	if ( is_super_admin() ) {
 		// If network administrator, give the option to see chapter, front matter and back matter types.


### PR DESCRIPTION
This resolves an inconsistency with displaying a submenu item for editing back matter items when viewed with an 'editor' role

![backmatter](https://cloud.githubusercontent.com/assets/2048170/3291944/b648b3c0-f589-11e3-857b-708d822e8c44.gif)
