### PR TITLE
Update requirements to Prince 11

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -71,7 +71,7 @@ However, we encourage you to upgrade your environment instead as [PHP 5.4 is no 
 
 *Part 3, Pressbooks dependencies:*
 
-*   For PDF export install [Prince][6] (note: this is not free software) - Version 20160929
+*   For PDF export install [Prince][6] (note: this is not free software) - Version 11
 *   For PDF export via mPDF install the [Pressbooks mPDF plugin][7]. You will also need to ensure that the following folders have write access and/or they are owned by the appropriate user. See http://codex.wordpress.org/Changing_File_Permissions for more details on adjusting file permissions.
     *   `wp-content/plugins/pressbooks-mpdf/symbionts/mpdf/ttfontdata`
     *   `wp-content/plugins/pressbooks-mpdf/symbionts/mpdf/tmp`

--- a/includes/pb-utility.php
+++ b/includes/pb-utility.php
@@ -429,7 +429,7 @@ function check_prince_install() {
 	if ( false !== strpos( $output, 'Prince' ) ) { // Command found.
 		$output = explode( 'Prince ', $output );
 		$version = $output[1];
-		if ( version_compare( $version, '20160929' ) >= 0 ) {
+		if ( version_compare( $version, '11' ) >= 0 ) {
 			return true;
 		}
 	}


### PR DESCRIPTION
[Prince 11](http://www.princexml.com/releases/11/) is out. This PR updates Pressbooks' dependency check for Prince 11 instead of the development build we were using before (20160929).