### PR TITLE
only get export meta value when needed

### DIFF
--- a/includes/class-pb-book.php
+++ b/includes/class-pb-book.php
@@ -145,7 +145,7 @@ class Book {
 	 * @see bottom of this file for more info
 	 * @return array
 	 */
-	static function getBookStructure( $id = '' ) {
+	static function getBookStructure( $id = '', $get_pb_export_meta=false  ) {
 
 		// -----------------------------------------------------------------------------
 		// Is cached?
@@ -197,6 +197,12 @@ class Book {
 
 				$post_name = static::fixSlug( $post->post_name );
 
+        if($get_pb_export_meta) {
+          $export = ( get_post_meta( $post->ID, 'pb_export', true ) ? true : false );
+        } else {
+          $export = false;
+        }
+
 				$book_structure[$type][] = array(
 					'ID' => $post->ID,
 					'post_title' => $post->post_title,
@@ -205,7 +211,7 @@ class Book {
 					'comment_count' => $post->comment_count,
 					'menu_order' => $post->menu_order,
 					'post_status' => $post->post_status,
-					'export' => ( get_post_meta( $post->ID, 'pb_export', true ) ? true : false ),
+					'export' => $export,
 					'post_parent' => $post->post_parent,
 				);
 			}
@@ -307,7 +313,7 @@ class Book {
 		// Precedence when using the + operator to merge arrays is from left to right
 		// -----------------------------------------------------------------------------
 
-		$book_contents = static::getBookStructure();
+    $book_contents = static::getBookStructure('', true);
 
 		foreach ( $book_contents as $type => $struct ) {
 

--- a/includes/class-pb-metadata.php
+++ b/includes/class-pb-metadata.php
@@ -406,7 +406,7 @@ class Metadata {
 	 */
 	function upgradeBook() {
 
-		$book_structure = Book::getBookStructure();
+    $book_structure = Book::getBookStructure('', true);
 		foreach ( $book_structure['__order'] as $post_id => $_ ) {
 
 			$meta = get_post_meta( $post_id );

--- a/includes/modules/api_v1/books/class-pb-booksapi.php
+++ b/includes/modules/api_v1/books/class-pb-booksapi.php
@@ -434,7 +434,7 @@ class BooksApi extends Api {
 				$book[$book_id]['book_id'] = $book_id;
 				$book[$book_id]['book_url'] = get_blogaddress_by_id( $book_id );
 				$book[$book_id]['book_meta'] = \PressBooks\Book::getBookInformation( intval( $book_id ) );
-				$book_structure = \PressBooks\Book::getBookStructure( intval( $book_id ) );
+				$book_structure = \PressBooks\Book::getBookStructure( intval( $book_id ), true );
 				$book[$book_id]['book_toc'] = $this->getToc( $book_structure, $book_id );
 			}
 		} else {
@@ -445,7 +445,7 @@ class BooksApi extends Api {
 			$book[$args['id']]['book_id'] = $args['id'];
 			$book[$args['id']]['book_url'] = get_blogaddress_by_id( $args['id'] );
 			$book[$args['id']]['book_meta'] = \PressBooks\Book::getBookInformation( intval( $args['id'] ) );
-			$book_structure = \PressBooks\Book::getBookStructure( intval( $args['id'] ) );
+			$book_structure = \PressBooks\Book::getBookStructure( intval( $args['id'] ), true );
 			$book[$args['id']]['book_toc'] = $this->getToc( $book_structure, $args['id'] );
 		}
 

--- a/includes/modules/export/epub/class-pb-epub201.php
+++ b/includes/modules/export/epub/class-pb-epub201.php
@@ -1851,7 +1851,7 @@ class Epub201 extends Export {
 		if ( ! $last_part )
 			return false;
 
-		$lookup = \PressBooks\Book::getBookStructure();
+    $lookup = \PressBooks\Book::getBookStructure('', true);
 		$lookup = $lookup['__export_lookup'];
 
 		if ( ! isset( $lookup[$last_part] ) )


### PR DESCRIPTION
The value of whether to export a page is only needed
when running exports. So don't fetch it for each page
on each page load. (TOC & because of navigation buttons)

The extra DB call for each page causes performance problems
with very large books

Test Plan:
 * TOC/sidebar TOC and navigation buttons should work as expected
 * Exporting anything should honer the export checkbox on a page