### PR TITLE
Add initial support for Pressbooks Plugins (closes #394).

### DIFF
--- a/hooks-admin.php
+++ b/hooks-admin.php
@@ -13,6 +13,7 @@ if ( ! defined( 'ABSPATH' ) )
 
 require( PB_PLUGIN_DIR . 'includes/admin/pb-dashboard.php' );
 require( PB_PLUGIN_DIR . 'includes/admin/pb-laf.php' );
+require( PB_PLUGIN_DIR . 'includes/admin/pb-plugins.php' );
 require( PB_PLUGIN_DIR . 'includes/admin/pb-analytics.php' );
 require( PB_PLUGIN_DIR . 'includes/admin/pb-metaboxes.php' );
 require( PB_PLUGIN_DIR . 'includes/admin/pb-customcss.php' );
@@ -44,6 +45,7 @@ if ( \PressBooks\Book::isBook() ) {
 	add_action( 'wp_dashboard_setup', '\PressBooks\Admin\Dashboard\replace_dashboard_widgets' );
 	remove_action( 'welcome_panel', 'wp_welcome_panel' );
 	add_action( 'customize_register', '\PressBooks\Admin\Laf\customize_register', 1000 );
+	add_filter( 'all_plugins', '\PressBooks\Admin\Plugins\filter_plugins' );
 } else {
 	// Fix extraneous menus
 	add_action( 'admin_menu', '\PressBooks\Admin\Laf\fix_root_admin_menu', 1 );
@@ -51,6 +53,9 @@ if ( \PressBooks\Book::isBook() ) {
 
 if ( is_network_admin() ) {
 	add_action( 'wp_network_dashboard_setup', '\PressBooks\Admin\Dashboard\replace_network_dashboard_widgets' );
+	add_action( 'install_plugins_tabs', '\PressBooks\Admin\Plugins\filter_install_plugins_tabs' );
+	add_action( 'install_plugins_pressbooks', '\PressBooks\Admin\Plugins\install_plugins' );
+	add_filter( 'install_plugins_table_api_args_pressbooks', '\PressBooks\Admin\Plugins\install_plugins_table_api_args_pressbooks');
 }
 
 if ( true == is_main_site() ) {

--- a/hooks-admin.php
+++ b/hooks-admin.php
@@ -45,7 +45,7 @@ if ( \PressBooks\Book::isBook() ) {
 	add_action( 'wp_dashboard_setup', '\PressBooks\Admin\Dashboard\replace_dashboard_widgets' );
 	remove_action( 'welcome_panel', 'wp_welcome_panel' );
 	add_action( 'customize_register', '\PressBooks\Admin\Laf\customize_register', 1000 );
-	add_filter( 'all_plugins', '\PressBooks\Admin\Plugins\filter_plugins' );
+	add_filter( 'all_plugins', '\Pressbooks\Admin\Plugins\filter_plugins', 10 );
 } else {
 	// Fix extraneous menus
 	add_action( 'admin_menu', '\PressBooks\Admin\Laf\fix_root_admin_menu', 1 );
@@ -53,9 +53,9 @@ if ( \PressBooks\Book::isBook() ) {
 
 if ( is_network_admin() ) {
 	add_action( 'wp_network_dashboard_setup', '\PressBooks\Admin\Dashboard\replace_network_dashboard_widgets' );
-	add_action( 'install_plugins_tabs', '\PressBooks\Admin\Plugins\filter_install_plugins_tabs' );
-	add_action( 'install_plugins_pressbooks', '\PressBooks\Admin\Plugins\install_plugins' );
-	add_filter( 'install_plugins_table_api_args_pressbooks', '\PressBooks\Admin\Plugins\install_plugins_table_api_args_pressbooks');
+	add_action( 'install_plugins_tabs', '\Pressbooks\Admin\Plugins\filter_install_plugins_tabs' );
+	add_action( 'install_plugins_pressbooks', '\Pressbooks\Admin\Plugins\install_plugins' );
+	add_filter( 'install_plugins_table_api_args_pressbooks', '\Pressbooks\Admin\Plugins\install_plugins_table_api_args_pressbooks');
 }
 
 if ( true == is_main_site() ) {

--- a/includes/admin/pb-laf.php
+++ b/includes/admin/pb-laf.php
@@ -76,7 +76,6 @@ function replace_book_admin_menu() {
 	remove_submenu_page( "tools.php", "import.php" );
 	remove_submenu_page( "tools.php", "export.php" );
 	remove_submenu_page( "tools.php", "ms-delete-site.php" );
-	remove_menu_page( "plugins.php" );
 
 	remove_submenu_page( "edit.php?post_type=chapter", "edit.php?post_type=chapter" );
 
@@ -586,7 +585,6 @@ function redirect_away_from_bad_urls() {
 		'nav-menus',
 		'options-(discussion|media|permalink|reading|writing)',
 		'plugin-(install|editor)',
-		'plugins',
 		'theme-editor',
 		'update-core',
 		'widgets',

--- a/includes/admin/pb-plugins.php
+++ b/includes/admin/pb-plugins.php
@@ -15,9 +15,11 @@ namespace PressBooks\Admin\Plugins;
  */
 
 function filter_plugins( $plugins ) {
-	foreach ( $plugins as $slug => $value ) {
-		if ( false === strpos( $slug, 'pressbooks-' ) )
-			unset( $plugins[$slug] );
+	if ( ! is_super_admin() ) {
+		foreach ( $plugins as $slug => $value ) {
+			if ( false === strpos( $slug, 'pressbooks-' ) )
+				unset( $plugins[$slug] );
+		}
 	}
 
 	return $plugins;

--- a/includes/admin/pb-plugins.php
+++ b/includes/admin/pb-plugins.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Control access to plugins.
+ *
+ * @author  Pressbooks <code@pressbooks.com>
+ * @license GPLv2 (or any later version)
+ */
+namespace PressBooks\Admin\Plugins;
+
+/**
+ * Hide plugins that aren't prefixed with `pressbooks-` (only applies to books).
+ *
+ * @param array $plugins
+ * @return array $plugins
+ */
+
+function filter_plugins( $plugins ) {
+	foreach ( $plugins as $slug => $value ) {
+		if ( false === strpos( $slug, 'pressbooks-' ) )
+			unset( $plugins[$slug] );
+	}
+
+	return $plugins;
+}
+
+/**
+ * Add a 'Pressbooks' tab to the plugin installer.
+ *
+ * @param array $tabs
+ * @return array $tabs
+ */
+
+function filter_install_plugins_tabs( $tabs ) {
+	$tabs = array_merge( array( 'pressbooks' => __( 'Pressbooks', 'pressbooks' ) ), $tabs );
+	return $tabs;
+}
+
+/**
+ * Set Plugin Installer API query arguments for the 'Pressbooks' tab of the plugin installer.
+ *
+ * @param array $args
+ * @return array $args
+ */
+
+function install_plugins_table_api_args_pressbooks( $args ) {
+	$args = array(
+		'page' => 1,
+		'per_page' => 30,
+		'fields' => array(
+			'last_updated' => true,
+			'icons' => true,
+			'active_installs' => true
+		),
+		'locale' => get_locale(),
+		'tag' => 'pressbooks'
+	);
+
+	return $args;
+}
+
+/**
+ * Output header text and display table for the 'Pressbooks' tab of the plugin installer.
+ *
+ * @codeCoverageIgnore
+ */
+function install_plugins() {
+	global $wp_list_table;
+
+	echo '<p>' . __( 'These plugins extend the functionality of Pressbooks.', 'pressbooks' ) . '</p>';
+	$wp_list_table->display();
+}

--- a/includes/admin/pb-plugins.php
+++ b/includes/admin/pb-plugins.php
@@ -5,10 +5,12 @@
  * @author  Pressbooks <code@pressbooks.com>
  * @license GPLv2 (or any later version)
  */
-namespace PressBooks\Admin\Plugins;
+namespace Pressbooks\Admin\Plugins;
 
 /**
  * Hide plugins that aren't prefixed with `pressbooks-` (only applies to books).
+ * To show all plugins to all users, place the following in a plugin that loads before Pressbooks:
+ * `remove_filter( 'all_plugins', '\Pressbooks\Admin\Plugins\filter_plugins', 10 );`
  *
  * @param array $plugins
  * @return array $plugins

--- a/tests/test-admin-plugins.php
+++ b/tests/test-admin-plugins.php
@@ -5,7 +5,7 @@ require_once( PB_PLUGIN_DIR . 'includes/admin/pb-plugins.php' );
 class Admin_PluginsTest extends \WP_UnitTestCase {
 
 	/**
-	 * @covers \PressBooks\Admin\Plugins\filter_plugins
+	 * @covers \Pressbooks\Admin\Plugins\filter_plugins
 	 */
 	public function test_filter_plugins() {
 		$plugins = array(
@@ -31,25 +31,25 @@ class Admin_PluginsTest extends \WP_UnitTestCase {
 				'AuthorName' => 'Brad Payne'
 			)
 		);
-		$filtered_plugins = \PressBooks\Admin\Plugins\filter_plugins( $plugins );
+		$filtered_plugins = \Pressbooks\Admin\Plugins\filter_plugins( $plugins );
 		$this->assertArrayHasKey('pressbooks-textbook/pressbooks-textbook.php', $filtered_plugins);
 	}
 
 	/**
-	 * @covers \PressBooks\Admin\Plugins\filter_install_plugins_tabs
+	 * @covers \Pressbooks\Admin\Plugins\filter_install_plugins_tabs
 	 */
 	public function test_filter_install_plugins_tabs() {
 		$tabs = array();
-		$tabs = \PressBooks\Admin\Plugins\filter_install_plugins_tabs( $tabs );
+		$tabs = \Pressbooks\Admin\Plugins\filter_install_plugins_tabs( $tabs );
 		$this->assertArrayHasKey('pressbooks', $tabs);
 	}
 
 	/**
-	 * @covers \PressBooks\Admin\Plugins\install_plugins_table_api_args_pressbooks
+	 * @covers \Pressbooks\Admin\Plugins\install_plugins_table_api_args_pressbooks
 	 */
 	public function test_install_plugins_table_api_args_pressbooks() {
 		$args = array();
-		$args = \PressBooks\Admin\Plugins\install_plugins_table_api_args_pressbooks( $args );
+		$args = \Pressbooks\Admin\Plugins\install_plugins_table_api_args_pressbooks( $args );
 		$this->assertEquals('pressbooks', $args['tag']);
 	}
 

--- a/tests/test-admin-plugins.php
+++ b/tests/test-admin-plugins.php
@@ -1,0 +1,56 @@
+<?php
+
+require_once( PB_PLUGIN_DIR . 'includes/admin/pb-plugins.php' );
+
+class Admin_PluginsTest extends \WP_UnitTestCase {
+
+	/**
+	 * @covers \PressBooks\Admin\Plugins\filter_plugins
+	 */
+	public function test_filter_plugins() {
+		$plugins = array(
+			'hello-dolly/hello.php' => array(
+        'Name' => 'Hello Dolly',
+        'PluginURI' => 'http://wordpress.org/extend/plugins/hello-dolly/',
+        'Version' => '1.6',
+        'Description' => 'This is not just a plugin, it symbolizes the hope and enthusiasm of an entire generation summed up in two words sung most famously by Louis Armstrong: Hello, Dolly. When activated you will randomly see a lyric from <cite>Hello, Dolly</cite> in the upper right of your admin screen on every page.',
+        'Author' => 'Matt Mullenweg',
+        'AuthorURI' => 'http://ma.tt/',
+        'Title' => 'Hello Dolly',
+        'AuthorName' => 'Matt Mullenweg'
+			),
+			'pressbooks-textbook/pressbooks-textbook.php' => array(
+				'Name' => 'Pressbooks Textbook',
+				'Version' => '2.1.2',
+				'Description' => 'A plugin that extends Pressbooks for textbook authoring',
+				'Author' => 'Brad Payne',
+				'AuthorURI' => 'http://bradpayne.ca',
+				'TextDomain' => 'pressbooks-textbook',
+				'DomainPath' => '/languages',
+				'Title' => 'Pressbooks Textbook',
+				'AuthorName' => 'Brad Payne'
+			)
+		);
+		$filtered_plugins = \PressBooks\Admin\Plugins\filter_plugins( $plugins );
+		$this->assertArrayHasKey('pressbooks-textbook/pressbooks-textbook.php', $filtered_plugins);
+	}
+
+	/**
+	 * @covers \PressBooks\Admin\Plugins\filter_install_plugins_tabs
+	 */
+	public function test_filter_install_plugins_tabs() {
+		$tabs = array();
+		$tabs = \PressBooks\Admin\Plugins\filter_install_plugins_tabs( $tabs );
+		$this->assertArrayHasKey('pressbooks', $tabs);
+	}
+
+	/**
+	 * @covers \PressBooks\Admin\Plugins\install_plugins_table_api_args_pressbooks
+	 */
+	public function test_install_plugins_table_api_args_pressbooks() {
+		$args = array();
+		$args = \PressBooks\Admin\Plugins\install_plugins_table_api_args_pressbooks( $args );
+		$this->assertEquals('pressbooks', $args['tag']);
+	}
+
+}

--- a/tests/test-analytics.php
+++ b/tests/test-analytics.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once './includes/admin/pb-analytics.php';
+require_once( PB_PLUGIN_DIR . 'includes/admin/pb-analytics.php' );
 
 class AnalyticsTest extends \WP_UnitTestCase {
 


### PR DESCRIPTION
1. Adds a tab to the plugin installer for network administrators which highlights plugins from the WordPress plugin directory that are tagged with `pressbooks`.
2. Enables access to the plugin interface for book administrators, restricting access to plugins prefixed with `pressbooks-`.