### PR TITLE
add support for internal links on subdirectory installations

### DIFF
--- a/includes/modules/export/xhtml/class-pb-xhtml11.php
+++ b/includes/modules/export/xhtml/class-pb-xhtml11.php
@@ -412,7 +412,9 @@ class Xhtml11 extends Export {
 	 * @return string
 	 */
 	protected function fixInternalLinks( $content ) {
-
+		// takes care of PB subdirectory installations of PB
+		$content = preg_replace("/href\=\"\/([a-z0-9]*)\/(front\-matter|chapter|back\-matter)\/([a-z0-9\-]*)([\/]?)(\#[a-z0-9\-]*)\"/", "href=\"$5\"", $content);	
+		// takes care of PB subdomain installations of PB
 		$content = preg_replace("/href\=\"\/(front\-matter|chapter|back\-matter)\/([a-z0-9\-]*)([\/]?)(\#[a-z0-9\-]*)\"/", "href=\"$4\"", $content);	
 		
 		$output = preg_replace("/href\=\"\/(front\-matter|chapter|back\-matter)\/([a-z0-9\-]*)([\/]?)\"/", "href=\"#$2\"", $content);


### PR DESCRIPTION
The quickest and dirtiest way to add support for internal linking on export routines for subdirectory installs as outlined in detail here: http://pressbookstest.trinfocafe.org/book/chapter/chapter-1/

Admittedly, I don't love this solution, but it works. Question for @greatislander — what risks are you aware of if we introduced a more robust function at this point in the routine, similar to what we see later, for instance, in epub export? https://github.com/pressbooks/pressbooks/blob/dev/includes/modules/export/epub/class-pb-epub201.php#L1819
