### PR TITLE
protocol relative url for latex images avoids mixed media message

### DIFF
--- a/symbionts/pressbooks-latex/automattic-latex-wpcom.php
+++ b/symbionts/pressbooks-latex/automattic-latex-wpcom.php
@@ -44,7 +44,7 @@ class Automattic_Latex_WPCOM {
 	function wrapper( $wrapper = false ) {}
 
 	function url() {
-		$this->url = 'http://s.wordpress.com/latex.php?latex=' . rawurlencode( $this->latex ) . "&bg=$this->bg_hex&fg=$this->fg_hex&s=$this->size";
+		$this->url = '//s.wordpress.com/latex.php?latex=' . rawurlencode( $this->latex ) . "&bg=$this->bg_hex&fg=$this->fg_hex&s=$this->size";
 		return $this->url;
 	}
 }

--- a/symbionts/pressbooks-latex/automattic-latex-wpcom.php
+++ b/symbionts/pressbooks-latex/automattic-latex-wpcom.php
@@ -44,7 +44,7 @@ class Automattic_Latex_WPCOM {
 	function wrapper( $wrapper = false ) {}
 
 	function url() {
-		$this->url = '//s.wordpress.com/latex.php?latex=' . rawurlencode( $this->latex ) . "&bg=$this->bg_hex&fg=$this->fg_hex&s=$this->size";
+		$this->url = 'https://s.wordpress.com/latex.php?latex=' . rawurlencode( $this->latex ) . "&bg=$this->bg_hex&fg=$this->fg_hex&s=$this->size";
 		return $this->url;
 	}
 }


### PR DESCRIPTION
On a site that is configured to serve over ssl, the images returned by the latex image rendering service triggers a mixed media warning. SSL for the domain s.wordpress.com is supported. https://s.wordpress.com/latex.php