### PR TITLE
stop the madness, unnecessary array reversal

### DIFF
--- a/symbionts/custom-metadata/README.md
+++ b/symbionts/custom-metadata/README.md
@@ -1,4 +1,4 @@
-# Custom Metada Manager for WordPress
+# Custom Metadata Manager for WordPress
 
 This code-only developer WordPress plugin allows you to add custom fields to your object types (post, pages, custom post types, users)
 

--- a/symbionts/custom-metadata/css/custom-metadata-manager.css
+++ b/symbionts/custom-metadata/css/custom-metadata-manager.css
@@ -60,12 +60,6 @@
 .custom-metadata-field.checkbox {
 	background: transparent;
 }
-.custom-metadata-field.checkbox div, .custom-metadata-field.checkbox label {
-	display: inline-block;
-}
-.custom-metadata-field.checkbox input {
-	margin: 0 1px 0 0;
-}
 
 .custom-metadata-field input[type="checkbox"] {
 	margin-right: 5px;

--- a/symbionts/custom-metadata/custom_metadata_examples.php
+++ b/symbionts/custom-metadata/custom_metadata_examples.php
@@ -151,6 +151,13 @@ function x_init_custom_fields() {
 			'label' => 'Timepicker field',
 		) );
 
+	// adds a colorpicker field to the 1st group
+	x_add_metadata_field( 'x_fieldColorpicker1', 'x_test', array(
+			'group' => 'x_metaBox1',
+			'field_type' => 'colorpicker',
+			'label' => 'Colorpicker field',
+		) );
+
 	// adds an upload field to the 1st group
 	x_add_metadata_field( 'x_fieldUpload1', 'x_test', array(
 			'group' => 'x_metaBox1',

--- a/symbionts/custom-metadata/js/custom-metadata-manager.js
+++ b/symbionts/custom-metadata/js/custom-metadata-manager.js
@@ -68,9 +68,9 @@
 					$div.attr( 'id', $field_id + '-1' ).attr( 'class', $field_id );
 
 					$.each( $field_inputs, function( k, field_input ){
-						
+
 						var $field_input = $( field_input );
-						
+
 						if ( ! _.isEmpty( $field_input.attr( 'id' ) ) ) {
 							$field_input.attr( 'id', $field_id );
 						}
@@ -195,6 +195,10 @@
 		$custom_metadata_field.find( '.custom-metadata-select2' ).each(function(index) {
 			$(this).select2({ placeholder : $(this).attr('data-placeholder'), allowClear : true });
 		});
+
+		// init the color picker fields
+		$( '.colorpicker' ).find( 'input' ).wpColorPicker();
+
 
 	});
 })(jQuery);


### PR DESCRIPTION
Problem: All multiple metadata fields passed to Custom Metadata Manager get reversed on every save. Affects contributing author, keywords, bisac subject in 'Book Info'. Should contributing authors be listed on the cover page, as contributing author 1, contributing author 2, contributing author 3, contributing author 4, each subsequent save of 'Book Info' will reverse this order. 

As the [Custom Metadata Manager](https://wordpress.org/plugins/custom-metadata/) hasn't been updated in a while, it feels low risk to affect the plugin code directly. Besides that, I can't see the purpose of `array_reverse()` in this particular circumstance — please shed some light on it if you know. 

...save:
![screen shot 2015-03-06 at 3 17 02 pm](https://cloud.githubusercontent.com/assets/2048170/6538188/e777a466-c413-11e4-8326-4d9a80648faa.png)

...and save again: 
![screen shot 2015-03-06 at 3 16 13 pm](https://cloud.githubusercontent.com/assets/2048170/6538196/fee24340-c413-11e4-9544-a5cbcb9ee8cd.png)