### PR TITLE
Fixed variable-related warnings on RESTful API, when debugging mode is enabled

### DIFF
--- a/includes/modules/api_v1/books/class-pb-booksapi.php
+++ b/includes/modules/api_v1/books/class-pb-booksapi.php
@@ -279,8 +279,7 @@ class BooksApi extends Api {
 		foreach ( $book['front-matter'] as $fm ){
 			$chapters[$fm['post_id']] = $fm; 
 		}
-		$chapters = $front_matter;
-		
+
 		// parts
 		for ( $i = 0; $i < $parts_count; $i ++ ) {
 			// chapters
@@ -443,7 +442,6 @@ class BooksApi extends Api {
 			if ( ! in_array( $args['id'], $this->public_books ) ) {
 				return $this->apiErrors( 'empty' );
 			}
-			$book[$args['id']];
 			$book[$args['id']]['book_id'] = $args['id'];
 			$book[$args['id']]['book_url'] = get_blogaddress_by_id( $args['id'] );
 			$book[$args['id']]['book_meta'] = \PressBooks\Book::getBookInformation( intval( $args['id'] ) );


### PR DESCRIPTION
When using the RESTful API (calling URL `/path/to/wp/installation/api/v1/books/2/?titles=a`), I was given some messages from PHP:
```
<br />
<b>Notice</b>:  Undefined offset: 2 in <b>/path/to/wp/installation/wp-content/plugins/pressbooks/includes/modules/api_v1/books/class-pb-booksapi.php</b> on line <b>446</b><br />
<br />
<b>Notice</b>:  Undefined variable: front_matter in <b>/path/to/wp/installation/wp-content/plugins/pressbooks/includes/modules/api_v1/books/class-pb-booksapi.php</b> on line <b>282</b><br />
```

I removed the mentioned variables, as they do not appear to be useful for anything. Even worse, `$front_matter` appears to delete data related to front matter chapters.
This breaks the inner workings of some plug-ins, like [Textbook](https://github.com/BCcampus/pressbooks-textbook)'s *Search and Import* feature.

Ironically, this only happens when the WordPress debugging mode is enabled, which sounds like this feature was developed without using it…