### PR TITLE
replacing declartion of constant not defined

### DIFF
--- a/includes/modules/export/mpdf/class-pb-pdf.php
+++ b/includes/modules/export/mpdf/class-pb-pdf.php
@@ -39,11 +39,6 @@ use \PressBooks\Modules\Export\Export;
 class Pdf extends Export {
 
 	/**
-	 * Path to mPDF
-	 */
-	const PATH_TO_LIB = PB_MPDF_DIR . 'symbionts/mpdf/mpdf.php';
-
-	/**
 	 * Fullpath to book CSS file.
 	 *
 	 * @var string
@@ -143,7 +138,7 @@ class Pdf extends Export {
 		if ( ! $this->isInstalled() ) {
 			return false; // mPDF is not installed
 		}
-		require_once( static::PATH_TO_LIB );
+		require_once( PB_MPDF_DIR . 'symbionts/mpdf/mpdf.php' );
 		$this->mpdf = new \mPDF( '' );
 		$this->mpdf->SetAnchor2Bookmark( 1 );
 		$this->mpdf->ignore_invalid_utf8 = true;


### PR DESCRIPTION
**problem description**:
Declaring a constant `PATH_TO_LIB` that depends on another constant `PB_MPDF_DIR` that is only declared in a (potentially) inactive plugin causes a large portion of the export menu to disappear when `isInstalled()` is called on the export template page. To recreate, grab the latest dev branch and deactivate, or have no pressbooks-mdpf installed.

**expected behaviour**: 

![screen shot 2015-11-24 at 2 53 20 pm](https://cloud.githubusercontent.com/assets/2048170/11384510/3e16a1ca-92c5-11e5-95ee-bd45973a7dec.png)

**actual**: 
![screen shot 2015-11-24 at 2 52 50 pm](https://cloud.githubusercontent.com/assets/2048170/11384446/c2782818-92c4-11e5-9156-0c59b18595e8.png)
