### PR TITLE
add contributing authors to book info, exports

### DIFF
--- a/admin/pb-admin-metaboxes.php
+++ b/admin/pb-admin-metaboxes.php
@@ -191,6 +191,13 @@ function add_meta_boxes() {
 		'label' => __( 'Author, file as', 'pressbooks' ),
 		'description' => __( 'This ensures that your ebook will sort properly in ebook stores, by the author\'s last name.', 'pressbooks' )
 	) );
+	
+	x_add_metadata_field( 'pb_contributing_authors', 'metadata', array(
+		'group' => 'general-book-information',
+		'label' => __( 'Contributing Authors', 'pressbooks' ),
+		'multiple' => true,
+		'description' => __( 'This may be used when more than one person shares the responsibility for the intellectual content of a book', 'pressbooks' )
+	) );
 
 	x_add_metadata_field( 'pb_publisher', 'metadata', array(
 		'group' => 'general-book-information',

--- a/includes/class-pb-book.php
+++ b/includes/class-pb-book.php
@@ -69,7 +69,7 @@ class Book {
 		// Book Information
 		// ----------------------------------------------------------------------------
 
-		$expected_array = array( 'pb_keywords_tags', 'pb_bisac_subject' );
+		$expected_array = array( 'pb_keywords_tags', 'pb_bisac_subject', 'pb_contributing_authors' );
 		$expected_the_content = array( 'pb_custom_copyright', 'pb_about_unlimited' );
 
 		$book_information = array();

--- a/includes/class-pb-metadata.php
+++ b/includes/class-pb-metadata.php
@@ -146,6 +146,7 @@ class Metadata {
 		    'about' => 'pb_bisac_subject',
 		    'alternativeHeadline' => 'pb_subtitle',
 		    'author' => 'pb_author',
+		    'contributor' => 'pb_contributing_authors',
 		    'copyrightHolder' => 'pb_copyright_holder',
 		    'copyrightYear' => 'pb_copyright_year',
 		    'datePublished' => 'pb_publication_date',

--- a/includes/modules/export/epub/class-pb-epub201.php
+++ b/includes/modules/export/epub/class-pb-epub201.php
@@ -793,6 +793,7 @@ class Epub201 extends Export {
 			$html .= sprintf( '<h2 class="subtitle">%s</h2>', @$metadata['pb_subtitle'] );
 			$html .= sprintf( '<div class="logo"></div>' );
 			$html .= sprintf( '<h3 class="author">%s</h3>', @$metadata['pb_author'] );
+			$html .= sprintf( '<h4 class="author">%s</h4>', @$metadata['pb_contributing_authors'] );
 			$html .= sprintf( '<h4 class="publisher">%s</h4>', @$metadata['pb_publisher'] );
 			$html .= sprintf( '<h5 class="publisher-city">%s</h5>', @$metadata['pb_publisher_city'] );
 		}

--- a/includes/modules/export/epub/templates/opf.php
+++ b/includes/modules/export/epub/templates/opf.php
@@ -51,6 +51,16 @@ echo '<?xml version="1.0" encoding="UTF-8" ?>' . "\n";
 		}
 		echo '</dc:creator>' . "\n";
 		unset( $meta['pb_author_file_as'], $meta['pb_author'] );
+		
+		// Contributing authors
+		if ( ! empty( $meta['pb_contributing_authors'] ) ){
+			$contributors = explode( ',', $meta['pb_contributing_authors'] );
+			
+			foreach ( $contributors as $contributor ){
+				echo '<dc:contributor opf:role="aut">' . trim( $contributor ) . '</dc:contributor>' . "\n";
+			}
+			unset( $meta['pb_contributing_authors'] );
+		}
 
 		// Copyright
 		if ( ! empty( $meta['pb_copyright_year'] ) || ! empty( $meta['pb_copyright_holder'] ) ) {

--- a/includes/modules/export/epub3/templates/opf.php
+++ b/includes/modules/export/epub3/templates/opf.php
@@ -52,6 +52,16 @@ echo '<?xml version="1.0" encoding="UTF-8" ?>' . "\n";
 			echo 'Authored by: ' . get_bloginfo( 'url' );
 		}
 		echo '</dc:creator>' . "\n";
+		
+		// Contributing authors
+		if ( ! empty( $meta['pb_contributing_authors'] ) ){
+			$contributors = explode( ',', $meta['pb_contributing_authors'] );
+			
+			foreach ( $contributors as $contributor ){
+				echo '<dc:contributor>' . trim( $contributor ) . '</dc:contributor>' . "\n";
+			}
+			unset( $meta['pb_contributing_authors'] );
+		}
 
 		echo '<meta refines="#author" property="file-as">';
 

--- a/includes/modules/export/hpub/class-pb-hpub.php
+++ b/includes/modules/export/hpub/class-pb-hpub.php
@@ -570,6 +570,7 @@ class Hpub extends Export {
 			$html .= sprintf( '<h2 class="subtitle">%s</h2>', @$metadata['pb_subtitle'] );
 			$html .= sprintf( '<div class="logo"></div>' );
 			$html .= sprintf( '<h3 class="author">%s</h3>', @$metadata['pb_author'] );
+			$html .= sprintf( '<h4 class="author">%s</h4>', @$metadata['pb_contributing_authors'] );
 			$html .= sprintf( '<h4 class="publisher">%s</h4>', @$metadata['pb_publisher'] );
 			$html .= sprintf( '<h5 class="publisher-city">%s</h5>', @$metadata['pb_publisher_city'] );
 		}

--- a/includes/modules/export/indesign/templates/xhtml.php
+++ b/includes/modules/export/indesign/templates/xhtml.php
@@ -25,6 +25,10 @@ echo '<?xml version="1.0" encoding="utf-8" ?>' ."\n";
 <?php if ( isset( $meta['pb_author'] ) ) {  ?>
 	<h2><?php echo $meta['pb_author']; ?></h2>
 <?php } ?>
+	
+<?php if ( isset( $meta['pb_contributing_authors'] ) ) {  ?>
+	<h3><?php echo $meta['pb_contributing_authors']; ?></h3>
+<?php } ?>
 
 <div class="page">
 	<?php if ( isset( $meta['pb_print_isbn'] ) ) { ?>

--- a/includes/modules/export/xhtml/class-pb-xhtml11.php
+++ b/includes/modules/export/xhtml/class-pb-xhtml11.php
@@ -563,6 +563,7 @@ class Xhtml11 extends Export {
 			printf( '<h2 class="subtitle">%s</h2>', @$metadata['pb_subtitle'] );
 			printf( '<div class="logo"></div>' );
 			printf( '<h3 class="author">%s</h3>', @$metadata['pb_author'] );
+			printf( '<h4 class="author">%s</h4>', @$metadata['pb_contributing_authors'] );
 			printf( '<h4 class="publisher">%s</h4>', @$metadata['pb_publisher'] );
 			printf( '<h5 class="publisher-city">%s</h5>', @$metadata['pb_publisher_city'] );
 		}

--- a/themes-book/pressbooks-book/functions.php
+++ b/themes-book/pressbooks-book/functions.php
@@ -13,7 +13,8 @@ add_filter( 'show_admin_bar', function () { return false; } );
 global $metakeys;
 $metakeys = array(
 	'pb_author' => __( 'Author', 'pressbooks' ),
-	'pb_publisher'  => __( 'Publisher', 'pressbooks' ),
+	'pb_contributing_authors' => __( 'Contributing Author', 'pressbooks' ),
+ 	'pb_publisher'  => __( 'Publisher', 'pressbooks' ),
 	'pb_print_isbn'  => __( 'Print ISBN', 'pressbooks' ),
 	'pb_keywords_tags'  => __( 'Keywords/Tags', 'pressbooks' ),
 	'pb_publication_date'  => __( 'Publication Date', 'pressbooks' ),


### PR DESCRIPTION
Adds a 'Contributing Authors' field to Book Info. Conforms to EPUB spec:  http://www.idpf.org/epub/20/spec/OPF_2.0_latest.htm#Section2.2.6

In Book Info:

![screen shot 2014-08-29 at 1 14 55 pm](https://cloud.githubusercontent.com/assets/2048170/4095790/3d7c07d4-2fb9-11e4-94c6-1b72ed99afa7.png)

Export routines, microdata/metadata, footer fields have been addressed: 

![screen shot 2014-08-29 at 12 59 54 pm](https://cloud.githubusercontent.com/assets/2048170/4095834/76ca56d0-2fb9-11e4-9152-756a455e30b5.png)

![screen shot 2014-08-29 at 12 15 42 pm](https://cloud.githubusercontent.com/assets/2048170/4095836/7e335e62-2fb9-11e4-80d3-b741244531a4.png)

![screen shot 2014-08-29 at 12 15 23 pm](https://cloud.githubusercontent.com/assets/2048170/4095837/8344a64a-2fb9-11e4-98b1-8c44cb4b2e4d.png)
