### PR TITLE
parity between what is displayed and what is actually set

### DIFF
--- a/themes-book/pressbooks-book/functions.php
+++ b/themes-book/pressbooks-book/functions.php
@@ -1105,6 +1105,11 @@ function pressbooks_theme_options_mpdf_init() {
 		'mpdf_page_size' => 'Letter',
 		'mpdf_include_cover' => 1,
 		'mpdf_indent_paragraphs' => 0,
+		'mpdf_include_toc' => 1,
+		'mpdf_mirror_margins' => 1,
+		'mpdf_margin_left' => 15,
+		'mpdf_margin_right' => 30,
+		'mpdf_hyphens' => 0,
 	);
 
 	if ( false == get_option( $_option ) ) {


### PR DESCRIPTION
There was a discrepancy between default settings that were displayed and what was actually saved in the db. resolves https://github.com/BCcampus/pressbooks-textbook/issues/53