### PR TITLE
Book cache

### DIFF
--- a/includes/class-pb-book.php
+++ b/includes/class-pb-book.php
@@ -185,6 +185,15 @@ class Book {
 
 		$q = new \WP_Query();
 
+		/**
+		 * Fetch all pb_export meta values for this book
+		 */
+		global $wpdb;
+		$post_ids_to_export = array();
+		foreach ( $wpdb->get_results( $wpdb->prepare( "SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = %s", 'pb_export' ), ARRAY_A ) as $val ) {
+			$post_ids_to_export[ $val['post_id'] ] = $val['meta_value'];
+		}
+
 		foreach ( $custom_types as $type ) {
 
 			$book_structure[ $type ] = array();
@@ -213,7 +222,7 @@ class Book {
 					'comment_count' => $post->comment_count,
 					'menu_order' => $post->menu_order,
 					'post_status' => $post->post_status,
-					'export' => ( get_post_meta( $post->ID, 'pb_export', true ) ? true : false ),
+					'export' => ( isset( $post_ids_to_export[ $post->ID ] ) && 1 == $post_ids_to_export[ $post->ID ] ) ? true : false,
 					'post_parent' => $post->post_parent,
 				);
 			}

--- a/tests/test-book.php
+++ b/tests/test-book.php
@@ -1,0 +1,56 @@
+<?php
+
+require_once( PB_PLUGIN_DIR . 'includes/class-pb-book.php' );
+
+class BookTest extends \WP_UnitTestCase {
+
+	protected $book_structure;
+	protected $page;
+
+	/**
+	 * Setup tests
+	 */
+	public function setUp() {
+		$new_post = array(
+			'post_title' => 'test chapter',
+			'post_type' => 'chapter',
+			'post_status' => 'publish',
+			'post_content' => 'some content'
+		);
+		$pid = wp_insert_post( $new_post );
+		update_post_meta( $pid, 'pb_export', true );
+
+		$this->book_structure = \Pressbooks\Book::getBookStructure();
+		$this->page = $this->book_structure['__orphans'][0]; // In __orphans because doesn't belong to a part
+	}
+
+	/**
+	 * @covers \Pressbooks\Book::getBookStructure
+	 */
+	public function test_returnsExportMetaValue() {
+		$this->assertTrue( $this->page['export'] );
+	}
+
+	/**
+	 * @covers \Pressbooks\Book::getBookStructure
+	 */
+	public function test_returnsCachedExportValue() {
+		update_post_meta( $this->page['ID'], 'pb_export', false );
+		$book_structure = \Pressbooks\Book::getBookStructure();
+		$this->page = $book_structure['__orphans'][0];
+
+		$this->assertTrue( $this->page['export'] );
+	}
+
+	/**
+	 * @covers \Pressbooks\Book::getBookStructure
+	 */
+	public function test_returnsLatestExportValueNoCache() {
+		update_post_meta( $this->page['ID'], 'pb_export', false );
+		wp_cache_flush();
+		$book_structure = \Pressbooks\Book::getBookStructure();
+
+		$this->assertFalse( $book_structure['__orphans'][0]['export'] );
+	}
+
+}


### PR DESCRIPTION
`Book::getBookStructure` gets the `export` metadata in an extra
`get_post_meta()` call.

The current method for this is inefficient. These tests will help
ensure the future optimization does not break this function.

This is based off this discussion here: https://github.com/pressbooks/pressbooks/pull/194