### PR TITLE
adding action hook to register theme directories

### DIFF
--- a/includes/class-pb-pressbooks.php
+++ b/includes/class-pb-pressbooks.php
@@ -36,6 +36,8 @@ class Pressbooks {
 		register_theme_directory( PB_PLUGIN_DIR . 'themes-root' );
 		register_theme_directory( PB_PLUGIN_DIR . 'themes-book' );
 
+		do_action('pressbooks_register_theme_directory');
+
 		// Check for local themes-root directory
 		if ( realpath ( WP_CONTENT_DIR . '/themes-root' ) ) :
 			register_theme_directory( WP_CONTENT_DIR . '/themes-root' );


### PR DESCRIPTION
Creating a theme for PB outside of PB involves some trickery. This action hook takes some of the magic out of actually getting a theme to display alongside PB core themes. Given all the recent refactoring on themes, this may make it easier for theme developers to create themes that PB doesn't have to maintain. 
A theme developer will still have to dance around the `allowedBookThemes` [function](https://github.com/pressbooks/pressbooks/blob/dev/includes/class-pb-pressbooks.php#L62) — anything added with this new action hook will be stripped away with [this] (https://github.com/pressbooks/pressbooks/blob/dev/includes/class-pb-pressbooks.php#L81) unless they append an array of themes to the `allowed_themes` filter and have it fire later (with a priority variable > 10). I'm not sure if the business needs are still present that would require all themes living in the `PB_PLUGIN_DIR` so I've left that alone. Needless to say, it would be nice if the condition were accommodating to themes that live in other directories.  

 