### PR TITLE
Add pb_audience field to book information

### DIFF
--- a/includes/admin/pb-metaboxes.php
+++ b/includes/admin/pb-metaboxes.php
@@ -359,6 +359,19 @@ function add_meta_boxes() {
 		'description' => __( 'This is not used by Pressbooks.', 'pressbooks' ),
 	) );
 
+	x_add_metadata_field( 'pb_audience', 'metadata', array(
+		'group' => 'additional-catalogue-information',
+		'field_type' => 'select',
+		'values' => array(
+			'' => __( 'Choose an audience&hellip;', 'pressbooks' ),
+			'juvenile' => __( 'Juvenile', 'pressbooks' ),
+			'young-adult' => __( 'Young Adult', 'pressbooks' ),
+			'adult' => __( 'Adult', 'pressbooks' ),
+		),
+		'label' => __( 'Audience', 'pressbooks' ),
+		'description' => __( 'The target audience for your book.', 'pressbooks' ),
+	) );
+
 	/**
 	 * Add metadata field for BISAC Subject(s).
 	 *


### PR DESCRIPTION
This PR adds a “Target Audience“ field to the Additional Book Information section of the Book Information page. This is based on the BISG standards:

* Juvenile (ages 0-11, see [here](http://bisg.org/page/JuvenileFiction))
* Young Adult (ages 12-18, see [here](http://bisg.org/page/YAFiction))
* Adult (ages 19 and up)