### PR TITLE
Fallbacks for getBookInformation()

### DIFF
--- a/includes/class-pb-book.php
+++ b/includes/class-pb-book.php
@@ -112,6 +112,7 @@ class Book {
 			$book_information[$key] = $val;
 		}
 		
+		// Return our best guess if no book information has been entered.
 		if ( empty( $book_information ) ) {
 			$book_information['pb_title'] = get_bloginfo( 'name' );
 			$author = get_user_by( 'email', get_bloginfo( 'admin_email' ) );

--- a/includes/class-pb-book.php
+++ b/includes/class-pb-book.php
@@ -111,6 +111,13 @@ class Book {
 
 			$book_information[$key] = $val;
 		}
+		
+		if ( empty( $book_information ) ) {
+			$book_information['pb_title'] = get_bloginfo( 'name' );
+			$author = get_user_by( 'email', get_bloginfo( 'admin_email' ) );
+			$book_information['pb_author'] = $author->display_name;
+			$book_information['pb_cover_image'] = \PressBooks\Image\default_cover_url();
+		}
 
 		// -----------------------------------------------------------------------------
 		// Cache & Return


### PR DESCRIPTION
In instances where no book information has been entered, the `getBookInformation()` function and its theme alias, `pb_get_book_information()`, return empty arrays. This pull request instead returns a simple array with a title (the book/blog name), an author (the book/blog administrator's display name), and the default cover image.