### PR TITLE
Deny attributes on epub3 export

### DIFF
--- a/includes/modules/export/epub3/class-pb-epub3.php
+++ b/includes/modules/export/epub3/class-pb-epub3.php
@@ -145,7 +145,7 @@ class Epub3 extends Epub\Epub201 {
 		$config = array (
 		    'valid_xhtml' => 1,
 		    'no_deprecated_attr' => 2,
-		    'deny_attribute' => 'cellpadding,cellspacing,frameborder,marginwidth,marginheight,scrolling',
+		    'deny_attribute' => 'cellpadding,cellspacing,frameborder,marginwidth,marginheight,scrolling,itemscope,itemtype,itemref,itemprop',
 		    'unique_ids' => 'fixme-',
 		    'hook' => '\PressBooks\Sanitize\html5_to_xhtml5',
 		    'tidy' => -1,


### PR DESCRIPTION
removing those attributes which generate errors against epubcheck 3.0.1

![screen shot 2014-09-02 at 2 33 39 pm](https://cloud.githubusercontent.com/assets/2048170/4126194/1aa3ff5e-32e9-11e4-8979-cddf130e5a56.png)
