### PR TITLE
Allow webbook Pressbooks promotion to be disabled

### DIFF
--- a/themes-book/pressbooks-book/css/book-info.css
+++ b/themes-book/pressbooks-book/css/book-info.css
@@ -258,11 +258,14 @@ a:active.btn.black {
 	height: 16px;
 }
 .right-block {
-	 height: auto;
-    float: right;
-    max-width: 350px;
-    width: 36.5%;
-    position: relative;
+	height: auto;
+  float: right;
+  max-width: 350px;
+  width: 36.5%;
+  position: relative;
+}
+.right-block .spacer {
+		height: 65px;
 }
 .pressbooks-brand {
 	display: block;

--- a/themes-book/pressbooks-book/functions.php
+++ b/themes-book/pressbooks-book/functions.php
@@ -628,8 +628,12 @@ function pressbooks_theme_add_metadata(){
 
 add_action( 'wp_head', 'pressbooks_theme_add_metadata' );
 
-function pressbooks_cover_branding() { ?>
+function pressbooks_cover_promo() { ?>
+	<?php if ( !defined( 'PB_HIDE_COVER_PROMO' ) || PB_HIDE_COVER_PROMO == false ) : ?>
 	<a href="https://pressbooks.com" class="pressbooks-brand"><img src="<?php bloginfo('template_url'); ?>/images/pressbooks-branding-2x.png" alt="pressbooks-branding" width="186" height="123" /> <span><?php _e('Make your own books on Pressbooks', 'pressbooks'); ?></span></a>
-<?php }
+	<?php else : ?>
+	<div class="spacer"></div>
+	<?php endif;
+}
 
-add_action( 'pb_cover_branding', 'pressbooks_cover_branding' );
+add_action( 'pb_cover_promo', 'pressbooks_cover_promo' );

--- a/themes-book/pressbooks-book/functions.php
+++ b/themes-book/pressbooks-book/functions.php
@@ -627,3 +627,9 @@ function pressbooks_theme_add_metadata(){
 }
 
 add_action( 'wp_head', 'pressbooks_theme_add_metadata' );
+
+function pressbooks_cover_branding() { ?>
+	<a href="https://pressbooks.com" class="pressbooks-brand"><img src="<?php bloginfo('template_url'); ?>/images/pressbooks-branding-2x.png" alt="pressbooks-branding" width="186" height="123" /> <span><?php _e('Make your own books on Pressbooks', 'pressbooks'); ?></span></a>
+<?php }
+
+add_action( 'pb_cover_branding', 'pressbooks_cover_branding' );

--- a/themes-book/pressbooks-book/page-cover-top-block.php
+++ b/themes-book/pressbooks-book/page-cover-top-block.php
@@ -1,5 +1,5 @@
 <section id="post-<?php the_ID(); ?>" <?php post_class( array( 'top-block', 'clearfix', 'home-post' ) ); ?>>
-	
+
 	<?php pb_get_links(false); ?>
 	<?php $metadata = pb_get_book_information();?>
 	<div class="log-wrap">	<!-- Login/Logout -->
@@ -13,56 +13,56 @@
 				<?php endif; ?>
 	    	<?php endif; ?>
 	    <?php endif; ?>
-	</div>   
+	</div>
 	<div class="right-block">
-		<a href="http://pressbooks.com" class="pressbooks-brand"><img src="<?php bloginfo('template_url'); ?>/images/pressbooks-branding-2x.png" alt="pressbooks-branding" width="186" height="123" /> <span><?php _e('Make your own books on Pressbooks', 'pressbooks'); ?></span></a>
-	</div>	
-						
+		<?php do_action('pb_cover_branding'); ?>
+	</div>
+
 			<div class="book-info">
 				<!-- Book Title -->
 				<h1><a href="<?php echo home_url( '/' ); ?>" title="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
-				
-					
+
+
 				<?php if ( ! empty( $metadata['pb_author'] ) ): ?>
 			     	<p class="book-author"><?php echo $metadata['pb_author']; ?></p>
 			     	<span class="stroke"></span>
 		     	<?php endif; ?>
-				
-					
+
+
 				<?php if ( ! empty( $metadata['pb_about_140'] ) ) : ?>
 					<p class="sub-title"><?php echo $metadata['pb_about_140']; ?></p>
 					<span class="detail"></span>
-				<?php endif; ?>						
-				
+				<?php endif; ?>
+
 				<?php if ( ! empty( $metadata['pb_about_50'] ) ): ?>
 					<p><?php echo pb_decode( $metadata['pb_about_50'] ); ?></p>
 				<?php endif; ?>
-		
+
 			</div> <!-- end .book-info -->
-			
+
 				<?php if ( ! empty( $metadata['pb_cover_image'] ) ): ?>
 				<div class="book-cover">
-				
+
 						<img src="<?php echo $metadata['pb_cover_image']; ?>" alt="book-cover" title="<?php bloginfo( 'name' ); ?> book cover" />
-					
-				</div>	
+
+				</div>
 				<?php endif; ?>
-				
+
 				<div class="call-to-action-wrap">
 					<?php global $first_chapter; ?>
 					<div class="call-to-action">
 						<a class="btn red" href="<?php global $first_chapter; echo $first_chapter; ?>"><span class="read-icon"></span><?php _e('Read', 'pressbooks'); ?></a>
-						
+
 						<?php if ( @array_filter( get_option( 'pressbooks_ecommerce_links' ) ) ) : ?>
 						 <!-- Buy -->
-							 <a class="btn black" href="<?php echo get_option('home'); ?>/buy"><span class="buy-icon"></span><?php _e('Buy', 'pressbooks'); ?></a>				
-						 <?php endif; ?>	
-						 
-						
-					</div> <!-- end .call-to-action -->		
+							 <a class="btn black" href="<?php echo get_option('home'); ?>/buy"><span class="buy-icon"></span><?php _e('Buy', 'pressbooks'); ?></a>
+						 <?php endif; ?>
+
+
+					</div> <!-- end .call-to-action -->
 				</div><!--  end .call-to-action-wrap -->
-				
-			
-			
-			
+
+
+
+
 	</section> <!-- end .top-block -->

--- a/themes-book/pressbooks-book/page-cover-top-block.php
+++ b/themes-book/pressbooks-book/page-cover-top-block.php
@@ -15,7 +15,7 @@
 	    <?php endif; ?>
 	</div>
 	<div class="right-block">
-		<?php do_action('pb_cover_branding'); ?>
+		<?php do_action( 'pb_cover_promo' ); ?>
 	</div>
 
 			<div class="book-info">


### PR DESCRIPTION
Webbooks currently include a promotion for Pressbooks.com. This PR allows that promotion to be hidden if the constant `PB_HIDE_COVER_PROMO` = true.