### PR TITLE
adding image resolution options

### DIFF
--- a/includes/modules/themeoptions/class-pb-pdfoptions.php
+++ b/includes/modules/themeoptions/class-pb-pdfoptions.php
@@ -250,6 +250,9 @@ class PDFOptions extends \Pressbooks\Options {
 			$_section,
 			array(
 				'300dpi' => __( 'High (300 DPI)', 'pressbooks' ),
+				'200dpi' => __( 'Med-High (200 DPI)', 'pressbooks' ),
+				'150dpi' => __( 'Medium (150 DPI)', 'pressbooks' ),
+				'100dpi' => __( 'Low-Med (100 DPI)', 'pressbooks' ),
 				'72dpi' => __( 'Low (72 DPI)', 'pressbooks' ),
 			)
 		);


### PR DESCRIPTION
Textbook authors affected by https://github.com/pressbooks/pressbooks/issues/497 can now choose from a greater array of options to decide what works for them. One of our textbook authors is having problems exporting a book with math formulas. Those formulas rendered with `pb-latex` are too big at 72 DPI and too small at 300 DPI. They render with greater clarity at around 100 DPI. 