### PR TITLE
Add custom meta hook in WRX import

### DIFF
--- a/includes/modules/import/wordpress/class-pb-wxr.php
+++ b/includes/modules/import/wordpress/class-pb-wxr.php
@@ -125,6 +125,9 @@ class Wxr extends Import {
 			if ( isset( $p['postmeta'] ) && is_array( $p['postmeta'] ) ) {
 				foreach ($meta_to_update as $meta_key) {
 					$meta_val = $this->searchForMetaValue( $meta_key, $p['postmeta'] );
+					if (is_serialized($meta_val)) {
+						$meta_val = unserialize($meta_val);
+					}
 					if ($meta_val) {
 						update_post_meta( $pid, $meta_key, $meta_val);
 					}


### PR DESCRIPTION
Wordpress allows plugin writers to add custom meta fields to posts, but the current Pressbooks WRX import does not provide a way to re-import these fields.

This change replaces the specific pb_section_author postmeta update in the WRX import with an extensible postmeta update with a filter hook plugin writers can use to extend the meta fields to update on import.
