### PR TITLE
unset variable to accurately represent which chapters belong to which…

### DIFF
--- a/includes/modules/api_v1/books/class-pb-booksapi.php
+++ b/includes/modules/api_v1/books/class-pb-booksapi.php
@@ -531,6 +531,7 @@ class BooksApi extends Api {
 			    'post_link' => get_permalink( $book['part'][$i]['ID'] ),
 			    'chapters' => $chapters,
 			);
+			unset( $chapters );
 		}
 
 		// back-matter


### PR DESCRIPTION
not destroying the value of this variable at the end of each loop has the unintended affect of adding chapters to parts to which they do not belong. The last part in a multi-part book is represented as having all the chapters in the entire book. This small change rectifies that.