### PR TITLE
removing base href in xhtml output

### DIFF
--- a/includes/modules/export/xhtml/class-pb-xhtml11.php
+++ b/includes/modules/export/xhtml/class-pb-xhtml11.php
@@ -187,7 +187,6 @@ class Xhtml11 extends Export {
 		echo "<head>\n";
 		echo '<meta content="text/html; charset=UTF-8" http-equiv="content-type" />' . "\n";
 		echo '<meta http-equiv="Content-Language" content="' . $this->lang . '" />' . "\n";
-		echo '<base href="' . trailingslashit( site_url( '', 'http' ) ) . '" />' . "\n";
 
 
 		$this->echoMetaData( $book_contents, $metadata );


### PR DESCRIPTION
please review https://github.com/pressbooks/pressbooks/commit/ea4a2f6690147ae658dc7d51bf4caed8cab02cd3 

I've tried to recreate the situation where 500 errors were generated after removing the `base href` declaration. I cannot, so maybe @connerbw could provide some context?

With `base href` undeclared/removed, anchor links work as expected in the XHTML file output. With `base href` declared, anchor/internal links (like in the TOC for instance `<a href="#chapter1">Some chapter</a>`) bring the user back to `http://somebasedomain.com/somebook/#chapter1`. Not only does this ignore the protocol (`is_ssl()`) of the site and exclude the necessary path (`/chapter/`,`/front-matter/`,`/back-matter/`) but it takes the user away from the file. 

Questions: 
1. Is this still necessary? 
2. Can it be removed without generating 500 errors - what am I missing? 
3. If it can't be removed, does it need to be modified to be accurate? 


