### PR TITLE
modifications for cleaner print output

### DIFF
--- a/themes-book/pressbooks-book/functions.php
+++ b/themes-book/pressbooks-book/functions.php
@@ -54,14 +54,14 @@ function pb_enqueue_scripts() {
 		$deps = array();
 		if ( ! pb_custom_stylesheet_imports_base() ) {
 			// Use default stylesheet as base (to avoid horribly broken webbook)
-			wp_register_style( 'pressbooks', PB_PLUGIN_URL . 'themes-book/pressbooks-book/style.css', array(), null, 'screen' );
+			wp_register_style( 'pressbooks', PB_PLUGIN_URL . 'themes-book/pressbooks-book/style.css', array(), null, 'screen,print' );
 			wp_enqueue_style( 'pressbooks' );
 			$deps = array( 'pressbooks' );
 		}
 		wp_register_style( 'pressbooks-custom-css', pb_get_custom_stylesheet_url(), $deps, get_option( 'pressbooks_last_custom_css' ), 'screen' );
 		wp_enqueue_style( 'pressbooks-custom-css' );
 	} else {
-		wp_register_style( 'pressbooks', get_bloginfo( 'stylesheet_url' ), array(), null, 'screen' );
+		wp_register_style( 'pressbooks', get_bloginfo( 'stylesheet_url' ), array(), null, 'screen,print' );
 		wp_enqueue_style( 'pressbooks' );
 	}
 	if (! is_front_page() ) {

--- a/themes-book/pressbooks-book/style.css
+++ b/themes-book/pressbooks-book/style.css
@@ -1821,11 +1821,15 @@ code {
   body {
     background: none !important;
   }
+  a{
+    color: #1f1f1d !important;
+  }
   #wrap {
     clear: both !important;
     display: block !important;
     float: none !important;
     position: relative !important;
+    margin: 0 auto !important;
   }
   #header {
     border-bottom: 2pt solid #000;
@@ -1841,23 +1845,35 @@ code {
   #access,
   #branding img,
   #respond,
+  #comments,
+  #searchform,
   .comment-edit-link,
   .edit-link,
   .navigation,
   .page-link,
-  .widget-area {
+  .widget-area,
+  .nav,
+  .share-wrap-single, 
+  .sidebar {
     display: none !important;
   }
   #container,
   #header,
-  #footer {
+  .footer {
     margin: 0;
     width: 100%;
+  }
+  .footer, 
+  nav {
+    background: none !important;
+    background-color: #ffffff !important;
+    color: #1f1f1d;
   }
   #content,
   .one-column #content {
     margin: 24pt 0 0;
     width: 100%;
+    padding: 10px;
   }
   .wp-caption p {
     font-size: 11pt;
@@ -1885,6 +1901,11 @@ code {
   }
   .home .sticky {
     border: none;
+  }
+  .wrapper{
+    height: auto !important;
+    min-height: 100px;
+    margin: 0 auto;
   }
 }
 /* =Debug Stuff (PL)


### PR DESCRIPTION
The main problem this solves is telling the browser it should use pressbooks-book/style.css and the CSS rules already declared for @media print (starting at line 1820). The rest is just clean up... to create consistency should a user want to print one page of a book. 
