### PR TITLE
Adopt WP_Site object (fixes #375)

### DIFF
--- a/assets/scss/fonts/_NotoSansDevanagariFont.scss
+++ b/assets/scss/fonts/_NotoSansDevanagariFont.scss
@@ -1,0 +1,15 @@
+// 'Noto Sans Devanagari', @import 'NotoSansDevanagariFont'
+
+@font-face {
+  font-family: 'Noto Sans Devanagari';
+  font-style: normal;
+  font-weight: 400;
+  src: url('uploads/assets/fonts/NotoSansDevanagari-Regular.ttf') format('truetype');
+}
+
+@font-face {
+  font-family: 'Noto Sans Devanagari';
+  font-style: normal;
+  font-weight: 700;
+  src: url('uploads/assets/fonts/NotoSansDevanagari-Regular.ttf') format('truetype');
+}

--- a/assets/scss/fonts/_NotoSerifDevanagariFont.scss
+++ b/assets/scss/fonts/_NotoSerifDevanagariFont.scss
@@ -1,0 +1,15 @@
+// 'Noto Serif Devanagari', @import 'NotoSerifDevanagariFont'
+
+@font-face {
+  font-family: 'Noto Serif Devanagari';
+  font-style: normal;
+  font-weight: 400;
+  src: url('uploads/assets/fonts/NotoSerifDevanagari-Regular.ttf') format('truetype');
+}
+
+@font-face {
+  font-family: 'Noto Serif Devanagari';
+  font-style: normal;
+  font-weight: 700;
+  src: url('uploads/assets/fonts/NotoSerifDevanagari-Regular.ttf') format('truetype');
+}

--- a/assets/scss/fonts/_fonts-hi.scss
+++ b/assets/scss/fonts/_fonts-hi.scss
@@ -1,0 +1,14 @@
+@import 'NotoSansDevanagariFont';
+@import 'NotoSerifDevanagariFont';
+
+// Sans-serif stack name
+
+$sans-serif-epub-hi: 'Noto Sans Devanagari';
+$sans-serif-prince-hi: 'Noto Sans Devanagari';
+$sans-serif-web-hi: 'Noto Sans Devanagari';
+
+// Serif stack name
+
+$serif-epub-hi: 'Noto Serif Devanagari';
+$serif-prince-hi: 'Noto Serif Devanagari';
+$serif-web-hi: 'Noto Serif Devanagari';

--- a/includes/class-pb-book.php
+++ b/includes/class-pb-book.php
@@ -9,7 +9,6 @@
  */
 namespace Pressbooks;
 
-
 class Book {
 
 	/**
@@ -46,6 +45,7 @@ class Book {
 	/**
 	 * Returns book information in a useful, string only, format. Data is converted to HTML.
 	 *
+	 * @param int $id The book ID.
 	 * @return array
 	 */
 	static function getBookInformation( $id = '' ) {

--- a/includes/class-pb-catalog.php
+++ b/includes/class-pb-catalog.php
@@ -164,7 +164,7 @@ class Catalog {
 		$already_loaded = array();
 
 		foreach ( $catalog as $val ) {
-			if ( ! get_blog_details( $val['blogs_id'] ) ) {
+			if ( ! get_site( $val['blogs_id'] ) ) {
 				$data[ $i ]['ID'] = "{$val['users_id']}:{$val['blogs_id']}";
 				$data[ $i ]['users_id'] = $val['users_id'];
 				$data[ $i ]['blogs_id'] = $val['blogs_id'];

--- a/includes/class-pb-globaltypography.php
+++ b/includes/class-pb-globaltypography.php
@@ -20,6 +20,7 @@ class GlobalTypography {
 			'grc' => __( 'Ancient Greek', 'pressbooks' ),
 			'ar' => __( 'Arabic', 'pressbooks' ),
 			'he' => __( 'Biblical Hebrew', 'pressbooks' ),
+			'hi' => __( 'Hindi', 'pressbooks' ),
 			'zh_HANS' => __( 'Chinese (Simplified)', 'pressbooks' ),
 			'zh_HANT' => __( 'Chinese (Traditional)', 'pressbooks' ),
 			'cop' => __( 'Coptic', 'pressbooks' ),
@@ -124,6 +125,9 @@ class GlobalTypography {
 				break;
 			case 'he': // Biblical Hebrew
 				$lang = 'he';
+				break;
+			case 'hi': // Biblical Hebrew
+				$lang = 'hi';
 				break;
 			case 'zh': // Chinese (Simplified)
 			case 'zh-cn':
@@ -318,6 +322,15 @@ class GlobalTypography {
 
 		// List fonts
 		$fontpacks = array(
+			'hi' => array(
+				'baseurl' => 'https://github.com/googlei18n/noto-fonts/raw/master/unhinted/',
+				'files' => array(
+					'NotoSansDevanagari-Regular.ttf',
+					'NotoSansDevanagari-Bold.ttf',
+					'NotoSerifDevanagari-Bold.ttf',
+					'NotoSerifDevanagari-Regular.ttf',
+				),
+			),
 			'ja' => array(
 				'baseurl' => 'https://github.com/googlei18n/noto-cjk/raw/master/',
 				'files' => array(

--- a/includes/modules/import/class-pb-import.php
+++ b/includes/modules/import/class-pb-import.php
@@ -289,6 +289,17 @@ abstract class Import {
 				case 'html':
 					$importer = new Html\Xhtml();
 					$ok = $importer->import( $current_import );
+					break;
+
+				default:
+					/**
+					 * Allows users to add a custom import routine for custom import type.
+					 *
+					 * @since 3.9.6
+					 */
+					$importer = apply_filters( 'pb_initialize_import', null );
+					$ok = $importer->import( $current_import );
+					break;
 			}
 
 			$msg = "Tried to import a file of type {$current_import['type_of']} and ";
@@ -305,12 +316,20 @@ abstract class Import {
 			// --------------------------------------------------------------------------------------------------------
 			// Set the 'pressbooks_current_import' option
 
-			$allowed_file_types = array(
+			/**
+			 * Allows users to append import options to the list of allowed file types.
+			 *
+			 * @since 3.9.6
+			 *
+			 * @param array The list of currently allowed file types.
+			 */
+			$allowed_file_types = apply_filters( 'pb_import_file_types', array(
 				'epub' => 'application/epub+zip',
 				'xml' => 'application/xml',
 				'odt' => 'application/vnd.oasis.opendocument.text',
 				'docx' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-			);
+			) );
+
 			$overrides = array( 'test_form' => false, 'mimes' => $allowed_file_types );
 
 			if ( ! function_exists( 'wp_handle_upload' ) ) {
@@ -345,6 +364,12 @@ abstract class Import {
 
 				case 'docx':
 					$importer = new Ooxml\Docx();
+					$ok = $importer->setCurrentImportOption( $upload );
+					break;
+
+				default:
+					/** This filter is documented above */
+					$importer = apply_filters( 'pb_initialize_import', null );
 					$ok = $importer->setCurrentImportOption( $upload );
 					break;
 			}

--- a/templates/admin/import.php
+++ b/templates/admin/import.php
@@ -9,6 +9,21 @@ $import_revoke_url = wp_nonce_url( get_admin_url( get_current_blog_id(), '/tools
 $current_import = get_option( 'pressbooks_current_import' );
 $custom_post_types = apply_filters( 'pb_import_custom_post_types', array() );
 
+/**
+ * Allows users to append import options to the select field.
+ *
+ * @since 3.9.6
+ *
+ * @param array The list of current import options in select field.
+ */
+$import_option_types = apply_filters( 'pb_select_import_type', array(
+	'wxr' => __( 'WXR (WordPress eXtended RSS)' ),
+	'epub' => __( 'EPUB (for Nook, iBooks, Kobo etc.)' ),
+	'odt' => __( 'ODT (word processing file format of OpenDocument)' ),
+	'docx' => __( 'DOCX (word processing file format of Microsoft)' ),
+	'html' => __( 'HTML (scrape content from a URL)' ),
+) );
+
 ?>
 <div class="wrap">
 
@@ -153,11 +168,9 @@ $custom_post_types = apply_filters( 'pb_import_custom_post_types', array() );
 					</th>
 					<td>
 						<select id="type_of" name="type_of" class="pb-html-target">
-							<option value="wxr"><?php _e( 'WXR (WordPress eXtended RSS)', 'pressbooks' ); ?></option>
-							<option value="epub"><?php _e( 'EPUB (for Nook, iBooks, Kobo etc.)', 'pressbooks' ); ?></option>
-							<option value="odt"><?php _e( 'ODT (word processing file format of OpenDocument)', 'pressbooks' ); ?></option>
-							<option value="docx"><?php _e( 'DOCX (word processing file format of Microsoft)', 'pressbooks' ); ?></option>
-							<option value="html"><?php _e( 'HTML (scrape content from a URL)', 'pressbooks' ); ?></option>
+							<?php foreach ( $import_option_types as $option => $label ) { ?>
+								<option value="<?php echo $option; ?>"><?php echo $label; ?></option>
+							<?php } ?>
 						</select>
 					</td>
 				</tr>


### PR DESCRIPTION
Handle get_blog_details() deprecation in 4.8.

See https://make.wordpress.org/core/2016/11/04/multisite-focused-changes-in-4-7/