### PR TITLE
enable social media integration as an option

### DIFF
--- a/themes-book/pressbooks-book/functions.php
+++ b/themes-book/pressbooks-book/functions.php
@@ -635,6 +635,16 @@ function pressbooks_theme_options_web_init() {
 		)
 	);
 
+	add_settings_field(
+		'social_media_buttons', 
+		__( 'Enable Social Media', 'pressbooks' ), 
+		'pressbooks_theme_social_media_callback',
+		$_page,
+		$_section,
+		array(
+		    __('Add buttons to each chapter so that readers may share links to your book through social media: Facebook, Twitter, Google+.', 'pressbooks' )
+		)
+	);
 	register_setting(
 		$_option, 
 		$_option, 
@@ -672,6 +682,18 @@ function pressbooks_theme_toc_collapse_callback( $args ) {
 	echo $html;
 }
 
+// Web Options Field Callback
+function pressbooks_theme_social_media_callback( $args ) {
+	$options = get_option( 'pressbooks_theme_options_web' );
+
+	if ( ! isset( $options['social_media'] ) ) {
+		$options['social_media'] = 1;
+	}
+	$html = '<input type="checkbox" id="social_media" name="pressbooks_theme_options_web[social_media]" value="1" ' . checked( 1, $options['social_media'], false ) . '/>';
+	$html .= '<label for="social_media"> ' . $args[0] . '</label>';
+	echo $html;
+}
+
 // Web Options Sanitize
 function pressbooks_theme_options_web_sanitize( $input ) {
 
@@ -688,7 +710,12 @@ function pressbooks_theme_options_web_sanitize( $input ) {
 	} else {
 		$options['accessibility_fontsize'] = 1;
 	}
-	return $options;
+	
+	if ( ! isset( $input['social_media'] ) || $input['social_media'] != '1' ) {
+		$options['social_media'] = 0;
+	} else {
+		$options['social_media'] = 1;
+	}	return $options;
 }
 
 add_action( 'admin_init', 'pressbooks_theme_options_web_init' );

--- a/themes-book/pressbooks-book/functions.php
+++ b/themes-book/pressbooks-book/functions.php
@@ -715,7 +715,9 @@ function pressbooks_theme_options_web_sanitize( $input ) {
 		$options['social_media'] = 0;
 	} else {
 		$options['social_media'] = 1;
-	}	return $options;
+	}	
+	
+	return $options;
 }
 
 add_action( 'admin_init', 'pressbooks_theme_options_web_init' );

--- a/themes-book/pressbooks-book/header.php
+++ b/themes-book/pressbooks-book/header.php
@@ -46,14 +46,19 @@ if ( is_front_page() ) {
 <body <?php body_class(); if(wp_title('', false) != '') { print ' id="' . str_replace(' ', '', strtolower(wp_title('', false))) . '"'; } ?>>
 <!-- Faccebook share js sdk -->
 <div id="fb-root"></div>
-<script>(function(d, s, id) {
+<?php
+$fb_script = get_option( 'pressbooks_theme_options_web' );
+
+if ( 1 === $fb_script['social_media'] ) {
+	echo '<script>(function(d, s, id) {
   var js, fjs = d.getElementsByTagName(s)[0];
   if (d.getElementById(id)) return;
   js = d.createElement(s); js.id = id;
   js.src = "//connect.facebook.net/en_US/all.js#xfbml=1";
   fjs.parentNode.insertBefore(js, fjs);
-}(document, 'script', 'facebook-jssdk'));</script>
-<!-- end Facebook JS -->
+}(document, "script", "facebook-jssdk"));</script>';
+}
+?>
 
 <?php get_template_part( 'content', 'accessibility-toolbar' ); ?>
 

--- a/themes-book/pressbooks-book/page-cover-second-block.php
+++ b/themes-book/pressbooks-book/page-cover-second-block.php
@@ -10,11 +10,16 @@
 										echo $about_unlimited; ?></p>
 								<?php endif; ?>	
 								
-							  <div id="share">
-								  <div id="twitter" data-url="<?php the_permalink(); ?>" data-text="Check out this great book on PressBooks." data-title="Tweet"></div>
-								  <div id="facebook" data-url="<?php the_permalink(); ?>" data-text="Check out this great book on PressBooks." data-title="Like"></div>
-								  <div id="googleplus" data-url="<?php the_permalink(); ?>" data-text="Check out this great book on PressBooks." data-title="+1"></div>
-</div>	
+									<div id="share">
+										<?php
+										$social_buttons = get_option( 'pressbooks_theme_options_web' );
+										if ( 1 === $social_buttons['social_media'] ) {
+											?>
+											<div id="twitter" data-url="<?php the_permalink(); ?>" data-text="Check out this great book on PressBooks." data-title="Tweet"></div>
+											<div id="facebook" data-url="<?php the_permalink(); ?>" data-text="Check out this great book on PressBooks." data-title="Like"></div>
+											<div id="googleplus" data-url="<?php the_permalink(); ?>" data-text="Check out this great book on PressBooks." data-title="+1"></div>
+										<?php } ?>	 
+									</div>	
 						</div>
 							
 								<?php	$args = $args = array(

--- a/themes-book/pressbooks-book/single.php
+++ b/themes-book/pressbooks-book/single.php
@@ -35,7 +35,12 @@
 			
 				</div><!-- #content -->
 			
-				<?php get_template_part( 'content', 'social-footer' ); ?> 
+				<?php 
+				$chapter_buttons = get_option( 'pressbooks_theme_options_web' );
+				if ( 1 === $chapter_buttons['social_media'] ) {
+					get_template_part( 'content', 'social-footer' ); 
+				}
+				?> 
 			
 				<?php comments_template( '', true ); ?>
 <?php else: ?>


### PR DESCRIPTION
A potential fix for https://github.com/pressbooks/pressbooks/issues/107

Default setting is to 'enable' so no change will come to books that currently use it, however, this now becomes an option for those who don't want it. 

Passes tests with 'Ghostery' and 'Privacy Badger' Add-ons for Firefox