### PR TITLE
fix webkit issue with catalogue page

### DIFF
--- a/themes-root/pressbooks-publisher-one/pb-catalog.php
+++ b/themes-root/pressbooks-publisher-one/pb-catalog.php
@@ -318,12 +318,10 @@ $_current_user_id = $catalog->getUserId();
 		$container.isotope({
 			itemSelector: '.book-data',
 			layoutMode: 'fitRows',
-		});
-		$container.isotope( 'on', 'layoutComplete',
-			function( isoInstance, laidOutItems ) {
-				$container.equalizer();
-			}
-		);
+		});		
+		function webkitTrigger( isoInstance, laidOutItems ) {
+			$container.equalizer();
+		}		
 		$container.equalizer({ columns: '> div.book-data', min: 350, resizeable: false });
 	});
 	// ]]>


### PR DESCRIPTION
I've tested this fix in the latest of FF, Safari and Chrome. fixes https://github.com/pressbooks/pressbooks/issues/91

Observations: `$container.equalizer()` wasn't firing inside `$container.isotope( 'on', 'layoutComplete'...`, in fact nothing was. Not even `console.log('is this thing on?');` Perhaps because `layoutComplete` is defaulted to true, `$container.equalizer()` didn't need binding to that event, explicitly. Just a guess. 

