### PR TITLE
fix for about the author style, accessibility button

### DIFF
--- a/themes-book/pressbooks-book/css/a11y.css
+++ b/themes-book/pressbooks-book/css/a11y.css
@@ -104,7 +104,7 @@
 	font-size: 1.25em;
 }
 
-.fontsize .description-book-info, .author-book-info{
+.fontsize .description-book-info, .fontsize .author-book-info{
 	font-size: 1.5em;
 }
 


### PR DESCRIPTION
The content in this div class would remain at the enlarged font-size regardless of whether the accessibility button was enabled or disabled. This fixes that problem. 