### PR TITLE
Add import metabox hooks

### DIFF
--- a/admin/templates/import.php
+++ b/admin/templates/import.php
@@ -85,7 +85,10 @@ $current_import = get_option( 'pressbooks_current_import' );
 		</table>
 		
 		<?php
-		do_action( 'add_import_meta_boxes' );
+		do_action( 'add_meta_boxes', 'pb_import' );
+		$fake_post = new stdClass();
+		$fake_post->ID = 0;
+		do_meta_boxes( 'pb_import', 'normal', $fake_post );
 		?>
 		<p><?php
 			submit_button( __( 'Start', 'pressbooks' ), 'primary', 'submit', false );


### PR DESCRIPTION
Sometimes, like with licensing or attribution, it would be handy to be able to specify custom postmeta fields on an import, to apply to all imported posts, rather than having to edit each post and set the postmeta.

This change adds a new stand-in "post type", pb_import, which plugin writers can hook their add_meta_boxes against if they want their meta fields to display on the import page.

Plugin writers may need to adjust their post save functions to handle post_type not being part of the $_POST variables during import.
