### PR TITLE
add specificity, preference for PB generated tags

### DIFF
--- a/includes/modules/import/html/class-pb-xhtml.php
+++ b/includes/modules/import/html/class-pb-xhtml.php
@@ -54,9 +54,14 @@ class Xhtml extends Import {
 		$author = ( isset( $meta['authors'] )) ? $meta['authors'] : $this->getAuthors( $html );
 		$license = ( isset( $meta['license'] )) ? $this->extractCCLicense( $meta['license'] ) : '';
 
-		// get the title
-		preg_match( '/<title>(.+)<\/title>/', $html, $matches );
-		$title = ( ! empty( $matches[1] ) ? wp_strip_all_tags( $matches[1] ) : '__UNKNOWN__' );
+		// get the title, preference to title set by PB
+		preg_match( '/<h2 class="entry-title">(.*)<\/h2>/', $html, $matches );
+		if ( ! empty( $matches[1] ) ) {
+			$title = wp_strip_all_tags( $matches[1] );
+		} else {
+			preg_match( '/<title>(.+)<\/title>/', $html, $matches );
+			$title = ( ! empty( $matches[1] ) ? wp_strip_all_tags( $matches[1] ) : '__UNKNOWN__' );
+		}
 
 		// just get the body
 		preg_match( '/(?:<body[^>]*>)(.*)<\/body>/isU', $html, $matches );
@@ -208,7 +213,11 @@ class Xhtml extends Import {
 		// general content area, greedy
 		preg_match( '/(?:<div id="content"[^>]*>)(.*)<\/div>/is', $html, $matches );
 		$html = ( ! empty( $matches[1] )) ? $matches[1] : $html;
-
+		
+		// specific PB content area, greedy
+		preg_match( '/(?:<div class="entry-content"[^>]*>)(.*)<\/div>/is', $html, $matches );
+		$html = ( ! empty( $matches[1] )) ? $matches[1] : $html;
+		
 		/* cull */
 		// get rid of script tags, ungreedy
 		$result = preg_replace( '/(?:<script[^>]*>)(.*)<\/script>/isU', '', $html );


### PR DESCRIPTION
Small tweaks to the XHTML import to better target content contained within HTML elements generated by PB. 

If the XHTML import source file is a PB site, this improves the title that gets pulled in, and also the content area. 