### PR TITLE
modify logic for epub3 display, labels for api and epub3

### DIFF
--- a/admin/templates/export.php
+++ b/admin/templates/export.php
@@ -120,14 +120,11 @@ if ( ! empty( $_GET['export_warning'] ) && ( get_option( 'pressbooks_email_valid
 	    
 	    <fieldset>
 	    <legend>Exotic formats:</legend>
-	    	<?php if ( in_array( network_site_url( null, 'http' ), array(
-	    		'http://textopress.com/',
-	    		'http://pressbooks.dev/',
-	    		'http://localhost/',
-	    		'http://localhost/pressbooks/',
-	    		'http://127.0.0.1/'
-	    	) ) ) { ?>
-	    	<input type="checkbox" id="epub3" name="export_formats[epub3]" value="1" <?php checked(1, $options['epub3'], false); ?>/><label for="epub3"> <?php _e( 'EPUB 3 (Experimental)', 'pressbooks' ); ?></label><br />
+	    	<?php 
+		$host = parse_url( network_site_url(), PHP_URL_HOST );
+
+		if ( 'pressbooks' != $host ) { ?>
+	    	<input type="checkbox" id="epub3" name="export_formats[epub3]" value="1" <?php checked(1, $options['epub3'], false); ?>/><label for="epub3"> <?php _e( 'EPUB 3 (Beta)', 'pressbooks' ); ?></label><br />
 	    	<?php } ?>
 	    	<input type="checkbox" id="hpub" name="export_formats[hpub]" value="1" <?php checked(1, $options['hpub'], false); ?>/><label for="hpub"> <?php _e( 'Hpub', 'pressbooks' ); ?></label><br />
 	    	<input type="checkbox" id="icml" name="export_formats[icml]" value="1" <?php checked(1, $options['icml'], false); ?>/><label for="icml"> <?php _e( 'ICML (for InDesign)', 'pressbooks' ); ?></label><br />

--- a/readme.txt
+++ b/readme.txt
@@ -199,7 +199,7 @@ TK.
 * Fixed bug that broke the running head in PDF exports.
 * Fixed bug that broke internal links in PDF exports.
 * Fixed bug that caused the Chapter Types menu item to be displayed twice for certain users.
-* Experimental PressBooks API (props to @bdolor; see http://pressbooks.com/api/v1/docs).
+* Beta PressBooks API (props to @bdolor; see http://pressbooks.com/api/v1/docs).
 * Collapsible TOCs for webbooks (props to @drlippman).
 * Import enhancements (props to @bdolor).
 * EPUB export enhancements (props to @bdolor).


### PR DESCRIPTION
Changing labels to 'Beta' which more accurately describes the state of both pieces of functionality. To encourage Beta testing of these two pieces of functionality, the logic for displaying EPUB3 output is now exclusive (of pressbooks.com) rather than inclusive of a handful of domains. This will keep EPUB3 off of pressbooks.com and make it available to others who will now have the opportunity to provide feedback which can inform further development. 