### PR TITLE
Add generator property to XHTML exports.

### DIFF
--- a/includes/modules/export/xhtml/class-pb-xhtml11.php
+++ b/includes/modules/export/xhtml/class-pb-xhtml11.php
@@ -191,6 +191,7 @@ class Xhtml11 extends Export {
 		echo "<head>\n";
 		echo '<meta content="text/html; charset=UTF-8" http-equiv="content-type" />' . "\n";
 		echo '<meta http-equiv="Content-Language" content="' . $this->lang . '" />' . "\n";
+		echo '<meta name="generator" content="Pressbooks ' . PB_PLUGIN_VERSION . '" />' . "\n";
 
 		$this->echoMetaData( $book_contents, $metadata );
 


### PR DESCRIPTION
This will help identify Pressbooks-generated PDFs (see http://www.princexml.com/doc/pdf-metadata/).