### PR TITLE
pid variable needs to be set before being assigned to chapter_parent

### DIFF
--- a/includes/modules/import/wordpress/class-pb-wxr.php
+++ b/includes/modules/import/wordpress/class-pb-wxr.php
@@ -128,11 +128,11 @@ class Wxr extends Import {
 				$new_post['post_parent'] = $chapter_parent;
 			}
 
+			$pid = wp_insert_post( $new_post );
+			
 			if ( 'part' == $post_type ) {
 				$chapter_parent = $pid;
 			}
-
-			$pid = wp_insert_post( $new_post );
 
 			$meta_to_update = apply_filters( 'pb_import_metakeys', array( 'pb_section_author', 'pb_section_license', 'pb_short_title', 'pb_subtitle' ) );
 			


### PR DESCRIPTION
The order of these was correct in original PR, but got switched around on manual merge https://github.com/pressbooks/pressbooks/commit/8f04041938c708f3f01dd99dddb5fee0923e265a

this reverts to the order in original PR
