### PR TITLE
use original url to get image id instead of $cover

### DIFF
--- a/includes/class-pb-catalog.php
+++ b/includes/class-pb-catalog.php
@@ -202,7 +202,7 @@ class Catalog {
 				$data[ $i ]['cover_url']['full'] = $cover;
 
 				// Cover Thumbnails
-				$cid = \Pressbooks\Image\attachment_id_from_url( $cover );
+				$cid = \Pressbooks\Image\attachment_id_from_url( $metadata['pb_cover_image'] );
 				foreach ( $cover_sizes as $size => $default ) {
 					$cid_thumb = wp_get_attachment_image_src( $cid, $size );
 					if ( $cid_thumb ) {
@@ -263,7 +263,7 @@ class Catalog {
 			$data[ $i ]['cover_url']['full'] = $cover;
 
 			// Cover Thumbnails
-			$cid = \Pressbooks\Image\attachment_id_from_url( $cover );
+			$cid = \Pressbooks\Image\attachment_id_from_url( $metadata['pb_cover_image'] );
 			foreach ( $cover_sizes as $size => $default ) {
 				$cid_thumb = wp_get_attachment_image_src( $cid, $size );
 				if ( $cid_thumb ) {


### PR DESCRIPTION
users who use a plugin to host images outside of wordpress
(ex: Amazon S3) would find that cover images were broken in the
catalog. This fixes the broken images by using the original url
instead of the url set in the variable $cover.