### PR TITLE
changing default to on

### DIFF
--- a/themes-book/pressbooks-book/functions.php
+++ b/themes-book/pressbooks-book/functions.php
@@ -529,7 +529,7 @@ function pressbooks_theme_copyright_license_callback( $args ) {
 	$options = get_option( 'pressbooks_theme_options_global' );
 
 	if ( ! isset( $options['copyright_license'] ) ) {
-		$options['copyright_license'] = 0;
+		$options['copyright_license'] = 1;
 	}
 	
 	$html = '<input type="checkbox" id="copyright_license" name="pressbooks_theme_options_global[copyright_license]" value="1" ' . checked( 1, $options['copyright_license'], false ) . '/>';


### PR DESCRIPTION
On new book creation, setting the default to 'on' will allow more people to derive benefit from the built-in license module. Users would still have to choose a license in 'Book Info' as demonstrated in the youtube video https://www.youtube.com/watch?v=3Zz6fJm9cWQ&feature=youtu.be 

Checking both the 'display the copyright license' checkbox in 'Appearance->Theme Options' and choosing a license in 'Book Info' are what is required to display creative commons copyright information on the footer of every web page and make it through the export routines. 