### PR TITLE
include social media buttons if variable has yet to be set

### DIFF
--- a/themes-book/pressbooks-book/functions.php
+++ b/themes-book/pressbooks-book/functions.php
@@ -642,7 +642,7 @@ function pressbooks_theme_options_web_init() {
 		$_page,
 		$_section,
 		array(
-		    __('Add buttons to each chapter so that readers may share links to your book through social media: Facebook, Twitter, Google+.', 'pressbooks' )
+		    __('Add buttons to cover page and each chapter so that readers may share links to your book through social media: Facebook, Twitter, Google+.', 'pressbooks' )
 		)
 	);
 	register_setting(

--- a/themes-book/pressbooks-book/header.php
+++ b/themes-book/pressbooks-book/header.php
@@ -49,7 +49,7 @@ if ( is_front_page() ) {
 <?php
 $fb_script = get_option( 'pressbooks_theme_options_web' );
 
-if ( 1 === $fb_script['social_media'] ) {
+if ( 1 === $fb_script['social_media'] || ! isset( $fb_script['social_media'] ) ) {
 	echo '<script>(function(d, s, id) {
   var js, fjs = d.getElementsByTagName(s)[0];
   if (d.getElementById(id)) return;

--- a/themes-book/pressbooks-book/page-cover-second-block.php
+++ b/themes-book/pressbooks-book/page-cover-second-block.php
@@ -13,8 +13,7 @@
 									<div id="share">
 										<?php
 										$social_buttons = get_option( 'pressbooks_theme_options_web' );
-										if ( 1 === $social_buttons['social_media'] || ! isset( $social_buttons['social_media'] ) ) {
-?>
+										if ( 1 === $social_buttons['social_media'] || ! isset( $social_buttons['social_media'] ) ) { ?>
 											<div id="twitter" data-url="<?php the_permalink(); ?>" data-text="Check out this great book on PressBooks." data-title="Tweet"></div>
 											<div id="facebook" data-url="<?php the_permalink(); ?>" data-text="Check out this great book on PressBooks." data-title="Like"></div>
 											<div id="googleplus" data-url="<?php the_permalink(); ?>" data-text="Check out this great book on PressBooks." data-title="+1"></div>

--- a/themes-book/pressbooks-book/page-cover-second-block.php
+++ b/themes-book/pressbooks-book/page-cover-second-block.php
@@ -13,8 +13,8 @@
 									<div id="share">
 										<?php
 										$social_buttons = get_option( 'pressbooks_theme_options_web' );
-										if ( 1 === $social_buttons['social_media'] ) {
-											?>
+										if ( 1 === $social_buttons['social_media'] || ! isset( $social_buttons['social_media'] ) ) {
+?>
 											<div id="twitter" data-url="<?php the_permalink(); ?>" data-text="Check out this great book on PressBooks." data-title="Tweet"></div>
 											<div id="facebook" data-url="<?php the_permalink(); ?>" data-text="Check out this great book on PressBooks." data-title="Like"></div>
 											<div id="googleplus" data-url="<?php the_permalink(); ?>" data-text="Check out this great book on PressBooks." data-title="+1"></div>

--- a/themes-book/pressbooks-book/single.php
+++ b/themes-book/pressbooks-book/single.php
@@ -37,7 +37,7 @@
 			
 				<?php 
 				$chapter_buttons = get_option( 'pressbooks_theme_options_web' );
-				if ( 1 === $chapter_buttons['social_media'] ) {
+				if ( 1 === $chapter_buttons['social_media'] || ! isset( $chapter_buttons['social_media'] ) ) {
 					get_template_part( 'content', 'social-footer' ); 
 				}
 				?> 


### PR DESCRIPTION
If users have not yet visited Appearance -> Theme Options -> Web Options and hit 'save', the variable that the condition relies on for displaying buttons will not have been set. This more permissive conditional statement will display social media buttons without requiring any action on the part of the users.  