### PR TITLE
Use WP_DEFAULT_THEME for book activation.

### DIFF
--- a/includes/class-pb-activation.php
+++ b/includes/class-pb-activation.php
@@ -25,9 +25,6 @@ class Activation {
 	 * @var array The set of default WP options to set up on activation
 	 */
 	private $opts = array(
-		'template' => 'pressbooks-book',
-		'stylesheet' => 'pressbooks-book',
-		'current_theme' => 'pressbooks-book',
 		'show_on_front' => 'page',
 		'rewrite_rules' => ''
 	);

--- a/pressbooks.php
+++ b/pressbooks.php
@@ -51,6 +51,9 @@ if ( ! defined( 'PB_PLUGIN_DIR' ) )
 if ( ! defined( 'PB_PLUGIN_URL' ) )
 	define ( 'PB_PLUGIN_URL', trailingslashit( plugins_url( 'pressbooks' ) ) ); // Must have trailing slash!
 
+if ( ! defined( 'WP_DEFAULT_THEME' ) )
+	define( 'WP_DEFAULT_THEME', 'pressbooks-book' );
+
 // -------------------------------------------------------------------------------------------------------------------
 // Class autoloader
 // -------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Our book activation routine set the `stylesheet` and `current_theme` options to a hardcoded default (`pressbooks-book`), which meant that the `WP_DEFAULT_THEME` constant was ignored even if it was present (see [here](https://premium.wpmudev.org/blog/how-to-set-the-default-theme-for-wordpress-multisite/) for details on this constant). This PR removes the hardcoded defaults and, instead, sets `WP_DEFAULT_THEME` to `pressbooks-book` if it hasn't been defined in `wp-config.php`.