### PR TITLE
Add full support for custom theme options (closes #470)

### DIFF
--- a/includes/admin/class-pb-network-sharingandprivacyoptions.php
+++ b/includes/admin/class-pb-network-sharingandprivacyoptions.php
@@ -34,7 +34,7 @@ class SharingAndPrivacyOptions extends \Pressbooks\Options {
 	* @param array $options
 	*/
 	function __construct( array $options ) {
-			$this->options = $options;
+		$this->options = $options;
 		$this->defaults = $this->getDefaults();
 		$this->booleans = $this->getBooleanOptions();
 

--- a/includes/class-pb-options.php
+++ b/includes/class-pb-options.php
@@ -153,7 +153,7 @@ abstract class Options {
 	 * @param string $size
 	 * @param bool $disabled
 	 */
-	protected function renderField( $id, $name, $option, $value = '', $description = '', $append = '', $type = 'text', $class = 'regular-text', $disabled = false ) {
+	static function renderField( $id, $name, $option, $value = '', $description = '', $append = '', $type = 'text', $class = 'regular-text', $disabled = false ) {
 		printf(
 			'<input id="%s" class="%s" name="%s[%s]" type="%s" value="%s" %s/>',
 			$id,
@@ -182,7 +182,7 @@ abstract class Options {
 	 * @param string $value
 	 * @param string $description
 	 */
-	protected function renderCheckbox( $id, $name, $option, $value = '', $description ) {
+	static function renderCheckbox( $id, $name, $option, $value = '', $description ) {
 		printf(
 			'<input id="%s" name="%s[%s]" type="checkbox" value="1" %s/><label for="%s">%s</label>',
 			$id,
@@ -204,7 +204,7 @@ abstract class Options {
 	 * @param string $args
 	 * @param bool $custom
 	 */
-	protected function renderRadioButtons( $id, $name, $option, $value = '', $args, $custom = false ) {
+	static function renderRadioButtons( $id, $name, $option, $value = '', $args, $custom = false ) {
 		$is_custom = false;
 		if ( ! array_key_exists( $value, $args ) ) {
 			$is_custom = true;
@@ -233,7 +233,7 @@ abstract class Options {
 	 * @param string $args
 	 * @param boolean $multiple
 	 */
-	protected function renderSelect( $id, $name, $option, $value = '', $args, $multiple = false ) {
+	static function renderSelect( $id, $name, $option, $value = '', $args, $multiple = false ) {
 		$options = '';
 		foreach ( $args as $key => $label ) {
 			$options .= sprintf(
@@ -262,7 +262,7 @@ abstract class Options {
 	 * @param string $args
 	 * @param boolean $multiple
 	 */
-	protected function renderCustomSelect( $id, $name, $value = '', $args, $multiple = false ) {
+	static function renderCustomSelect( $id, $name, $value = '', $args, $multiple = false ) {
 		$is_custom = false;
 		if ( ! array_key_exists( $value, $args ) ) {
 			$is_custom = true;

--- a/includes/class-pb-options.php
+++ b/includes/class-pb-options.php
@@ -141,100 +141,117 @@ abstract class Options {
 	}
 
 	/**
-	* Render an input.
-	*
-	* @param string $id
-	* @param string $name
+	 * Render an input.
+	 *
+	 * @param string $id
+	 * @param string $name
 	 * @param string $option
-	* @param string $value
+	 * @param string $value
 	 * @param string $description
 	 * @param string $append
 	 * @param string $type
 	 * @param string $size
 	 * @param bool $disabled
-	*/
+	 */
 	protected function renderField( $id, $name, $option, $value = '', $description = '', $append = '', $type = 'text', $class = 'regular-text', $disabled = false ) {
-	?>
-		<input id="<?php echo $id;
-?>" class="<?php echo $class;
-?>" name="<?php echo $name;
-?>[<?php echo $option;
-?>]" type="<?php echo $type;
-?>" value="<?php echo $value; ?>" <?php if ( $disabled ) : ?> disabled<?php endif; ?>/><?php if ( $append ) : ?> <?php echo $append; ?><?php endif; ?>
-			<?php if ( $description ) : ?><p class="description"><?php echo $description; ?><?php endif; ?>
-		<?php }
+		printf(
+			'<input id="%s" class="%s" name="%s[%s]" type="%s" value="%s" %s/>',
+			$id,
+			$class,
+			$name,
+			$option,
+			$type,
+			$value,
+			( $disabled ) ? ' disabled' : ''
+		);
+		if ( $append ) {
+			echo ' ' . $append;
+		}
+		printf(
+			'<p class="description">%s</p>',
+			$description
+		);
+	}
 
 	/**
-	* Render a checkbox.
-	*
-	* @param string $id
-	* @param string $name
+	 * Render a checkbox.
+	 *
+	 * @param string $id
+	 * @param string $name
 	 * @param string $option
-	* @param string $value
+	 * @param string $value
 	 * @param string $description
-	*/
+	 */
 	protected function renderCheckbox( $id, $name, $option, $value = '', $description ) {
-	?>
-		<input id="<?php echo $id;
-?>" name="<?php echo $name;
-?>[<?php echo $option;
-?>]" type="checkbox" value="1" <?php echo checked( 1, $value, false ); ?>/>
-		<label for="<?php echo $id;
-?>"><?php echo $description; ?></label>
-	<?php }
+		printf(
+			'<input id="%s" name="%s[%s]" type="checkbox" value="1" %s/><label for="%s">%s</label>',
+			$id,
+			$name,
+			$option,
+			checked( 1, $value, false ),
+			$id,
+			$description
+		);
+	}
 
 	/**
-	* Render radio buttons.
-	*
-	* @param string $id
-	* @param string $name
+	 * Render radio buttons.
+	 *
+	 * @param string $id
+	 * @param string $name
 	 * @param string $option
-	* @param string $value
+	 * @param string $value
 	 * @param string $args
 	 * @param bool $custom
-	*/
+	 */
 	protected function renderRadioButtons( $id, $name, $option, $value = '', $args, $custom = false ) {
 		$is_custom = false;
 		if ( ! array_key_exists( $value, $args ) ) {
 			$is_custom = true;
 		}
-		foreach ( $args as $key => $label ) { ?>
-			<label for="<?php echo $id . '_' . sanitize_key( $key ); ?>">
-				<input type="radio" id="<?php echo $id . '_' . sanitize_key( $key );
-?>" name="<?php echo $name;
-?>[<?php echo $option;
-?>]" value="<?php echo $key; ?>" <?php if ( $custom && $is_custom ) {
-	if ( '' == $key ) {
-		echo('checked');
-	}
-} else {
-	checked( $key, $value );
-} ?>/><?php echo $label; ?>
-			</label><br />
-		<?php }
+		foreach ( $args as $key => $label ) {
+			printf(
+				'<label for="%s"><input type="radio" id="%s" name="%s[%s]" value="%s" %s/>%s</label><br />',
+				$id . '_' . sanitize_key( $key ),
+				$id . '_' . sanitize_key( $key ),
+				$name,
+				$option,
+				$key,
+				( $custom && $is_custom && '' == $key ) ? 'checked' : checked( $key, $value, false ),
+				$label
+			);
+		}
 	}
 
 	/**
-	* Render a select element.
-	*
-	* @param string $id
-	* @param string $name
+	 * Render a select element.
+	 *
+	 * @param string $id
+	 * @param string $name
 	 * @param string $option
-	* @param string $value
+	 * @param string $value
 	 * @param string $args
 	 * @param boolean $multiple
-	*/
+	 */
 	protected function renderSelect( $id, $name, $option, $value = '', $args, $multiple = false ) {
-	?>
-		<select name='<?php echo $name;
-?>[<?php echo $option;
-?>]' id='<?php echo $id; ?>'<?php if ( $multiple ) : ?>multiple<?php endif; ?>>
-		<?php foreach ( $args as $key => $label ) { ?>
-			<option value='<?php echo $key; ?>' <?php selected( $key, $value );
-?>><?php echo $label; ?></option>
-		<?php } ?>
-		</select>
-	<?php }
+		$options = '';
+		foreach ( $args as $key => $label ) {
+			$options .= sprintf(
+				'<option value="%s" %s>%s</option>',
+				$key,
+				selected( $key, $value, false ),
+				$label
+			);
+		}
+		printf(
+			'<select name="%s[%s]" id="%s"%s>%s</select>',
+			$name,
+			$option,
+			$id,
+			( $multiple ) ? ' multiple' : '',
+			$options
+		);
+	}
 
 	/**
 	 * Render a custom select element.
@@ -249,16 +266,22 @@ abstract class Options {
 		$is_custom = false;
 		if ( ! array_key_exists( $value, $args ) ) {
 			$is_custom = true;
-		} ?>
-		<select name='<?php echo $name; ?>' id='<?php echo $id; ?>'>
-		<?php foreach ( $args as $key => $label ) { ?>
-			<option value='<?php echo $key; ?>' <?php
-			if ( '' == $key && $is_custom ) {
-				echo 'selected';
-			} else {
-				selected( $key, $value );
-			} ?>><?php echo $label; ?></option>
-		<?php } ?>
-		</select><br />
-	<?php }
+		}
+		$options = '';
+		foreach ( $args as $key => $label ) {
+			$options .= sprintf(
+				'<option value="%s" %s>%s</option>',
+				$key,
+				( '' == $key && $is_custom ) ? ' selected' : selected( $key, $value, false ),
+				$label
+			);
+		}
+		printf(
+			'<select name="%s" id="%s"%s>%s</select><br />',
+			$name,
+			$id,
+			( $multiple ) ? ' multiple' : '',
+			$options
+		);
+	}
 }

--- a/includes/modules/themeoptions/class-pb-ebookoptions.php
+++ b/includes/modules/themeoptions/class-pb-ebookoptions.php
@@ -91,6 +91,13 @@ class EbookOptions extends \Pressbooks\Options {
 			)
 		);
 
+		/**
+		 * Add custom settings fields.
+		 *
+		 * @since 3.9.7
+		 */
+		do_action( 'pb_theme_options_ebook_add_settings_fields', $_page, $_section );
+
 		register_setting(
 			$_option,
 			$_option,

--- a/includes/modules/themeoptions/class-pb-ebookoptions.php
+++ b/includes/modules/themeoptions/class-pb-ebookoptions.php
@@ -203,7 +203,9 @@ class EbookOptions extends \Pressbooks\Options {
 	 */
 	static function getBooleanOptions() {
 		/**
-		 * @since 3.9.7 TODO
+		 * Allow custom boolean options to be passed to sanitization routines.
+		 *
+		 * @since 3.9.7
 		 */
 		return apply_filters( 'pb_theme_options_ebook_booleans', array(
 			'ebook_compress_images'
@@ -217,7 +219,9 @@ class EbookOptions extends \Pressbooks\Options {
 	 */
 	static function getStringOptions() {
 		/**
-		 * @since 3.9.7 TODO
+		 * Allow custom string options to be passed to sanitization routines.
+		 *
+		 * @since 3.9.7
 		 */
 		return apply_filters( 'pb_theme_options_ebook_strings', array() );
 	}
@@ -229,7 +233,9 @@ class EbookOptions extends \Pressbooks\Options {
 	 */
 	static function getIntegerOptions() {
 		/**
-		 * @since 3.9.7 TODO
+		 * Allow custom integer options to be passed to sanitization routines.
+		 *
+		 * @since 3.9.7
 		 */
 		return apply_filters( 'pb_theme_options_ebook_integers', array() );
 	}
@@ -241,7 +247,9 @@ class EbookOptions extends \Pressbooks\Options {
 	 */
 	static function getFloatOptions() {
 		/**
-		 * @since 3.9.7 TODO
+		 * Allow custom float options to be passed to sanitization routines.
+		 *
+		 * @since 3.9.7
 		 */
 		return apply_filters( 'pb_theme_options_ebook_floats', array() );
 	}
@@ -253,7 +261,9 @@ class EbookOptions extends \Pressbooks\Options {
 	 */
 	static function getPredefinedOptions() {
 		/**
-		 * @since 3.9.7 TODO
+		 * Allow custom predifined options to be passed to sanitization routines.
+		 *
+		 * @since 3.9.7
 		 */
 		return apply_filters( 'pb_theme_options_ebook_predefined', array(
 			'ebook_paragraph_separation'

--- a/includes/modules/themeoptions/class-pb-ebookoptions.php
+++ b/includes/modules/themeoptions/class-pb-ebookoptions.php
@@ -35,9 +35,12 @@ class EbookOptions extends \Pressbooks\Options {
 	* @param array $options
 	*/
 	function __construct( array $options ) {
-			$this->options = $options;
+		$this->options = $options;
 		$this->defaults = $this->getDefaults();
 		$this->booleans = $this->getBooleanOptions();
+		$this->strings = $this->getStringOptions();
+		$this->integers = $this->getIntegerOptions();
+		$this->floats = $this->getFloatOptions();
 		$this->predefined = $this->getPredefinedOptions();
 
 		foreach ( $this->defaults as $key => $value ) {
@@ -174,7 +177,10 @@ class EbookOptions extends \Pressbooks\Options {
 	 * @return array $defaults
 	 */
 	static function getDefaults() {
-		return apply_filters( 'pressbooks_theme_options_ebook_defaults', array(
+		/**
+		 * @since 3.9.7 TODO
+		 */
+		return apply_filters( 'pb_theme_options_ebook_defaults', array(
 			'ebook_paragraph_separation' => 'indent',
 			'ebook_compress_images' => 0,
 		) );
@@ -196,9 +202,48 @@ class EbookOptions extends \Pressbooks\Options {
 	 * @return array $options
 	 */
 	static function getBooleanOptions() {
-		return array(
+		/**
+		 * @since 3.9.7 TODO
+		 */
+		return apply_filters( 'pb_theme_options_ebook_booleans', array(
 			'ebook_compress_images'
-		);
+		) );
+	}
+
+	/**
+	 * Get an array of options which return strings.
+	 *
+	 * @return array $options
+	 */
+	static function getStringOptions() {
+		/**
+		 * @since 3.9.7 TODO
+		 */
+		return apply_filters( 'pb_theme_options_ebook_strings', array() );
+	}
+
+	/**
+	 * Get an array of options which return integers.
+	 *
+	 * @return array $options
+	 */
+	static function getIntegerOptions() {
+		/**
+		 * @since 3.9.7 TODO
+		 */
+		return apply_filters( 'pb_theme_options_ebook_integers', array() );
+	}
+
+	/**
+	 * Get an array of options which return floats.
+	 *
+	 * @return array $options
+	 */
+	static function getFloatOptions() {
+		/**
+		 * @since 3.9.7 TODO
+		 */
+		return apply_filters( 'pb_theme_options_ebook_floats', array() );
 	}
 
 	/**
@@ -207,8 +252,11 @@ class EbookOptions extends \Pressbooks\Options {
 	 * @return array $options
 	 */
 	static function getPredefinedOptions() {
-		return array(
+		/**
+		 * @since 3.9.7 TODO
+		 */
+		return apply_filters( 'pb_theme_options_ebook_predefined', array(
 			'ebook_paragraph_separation'
-		);
+		) );
 	}
 }

--- a/includes/modules/themeoptions/class-pb-globaloptions.php
+++ b/includes/modules/themeoptions/class-pb-globaloptions.php
@@ -37,9 +37,13 @@ class GlobalOptions extends \Pressbooks\Options {
 	* @param array $options
 	*/
 	function __construct( array $options ) {
-			$this->options = $options;
+		$this->options = $options;
 		$this->defaults = $this->getDefaults();
 		$this->booleans = $this->getBooleanOptions();
+		$this->strings = $this->getStringOptions();
+		$this->integers = $this->getIntegerOptions();
+		$this->floats = $this->getFloatOptions();
+		$this->predefined = $this->getPredefinedOptions();
 
 		foreach ( $this->defaults as $key => $value ) {
 			if ( ! isset( $this->options[ $key ] ) ) {
@@ -283,7 +287,10 @@ class GlobalOptions extends \Pressbooks\Options {
 	 * @return array $defaults
 	 */
 	static function getDefaults() {
-		return apply_filters( 'pressbooks_theme_options_global_defaults', array(
+		/**
+		 * @since 3.9.7 TODO
+		 */
+		return apply_filters( 'pb_theme_options_global_defaults', array(
 			'chapter_numbers' => 1,
 			'parse_subsections' => 0,
 			'copyright_license' => 0,
@@ -306,11 +313,50 @@ class GlobalOptions extends \Pressbooks\Options {
 	 * @return array $options
 	 */
 	static function getBooleanOptions() {
-		return array(
+		/**
+		 * @since 3.9.7 TODO
+		 */
+		return apply_filters( 'pb_theme_options_global_booleans', array(
 			'chapter_numbers',
 			'parse_subsections',
 			'copyright_license',
-		);
+		) );
+	}
+
+	/**
+	 * Get an array of options which return strings.
+	 *
+	 * @return array $options
+	 */
+	static function getStringOptions() {
+		/**
+		 * @since 3.9.7 TODO
+		 */
+		return apply_filters( 'pb_theme_options_global_strings', array() );
+	}
+
+	/**
+	 * Get an array of options which return integers.
+	 *
+	 * @return array $options
+	 */
+	static function getIntegerOptions() {
+		/**
+		 * @since 3.9.7 TODO
+		 */
+		return apply_filters( 'pb_theme_options_global_integers', array() );
+	}
+
+	/**
+	 * Get an array of options which return floats.
+	 *
+	 * @return array $options
+	 */
+	static function getFloatOptions() {
+		/**
+		 * @since 3.9.7 TODO
+		 */
+		return apply_filters( 'pb_theme_options_global_floats', array() );
 	}
 
 	/**
@@ -319,6 +365,9 @@ class GlobalOptions extends \Pressbooks\Options {
 	 * @return array $options
 	 */
 	static function getPredefinedOptions() {
-		return array();
+		/**
+		 * @since 3.9.7 TODO
+		 */
+		return apply_filters( 'pb_theme_options_global_predefined', array() );
 	}
 }

--- a/includes/modules/themeoptions/class-pb-globaloptions.php
+++ b/includes/modules/themeoptions/class-pb-globaloptions.php
@@ -314,7 +314,9 @@ class GlobalOptions extends \Pressbooks\Options {
 	 */
 	static function getBooleanOptions() {
 		/**
-		 * @since 3.9.7 TODO
+		 * Allow custom boolean options to be passed to sanitization routines.
+		 *
+		 * @since 3.9.7
 		 */
 		return apply_filters( 'pb_theme_options_global_booleans', array(
 			'chapter_numbers',
@@ -330,7 +332,9 @@ class GlobalOptions extends \Pressbooks\Options {
 	 */
 	static function getStringOptions() {
 		/**
-		 * @since 3.9.7 TODO
+		 * Allow custom string options to be passed to sanitization routines.
+		 *
+		 * @since 3.9.7
 		 */
 		return apply_filters( 'pb_theme_options_global_strings', array() );
 	}
@@ -342,7 +346,9 @@ class GlobalOptions extends \Pressbooks\Options {
 	 */
 	static function getIntegerOptions() {
 		/**
-		 * @since 3.9.7 TODO
+		 * Allow custom integer options to be passed to sanitization routines.
+		 *
+		 * @since 3.9.7
 		 */
 		return apply_filters( 'pb_theme_options_global_integers', array() );
 	}
@@ -354,7 +360,9 @@ class GlobalOptions extends \Pressbooks\Options {
 	 */
 	static function getFloatOptions() {
 		/**
-		 * @since 3.9.7 TODO
+		 * Allow custom float options to be passed to sanitization routines.
+		 *
+		 * @since 3.9.7
 		 */
 		return apply_filters( 'pb_theme_options_global_floats', array() );
 	}
@@ -366,7 +374,9 @@ class GlobalOptions extends \Pressbooks\Options {
 	 */
 	static function getPredefinedOptions() {
 		/**
-		 * @since 3.9.7 TODO
+		 * Allow custom predifined options to be passed to sanitization routines.
+		 *
+		 * @since 3.9.7
 		 */
 		return apply_filters( 'pb_theme_options_global_predefined', array() );
 	}

--- a/includes/modules/themeoptions/class-pb-globaloptions.php
+++ b/includes/modules/themeoptions/class-pb-globaloptions.php
@@ -124,6 +124,13 @@ class GlobalOptions extends \Pressbooks\Options {
 			)
 		);
 
+		/**
+		 * Add custom settings fields.
+		 *
+		 * @since 3.9.7
+		 */
+		do_action( 'pb_theme_options_global_add_settings_fields', $_page, $_section );
+
 		register_setting(
 			$_page,
 			$_option,

--- a/includes/modules/themeoptions/class-pb-mpdfoptions.php
+++ b/includes/modules/themeoptions/class-pb-mpdfoptions.php
@@ -222,6 +222,13 @@ class MPDFOptions extends \Pressbooks\Options {
 			)
 		);
 
+		/**
+		 * Add custom settings fields.
+		 *
+		 * @since 3.9.7
+		 */
+		do_action( 'pb_theme_options_mpdf_add_settings_fields', $_page, $_section );
+
 		register_setting(
 			$_option,
 			$_option,

--- a/includes/modules/themeoptions/class-pb-mpdfoptions.php
+++ b/includes/modules/themeoptions/class-pb-mpdfoptions.php
@@ -377,7 +377,9 @@ class MPDFOptions extends \Pressbooks\Options {
 	 */
 	static function getBooleanOptions() {
 		/**
-		 * @since 3.9.7 TODO
+		 * Allow custom boolean options to be passed to sanitization routines.
+		 *
+		 * @since 3.9.7
 		 */
 		return apply_filters( 'pb_theme_options_mpdf_booleans', array(
 			'mpdf_mirror_margins',
@@ -396,7 +398,9 @@ class MPDFOptions extends \Pressbooks\Options {
 	 */
 	static function getStringOptions() {
 		/**
-		 * @since 3.9.7 TODO
+		 * Allow custom string options to be passed to sanitization routines.
+		 *
+		 * @since 3.9.7
 		 */
 		return apply_filters( 'pb_theme_options_mpdf_strings', array() );
 	}
@@ -408,7 +412,9 @@ class MPDFOptions extends \Pressbooks\Options {
 	 */
 	static function getIntegerOptions() {
 		/**
-		 * @since 3.9.7 TODO
+		 * Allow custom integer options to be passed to sanitization routines.
+		 *
+		 * @since 3.9.7
 		 */
 		return apply_filters( 'pb_theme_options_mpdf_integers', array(
 			'mpdf_left_margin',
@@ -423,7 +429,9 @@ class MPDFOptions extends \Pressbooks\Options {
 	 */
 	static function getFloatOptions() {
 		/**
-		 * @since 3.9.7 TODO
+		 * Allow custom float options to be passed to sanitization routines.
+		 *
+		 * @since 3.9.7
 		 */
 		return apply_filters( 'pb_theme_options_mpdf_floats', array() );
 	}
@@ -435,7 +443,9 @@ class MPDFOptions extends \Pressbooks\Options {
 	 */
 	static function getPredefinedOptions() {
 		/**
-		 * @since 3.9.7 TODO
+		 * Allow custom predifined options to be passed to sanitization routines.
+		 *
+		 * @since 3.9.7
 		 */
 		return apply_filters( 'pb_theme_options_mpdf_predefined', array(
 			'mpdf_page_size'

--- a/includes/modules/themeoptions/class-pb-mpdfoptions.php
+++ b/includes/modules/themeoptions/class-pb-mpdfoptions.php
@@ -41,7 +41,9 @@ class MPDFOptions extends \Pressbooks\Options {
 		$this->options = $options;
 		$this->defaults = $this->getDefaults();
 		$this->booleans = $this->getBooleanOptions();
+		$this->strings = $this->getStringOptions();
 		$this->integers = $this->getIntegerOptions();
+		$this->floats = $this->getFloatOptions();
 		$this->predefined = $this->getPredefinedOptions();
 
 		foreach ( $this->defaults as $key => $value ) {
@@ -342,7 +344,10 @@ class MPDFOptions extends \Pressbooks\Options {
 	 * @return array $defaults
 	 */
 	static function getDefaults() {
-		return apply_filters( 'pressbooks_theme_options_mpdf_defaults', array(
+		/**
+		 * @since 3.9.7 TODO
+		 */
+		return apply_filters( 'pb_theme_options_mpdf_defaults', array(
 			'mpdf_page_size' => 'Letter',
 			'mpdf_include_cover' => 1,
 			'mpdf_indent_paragraphs' => 0,
@@ -371,14 +376,29 @@ class MPDFOptions extends \Pressbooks\Options {
 	 * @return array $options
 	 */
 	static function getBooleanOptions() {
-		return array(
+		/**
+		 * @since 3.9.7 TODO
+		 */
+		return apply_filters( 'pb_theme_options_mpdf_booleans', array(
 			'mpdf_mirror_margins',
 			'mpdf_include_cover',
 			'mpdf_include_toc',
 			'mpdf_indent_paragraphs',
 			'mpdf_hyphens',
 			'mpdf_fontsize',
-		);
+		) );
+	}
+
+	/**
+	 * Get an array of options which return strings.
+	 *
+	 * @return array $options
+	 */
+	static function getStringOptions() {
+		/**
+		 * @since 3.9.7 TODO
+		 */
+		return apply_filters( 'pb_theme_options_mpdf_strings', array() );
 	}
 
 	/**
@@ -387,10 +407,25 @@ class MPDFOptions extends \Pressbooks\Options {
 	 * @return array $options
 	 */
 	static function getIntegerOptions() {
-		return array(
+		/**
+		 * @since 3.9.7 TODO
+		 */
+		return apply_filters( 'pb_theme_options_mpdf_integers', array(
 			'mpdf_left_margin',
 			'mpdf_right_margin',
-		);
+		) );
+	}
+
+	/**
+	 * Get an array of options which return floats.
+	 *
+	 * @return array $options
+	 */
+	static function getFloatOptions() {
+		/**
+		 * @since 3.9.7 TODO
+		 */
+		return apply_filters( 'pb_theme_options_mpdf_floats', array() );
 	}
 
 	/**
@@ -399,8 +434,11 @@ class MPDFOptions extends \Pressbooks\Options {
 	 * @return array $options
 	 */
 	static function getPredefinedOptions() {
-		return array(
+		/**
+		 * @since 3.9.7 TODO
+		 */
+		return apply_filters( 'pb_theme_options_mpdf_predefined', array(
 			'mpdf_page_size'
-		);
+		) );
 	}
 }

--- a/includes/modules/themeoptions/class-pb-pdfoptions.php
+++ b/includes/modules/themeoptions/class-pb-pdfoptions.php
@@ -1034,7 +1034,9 @@ class PDFOptions extends \Pressbooks\Options {
 	 */
 	static function getBooleanOptions() {
 		/**
-		 * @since 3.9.7 TODO
+		 * Allow custom boolean options to be passed to sanitization routines.
+		 *
+		 * @since 3.9.7
 		 */
 		return apply_filters( 'pb_theme_options_pdf_booleans', array(
 			'pdf_hyphens',
@@ -1052,7 +1054,9 @@ class PDFOptions extends \Pressbooks\Options {
 	 */
 	static function getStringOptions() {
 		/**
-		 * @since 3.9.7 TODO
+		 * Allow custom string options to be passed to sanitization routines.
+		 *
+		 * @since 3.9.7
 		 */
 		return apply_filters( 'pb_theme_options_pdf_strings', array(
 			'pdf_page_width',
@@ -1081,7 +1085,9 @@ class PDFOptions extends \Pressbooks\Options {
 	 */
 	static function getIntegerOptions() {
 		/**
-		 * @since 3.9.7 TODO
+		 * Allow custom integer options to be passed to sanitization routines.
+		 *
+		 * @since 3.9.7
 		 */
 		return apply_filters( 'pb_theme_options_pdf_integers', array(
 			'pdf_body_font_size',
@@ -1097,7 +1103,9 @@ class PDFOptions extends \Pressbooks\Options {
 	 */
 	static function getFloatOptions() {
 		/**
-		 * @since 3.9.7 TODO
+		 * Allow custom float options to be passed to sanitization routines.
+		 *
+		 * @since 3.9.7
 		 */
 		return apply_filters( 'pb_theme_options_pdf_floats', array(
 			'pdf_body_line_height'
@@ -1111,7 +1119,9 @@ class PDFOptions extends \Pressbooks\Options {
 	 */
 	static function getPredefinedOptions() {
 		/**
-		 * @since 3.9.7 TODO
+		 * Allow custom predifined options to be passed to sanitization routines.
+		 *
+		 * @since 3.9.7
 		 */
 		return apply_filters( 'pb_theme_options_pdf_predefined', array(
 			'pdf_paragraph_separation',

--- a/includes/modules/themeoptions/class-pb-pdfoptions.php
+++ b/includes/modules/themeoptions/class-pb-pdfoptions.php
@@ -514,6 +514,13 @@ class PDFOptions extends \Pressbooks\Options {
 			);
 		}
 
+		/**
+		 * Add custom settings fields.
+		 *
+		 * @since 3.9.7
+		 */
+		do_action( 'pb_theme_options_pdf_add_settings_fields', $_page, $_section );
+
 		register_setting(
 			$_option,
 			$_option,

--- a/includes/modules/themeoptions/class-pb-pdfoptions.php
+++ b/includes/modules/themeoptions/class-pb-pdfoptions.php
@@ -38,7 +38,7 @@ class PDFOptions extends \Pressbooks\Options {
 	* @param array $options
 	*/
 	function __construct( array $options ) {
-			$this->options = $options;
+		$this->options = $options;
 		$this->defaults = $this->getDefaults();
 		$this->booleans = $this->getBooleanOptions();
 		$this->strings = $this->getStringOptions();
@@ -981,7 +981,10 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @return array $defaults
 	 */
 	static function getDefaults() {
-		return apply_filters( 'pressbooks_theme_options_pdf_defaults', array(
+		/**
+		 * @since 3.9.7 TODO
+		 */
+		return apply_filters( 'pb_theme_options_pdf_defaults', array(
 			'pdf_body_font_size' => '11',
 			'pdf_body_line_height' => '1.4',
 			'pdf_page_width' => '5.5in',
@@ -1030,13 +1033,16 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @return array $options
 	 */
 	static function getBooleanOptions() {
-		return array(
+		/**
+		 * @since 3.9.7 TODO
+		 */
+		return apply_filters( 'pb_theme_options_pdf_booleans', array(
 			'pdf_hyphens',
 			'pdf_toc',
 			'pdf_crop_marks',
 			'pdf_romanize_parts',
 			'pdf_fontsize',
-		);
+		) );
 	}
 
 	/**
@@ -1045,7 +1051,10 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @return array $options
 	 */
 	static function getStringOptions() {
-		return array(
+		/**
+		 * @since 3.9.7 TODO
+		 */
+		return apply_filters( 'pb_theme_options_pdf_strings', array(
 			'pdf_page_width',
 			'pdf_page_height',
 			'pdf_page_margin_outside',
@@ -1062,7 +1071,7 @@ class PDFOptions extends \Pressbooks\Options {
 			'running_content_chapter_right',
 			'running_content_back_matter_left',
 			'running_content_back_matter_right',
-		);
+		) );
 	}
 
 	/**
@@ -1071,11 +1080,14 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @return array $options
 	 */
 	static function getIntegerOptions() {
-		return array(
+		/**
+		 * @since 3.9.7 TODO
+		 */
+		return apply_filters( 'pb_theme_options_pdf_integers', array(
 			'pdf_body_font_size',
 			'widows',
 			'orphans',
-		);
+		) );
 	}
 
 	/**
@@ -1084,9 +1096,12 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @return array $options
 	 */
 	static function getFloatOptions() {
-		return array(
+		/**
+		 * @since 3.9.7 TODO
+		 */
+		return apply_filters( 'pb_theme_options_pdf_floats', array(
 			'pdf_body_line_height'
-		);
+		) );
 	}
 
 	/**
@@ -1095,11 +1110,14 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @return array $options
 	 */
 	static function getPredefinedOptions() {
-		return array(
+		/**
+		 * @since 3.9.7 TODO
+		 */
+		return apply_filters( 'pb_theme_options_pdf_predefined', array(
 			'pdf_paragraph_separation',
 			'pdf_blankpages',
 			'pdf_image_resolution',
 			'pdf_footnotes_style',
-		);
+		) );
 	}
 }

--- a/includes/modules/themeoptions/class-pb-themeoptions.php
+++ b/includes/modules/themeoptions/class-pb-themeoptions.php
@@ -99,7 +99,9 @@ class ThemeOptions {
 		}
 
 		/**
-		 * @since 3.9.7 TODO
+		 * Add a custom tab to the theme options page.
+		 *
+		 * @since 3.9.7
 		 */
 		return apply_filters( 'pb_theme_options_tabs', $tabs );
 	}

--- a/includes/modules/themeoptions/class-pb-themeoptions.php
+++ b/includes/modules/themeoptions/class-pb-themeoptions.php
@@ -98,6 +98,9 @@ class ThemeOptions {
 			unset( $tabs['mpdf'] );
 		}
 
-		return apply_filters( 'pressbooks_theme_options_tabs', $tabs );
+		/**
+		 * @since 3.9.7 TODO
+		 */
+		return apply_filters( 'pb_theme_options_tabs', $tabs );
 	}
 }

--- a/includes/modules/themeoptions/class-pb-weboptions.php
+++ b/includes/modules/themeoptions/class-pb-weboptions.php
@@ -90,6 +90,13 @@ class WebOptions extends \Pressbooks\Options {
 			)
 		);
 
+		/**
+		 * Add custom settings fields.
+		 *
+		 * @since 3.9.7
+		 */
+		do_action( 'pb_theme_options_web_add_settings_fields', $_page, $_section );
+
 		register_setting(
 			$_page,
 			$_option,

--- a/includes/modules/themeoptions/class-pb-weboptions.php
+++ b/includes/modules/themeoptions/class-pb-weboptions.php
@@ -35,9 +35,13 @@ class WebOptions extends \Pressbooks\Options {
 	* @param array $options
 	*/
 	function __construct( array $options ) {
-			$this->options = $options;
+		$this->options = $options;
 		$this->defaults = $this->getDefaults();
 		$this->booleans = $this->getBooleanOptions();
+		$this->strings = $this->getStringOptions();
+		$this->integers = $this->getIntegerOptions();
+		$this->floats = $this->getFloatOptions();
+		$this->predefined = $this->getPredefinedOptions();
 
 		foreach ( $this->defaults as $key => $value ) {
 			if ( ! isset( $this->options[ $key ] ) ) {
@@ -176,7 +180,10 @@ class WebOptions extends \Pressbooks\Options {
 	 * @return array $defaults
 	 */
 	static function getDefaults() {
-		return apply_filters( 'pressbooks_theme_options_web_defaults', array(
+		/**
+		 * @since 3.9.7 TODO
+		 */
+		return apply_filters( 'pb_theme_options_web_defaults', array(
 			'social_media' => 1,
 			'part_title' => 0,
 		) );
@@ -198,9 +205,60 @@ class WebOptions extends \Pressbooks\Options {
 	 * @return array $options
 	 */
 	static function getBooleanOptions() {
-		return array(
+		/**
+		 * @since 3.9.7 TODO
+		 */
+		return apply_filters( 'pb_theme_options_web_booleans', array(
 			'social_media',
 			'part_title',
-		);
+		) );
+	}
+
+	/**
+	 * Get an array of options which return strings.
+	 *
+	 * @return array $options
+	 */
+	static function getStringOptions() {
+		/**
+		 * @since 3.9.7 TODO
+		 */
+		return apply_filters( 'pb_theme_options_web_strings', array() );
+	}
+
+	/**
+	 * Get an array of options which return integers.
+	 *
+	 * @return array $options
+	 */
+	static function getIntegerOptions() {
+		/**
+		 * @since 3.9.7 TODO
+		 */
+		return apply_filters( 'pb_theme_options_web_integers', array() );
+	}
+
+	/**
+	 * Get an array of options which return floats.
+	 *
+	 * @return array $options
+	 */
+	static function getFloatOptions() {
+		/**
+		 * @since 3.9.7 TODO
+		 */
+		return apply_filters( 'pb_theme_options_web_floats', array() );
+	}
+
+	/**
+	 * Get an array of options which return predefined values.
+	 *
+	 * @return array $options
+	 */
+	static function getPredefinedOptions() {
+		/**
+		 * @since 3.9.7 TODO
+		 */
+		return apply_filters( 'pb_theme_options_web_predefined', array() );
 	}
 }

--- a/includes/modules/themeoptions/class-pb-weboptions.php
+++ b/includes/modules/themeoptions/class-pb-weboptions.php
@@ -206,7 +206,9 @@ class WebOptions extends \Pressbooks\Options {
 	 */
 	static function getBooleanOptions() {
 		/**
-		 * @since 3.9.7 TODO
+		 * Allow custom boolean options to be passed to sanitization routines.
+		 *
+		 * @since 3.9.7
 		 */
 		return apply_filters( 'pb_theme_options_web_booleans', array(
 			'social_media',
@@ -221,7 +223,9 @@ class WebOptions extends \Pressbooks\Options {
 	 */
 	static function getStringOptions() {
 		/**
-		 * @since 3.9.7 TODO
+		 * Allow custom string options to be passed to sanitization routines.
+		 *
+		 * @since 3.9.7
 		 */
 		return apply_filters( 'pb_theme_options_web_strings', array() );
 	}
@@ -233,7 +237,9 @@ class WebOptions extends \Pressbooks\Options {
 	 */
 	static function getIntegerOptions() {
 		/**
-		 * @since 3.9.7 TODO
+		 * Allow custom integer options to be passed to sanitization routines.
+		 *
+		 * @since 3.9.7
 		 */
 		return apply_filters( 'pb_theme_options_web_integers', array() );
 	}
@@ -245,7 +251,9 @@ class WebOptions extends \Pressbooks\Options {
 	 */
 	static function getFloatOptions() {
 		/**
-		 * @since 3.9.7 TODO
+		 * Allow custom float options to be passed to sanitization routines.
+		 *
+		 * @since 3.9.7
 		 */
 		return apply_filters( 'pb_theme_options_web_floats', array() );
 	}
@@ -257,7 +265,9 @@ class WebOptions extends \Pressbooks\Options {
 	 */
 	static function getPredefinedOptions() {
 		/**
-		 * @since 3.9.7 TODO
+		 * Allow custom predifined options to be passed to sanitization routines.
+		 *
+		 * @since 3.9.7
 		 */
 		return apply_filters( 'pb_theme_options_web_predefined', array() );
 	}


### PR DESCRIPTION
- [x] Add filters to all theme `get<Type>Options()` methods to ensure sanitization of custom options.
- [x] Add actions to register new options within existing sections.