### PR TITLE
add filter hook 'pb_epub_has_dependencies' to epub export class

### DIFF
--- a/includes/modules/export/epub/class-pb-epub201.php
+++ b/includes/modules/export/epub/class-pb-epub201.php
@@ -2178,7 +2178,7 @@ class Epub201 extends Export {
 			return true;
 		}
 
-		return false;
+		return apply_filters('pb_epub_has_dependencies', false);
 	}
 
 }

--- a/includes/modules/export/epub/class-pb-epub201.php
+++ b/includes/modules/export/epub/class-pb-epub201.php
@@ -2178,7 +2178,7 @@ class Epub201 extends Export {
 			return true;
 		}
 
-		return apply_filters('pb_epub_has_dependencies', false);
+		return false;
 	}
 
 }

--- a/includes/pb-utility.php
+++ b/includes/pb-utility.php
@@ -382,7 +382,7 @@ function check_epubcheck_install() {
 		}
 	}
 
-	return false;
+	return apply_filters( 'pb_epub_has_dependencies', false );
 }
 
 /**


### PR DESCRIPTION
this allows a user to enable the epub export option in the admin area under 'exports' by hooking into the 'pb_epub_has_dependencies' filter and without having to install the dependency EpubCheck, as installing system level dependencies may not be an option for some users.