### PR TITLE
deny microdata attributes in epub2 export

### DIFF
--- a/includes/modules/export/epub/class-pb-epub201.php
+++ b/includes/modules/export/epub/class-pb-epub201.php
@@ -408,6 +408,7 @@ class Epub201 extends Export {
 			'valid_xhtml' => 1,
 			'no_deprecated_attr' => 2,
 			'unique_ids' => 'fixme-',
+			'deny_attribute' => 'itemscope,itemtype,itemref,itemprop',
 			'hook' => '\PressBooks\Sanitize\html5_to_xhtml11',
 			'tidy' => -1,
 		);


### PR DESCRIPTION
microdata attributes generate epubcheck errors in an EPUB2 export.

![screen shot 2014-09-24 at 9 23 03 am](https://cloud.githubusercontent.com/assets/2048170/4406636/b0a91cb8-44c4-11e4-83db-72f6eac4d677.png)
