### PR TITLE
apply_filters call allows caption shortcode to render on parts content

### DIFF
--- a/themes-book/pressbooks-book/single.php
+++ b/themes-book/pressbooks-book/single.php
@@ -26,8 +26,8 @@
 						}
 						echo $content;
 					} else {
-						echo get_post_meta( $post->ID, 'pb_part_content', true );
-					} ?>
+						echo apply_filters( 'the_content', get_post_meta( $post->ID, 'pb_part_content', true ) );
+			} ?>
 
 					</div><!-- .entry-content -->
 				</div><!-- #post-## -->


### PR DESCRIPTION
If 'parts' contain content, specifically images with captions, the caption shortcode [caption id='someid'] will now render the desired html. 

BEFORE: 
![screen shot 2014-07-08 at 11 46 17 am](https://cloud.githubusercontent.com/assets/2048170/3514874/492ff714-06d0-11e4-8683-6bd6c166363e.png)

AFTER: 
![screen shot 2014-07-08 at 11 45 43 am](https://cloud.githubusercontent.com/assets/2048170/3514880/5307febc-06d0-11e4-9640-779187134752.png)
