### PR TITLE
Allow import as draft content or published content (fixes #593)

### DIFF
--- a/includes/modules/import/class-pb-import.php
+++ b/includes/modules/import/class-pb-import.php
@@ -258,6 +258,9 @@ abstract class Import {
 
 		if ( @$_GET['import'] && is_array( @$_POST['chapters'] ) && is_array( $current_import ) && isset( $current_import['file'] ) && check_admin_referer( 'pb-import' ) ) {
 
+			// Set post status
+			$current_import['default_post_status'] = ( isset( $_POST['import_as_drafts'] ) ) ? 'draft' : 'publish';
+
 			// --------------------------------------------------------------------------------------------------------
 			// Do Import
 
@@ -345,6 +348,7 @@ abstract class Import {
 			}
 
 			$ok = false;
+
 			switch ( $_POST['type_of'] ) {
 
 				case 'wxr':

--- a/includes/modules/import/epub/class-pb-epub201.php
+++ b/includes/modules/import/epub/class-pb-epub201.php
@@ -187,7 +187,7 @@ class Epub201 extends Import {
 			}
 
 			// Insert
-			$this->kneadAndInsert( $href, $this->determinePostType( $id ), $chapter_parent );
+			$this->kneadAndInsert( $href, $this->determinePostType( $id ), $chapter_parent, $current_import['default_post_status'] );
 			++$total;
 		}
 
@@ -283,7 +283,7 @@ class Epub201 extends Import {
 	 * @param string $post_type
 	 * @param int $chapter_parent
 	 */
-	protected function kneadAndInsert( $href, $post_type, $chapter_parent ) {
+	protected function kneadAndInsert( $href, $post_type, $chapter_parent, $post_status ) {
 
 		$html = $this->getZipContent( $href, false );
 
@@ -300,7 +300,7 @@ class Epub201 extends Import {
 			'post_title' => $title,
 			'post_content' => $body,
 			'post_type' => $post_type,
-			'post_status' => 'draft',
+			'post_status' => $post_status,
 		);
 
 		if ( 'chapter' == $post_type ) {

--- a/includes/modules/import/html/class-pb-xhtml.php
+++ b/includes/modules/import/html/class-pb-xhtml.php
@@ -46,7 +46,7 @@ class Xhtml extends Import {
 		$post_type = $this->determinePostType( $id[0] );
 		$chapter_parent = $this->getChapterParent();
 
-		$body = $this->kneadandInsert( $html['body'], $post_type, $chapter_parent, $domain );
+		$body = $this->kneadandInsert( $html['body'], $post_type, $chapter_parent, $domain, $current_import['default_post_status'] );
 
 		// Done
 		return $this->revokeCurrentImport();
@@ -60,7 +60,7 @@ class Xhtml extends Import {
 	 * @param int $chapter_parent
 	 * @param string $domain domain name of the webpage
 	 */
-	function kneadandInsert( $html, $post_type, $chapter_parent, $domain ) {
+	function kneadandInsert( $html, $post_type, $chapter_parent, $domain, $post_status ) {
 		$matches = array();
 
 		$meta = $this->getLicenseAttribution( $html );
@@ -91,7 +91,7 @@ class Xhtml extends Import {
 		    'post_title' => $title,
 		    'post_content' => $body,
 		    'post_type' => $post_type,
-		    'post_status' => 'draft',
+		    'post_status' => $post_status,
 		);
 
 		if ( 'chapter' == $post_type ) {

--- a/includes/modules/import/odf/class-pb-odt.php
+++ b/includes/modules/import/odf/class-pb-odt.php
@@ -74,7 +74,7 @@ class Odt extends Import {
 			}
 
 			$html = $this->parseContent( $dom_doc, $chapter_title );
-			$this->kneadAndInsert( $html, $chapter_title, $this->determinePostType( $id ), $chapter_parent );
+			$this->kneadAndInsert( $html, $chapter_title, $this->determinePostType( $id ), $chapter_parent, $current_import['default_post_status'] );
 		}
 
 		// Done
@@ -104,7 +104,7 @@ class Odt extends Import {
 	 * @param string $post_type (front-matter', 'chapter', 'back-matter')
 	 * @param int $chapter_parent
 	 */
-	protected function kneadAndInsert( $html, $title, $post_type, $chapter_parent ) {
+	protected function kneadAndInsert( $html, $title, $post_type, $chapter_parent, $post_status ) {
 
 		$body = $this->tidy( $html );
 		$body = $this->kneadHTML( $body );
@@ -115,7 +115,7 @@ class Odt extends Import {
 			'post_title' => $title,
 			'post_content' => $body,
 			'post_type' => $post_type,
-			'post_status' => 'draft',
+			'post_status' => $post_status,
 		);
 
 		if ( 'chapter' == $post_type ) {

--- a/includes/modules/import/ooxml/class-pb-docx.php
+++ b/includes/modules/import/ooxml/class-pb-docx.php
@@ -126,7 +126,7 @@ class Docx extends Import {
 			}
 
 			$html = $this->parseContent( $dom_doc, $chapter_title );
-			$this->kneadAndInsert( $html, $chapter_title, $this->determinePostType( $id ), $chapter_parent );
+			$this->kneadAndInsert( $html, $chapter_title, $this->determinePostType( $id ), $chapter_parent, $current_import['default_post_status'] );
 		}
 		// Done
 		return $this->revokeCurrentImport();
@@ -227,7 +227,7 @@ class Docx extends Import {
 	 * @param string $post_type (front-matter', 'chapter', 'back-matter')
 	 * @param int $chapter_parent
 	 */
-	protected function kneadAndInsert( $html, $title, $post_type, $chapter_parent ) {
+	protected function kneadAndInsert( $html, $title, $post_type, $chapter_parent, $post_status ) {
 
 		$body = $this->tidy( $html );
 		$body = $this->kneadHTML( $body );
@@ -238,7 +238,7 @@ class Docx extends Import {
 		    'post_title' => $title,
 		    'post_content' => $body,
 		    'post_type' => $post_type,
-		    'post_status' => 'draft',
+		    'post_status' => $post_status,
 		);
 
 		if ( 'chapter' == $post_type ) {

--- a/includes/modules/import/wordpress/class-pb-wxr.php
+++ b/includes/modules/import/wordpress/class-pb-wxr.php
@@ -168,7 +168,7 @@ class Wxr extends Import {
 			if ( 'metadata' == $post_type ) {
 				$pid = $this->bookInfoPid();
 			} else {
-				$pid = $this->insertNewPost( $post_type, $p, $html, $chapter_parent );
+				$pid = $this->insertNewPost( $post_type, $p, $html, $chapter_parent, $current_import['default_post_status'] );
 				if ( 'part' == $post_type ) {
 					$chapter_parent = $pid;
 				}
@@ -340,14 +340,14 @@ class Wxr extends Import {
 	 *
 	 * @return int Post ID
 	 */
-	protected function insertNewPost( $post_type, $p, $html, $chapter_parent ) {
+	protected function insertNewPost( $post_type, $p, $html, $chapter_parent, $post_status ) {
 
 		$custom_post_types = apply_filters( 'pb_import_custom_post_types', array() );
 
 		$new_post = array(
 			'post_title' => wp_strip_all_tags( $p['post_title'] ),
 			'post_type' => $post_type,
-			'post_status' => ( 'part' == $post_type || in_array( $post_type, $custom_post_types ) ) ? 'publish' : 'draft',
+			'post_status' => ( 'part' == $post_type ) ? 'publish' : $post_status,
 		);
 
 		if ( 'part' != $post_type ) {

--- a/templates/admin/import.php
+++ b/templates/admin/import.php
@@ -113,6 +113,8 @@ $import_option_types = apply_filters( 'pb_select_import_type', array(
 			</tbody>
 		</table>
 
+		<p><input type='checkbox' id='import_as_drafts' name='import_as_drafts' value='1' checked><label for="import_as_drafts"> <?php _e( 'Import as drafts', 'pressbooks' ); ?></label></p>
+
 		<p><?php
 			submit_button( __( 'Import Selection', 'pressbooks' ), 'primary', 'submit', false );
 			echo ' &nbsp; ';


### PR DESCRIPTION
This PR adds a checkbox on the import content selection screen (checked by default) to determine whether content is imported with draft or published status.

![screen shot 2017-01-03 at 3 34 06 pm](https://cloud.githubusercontent.com/assets/605361/21620316/183f0b50-d1ca-11e6-8552-700f895a70e2.png)
