### PR TITLE
Give users ability to customize catalog sidebar color

### DIFF
--- a/assets/js/color-pick.js
+++ b/assets/js/color-pick.js
@@ -1,0 +1,5 @@
+(function ($) {
+  $(function () {
+    $('.pb_catalog_color').wpColorPicker();
+  });
+}(jQuery));

--- a/functions.php
+++ b/functions.php
@@ -285,6 +285,16 @@ function pb_tag_sections( $content, $id ) {
  * @return string
  */
 function pb_thumbify( $thumb, $path ) {
-
-	return \Pressbooks\Image\thumbify( $thumb, $path );
+	return \PressBooks\Image\thumbify( $thumb, $path );
 }
+
+/**
+ * Load color picker script in admin area
+ *
+ * @param $hook
+ */
+function pb_color_picker_assets( $hook ) {
+  wp_enqueue_style( 'wp-color-picker' );
+  wp_enqueue_script( 'color-pick', plugins_url( 'assets/js/color-pick.js', __FILE__ ), array( 'wp-color-picker' ), false, true );
+}
+add_action( 'admin_enqueue_scripts', 'pb_color_picker_assets' );

--- a/includes/class-pb-catalog.php
+++ b/includes/class-pb-catalog.php
@@ -67,6 +67,7 @@ class Catalog {
 		'pb_catalog_about' => '%s',
 		'pb_catalog_logo' => '%s',
 		'pb_catalog_url' => '%s',
+		'pb_catalog_color' => '%s',
 		// Tags added in constructor (Ie. pb_catalog_tag_1_name, pb_catalog_tag_2_name, ...)
 	);
 

--- a/templates/admin/catalog.php
+++ b/templates/admin/catalog.php
@@ -110,6 +110,9 @@ else:
 				</tr>
 			<?php } ?>
 			<tr>
+				<th><label for="pb_catalog_color"><?php _e( 'Sidebar Color', 'pressbooks' ); ?></label></th>
+				<td><input type="text" name="pb_catalog_color" id="pb_catalog_color" class="pb_catalog_color" value="<?php echo esc_attr( $p['pb_catalog_color'] ) ?>" /></td>
+			<tr>
 				<th><label for="pb_catalog_logo"><?php _e( 'Logo Or Image', 'pressbooks' ); ?></label></th>
 				<td><?php \Pressbooks\Image\catalog_logo_box( $user_id ); ?></td>
 			</tr>

--- a/templates/pb-catalog.php
+++ b/templates/pb-catalog.php
@@ -177,7 +177,11 @@ $_current_user_id = $catalog->getUserId();
 				?>
 			<?php endif; ?>
 		</div> <!-- end .log-wrap -->
-	<div id="catalog-sidebar" class="catalog-sidebar">
+	<?php if ( ! empty( $profile['pb_catalog_color'] ) ) : ?>
+		<div id="catalog-sidebar" class="catalog-sidebar" style="background-color:<?php echo $profile['pb_catalog_color']; ?>">
+	<?php else : ?>
+		<div id="catalog-sidebar" class="catalog-sidebar">
+	<?php endif ?>
 		<h2 class="pressbooks-logo">
 			<a href="<?php echo network_site_url(); ?>">Pressbooks</a>
 		</h2>


### PR DESCRIPTION
In response to a feature that was requested of us, this feature allows users to choose their own Catalog Sidebar color from the Edit Catalog page.  The input uses the native Wordpress color picker for ease of use.