### PR TITLE
added Pressbooks\Utility\remote_get_retry() to fix fetching images

### DIFF
--- a/includes/modules/export/epub/class-pb-epub201.php
+++ b/includes/modules/export/epub/class-pb-epub201.php
@@ -1757,7 +1757,7 @@ class Epub201 extends Export {
 			return $this->fetchedImageCache[ $url ];
 		}
 
-		$response = wp_remote_get( $url, array( 'timeout' => $this->timeout ) );
+		$response = \Pressbooks\Utility\remote_get_retry( $url, array( 'timeout' => $this->timeout ) );
 
 		// WordPress error?
 		if ( is_wp_error( $response ) ) {

--- a/includes/pb-utility.php
+++ b/includes/pb-utility.php
@@ -684,6 +684,30 @@ function template( $path, array $vars = array() ) {
 	return $output;
 }
 
+function remote_get_retry($url, $args, $retry = 3, $attempts = 0, $response = []){
+	$completed = false;
+
+	if($attempts >= $retry){
+		$completed = true;
+	}
+
+	if( $completed ) return $response;
+
+	$attempts++;
+
+	$response = wp_remote_get($url, $args);
+
+	$retryResponseCodes = apply_filters( 'pressbooks_remote_get_retry_response_codes', [ 400 ]);
+
+	if( ! is_array($response) || ! in_array( $response['response']['code'], $retryResponseCodes ) ) {
+		return $response;
+	}
+
+	$sleep = apply_filters( 'pressbooks_remote_get_retry_wait_time', 1000);
+	usleep($sleep);
+	return remote_get_retry($url, $args, $retry, $attempts, $response);
+}
+
 /**
  * Get paths for assets
  */

--- a/includes/pb-utility.php
+++ b/includes/pb-utility.php
@@ -684,28 +684,29 @@ function template( $path, array $vars = array() ) {
 	return $output;
 }
 
-function remote_get_retry($url, $args, $retry = 3, $attempts = 0, $response = []){
+function remote_get_retry( $url, $args, $retry = 3, $attempts = 0, $response = [] ) {
 	$completed = false;
 
-	if($attempts >= $retry){
+	if ( $attempts >= $retry ) {
 		$completed = true;
 	}
 
-	if( $completed ) return $response;
+	if ( $completed ) { return $response;
+	}
 
 	$attempts++;
 
-	$response = wp_remote_get($url, $args);
+	$response = wp_remote_get( $url, $args );
 
-	$retryResponseCodes = apply_filters( 'pressbooks_remote_get_retry_response_codes', [ 400 ]);
+	$retryResponseCodes = apply_filters( 'pressbooks_remote_get_retry_response_codes', [ 400 ] );
 
-	if( ! is_array($response) || ! in_array( $response['response']['code'], $retryResponseCodes ) ) {
+	if ( ! is_array( $response ) || ! in_array( $response['response']['code'], $retryResponseCodes ) ) {
 		return $response;
 	}
 
-	$sleep = apply_filters( 'pressbooks_remote_get_retry_wait_time', 1000);
-	usleep($sleep);
-	return remote_get_retry($url, $args, $retry, $attempts, $response);
+	$sleep = apply_filters( 'pressbooks_remote_get_retry_wait_time', 1000 );
+	usleep( $sleep );
+	return remote_get_retry( $url, $args, $retry, $attempts, $response );
 }
 
 /**

--- a/tests/test-remote-get-retry.php
+++ b/tests/test-remote-get-retry.php
@@ -1,0 +1,41 @@
+<?php
+
+class Remote_Get_RetryTest extends \WP_UnitTestCase {
+
+    public function setUp(){
+        parent::setUp();
+
+        $i = 0;
+        $mockedResponses = [
+            ['response' => ['code' => 400] ],
+            ['response' => ['code' => 400] ],
+            ['response' => ['code' => 200] ],
+        ];
+
+        add_filter( 'pre_http_request', function ($preempt, $request, $url) use (&$i, $mockedResponses){
+            $preempt = $mockedResponses[$i];
+            $i++;
+            return $preempt;
+        }, 1, 3);
+
+        // disable sleep to speed up tests
+        add_filter( 'pressbooks_remote_get_retry_wait_time', function($sleep) {
+            return 0;
+        });
+    }
+
+
+    public function test_remote_get_retry() {
+
+        $response = \Pressbooks\Utility\remote_get_retry('http://example.com', []);
+
+        $this->assertEquals($response['response']['code'], 200);
+    }
+
+    public function test_remote_get_single_retry() {
+
+        $response = \Pressbooks\Utility\remote_get_retry('http://example.com', [], 1);
+
+        $this->assertEquals($response['response']['code'], 400);
+    }
+}


### PR DESCRIPTION
This adds a generic function to facilitate retrying the fetching of assets. Case in point, if a server is under load, it may freak out and respond with error code 400. This leads to Epub exports that don't pass validation which is a nono. This adds the ability to retry the request after a cooldown.