### PR TITLE
Fix for max import size

### DIFF
--- a/admin/templates/import.php
+++ b/admin/templates/import.php
@@ -127,7 +127,7 @@ $current_import = get_option( 'pressbooks_current_import' );
 			</script>
 		<p>
 			<?php _e( 'Supported file extensions:', 'pressbooks' ); ?> XML, EPUB, ODT, DOCX, HTML <br />
-			<?php _e( 'Maximum file size:', 'pressbooks' ); echo ' ' . ini_get( 'upload_max_filesize' ); ?>
+			<?php _e( 'Maximum file size:', 'pressbooks' ); echo ' ' . \PressBooks\Utility\file_upload_max_size(); ?>
 		</p>
 
 		<form id="pb-import-form" action="<?php echo $import_form_url ?>" enctype="multipart/form-data" method="post">

--- a/includes/pb-utility.php
+++ b/includes/pb-utility.php
@@ -339,3 +339,45 @@ function show_experimental_features() {
 
 	return $result;
 }
+
+/**
+ * Function to return a string representing max import size by comparing values of upload_max_filesize, post_max_size
+ * Uses parse_size helper function since the values in php.ini are strings like 64M and 128K
+ * @return string
+ */
+
+function file_upload_max_size() {
+  static $max_size = -1;
+  //  This function is adapted from Drupal and http://stackoverflow.com/questions/13076480/php-get-actual-maximum-upload-size 
+  if ($max_size < 0) {
+    
+    $post_max_size_str=ini_get('post_max_size');
+    $upload_max_filesize_str=ini_get('upload_max_filesize');
+    $post_max_size=parse_size($post_max_size_str);
+    $upload_max_filesize=parse_size($upload_max_filesize_str);
+
+    // If upload_max_size is less, then reduce. Except if upload_max_size is
+    // zero, which indicates no limit.
+    $returnVal = $post_max_size_str;
+    if ($upload_max_filesize > 0 && $upload_max_filesize < $post_max_size) {
+      $returnVal = $upload_max_filesize_str;
+    }
+  }
+  return $returnVal;
+}
+
+/**
+ * parse_size converts php.ini values from strings (like 128M or 64K) into actual numbers that can be compared
+ * @return integer
+ */
+function parse_size($size) {
+  $unit = preg_replace('/[^bkmgtpezy]/i', '', $size); // Remove the non-unit characters from the size.
+  $size = preg_replace('/[^0-9\.]/', '', $size); // Remove the non-numeric characters from the size.
+  if ($unit) {
+    // Find the position of the unit in the ordered string which is the power of magnitude to multiply a kilobyte by.
+    return round($size * pow(1024, stripos('bkmgtpezy', $unit[0])));
+  }
+  else {
+    return round($size);
+  }
+}


### PR DESCRIPTION
Hi,
  Apologies in advance if I've broken any etiquette rules with an unsolicited pull request for code.  If you prefer to have an open issue first, please let me know!

We are hosting our own pressbooks instance and ran into an issue with importing ePubs.  Specifically, the file size listed on the import page only pays attention to php's upload_max_filesize setting.  We needed to increase both upload_max_filesize and post_max_filesize to allow imports over the default 2MB

So, to accurately show max import size, you need the minimum of those 2 values.  Unfortunately they're stored as string values that allow suffixes like M and K, so they have to be converted to bytes.  I came across this SO thread which had a drupal snippet that I adapted to suit this purpose.  I placed it in PB utilities as that seemed a logical place.

http://stackoverflow.com/questions/13076480/php-get-actual-maximum-upload-size

So, feel free to use/modify/ignore, but thought you may like to have it!