### PR TITLE
function to modify urls to protocol relative

### DIFF
--- a/includes/class-pb-metadata.php
+++ b/includes/class-pb-metadata.php
@@ -287,8 +287,9 @@ class Metadata {
 		if ( is_object( $response ) ) {
 			$content = $response->asXML();
 			$content = trim( str_replace( array( '<p xmlns:dct="http://purl.org/dc/terms/">', '</p>', '<html>', '</html>' ), array( '', '', '', '' ), $content ) );
+			$content = preg_replace( "/http:\/\/i.creativecommons/iU", "https://i.creativecommons", $content );
 
-			$html = '<div class="license-attribution" xmlns:cc="http://creativecommons.org/ns#"><p xmlns:dct="http://purl.org/dc/terms/">' . rtrim( $content, "." ) . ', ' . __("except where otherwise noted.", "pressbooks") .'</p></div>';
+			$html = '<div class="license-attribution" xmlns:cc="http://creativecommons.org/ns#"><p xmlns:dct="http://purl.org/dc/terms/">' . rtrim( $content, "." ) . ', ' . __( "except where otherwise noted.", "pressbooks" ) . '</p></div>';
 		}
 
 		return html_entity_decode( $html, ENT_XHTML, 'UTF-8' );

--- a/themes-book/pressbooks-book/functions.php
+++ b/themes-book/pressbooks-book/functions.php
@@ -30,7 +30,7 @@ function pressbooks_book_info_page () {
 
 	if ( is_front_page() ) {
 		wp_enqueue_style( 'pressbooks-book-info', get_template_directory_uri() . '/css/book-info.css', array(), '20130713', 'all' );
-		wp_enqueue_style( 'book-info-fonts', 'http://fonts.googleapis.com/css?family=Droid+Serif:400,700|Oswald:300,400,700' );
+		wp_enqueue_style( 'book-info-fonts', 'https://fonts.googleapis.com/css?family=Droid+Serif:400,700|Oswald:300,400,700' );
 
 		// Book info page Table of Content columns
 		wp_enqueue_script( 'columnizer',  PB_PLUGIN_URL . 'symbionts/jquery/jquery.columnizer.js', array( 'jquery' ), '1.6.0', false );


### PR DESCRIPTION
We've recently forced our instance of PB to serve over SSL. To prevent a mixed media warning all `<img src` values for cover images need to be updated. 

![screen shot 2016-02-11 at 10 27 50 am](https://cloud.githubusercontent.com/assets/2048170/12986106/728a8ba6-d0aa-11e5-9d64-c9854241587b.png)

PR introduces a simple utility function and a couple of wrappers to modify urls to become better versions of themselves, to be protocol relative. While the `src` value for cover images can be manually set/reset only when a new image is uploaded,  it means re-uploading hundreds of images. This avoids that manual task. 