### PR TITLE
resolves fatal errors on git submodule update init command

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,15 @@
 [submodule "symbionts/phpsass"]
 	path = symbionts/phpsass
-	url = git@github.com:richthegeek/phpsass.git
+	url = https://github.com/richthegeek/phpsass.git
 [submodule "symbionts/search-regex"]
 	path = symbionts/search-regex
-	url = git@github.com:pressbooks/search-regex.git
+	url = https://github.com/pressbooks/search-regex.git
 [submodule "symbionts/custom-metadata"]
 	path = symbionts/custom-metadata
-	url = git@github.com:pressbooks/custom-metadata.git
+	url = https://github.com/pressbooks/custom-metadata.git
 [submodule "symbionts/mce-table-buttons"]
 	path = symbionts/mce-table-buttons
-	url = git@github.com:pressbooks/mce-table-buttons.git
+	url = https://github.com/pressbooks/mce-table-buttons.git
 [submodule "symbionts/disable-comments"]
 	path = symbionts/disable-comments
-	url = git@github.com:pressbooks/disable-comments.git
+	url = https://github.com/pressbooks/disable-comments.git


### PR DESCRIPTION
Using `git@github.com` generates a fatal error 'Permission denied (publickey). fatal: Could not read from remote repository' on the command `git submodule update --init` 

![screen shot 2015-09-16 at 10 23 03 am](https://cloud.githubusercontent.com/assets/2048170/9912539/0354001c-5c5d-11e5-910f-69bd6a481cb2.png)



