### PR TITLE
fix for mixed content warning in ssl

### DIFF
--- a/includes/class-pb-metadata.php
+++ b/includes/class-pb-metadata.php
@@ -175,7 +175,7 @@ class Metadata {
 
 	/**
 	 * Takes a known string from metadata, builds a url to hit an api which returns an xml response
-	 * @see http://api.creativecommons.org/docs/readme_15.html
+	 * @see https://api.creativecommons.org/docs/readme_15.html
 	 * 
 	 * @param string $type license type
 	 * @param string $copyright_holder of the page
@@ -184,7 +184,7 @@ class Metadata {
 	 * @return string $xml response
 	 */
 	static function getLicenseXml( $type, $copyright_holder, $src_url, $title, $lang = '' ) {
-		$endpoint = 'http://api.creativecommons.org/rest/1.5/';
+		$endpoint = 'https://api.creativecommons.org/rest/1.5/';
 		$xml = '';
 		$lang = ( ! empty( $lang ) ) ? substr( $lang, 0, 2 ) : '';
 		$expected = array(

--- a/themes-book/pressbooks-book/header.php
+++ b/themes-book/pressbooks-book/header.php
@@ -7,7 +7,7 @@
 <!--[if (gt IE 9)|!(IE)]><!--><html <?php language_attributes(); ?> class="no-js"> <!--<![endif]-->
 <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
     <!--[if lt IE 9]>
-      <script src="http://html5shim.googlecode.com/svn/trunk/html5.js">
+      <script src="https://html5shim.googlecode.com/svn/trunk/html5.js">
       </script>
     <![endif]-->
 <head>


### PR DESCRIPTION
The two links I've changed redirect to https anyways, so this will help on instances of PB that are delivered via SSL