### PR TITLE
recover from recoverable error with imagecreatefrom

### DIFF
--- a/includes/pb-image.php
+++ b/includes/pb-image.php
@@ -402,8 +402,23 @@ function resize_down( $format, $fullpath, $MAX_W = 1024, $MAX_H = 1024 ) {
 
 	$func = 'imagecreatefrom' . $format;
 	$src = $func( $fullpath );
-	if ( ! $src )
-		throw new \Exception( 'Invalid image format' );
+
+	// try again, but ignore warnings for jpeg only
+	if ( ! $src && 0 === strcmp( 'jpeg', $format ) ) {
+		ini_set( 'gd.jpeg_ignore_warning', 1 );
+		$src = '@' . $func( $fullpath );
+	}
+
+	// try again, but replace with placeholder image
+	if ( ! $src ) {
+		$src        = imagecreatetruecolor( 150, 100 );
+		$bkgd_color = imagecolorallocate( $src, 255, 255, 255 );
+		$font_color = imagecolorallocate( $src, 0, 0, 0 );
+
+		imagefilledrectangle( $src, 0, 0, 150, 100, $bkgd_color );
+		imagestring( $src, 3, 5, 5, 'Error loading image', $font_color );
+
+	}
 
 	list( $orig_w, $orig_h ) = getimagesize( $fullpath );
 	$ratio = $orig_w * 1.0 / $orig_h;


### PR DESCRIPTION
This addresses an edge case where an export attempt failed to produce an export file due to a recoverable error generated by `imagecreatefromjpeg()`: 'Premature end of JPEG file'.

![screen shot 2016-06-29 at 9 38 58 am](https://cloud.githubusercontent.com/assets/2048170/16460745/c8a37e9e-3ddd-11e6-99d3-9115936a4f1e.png)

Result: No export file gets generated, and a generic error message 'Invalid image format' is displayed to the user. The goal of this is to produce an export file. First, it attempts to suppress the error messages and produce an image regardless of the warnings. Should that fail, it generates a new image which contains the string 'Error loading image' in its place 

ref: https://secure.php.net/manual/en/image.configuration.php
