### PR TITLE
fix undefined index error in mpdf theme options

### DIFF
--- a/includes/modules/themeoptions/class-pb-mpdfoptions.php
+++ b/includes/modules/themeoptions/class-pb-mpdfoptions.php
@@ -38,7 +38,7 @@ class MPDFOptions extends \Pressbooks\Options {
 	* @param array $options
 	*/
 	function __construct( array $options ) {
-			$this->options = $options;
+		$this->options = $options;
 		$this->defaults = $this->getDefaults();
 		$this->booleans = $this->getBooleanOptions();
 		$this->integers = $this->getIntegerOptions();
@@ -351,6 +351,7 @@ class MPDFOptions extends \Pressbooks\Options {
 			'mpdf_margin_left' => 15,
 			'mpdf_margin_right' => 30,
 			'mpdf_hyphens' => 0,
+			'mpdf_fontsize' => 0,
 		) );
 	}
 


### PR DESCRIPTION
This change resolves an error 'Undefined index: mpdf_fontsize on line 319'
on the mpdf tab of the theme options area.