### PR TITLE
fix logic for toc collapse

### DIFF
--- a/themes-book/pressbooks-book/js/toc_collapse.js
+++ b/themes-book/pressbooks-book/js/toc_collapse.js
@@ -1,7 +1,7 @@
 jQuery(function($) {
 	var $toc = $("#toc");
 	var $tocbutton = $(".toc-btn");
-	if ( $toc.length < 0 && $tocbutton.length < 0 && ( $(window).height() - ( $tocbutton.offset().top + $tocbutton.height() + $toc.height() ) ) < 0 ) {
+	if ( $toc.length > 0 && $tocbutton.length > 0 && ( $(window).height() - ( $tocbutton.offset().top + $tocbutton.height() + $toc.height() ) ) < 0 ) {
 		$("#toc > ul").find("li h4:not(:has(a)):not(:empty)").on('click', function() {
 				jQuery(this).parent().next().slideToggle(100);
 				var dashicon = $(this).find(".dashicons");


### PR DESCRIPTION
Presumably this condition checks for the existence of a TOC. 

If the TOC exists, the lengths of `.toc-btn` and `#toc` will never be less than 1, so the collapsible toc function will never fire if it checks for a value less than zero. 

![screen shot 2016-09-12 at 12 26 32 pm](https://cloud.githubusercontent.com/assets/2048170/18449540/644aba38-78e4-11e6-873d-2560fbaa1796.png)

![screen shot 2016-09-12 at 12 18 15 pm](https://cloud.githubusercontent.com/assets/2048170/18449565/75b23ea4-78e4-11e6-8269-984376020753.png)

