### PR TITLE
remove conditions for fatal error

### DIFF
--- a/includes/admin/class-pb-exportoptions.php
+++ b/includes/admin/class-pb-exportoptions.php
@@ -201,4 +201,14 @@ class ExportOptions extends \Pressbooks\Options {
 	static function getPredefinedOptions() {
 		return array();
 	}
+
+	/**
+	 * Filter the array of default values for this set of options
+	 *
+	 * @param array $defaults
+	 * @return array $defaults
+	 */
+	static function filterDefaults( $defaults ) {
+		return $defaults;
+	}
 }


### PR DESCRIPTION
fatal error encountered due to an abstract class not implementing all methods. 

![screen shot 2016-09-20 at 10 15 53 am](https://cloud.githubusercontent.com/assets/2048170/18681079/4658366c-7f1b-11e6-8f42-d1cef9d37778.png)

Don't know if this functionality is actually what is desired for `filterDefaults()`, but it moves things past a 500 error. 