### PR TITLE
Removes presumption of superscript for endnote and footnote references

### DIFF
--- a/includes/modules/import/ooxml/xsl/docx2html.xsl
+++ b/includes/modules/import/ooxml/xsl/docx2html.xsl
@@ -3273,12 +3273,12 @@
 
 	      <xsl:choose>
 		      <xsl:when test="ancestor::w:sdtContent/preceding-sibling::w:sdtPr[1]/w:citation">
-			      <xsl:element name="cite">
+			      <cite>
 				      <xsl:apply-templates select="*"/>
-			      </xsl:element>
+			      </cite>
 		      </xsl:when>
 		      <xsl:when test="w:rPr/w:rStyle/@w:val = 'FootnoteReference'">
-				      <xsl:element name="a">
+				      <a>
           <xsl:variable name="fnanchor" select="concat('sdfootnote', w:footnoteReference/@w:id,'anc')"/>
           <xsl:attribute name="name">
             <xsl:value-of select="$fnanchor"/>
@@ -3289,13 +3289,11 @@
 					      <xsl:attribute name="href">
 						      <xsl:value-of select="concat('#sdfootnote', w:footnoteReference/@w:id,'sym')"/>
 					      </xsl:attribute>
-					      <xsl:element name="sup">
-						      <xsl:value-of select="w:footnoteReference/@w:id"/>
-					      </xsl:element>
-				      </xsl:element>
+					      <xsl:value-of select="w:footnoteReference/@w:id"/>
+				      </a>
 		      </xsl:when>
 		      <xsl:when test="w:endnoteReference">
-				      <xsl:element name="a">
+				      <a>
           <xsl:variable name="fnanchor" select="concat('sdfootnote', w:endnoteReference/@w:id,'anc')"/>
           <xsl:attribute name="name">
             <xsl:value-of select="$fnanchor"/>
@@ -3306,10 +3304,8 @@
 					      <xsl:attribute name="href">
 						      <xsl:value-of select="concat('#sdfootnote', w:endnoteReference/@w:id,'sym')"/>
 					      </xsl:attribute>
-					      <xsl:element name="sup">
-						      <xsl:value-of select="w:endnoteReference/@w:id"/>
-					      </xsl:element>
-				      </xsl:element>			      
+					      <xsl:value-of select="w:endnoteReference/@w:id"/>
+				      </a>
 		      </xsl:when>
 		      
 		      <xsl:otherwise>


### PR DESCRIPTION
I separated this out, as it may be more controversial.

Since the Word import now acknowledges inline formatting, when note references are superscript in the document, we end up with:
```html
<sup class="import-EndnoteReference">
  <a name="sdfootnote1anc" id="sdfootnote1anc" href="#sdfootnote1sym">
    <sup>1</sup>
  </a>
</sup>
```
The inner hard-coded `<sup>` is superfluous. I would argue that if the references are _not_ superscripted in the original Word source, that should be honored by the import. (Superscript is the Word default; the user would have had to specifically ask not to superscript the footnote or endnote references to avoid it.)

While I was doing this, I cleaned up some unnecessarily obfuscated use of `<xsl:element>`.