### PR TITLE
replacing string value with boolean

### DIFF
--- a/includes/class-pb-options.php
+++ b/includes/class-pb-options.php
@@ -95,7 +95,7 @@ abstract class Options {
 		}
 
 		foreach ( $this->booleans as $key ) {
-			if ( ! isset( $input[ $key ] ) || $input[ $key ] !== '1' ) {
+			if ( ! isset( $input[ $key ] ) || $input[ $key ] !== 1 ) {
 				$options[$key] = 0;
 			} else {
 				$options[$key] = 1;


### PR DESCRIPTION
Previous values for options were stored as integers/boolean and were being blown away (reset to 0/false) when this function compared the previously stored value with a string. 

