### PR TITLE
fix docx import, look for images in alternate directory

### DIFF
--- a/includes/modules/import/ooxml/class-pb-docx.php
+++ b/includes/modules/import/ooxml/class-pb-docx.php
@@ -334,9 +334,20 @@ class Docx extends Import {
 		$image_content = $this->getZipContent( $img_location, false );
 
 		if ( ! $image_content ) {
-			$already_done[$img_location] = '';
+			// try a different directory in the zip container
+			try {
+				$alt_img_location = 'word/' . $img_location;
+				$image_content = $this->getZipContent( $alt_img_location, false );
 
-			return '';
+				if ( ! $image_content ) {
+					throw new \Exception( 'Image could not be retrieved in the DOCX file with PressBooks\Import\Ooxml\fetchAndSaveUniqueImage()' );
+				}
+			} catch ( \Exception $exc ) {
+				$this->log( $exc->getMessage() );
+				$already_done[$img_location] = '';
+
+				return '';
+			}
 		}
 
 		$tmp_name = $this->createTmpFile();
@@ -683,18 +694,18 @@ class Docx extends Import {
 		foreach ( $relations->Relationship as $rel ) {
 			if ( $rel["Type"] == $schema ) {
 				switch ( $id ) {
-
+					// must be cast as a string to avoid returning SimpleXml Object.
 					case 'footnotes':
-						$path = 'word/' . $rel['Target'];
+						$path = 'word/' . ( string ) $rel['Target'];
 						break;
 					case 'endnotes':
-						$path = 'word/' . $rel['Target'];
+						$path = 'word/' . ( string ) $rel['Target'];
 						break;
 					case 'hyperlink':
 						$path["{$rel['Id']}"] = ( string ) $rel['Target'];
 						break;
 					default:
-						$path = $rel['Target'];
+						$path = ( string ) $rel['Target'];
 						break;
 				}
 			}


### PR DESCRIPTION
@hughmcguire - as discussed, this should resolve some images not being pulled in with the docx import. It was necessary to cast the image path as a string and to look for the images in an alternate directory. I've tested it minimally (with one or two docs) and seems to resolve it. Please let me know if it needs further tweaking. 