### PR TITLE
ePub3 validation fix for users who change path to epubcheck

### DIFF
--- a/includes/modules/export/epub/class-pb-epub201.php
+++ b/includes/modules/export/epub/class-pb-epub201.php
@@ -228,7 +228,11 @@ class Epub201 extends Export {
 	function validate() {
 
 		// Epubcheck command, (quiet flag requires version 3.0.1+)
-		$command = PB_EPUBCHECK_COMMAND . ' -quiet ' . escapeshellcmd( $this->outputPath ) . ' 2>&1';
+		$epubCheckCommand = PB_EPUBCHECK_COMMAND;
+		if ( $this->suffix == "_3.epub" && strpos( $epubCheckCommand, '-v 3' ) === false ) {
+			$epubCheckCommand = $epubCheckCommand . " -v 3.0";
+		}
+		$command = $epubCheckCommand . ' -quiet ' . escapeshellcmd( $this->outputPath ) . ' 2>&1';
 
 		// Execute command
 		$output = array();

--- a/includes/modules/export/epub/class-pb-epub201.php
+++ b/includes/modules/export/epub/class-pb-epub201.php
@@ -229,7 +229,7 @@ class Epub201 extends Export {
 
 		// Epubcheck command, (quiet flag requires version 3.0.1+)
 		$epubCheckCommand = PB_EPUBCHECK_COMMAND;
-		if ( $this->suffix == "_3.epub" && strpos( $epubCheckCommand, '-v 3' ) === false ) {
+		if ( $this->suffix == "_3.epub" && false === strpos( $epubCheckCommand, '-v 3' ) ) {
 			$epubCheckCommand = $epubCheckCommand . " -v 3.0";
 		}
 		$command = $epubCheckCommand . ' -quiet ' . escapeshellcmd( $this->outputPath ) . ' 2>&1';


### PR DESCRIPTION
We have a path for PB_EPUBCHECK_COMMAND defined in wp-config.php.  We needed a way for ePub2 files to validate against the ePub2 spec and ePub3 files to validate against ePub3.  There's only one constant, so this was my workaround ... an alternative would be to define a second constant but this seems to work for us so thought I'd put it out in case you like it.

I think that even if you didn't defined the command path yourself, if you were simultaneously exporting an ePub2 and an ePub3 in the current system, the validator would run against ePub v2 both times since the constant would already be defined by the time the second one came around.  I could be wrong though as I haven't looked into the internals of the export routine to verify that the loop all happens in one request.