### PR TITLE
fix for internal links for subdirectory installs

### DIFF
--- a/includes/modules/export/xhtml/class-pb-xhtml11.php
+++ b/includes/modules/export/xhtml/class-pb-xhtml11.php
@@ -413,14 +413,14 @@ class Xhtml11 extends Export {
 	 */
 	protected function fixInternalLinks( $content ) {
 		// takes care of PB subdirectory installations of PB
-		$content = preg_replace("/href\=\"\/([a-z0-9]*)\/(front\-matter|chapter|back\-matter)\/([a-z0-9\-]*)([\/]?)(\#[a-z0-9\-]*)\"/", "href=\"$5\"", $content);	
+		$content = preg_replace( "/href\=\"\/([a-z0-9]*)\/(front\-matter|chapter|back\-matter)\/([a-z0-9\-]*)([\/]?)(\#[a-z0-9\-]*)\"/", "href=\"$5\"", $content );
+		$content = preg_replace( "/href\=\"\/([a-z0-9]*)\/(front\-matter|chapter|back\-matter)\/([a-z0-9\-]*)([\/]?)\"/", "href=\"#$3\"", $content );
+
 		// takes care of PB subdomain installations of PB
-		$content = preg_replace("/href\=\"\/(front\-matter|chapter|back\-matter)\/([a-z0-9\-]*)([\/]?)(\#[a-z0-9\-]*)\"/", "href=\"$4\"", $content);	
-		
-		$output = preg_replace("/href\=\"\/(front\-matter|chapter|back\-matter)\/([a-z0-9\-]*)([\/]?)\"/", "href=\"#$2\"", $content);
-		
+		$content = preg_replace( "/href\=\"\/(front\-matter|chapter|back\-matter)\/([a-z0-9\-]*)([\/]?)(\#[a-z0-9\-]*)\"/", "href=\"$4\"", $content );
+		$output = preg_replace( "/href\=\"\/(front\-matter|chapter|back\-matter)\/([a-z0-9\-]*)([\/]?)\"/", "href=\"#$2\"", $content );
+
 		return $output;
-		
 	}
 
 	/**


### PR DESCRIPTION
When an author [follows the instructions in the guide](http://guide.pressbooks.com/chapter/adding-hyperlinks-internal-and-external/) to create internal links to pages (not anchors) within a book on a sub-directory install, those internal links aren't properly converted to bookmarks in PDF as expected, and as is the case with sub-domain installs. 

The pattern this new `preg_replace` (line 417) is looking for is:

`<a href="/bookname/chapter/chapter-title/">internal link</a>` which, if detected, will convert to:
`<a href="#chapter-title">internal link</a>` on export. 

The instructions in the guide will need to be updated in order to accommodate the difference for a sub-directory install. The only difference being, that the value of the relative link *must* contain the book name. 
`<a href="/bookname/chapter/chapter-title/">internal link</a>` for a sub-directory install and 
`<a href="/chapter/chapter-title/">internal link</a>` for a sub-domain install.

Tested on a sub-directory install for WEB, PDF (prince), EPUB2/3, XHTML 

Thanks to @JackDougherty for pointing out the inconsistency in experience, outlined in detail here http://pressbookstest.trinfocafe.org/book/chapter/internal-link-test/