### PR TITLE
Display audio embeds in ePub 3 files

### DIFF
--- a/includes/modules/export/epub/class-pb-epub201.php
+++ b/includes/modules/export/epub/class-pb-epub201.php
@@ -1167,6 +1167,9 @@ class Epub201 extends Export {
 					Sanitize\decode( $title ),
 					$content,
 					'' );
+				
+				// Audio shortcodes in ePub3 exports (which inherit this method) result in the creation of <br> tags without closing tags, which breaks validation
+				$vars['post_content'] = str_ireplace( '<br>', '<br />', $vars['post_content'] ); 
 
 				$file_id = 'chapter-' . sprintf( "%03s", $j );
 				$filename = "{$file_id}-{$slug}.{$this->filext}";

--- a/includes/modules/export/epub3/class-pb-epub3.php
+++ b/includes/modules/export/epub3/class-pb-epub3.php
@@ -294,6 +294,10 @@ class Epub3 extends Epub\Epub201 {
 
 		libxml_use_internal_errors( true );
 
+		//these lines are produced by wordpress if Audio or Video are embedded and cause validation to fail
+		$html = str_replace( "<!--[if lt IE 9]><script>document.createElement('audio');</script><![endif] -->", '', $html );
+		$html = str_replace( "<!--[if lt IE 9]><script>document.createElement('video');</script><![endif] -->", '', $html );
+
 		// Load HTMl snippet into DOMDocument using UTF-8 hack
 		$utf8_hack = '<?xml version="1.0" encoding="UTF-8"?>';
 		$doc = new \DOMDocument();
@@ -459,6 +463,16 @@ class Epub3 extends Epub\Epub201 {
 
 			$sources = $doc->getElementsByTagName( $tag );
 			foreach ( $sources as $source ) {
+
+				if ( $tag == 'audio' ) {
+					//  Wordpress uses MediaElementJS by default and hides audio until javascript unhides it.  Here's a workaround  
+					$oldStyle = $source->getAttribute( 'style' );
+					$newStyle = str_replace( 'visibility: hidden;', '', $oldStyle );
+					$source->setAttribute( 'style', $newStyle );
+
+					//The Audio Player always shows 'Loading' until pressing play if you don't add this
+					$source->setAttribute( 'preload', '' );
+				}
 
 				if ( $source->getAttribute( 'src' ) != '' ) {
 					// Fetch the audio file


### PR DESCRIPTION
I realized the ePub3 export is currently in beta, but the audio embeds aren't functional because they are hidden due to the way wordpress handles the audio shortcut.  In addition, the output of unclosed BR tags as well as the conditional IE9 comment break validation.  This PR fixes those issues.  It's possible you'll want a different approach to solve these problems (maybe it's possible to handle them further upstream) but this got things working on my end and at least brings the issues to your attention.