### PR TITLE
add child theme support for toc collapse

### DIFF
--- a/themes-book/pressbooks-book/functions.php
+++ b/themes-book/pressbooks-book/functions.php
@@ -76,7 +76,7 @@ function pb_enqueue_scripts() {
 	
 	$options = get_option( 'pressbooks_theme_options_global' );
 	if ( @$options['toc_collapse'] ) {
-		wp_enqueue_script( 'pressbooks_toc_collapse',	get_stylesheet_directory_uri() . '/js/toc_collapse.js', array( 'jquery' ) );
+		wp_enqueue_script( 'pressbooks_toc_collapse',	get_template_directory_uri() . '/js/toc_collapse.js', array( 'jquery' ) );
 		wp_enqueue_style( 'dashicons' );
 	}
 }


### PR DESCRIPTION
`get_template_directory_ui()` will look for the js script in luther (parent theme) directory, instead of in a child theme's stylesheet directory (where it won't find it). Gives collapsing TOC functionality to child themes without having to copy the script to other directories. 