### PR TITLE
adding structured data to base theme

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -97,6 +97,25 @@ function pb_is_custom_theme() {
 	return \PressBooks\CustomCss::isCustomCss();
 }
 
+/**
+ * Shortcut to \PressBooks\Metadata::getSeoMetaElements();
+ * 
+ * @return string
+ */
+function pb_get_seo_meta_elements() {
+
+	return \PressBooks\Metadata::getSeoMetaElements();
+}
+
+/**
+ * Shortcut to \PressBooks\Metadata::getMicrodataElements();
+ * 
+ * @return string
+ */
+function pb_get_microdata_elements() {
+
+	return \PressBooks\Metadata::getMicrodataElements();
+}
 
 /**
  * Get url to the custom stylesheet for web.

--- a/includes/class-pb-metadata.php
+++ b/includes/class-pb-metadata.php
@@ -85,8 +85,8 @@ class Metadata {
 
 		return get_post_meta( $meta_post->ID );
 	}
-
-
+	
+		
 	/**
 	 * Return a database ID for a given meta key.
 	 *
@@ -106,7 +106,69 @@ class Metadata {
 
 		return false;
 	}
+	
+	/**
+	 * Returns an html blob of meta elements based on what is set in 'Book Information'
+	 * 
+	 * @return string 
+	 */
+	function getSeoMetaElements() {
+		// map items that are already captured
+		$meta_mapping = array(
+		    'author' => 'pb_author',
+		    'description' => 'pb_about_50',
+		    'keywords' => 'pb_keywords_tags',
+		    'publisher' => 'pb_publisher'
+		);
+		$html = "<meta name='application-name' content='PressBooks'>\n";
+		$metadata = Book::getBookInformation();
 
+		// create meta elements
+		foreach ( $meta_mapping as $name => $content ) {
+			if ( array_key_exists( $content, $metadata ) ) {
+				$html .= "<meta name='" . $name . "' content='" . $metadata[$content] . "'>\n";
+			}
+		}
+
+		return $html;
+	}
+	
+	/**
+	 * Returns an html blob of microdata elements based on what is set in 'Book Information'
+	 *  
+	 * @return string
+	 */
+	function getMicrodataElements() {
+		// map items that are already captured
+		$micro_mapping = array(
+		    'about' => 'pb_bisac_subject',
+		    'alternativeHeadline' => 'pb_subtitle',
+		    'author' => 'pb_author',
+		    'copyrightHolder' => 'pb_copyright_holder',
+		    'copyrightYear' => 'pb_copyright_year',
+		    'datePublished' => 'pb_publication_date',
+		    'description' => 'pb_about_50',
+		    'editor' => 'pb_editor',
+		    'image' => 'pb_cover_image',
+		    'inLanguage' => 'pb_language',
+		    'keywords' => 'pb_keywords_tags',
+		    'publisher' => 'pb_publisher',
+		);
+		$metadata = Book::getBookInformation();
+
+		// create microdata elements
+		foreach ( $micro_mapping as $itemprop => $content ) {
+			if ( array_key_exists( $content, $metadata ) ) {
+				if ( 'pb_publication_date' == $content ) {
+					$content = date( 'Y-m-d', $metadata[$content] );
+				} else {
+					$content = $metadata[$content];
+				}
+				$html .= "<meta itemprop='" . $itemprop . "' content='" . $content . "' id='" . $itemprop . "'>\n";
+			}
+		}
+		return $html;
+	}
 
 	// ----------------------------------------------------------------------------------------------------------------
 	// Upgrades

--- a/themes-book/pressbooks-book/footer.php
+++ b/themes-book/pressbooks-book/footer.php
@@ -48,6 +48,7 @@
 			<p class="cie-name"><a href="http://pressbooks.com"><?php _e('PressBooks.com: Simple Book Production', 'pressbooks'); ?></a></p>
 	</div><!-- #inner -->
 </div><!-- #footer -->
+</span><!-- schema.org -->
 <?php wp_footer(); ?>
 </body>
 </html>

--- a/themes-book/pressbooks-book/header.php
+++ b/themes-book/pressbooks-book/header.php
@@ -13,6 +13,14 @@
 <head>
 <meta charset="<?php bloginfo( 'charset' ); ?>" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<?php
+if ( is_front_page() ) {
+	echo pb_get_seo_meta_elements();
+	echo pb_get_microdata_elements();
+} else {
+	echo pb_get_microdata_elements();
+}
+?>
 <link rel="shortcut icon" href="<?php bloginfo('stylesheet_directory'); ?>/favicon.ico" />
 <title><?php
 	global $page, $paged;
@@ -50,11 +58,13 @@
 	 <?php if (is_front_page()):?>
 	 
 	 	<!-- home page wrap -->
-	 	
+	 	<span itemscope itemtype="http://schema.org/Book" itemref="about alternativeHeadline author copyrightHolder copyrightYear datePublished description editor 
+		      image inLanguage keywords publisher">
+		      
 	 		<div class="book-info-container">
 	 
 		<?php else: ?>  	 
-			
+		<span itemscope itemtype="http://schema.org/WebPage" itemref="about copyrightHolder copyrightYear inLanguage publisher">		
 		<div class="nav-container">
 				<nav>
 			


### PR DESCRIPTION
This adds metadata to the head element based on schema.org which Google, Bing and Yahoo will like. The cover page is identified as a [schema.org/Book](http://schema.org/Book) and the rest of the pages are identified as [schema.org/WebPage](http://schema.org/WebPage). 
- I chose to put the microdata in the head element and link it with `itemref`to be non-intrusive should the templates change. 
- These changes will cascade through to all child themes that use 'Luther' as a parent if those child themes don't override any of the template files. 
- I created shortcuts to the functions should other themes/theme designers also want to make use of the functionality. 

![screen shot 2014-06-19 at 7 51 31 am](https://cloud.githubusercontent.com/assets/2048170/3329129/dfce1550-f7c3-11e3-807f-f14bba981633.png)

This is the output of the above cover page using Google's 'Structured Data Testing Tool': 

![screen shot 2014-06-19 at 7 52 20 am](https://cloud.githubusercontent.com/assets/2048170/3329263/263f04ee-f7c5-11e3-8799-1a65f077eae8.png)
