### PR TITLE
rectifies sprintf problem with percentage in parts

### DIFF
--- a/includes/modules/export/epub/class-pb-epub201.php
+++ b/includes/modules/export/epub/class-pb-epub201.php
@@ -1073,7 +1073,7 @@ class Epub201 extends Export {
 	protected function createPartsAndChapters( $book_contents, $metadata ) {
 
 		$part_printf = '<div class="part %s" id="%s">';
-		$part_printf .= '<div class="part-title-wrap"><h3 class="part-number">%s</h3><h1 class="part-title">%s</h1></div>';
+		$part_printf .= '<div class="part-title-wrap"><h3 class="part-number">%s</h3><h1 class="part-title">%s</h1></div>%s';
 		$part_printf .= '</div>';
 
 		$chapter_printf = '<div class="chapter %s" id="%s">';
@@ -1108,7 +1108,7 @@ class Epub201 extends Export {
 			$part_content = trim( get_post_meta( $part['ID'], 'pb_part_content', true ) );
 			if ( $part_content ) {
 				$part_content = $this->kneadHtml( $this->preProcessPostContent( $part_content ), 'custom' );
-				$part_printf_changed = str_replace( '</h1></div></div>', "</h1></div><div class=\"ugc part-ugc\">{$part_content}</div></div>", $part_printf );
+				$part_printf_changed = str_replace( '</h1></div>%s</div>', "</h1></div><div class=\"ugc part-ugc\">%s</div></div>", $part_printf );
 			}
 
 			foreach ( $part['chapters'] as $chapter ) {
@@ -1197,7 +1197,8 @@ class Epub201 extends Export {
 					$invisibility,
 					$slug,
 					( $this->numbered ? ( $this->romanizePartNumbers ? \PressBooks\L10n\romanize( $m ) : $m ) : '' ),
-					Sanitize\decode( $part['post_title'] ) );
+					Sanitize\decode( $part['post_title'] ),
+					$part_content );
 
 				$file_id = 'part-' . sprintf( "%03s", $i );
 				$filename = "{$file_id}-{$slug}.{$this->filext}";

--- a/includes/modules/export/hpub/class-pb-hpub.php
+++ b/includes/modules/export/hpub/class-pb-hpub.php
@@ -813,7 +813,7 @@ class Hpub extends Export {
 	protected function createPartsAndChapters( $book_contents, $metadata ) {
 
 		$part_printf = '<div class="part %s" id="%s">';
-		$part_printf .= '<div class="part-title-wrap"><h3 class="part-number">%s</h3><h1 class="part-title">%s</h1></div>';
+		$part_printf .= '<div class="part-title-wrap"><h3 class="part-number">%s</h3><h1 class="part-title">%s</h1></div>%s';
 		$part_printf .= '</div>';
 
 		$chapter_printf = '<div class="chapter %s" id="%s">';
@@ -847,7 +847,7 @@ class Hpub extends Export {
 			$part_content = trim( get_post_meta( $part['ID'], 'pb_part_content', true ) );
 			if ( $part_content ) {
 				$part_content = $this->kneadHtml( $this->preProcessPostContent( $part_content ), 'custom' );
-				$part_printf_changed = str_replace( '</h1></div></div>', "</h1></div><div class=\"ugc part-ugc\">{$part_content}</div></div>", $part_printf );
+				$part_printf_changed = str_replace( '</h1></div>%s</div>', "</h1></div><div class=\"ugc part-ugc\">%s</div></div>", $part_printf );
 			}
 
 			foreach ( $part['chapters'] as $chapter ) {
@@ -936,7 +936,8 @@ class Hpub extends Export {
 					$invisibility,
 					$slug,
 					$m,
-					Sanitize\decode( $part['post_title'] ) );
+					Sanitize\decode( $part['post_title'] ),
+					$part_content );
 
 				$file_id = 'part-' . sprintf( "%03s", $i );
 				$filename = "{$file_id}-{$slug}.html";

--- a/includes/modules/export/xhtml/class-pb-xhtml11.php
+++ b/includes/modules/export/xhtml/class-pb-xhtml11.php
@@ -857,7 +857,7 @@ class Xhtml11 extends Export {
 	protected function echoPartsAndChapters( $book_contents, $metadata ) {
 
 		$part_printf = '<div class="part %s" id="%s">';
-		$part_printf .= '<div class="part-title-wrap"><h3 class="part-number">%s</h3><h1 class="part-title">%s</h1></div>';
+		$part_printf .= '<div class="part-title-wrap"><h3 class="part-number">%s</h3><h1 class="part-title">%s</h1></div>%s';
 		$part_printf .= '</div>';
 
 		$chapter_printf = '<div class="chapter %s" id="%s">';
@@ -884,7 +884,7 @@ class Xhtml11 extends Export {
 			$part_content = trim( get_post_meta( $part['ID'], 'pb_part_content', true ) );
 			if ( $part_content ) {
 				$part_content = $this->preProcessPostContent( $part_content );
-				$part_printf_changed = str_replace( '</h1></div></div>', "</h1></div><div class=\"ugc part-ugc\">{$part_content}</div></div>", $part_printf );
+				$part_printf_changed = str_replace( '</h1></div>%s</div>', "</h1></div><div class=\"ugc part-ugc\">%s</div></div>", $part_printf );
 			}
 
 			$m = ( $invisibility == 'invisible' ) ? '' : $i;
@@ -893,7 +893,8 @@ class Xhtml11 extends Export {
 				$invisibility,
 				$slug,
 				$m,
-				Sanitize\decode( $title ) ) . "\n";
+				Sanitize\decode( $title ),
+				$part_content ) . "\n";
 
 			$my_chapters = '';
 


### PR DESCRIPTION
If within a 'part' a percentage symbol '%' is placed and referenced later by `$part_content` in the export routine, it acts as an unintentional placeholder for a formatted string when passed to `sprintf()`. This results in wiping out all content in the part during the export. 

By modifying how we pass part content to `sprintf()` allows for percentage symbols in the content area to make it through export routines. 

Note: this PR makes it similar to how content is passed to `sprintf()` in chapters.
