### PR TITLE
support styled Word (Office Open XML) docs on import

### DIFF
--- a/includes/modules/import/ooxml/class-pb-docx.php
+++ b/includes/modules/import/ooxml/class-pb-docx.php
@@ -49,7 +49,7 @@ class Docx extends Import {
 	const FOOTNOTES_SCHEMA = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/footnotes';
 	const ENDNOTES_SCHEMA = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/endnotes';
 	const HYPERLINK_SCHEMA = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink';
-
+	const STYLESHEET_SCHEMA = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles';
 	/**
 	 *
 	 */
@@ -72,10 +72,12 @@ class Docx extends Import {
 		// get the paths to content
 		$doc_path = $this->getTargetPath( self::DOCUMENT_SCHEMA );
 		$meta_path = $this->getTargetPath( self::METADATA_SCHEMA );
+		$styles_path = $this->getTargetPath( self::STYLESHEET_SCHEMA );
 
 		// get the content
 		$xml = $this->getZipContent( $doc_path );
 		$meta = $this->getZipContent( $meta_path );
+		$styles = $this->getZipContent( $styles_path );
 
 		// get all Footnote IDs from document
 		$fn_ids = $this->getIDs( $xml );
@@ -105,6 +107,9 @@ class Docx extends Import {
 		$xsl = new \DOMDocument();
 		$xsl->load( __DIR__ . '/xsl/docx2html.xsl' );
 		$proc->importStylesheet( $xsl );
+
+		// cram the styles into the main document
+		$xml->documentElement->appendChild( $styles->documentElement );
 
 		// throw it back into the DOM
 		$dom_doc = $proc->transformToDoc( $xml );

--- a/includes/modules/import/ooxml/class-pb-docx.php
+++ b/includes/modules/import/ooxml/class-pb-docx.php
@@ -72,7 +72,7 @@ class Docx extends Import {
 		// get the paths to content
 		$doc_path = $this->getTargetPath( self::DOCUMENT_SCHEMA );
 		$meta_path = $this->getTargetPath( self::METADATA_SCHEMA );
-		$styles_path = $this->getTargetPath( self::STYLESHEET_SCHEMA );
+		$styles_path = $this->getTargetPath( self::STYLESHEET_SCHEMA, true );
 
 		// get the content
 		$xml = $this->getZipContent( $doc_path );
@@ -109,7 +109,7 @@ class Docx extends Import {
 		$proc->importStylesheet( $xsl );
 
 		// cram the styles into the main document
-		$xml->documentElement->appendChild( $styles->documentElement );
+		$xml->documentElement->appendChild( $xml->importNode( $styles->documentElement, true ) );
 
 		// throw it back into the DOM
 		$dom_doc = $proc->transformToDoc( $xml );


### PR DESCRIPTION
Fixes #582.

Small change to PHP sticks the stylesheet into the document for access by the XSLT.

Major changes to the XSLT access named styles for both paragraphs and inline runs. Makes `class` attributes available to custom CSS, and also generates inline CSS directives in the `style` attribute. Notes variant language tagging in the `lang` attribute. Attempts some amount of semantics in inline styles (building on work that was already there for _e.g._ `sup` and `sub`).