### PR TITLE
add filter hook 'pressbooks_session_configuration'

### DIFF
--- a/pressbooks.php
+++ b/pressbooks.php
@@ -24,6 +24,7 @@ function _pb_session_start() {
 	if ( ! session_id() ) {
 		if ( ! headers_sent() ) {
 			ini_set( 'session.use_only_cookies', true );
+			apply_filters( 'pressbooks_session_configuration', false );
 			session_start();
 		} else {
 			error_log( 'There was a problem with _pb_session_start(), headers already sent!' );


### PR DESCRIPTION
some hosting platforms have requirements around sessions handling
that would require the modification of the way pressbooks handles
sessions. This filter allows users of pressbooks to add
custom configurations to session.