### PR TITLE
Adds possibility for numbered headlines in content

### DIFF
--- a/docs/themes-book.txt
+++ b/docs/themes-book.txt
@@ -119,6 +119,17 @@ More functions available to book designers. See: pressbooks/functions.php
  + `pb_get_chapter_number( $post_name )`
  + `pb_thumbify( $thumb, $path )`
 
+More filters available to book designers:
+
+ + `pb_headline_add_numbers`
+
+Examples:
+
+    function pressbooks_theme_headline_add_numbers( $content, $cna ){
+      return(implode("-",$cna)." --- ".$content);
+    }
+    add_filter( 'pb_headline_add_numbers', 'pressbooks_theme_headline_add_numbers', 10, 2);
+
 == The HTML ==
 
 Top level elements (i.e. children nodes of <body>):

--- a/hooks.php
+++ b/hooks.php
@@ -13,6 +13,7 @@ if ( ! defined( 'ABSPATH' ) )
 
 require( PB_PLUGIN_DIR . 'includes/pb-utility.php' );
 require( PB_PLUGIN_DIR . 'includes/pb-image.php' );
+require(PB_PLUGIN_DIR . 'includes/pb-content.php');
 require( PB_PLUGIN_DIR . 'includes/pb-l10n.php' );
 require( PB_PLUGIN_DIR . 'includes/pb-postype.php' );
 require( PB_PLUGIN_DIR . 'includes/pb-redirect.php' );
@@ -41,6 +42,10 @@ if ( \PressBooks\Book::isBook() && \PressBooks\l10n\use_book_locale() ) {
 } else {
 	add_filter( 'locale', '\PressBooks\L10n\set_locale' );
 }
+// -------------------------------------------------------------------------------------------------------------------
+// Content Modifications
+// -------------------------------------------------------------------------------------------------------------------
+add_filter( 'the_content', '\PressBooks\Content\headline_add_numbers' );
 
 // -------------------------------------------------------------------------------------------------------------------
 // Images

--- a/includes/pb-content.php
+++ b/includes/pb-content.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * @author  PressBooks <code@pressbooks.com>
+ * @license GPLv2 (or any later version)
+ */
+namespace PressBooks\Content;
+
+/**
+ * Add numbers to headlines in content
+ * @param $content
+ *
+ */
+
+function headline_add_numbers( $content) {
+    global $id;
+    $post = get_post($id);
+    $cn = pb_get_chapter_number($post->post_name);
+    if($cn){
+        $cna = array();
+        $cna[0] = $cn;
+        $cna[1] = 0;
+        $cna[2] = 0;
+        $cna[3] = 0;
+        $cna[4] = 0;
+        $cna[5] = 0;
+        $cna[6] = 0;
+        $html = new \DOMDocument();
+        $html->loadHTML($content);
+        $xpath = new \DOMXpath($html);
+        foreach( $xpath->query('/html/body/*[self::h1 or self::h2 or self::h3 or self::h4 or self::h5 or self::h6]') as $node ) {
+            $nn = $node->nodeName;
+            $nn = substr($nn, 1);
+            $nn = intval($nn);
+
+            $cna[$nn] ++;
+            for($i = $nn+1; $i <7; $i++){
+                $cna[$i] = 0;
+            }
+
+
+            /**
+             * Filter the headline numbering.
+             *
+             * <code>
+             * function pressbooks_theme_headline_add_numbers( $content, $cna){
+             *   return(implode("-",$cna)." --- ".$content);
+             * }
+             * add_filter('pb_headline_add_numbers', 'pressbooks_theme_headline_add_numbers', 10, 2);
+             * </code>
+             *
+             * @param string $content Content of the current headline.
+             * @param array $headlineCount Array with Numbers representing the current headline. 1.2.3 h2 has an array $hc[0]=1, $nc[1]=2, $nc[2]=3
+             *
+             */
+            $v = apply_filters("pb_headline_add_numbers", $node->nodeValue, array_slice($cna, 0, $nn-6));
+            if($v == $node->nodeValue){
+                $node->nodeValue = implode(".",array_slice($cna, 0, $nn-6))." ".$node->nodeValue;
+            }else{
+                $node->nodeValue = $v;
+            }
+
+        }
+        $content = $html->saveHTML();
+    }
+    return $content;
+}


### PR DESCRIPTION
Adds the possibility for numbered headlines in the content.
To "h1" e.g. "1.1" is added. To "h2" "1.2.5".
Filter hook „pb_subheadline_add_numbers“ enables theme developers to
style the the numbers.
