### PR TITLE
Show real page titles in EPUB import

### DIFF
--- a/includes/modules/import/epub/class-pb-epub201.php
+++ b/includes/modules/import/epub/class-pb-epub201.php
@@ -285,7 +285,7 @@ class Epub201 extends Import {
 
 		$matches = array();
 
-		preg_match( '/<title>(.+)<\/title>/', $html, $matches );
+		preg_match( '/(?:<title[^>]*>)(.+)<\/title>/isU', $html, $matches );
 		$title = ( ! empty( $matches[1] ) ? wp_strip_all_tags( $matches[1] ) : '__UNKNOWN__' );
 
 		preg_match( '/(?:<body[^>]*>)(.*)<\/body>/isU', $html, $matches );


### PR DESCRIPTION
Currently the EPUB import displays the EPUB page ID on the import page rather than the real page title.  This can make it challenging to determine which content to select to import.

This change extracts the page title from the content page for display on the import page.
