### PR TITLE
Import custom post types and associated terms/taxonomies

### DIFF
--- a/includes/modules/import/class-pb-import.php
+++ b/includes/modules/import/class-pb-import.php
@@ -146,11 +146,7 @@ abstract class Import {
 	 */
 	protected function determinePostType( $id ) {
 
-		$supported_types = array( 'front-matter', 'chapter', 'part', 'back-matter', 'metadata' );
-
-		if ( has_filter( 'custom_post_types' ) ) {
-			$supported_types = apply_filters( 'custom_post_types', $supported_types );
-		}
+		$supported_types = apply_filters( 'pb_import_custom_post_types', array( 'front-matter', 'chapter', 'part', 'back-matter', 'metadata' ) );
 
 		$default = 'chapter';
 

--- a/includes/modules/import/class-pb-import.php
+++ b/includes/modules/import/class-pb-import.php
@@ -147,6 +147,11 @@ abstract class Import {
 	protected function determinePostType( $id ) {
 
 		$supported_types = array( 'front-matter', 'chapter', 'part', 'back-matter', 'metadata' );
+
+		if ( has_filter( 'custom_post_types' ) ) {
+			$supported_types = apply_filters( 'custom_post_types', $supported_types );
+		}
+
 		$default = 'chapter';
 
 		if ( ! @is_array( $_POST['chapters'] ) )

--- a/includes/modules/import/wordpress/class-pb-wxr.php
+++ b/includes/modules/import/wordpress/class-pb-wxr.php
@@ -46,6 +46,11 @@ class Wxr extends Import {
 
 		$supported_post_types = array( 'post', 'page', 'front-matter', 'chapter', 'part', 'back-matter', 'metadata' );
 
+		// check for additional post types and add them to the list of supported post types
+		if ( has_filter( 'custom_post_types' ) ) {
+			$supported_post_types = apply_filters( 'custom_post_types', $supported_post_types );
+		}
+
 		if ( $this->isPbWxr ) {
 			//put the posts in correct part / menu_order order
 			$xml['posts'] = $this->customNestedSort( $xml['posts'] );
@@ -82,7 +87,7 @@ class Wxr extends Import {
 		}
 
 		$this->pbCheck( $xml );
-		
+
 		if ( $this->isPbWxr ) {
 			$xml['posts'] = $this->customNestedSort( $xml['posts'] );
 		}
@@ -90,9 +95,39 @@ class Wxr extends Import {
 		$match_ids = array_flip( array_keys( $current_import['chapters'] ) );
 		$chapter_parent = $this->getChapterParent();
 		$total = 0;
+		$taxonomies = array();
+
+		if ( has_filter( 'custom_post_types' ) ) {
+			$custom_post_types = apply_filters( 'custom_post_types', array() );
+		} else {
+			$custom_post_types = array();
+		}
+
+		// import custom taxonomies...
+		if ( has_filter( 'custom_taxonomies' ) ) {
+			$taxonomies = apply_filters( 'custom_taxonomies', $taxonomies );
+		}
+
+		// set custom terms...
+		if ( has_filter( 'custom_terms' ) ) {
+			$terms = apply_filters( 'custom_terms', $xml['terms'] );
+
+			// and import them.
+			foreach ( $terms as $t ) {
+				if ( in_array( $t['term_taxonomy'], $taxonomies ) ) {
+					wp_insert_term(
+						$t['slug'],
+						$t['term_taxonomy'],
+						array(
+							'description' => $t['term_description']
+						)
+					);
+				}
+			}
+		}
 
 		libxml_use_internal_errors( true );
-		
+
 		foreach ( $xml['posts'] as $p ) {
 
 			// Skip
@@ -122,6 +157,22 @@ class Wxr extends Import {
 				$pid = $this->insertNewPost( $post_type, $p, $html, $chapter_parent );
 				if ( 'part' == $post_type ) {
 					$chapter_parent = $pid;
+				}
+			}
+
+			// if this is a custom post type,
+			// and it has terms associated with it...
+			if ( ( in_array( $post_type, $custom_post_types ) && $p['terms'] == true ) ) {
+				// associate post with terms.
+				foreach ( $p['terms'] as $t ) {
+					if ( in_array( $t['domain'], $taxonomies ) ) {
+						wp_set_object_terms(
+							$pid,
+							$t['slug'],
+							$t['domain'],
+							true
+						);
+					}
 				}
 			}
 
@@ -165,7 +216,7 @@ class Wxr extends Import {
 		}
 
 	}
-	
+
 	/**
 	 * Custom sort for the xml posts to put them in correct nested order
 	 *
@@ -175,7 +226,7 @@ class Wxr extends Import {
 	 */
 	 protected function customNestedSort( $xml ) {
 	 	 $array = array();
-	 	 
+
 	 	 //first, put them in ascending menu_order
 	 	 usort( $xml, function ( $a, $b ) {
 	 	 	return ( $a['menu_order'] - $b['menu_order'] );
@@ -188,14 +239,14 @@ class Wxr extends Import {
 				 break;
 			 }
 		 }
-	 	 
+
 	 	 //now, list all front matter
 	 	 foreach ( $xml as $p ) {
 	 	 	if ( 'front-matter' == $p['post_type'] ) {
-	 	 		$array[] = $p;	
+	 	 		$array[] = $p;
 	 	 	}
 	 	 }
-	 	 
+
 	 	 //now, list all parts, then their associated chapters
 	 	 foreach ( $xml as $p ) {
 	 	 	if ( 'part' == $p['post_type'] ) {
@@ -207,13 +258,25 @@ class Wxr extends Import {
 	 	 		}
 	 	 	}
 	 	 }
-	 	 
+
 	 	 //now, list all back matter
 	 	 foreach ( $xml as $p ) {
 	 	 	if ( 'back-matter' == $p['post_type'] ) {
-	 	 		$array[] = $p;	
+	 	 		$array[] = $p;
 	 	 	}
 	 	 }
+
+		 // Remaining custom post types
+		 if ( has_filter( 'custom_post_types' ) ) {
+			 $custom_post_types = apply_filters( 'custom_post_types', array() );
+
+			 foreach ( $xml as $p ) {
+				 if ( in_array( $p['post_type'], $custom_post_types ) ) {
+					 $array[] = $p;
+				 }
+			 }
+		 }
+
 	 	 return $array;
 	 }
 
@@ -253,10 +316,16 @@ class Wxr extends Import {
 	 */
 	protected function insertNewPost( $post_type, $p, $html, $chapter_parent ) {
 
+		if ( has_filter( 'custom_post_types' ) ) {
+			$custom_post_types = apply_filters( 'custom_post_types', array() );
+		} else {
+			$custom_post_types = array();
+		}
+
 		$new_post = array(
 			'post_title' => wp_strip_all_tags( $p['post_title'] ),
 			'post_type' => $post_type,
-			'post_status' => ( 'part' == $post_type ) ? 'publish' : 'draft',
+			'post_status' => ( 'part' == $post_type || in_array( $post_type, $custom_post_types ) ) ? 'publish' : 'draft',
 		);
 
 		if ( 'part' != $post_type ) {
@@ -370,7 +439,7 @@ class Wxr extends Import {
 
 		return '';
 	}
-	
+
 	/**
 	 * Parse HTML snippet, save all found <img> tags using media_handle_sideload(), return the HTML with changed <img> paths.
 	 *
@@ -405,7 +474,7 @@ class Wxr extends Import {
 	 * Load remote url of image into WP using media_handle_sideload()
 	 * Will return an empty string if something went wrong.
 	 *
-	 * @param string $url 
+	 * @param string $url
 	 *
 	 * @see media_handle_sideload
 	 *

--- a/includes/modules/import/wordpress/class-pb-wxr.php
+++ b/includes/modules/import/wordpress/class-pb-wxr.php
@@ -97,14 +97,16 @@ class Wxr extends Import {
 		// set custom terms...
 		$terms = apply_filters( 'pb_import_custom_terms', $xml['terms'] );
 
-		// and import them.
+		// and import them if they don't already exist.
 		foreach ( $terms as $t ) {
-			if ( in_array( $t['term_taxonomy'], $taxonomies ) ) {
+			$term = term_exists( $t['term_name'], $t['term_taxonomy'] );
+			if ( $term === null || $term === 0 ) {
 				wp_insert_term(
-					$t['slug'],
+					$t['term_name'],
 					$t['term_taxonomy'],
 					array(
-						'description' => $t['term_description']
+						'description' => $t['term_description'],
+						'slug' => $t['slug']
 					)
 				);
 			}

--- a/includes/modules/import/wordpress/class-pb-wxr.php
+++ b/includes/modules/import/wordpress/class-pb-wxr.php
@@ -44,12 +44,7 @@ class Wxr extends Import {
 			'allow_parts' => true
 		);
 
-		$supported_post_types = array( 'post', 'page', 'front-matter', 'chapter', 'part', 'back-matter', 'metadata' );
-
-		// check for additional post types and add them to the list of supported post types
-		if ( has_filter( 'custom_post_types' ) ) {
-			$supported_post_types = apply_filters( 'custom_post_types', $supported_post_types );
-		}
+		$supported_post_types = apply_filters( 'pb_import_custom_post_types', array( 'post', 'page', 'front-matter', 'chapter', 'part', 'back-matter', 'metadata' ) );
 
 		if ( $this->isPbWxr ) {
 			//put the posts in correct part / menu_order order
@@ -91,38 +86,27 @@ class Wxr extends Import {
 		if ( $this->isPbWxr ) {
 			$xml['posts'] = $this->customNestedSort( $xml['posts'] );
 		}
-		
+
 		$match_ids = array_flip( array_keys( $current_import['chapters'] ) );
 		$chapter_parent = $this->getChapterParent();
 		$total = 0;
-		$taxonomies = array();
+		$taxonomies = apply_filters( 'pb_import_custom_taxonomies', array( 'front-matter-type', 'chapter-type', 'back-matter-type' ) );
 
-		if ( has_filter( 'custom_post_types' ) ) {
-			$custom_post_types = apply_filters( 'custom_post_types', array() );
-		} else {
-			$custom_post_types = array();
-		}
-
-		// import custom taxonomies...
-		if ( has_filter( 'custom_taxonomies' ) ) {
-			$taxonomies = apply_filters( 'custom_taxonomies', $taxonomies );
-		}
+		$custom_post_types = apply_filters( 'pb_import_custom_post_types', array() );
 
 		// set custom terms...
-		if ( has_filter( 'custom_terms' ) ) {
-			$terms = apply_filters( 'custom_terms', $xml['terms'] );
+		$terms = apply_filters( 'pb_import_custom_terms', $xml['terms'] );
 
-			// and import them.
-			foreach ( $terms as $t ) {
-				if ( in_array( $t['term_taxonomy'], $taxonomies ) ) {
-					wp_insert_term(
-						$t['slug'],
-						$t['term_taxonomy'],
-						array(
-							'description' => $t['term_description']
-						)
-					);
-				}
+		// and import them.
+		foreach ( $terms as $t ) {
+			if ( in_array( $t['term_taxonomy'], $taxonomies ) ) {
+				wp_insert_term(
+					$t['slug'],
+					$t['term_taxonomy'],
+					array(
+						'description' => $t['term_description']
+					)
+				);
 			}
 		}
 
@@ -267,13 +251,11 @@ class Wxr extends Import {
 	 	 }
 
 		 // Remaining custom post types
-		 if ( has_filter( 'custom_post_types' ) ) {
-			 $custom_post_types = apply_filters( 'custom_post_types', array() );
+		 $custom_post_types = apply_filters( 'pb_import_custom_post_types', array() );
 
-			 foreach ( $xml as $p ) {
-				 if ( in_array( $p['post_type'], $custom_post_types ) ) {
-					 $array[] = $p;
-				 }
+		 foreach ( $xml as $p ) {
+			 if ( in_array( $p['post_type'], $custom_post_types ) ) {
+				 $array[] = $p;
 			 }
 		 }
 
@@ -316,11 +298,7 @@ class Wxr extends Import {
 	 */
 	protected function insertNewPost( $post_type, $p, $html, $chapter_parent ) {
 
-		if ( has_filter( 'custom_post_types' ) ) {
-			$custom_post_types = apply_filters( 'custom_post_types', array() );
-		} else {
-			$custom_post_types = array();
-		}
+		$custom_post_types = apply_filters( 'pb_import_custom_post_types', array() );
 
 		$new_post = array(
 			'post_title' => wp_strip_all_tags( $p['post_title'] ),

--- a/templates/admin/import.php
+++ b/templates/admin/import.php
@@ -7,6 +7,10 @@ $import_form_url = wp_nonce_url( get_admin_url( get_current_blog_id(), '/tools.p
 $import_revoke_url = wp_nonce_url( get_admin_url( get_current_blog_id(), '/tools.php?page=pb_import&revoke=yes' ), 'pb-revoke-import' );
 $current_import = get_option( 'pressbooks_current_import' );
 
+if ( has_filter( 'custom_post_types' ) ) {
+	$custom_post_types = apply_filters( 'custom_post_types', array() );
+}
+
 ?>
 <div class="wrap">
 
@@ -62,6 +66,9 @@ $current_import = get_option( 'pressbooks_current_import' );
 				<th style="width:10%;"><?php _e( 'Part', 'pressbooks' ); ?></th>
 				<?php } ?>
 				<th style="width:10%;"><?php _e( 'Back Matter', 'pressbooks' ); ?></th>
+				<?php if ( has_filter( 'custom_post_types' ) ) { ?>
+				<th style="width:10%;"><?php _e( 'Other', 'pressbooks' ); ?></th>
+				<?php } ?>
 			</tr>
 			</thead>
 			<tbody>
@@ -86,6 +93,9 @@ $current_import = get_option( 'pressbooks_current_import' );
 						<td><input type='radio' name='chapters[<?php echo $key; ?>][type]' value='part' <?php checked(isset( $current_import['post_types'][$key] ) && 'part' == $current_import['post_types'][$key]);?>></td>
 						<?php } ?>
 						<td><input type='radio' name='chapters[<?php echo $key; ?>][type]' value='back-matter' <?php checked(isset( $current_import['post_types'][$key] ) && 'back-matter' == $current_import['post_types'][$key]);?>></td>
+						<?php if ( has_filter( 'custom_post_types' ) ) { ?>
+						<td><input type='radio' name='chapters[<?php echo $key; ?>][type]' value='<?php echo $current_import["post_types"][$key] ?>' <?php checked(isset( $current_import['post_types'][$key] ) && in_array($current_import['post_types'][$key], $custom_post_types));?>></td>
+						<?php } ?>
 					<?php } ?>
 				</tr>
 				<?php
@@ -110,11 +120,11 @@ $current_import = get_option( 'pressbooks_current_import' );
 		<script type="text/javascript">
 			jQuery(function ($) {
 				$('#pb-www').hide();
-				
+
 				$( ".pb-html-target").change(
 					function(){
 						var val = $('.pb-html-target').val();
-						
+
 							if (val == 'html') {
 							$('#pb-file').hide();
 							$('#pb-www').show();
@@ -123,11 +133,11 @@ $current_import = get_option( 'pressbooks_current_import' );
 							$('#pb-www').hide();
 							// clear http value at input elem
 							$('.widefat').val('');
-							
-						}	
-					
+
+						}
+
 					});
-				
+
 			});
 			</script>
 		<p>

--- a/templates/admin/import.php
+++ b/templates/admin/import.php
@@ -6,10 +6,7 @@ if ( ! defined( 'ABSPATH' ) )
 $import_form_url = wp_nonce_url( get_admin_url( get_current_blog_id(), '/tools.php?page=pb_import&import=yes' ), 'pb-import' );
 $import_revoke_url = wp_nonce_url( get_admin_url( get_current_blog_id(), '/tools.php?page=pb_import&revoke=yes' ), 'pb-revoke-import' );
 $current_import = get_option( 'pressbooks_current_import' );
-
-if ( has_filter( 'custom_post_types' ) ) {
-	$custom_post_types = apply_filters( 'custom_post_types', array() );
-}
+$custom_post_types = apply_filters( 'pb_import_custom_post_types', array() );
 
 ?>
 <div class="wrap">
@@ -66,7 +63,7 @@ if ( has_filter( 'custom_post_types' ) ) {
 				<th style="width:10%;"><?php _e( 'Part', 'pressbooks' ); ?></th>
 				<?php } ?>
 				<th style="width:10%;"><?php _e( 'Back Matter', 'pressbooks' ); ?></th>
-				<?php if ( has_filter( 'custom_post_types' ) ) { ?>
+				<?php if ( has_filter( 'pb_import_custom_post_types' ) ) { ?>
 				<th style="width:10%;"><?php _e( 'Other', 'pressbooks' ); ?></th>
 				<?php } ?>
 			</tr>
@@ -93,7 +90,7 @@ if ( has_filter( 'custom_post_types' ) ) {
 						<td><input type='radio' name='chapters[<?php echo $key; ?>][type]' value='part' <?php checked(isset( $current_import['post_types'][$key] ) && 'part' == $current_import['post_types'][$key]);?>></td>
 						<?php } ?>
 						<td><input type='radio' name='chapters[<?php echo $key; ?>][type]' value='back-matter' <?php checked(isset( $current_import['post_types'][$key] ) && 'back-matter' == $current_import['post_types'][$key]);?>></td>
-						<?php if ( has_filter( 'custom_post_types' ) ) { ?>
+						<?php if ( has_filter( 'pb_import_custom_post_types' ) ) { ?>
 						<td><input type='radio' name='chapters[<?php echo $key; ?>][type]' value='<?php echo $current_import["post_types"][$key] ?>' <?php checked(isset( $current_import['post_types'][$key] ) && in_array($current_import['post_types'][$key], $custom_post_types));?>></td>
 						<?php } ?>
 					<?php } ?>


### PR DESCRIPTION
This allows another plugin to register filters that will import custom post types, taxonomies, and terms during a pressbooks import.