### PR TITLE
Add wp_filter to append content to chapter exports

### DIFF
--- a/includes/modules/export/epub/class-pb-epub201.php
+++ b/includes/modules/export/epub/class-pb-epub201.php
@@ -1036,6 +1036,7 @@ class Epub201 extends Export {
 			'post_title' => '',
 			'stylesheet' => $this->stylesheet,
 			'post_content' => '',
+			'append_front_matter_content' => '',
 			'isbn' => @$metadata['pb_ebook_isbn'],
 			'lang' => $this->lang,
 		);
@@ -1058,7 +1059,7 @@ class Epub201 extends Export {
 			$slug = $front_matter['post_name'];
 			$title = ( get_post_meta( $id, 'pb_show_title', true ) ? $front_matter['post_title'] : '' );
 			$content = $this->kneadHtml( $front_matter['post_content'], 'front-matter', $i );
-
+			$append_front_matter_content = $this->kneadHtml( apply_filters( 'pb_append_front_matter_content', '', $id ), 'front-matter' );
 			$short_title = trim( get_post_meta( $id, 'pb_short_title', true ) );
 			$subtitle = trim( get_post_meta( $id, 'pb_subtitle', true ) );
 			$author = trim( get_post_meta( $id, 'pb_section_author', true ) );
@@ -1090,6 +1091,7 @@ class Epub201 extends Export {
 				$i,
 				Sanitize\decode( $title ),
 				$content,
+				$var['append_front_matter_content'] = $append_front_matter_content,
 				'' );
 
 			$file_id = 'front-matter-' . sprintf( "%03s", $i );
@@ -1164,7 +1166,7 @@ class Epub201 extends Export {
 			'post_title' => '',
 			'stylesheet' => $this->stylesheet,
 			'post_content' => '',
-			'append_content' => '',
+			'append_chapter_content' => '',
 			'isbn' => @$metadata['pb_ebook_isbn'],
 			'lang' => $this->lang,
 		);
@@ -1203,7 +1205,7 @@ class Epub201 extends Export {
 				$slug = $chapter['post_name'];
 				$title = ( get_post_meta( $id, 'pb_show_title', true ) ? $chapter['post_title'] : '' );
 				$content = $this->kneadHtml( $chapter['post_content'], 'chapter', $j );
-				$append_content = $this->kneadHtml( apply_filters( 'pb_append_html_to_export_page', '', $id ), 'chapter' );
+				$append_chapter_content = $this->kneadHtml( apply_filters( 'pb_append_chapter_content', '', $id ), 'chapter' );
 				$short_title = false; // Ie. running header title is not used in EPUB
 				$subtitle = trim( get_post_meta( $id, 'pb_subtitle', true ) );
 				$author = trim( get_post_meta( $id, 'pb_section_author', true ) );
@@ -1243,7 +1245,7 @@ class Epub201 extends Export {
 					( $this->numbered ? $n : '' ),
 					Sanitize\decode( $title ),
 					$content,
-					$var['append_content'] = $append_content,
+					$var['append_chapter_content'] = $append_chapter_content,
 					'' );
 
 				$file_id = 'chapter-' . sprintf( "%03s", $j );
@@ -1386,6 +1388,7 @@ class Epub201 extends Export {
 			'post_title' => '',
 			'stylesheet' => $this->stylesheet,
 			'post_content' => '',
+			'append_back_matter_content' => '',
 			'isbn' => @$metadata['pb_ebook_isbn'],
 			'lang' => $this->lang,
 		);
@@ -1401,7 +1404,7 @@ class Epub201 extends Export {
 			$slug = $back_matter['post_name'];
 			$title = ( get_post_meta( $id, 'pb_show_title', true ) ? $back_matter['post_title'] : '' );
 			$content = $this->kneadHtml( $back_matter['post_content'], 'back-matter', $i );
-
+			$append_back_matter_content = $this->kneadHtml( apply_filters( 'pb_append_back_matter_content', '', $id ), 'back-matter' );
 			$short_title = trim( get_post_meta( $id, 'pb_short_title', true ) );
 			$subtitle = trim( get_post_meta( $id, 'pb_subtitle', true ) );
 			$author = trim( get_post_meta( $id, 'pb_section_author', true ) );
@@ -1433,6 +1436,7 @@ class Epub201 extends Export {
 				$i,
 				Sanitize\decode( $title ),
 				$content,
+				$var['append_back_matter_content'] = $append_back_matter_content,
 				'' );
 
 			$file_id = 'back-matter-' . sprintf( "%03s", $i );

--- a/includes/modules/export/epub/class-pb-epub201.php
+++ b/includes/modules/export/epub/class-pb-epub201.php
@@ -1164,6 +1164,7 @@ class Epub201 extends Export {
 			'post_title' => '',
 			'stylesheet' => $this->stylesheet,
 			'post_content' => '',
+			'append_content' => '',
 			'isbn' => @$metadata['pb_ebook_isbn'],
 			'lang' => $this->lang,
 		);
@@ -1202,7 +1203,7 @@ class Epub201 extends Export {
 				$slug = $chapter['post_name'];
 				$title = ( get_post_meta( $id, 'pb_show_title', true ) ? $chapter['post_title'] : '' );
 				$content = $this->kneadHtml( $chapter['post_content'], 'chapter', $j );
-
+				$append_content = $this->kneadHtml( apply_filters( 'pb_append_html_to_export_page', '', $id ), 'chapter' );
 				$short_title = false; // Ie. running header title is not used in EPUB
 				$subtitle = trim( get_post_meta( $id, 'pb_subtitle', true ) );
 				$author = trim( get_post_meta( $id, 'pb_section_author', true ) );
@@ -1242,6 +1243,7 @@ class Epub201 extends Export {
 					( $this->numbered ? $n : '' ),
 					Sanitize\decode( $title ),
 					$content,
+					$var['append_content'] = $append_content,
 					'' );
 
 				$file_id = 'chapter-' . sprintf( "%03s", $j );

--- a/includes/modules/export/xhtml/class-pb-xhtml11.php
+++ b/includes/modules/export/xhtml/class-pb-xhtml11.php
@@ -986,7 +986,7 @@ class Xhtml11 extends Export {
 				$slug = $chapter['post_name'];
 				$title = ( get_post_meta( $id, 'pb_show_title', true ) ? $chapter['post_title'] : '<span class="display-none">' . $chapter['post_title'] . '</span>' ); // Preserve auto-indexing in Prince using hidden span
 				$content = $chapter['post_content'];
-
+				$append_content = apply_filters( 'pb_append_html_to_export_page', '', $id );
 				$short_title = trim( get_post_meta( $id, 'pb_short_title', true ) );
 				$subtitle = trim( get_post_meta( $id, 'pb_subtitle', true ) );
 				$author = trim( get_post_meta( $id, 'pb_section_author', true ) );
@@ -1024,6 +1024,7 @@ class Xhtml11 extends Export {
 					$n,
 					Sanitize\decode( $title ),
 					$content,
+					$append_content,
 					$this->doEndnotes( $id ) ) . "\n";
 
 				if ( $subclass !== 'numberless' ) ++$j;

--- a/includes/modules/export/xhtml/class-pb-xhtml11.php
+++ b/includes/modules/export/xhtml/class-pb-xhtml11.php
@@ -860,7 +860,7 @@ class Xhtml11 extends Export {
 			$slug = $front_matter['post_name'];
 			$title = ( get_post_meta( $id, 'pb_show_title', true ) ? $front_matter['post_title'] : '<span class="display-none">' . $front_matter['post_title'] . '</span>' ); // Preserve auto-indexing in Prince using hidden span
 			$content = $front_matter['post_content'];
-
+			$append_front_matter_content = apply_filters( 'pb_append_front_matter_content', '', $id );
 			$short_title = trim( get_post_meta( $id, 'pb_short_title', true ) );
 			$subtitle = trim( get_post_meta( $id, 'pb_subtitle', true ) );
 			$author = trim( get_post_meta( $id, 'pb_section_author', true ) );
@@ -890,6 +890,7 @@ class Xhtml11 extends Export {
 				$i,
 				Sanitize\decode( $title ),
 				$content,
+				$append_front_matter_content,
 				$this->doEndnotes( $id ) );
 
 			echo "\n";
@@ -986,7 +987,7 @@ class Xhtml11 extends Export {
 				$slug = $chapter['post_name'];
 				$title = ( get_post_meta( $id, 'pb_show_title', true ) ? $chapter['post_title'] : '<span class="display-none">' . $chapter['post_title'] . '</span>' ); // Preserve auto-indexing in Prince using hidden span
 				$content = $chapter['post_content'];
-				$append_content = apply_filters( 'pb_append_html_to_export_page', '', $id );
+				$append_chapter_content = apply_filters( 'pb_append_chapter_content', '', $id );
 				$short_title = trim( get_post_meta( $id, 'pb_short_title', true ) );
 				$subtitle = trim( get_post_meta( $id, 'pb_subtitle', true ) );
 				$author = trim( get_post_meta( $id, 'pb_section_author', true ) );
@@ -1024,7 +1025,7 @@ class Xhtml11 extends Export {
 					$n,
 					Sanitize\decode( $title ),
 					$content,
-					$append_content,
+					$append_chapter_content,
 					$this->doEndnotes( $id ) ) . "\n";
 
 				if ( $subclass !== 'numberless' ) ++$j;
@@ -1081,7 +1082,7 @@ class Xhtml11 extends Export {
 			$slug = $back_matter['post_name'];
 			$title = ( get_post_meta( $id, 'pb_show_title', true ) ? $back_matter['post_title'] : '<span class="display-none">' . $back_matter['post_title'] . '</span>' ); // Preserve auto-indexing in Prince using hidden span
 			$content = $back_matter['post_content'];
-
+			$append_back_matter_content = apply_filters( 'pb_append_back_matter_content', '', $id );
 			$short_title = trim( get_post_meta( $id, 'pb_short_title', true ) );
 			$subtitle = trim( get_post_meta( $id, 'pb_subtitle', true ) );
 			$author = trim( get_post_meta( $id, 'pb_section_author', true ) );
@@ -1111,6 +1112,7 @@ class Xhtml11 extends Export {
 				$i,
 				Sanitize\decode( $title ),
 				$content,
+				$append_back_matter_content,
 				$this->doEndnotes( $id ) );
 
 			echo "\n";


### PR DESCRIPTION
For content exported in html format, this allows another plugin
to register a wordpress filter that will append content to the
end of a chapter.