### PR TITLE
safety dance because as far as I can tell, WP is not friendly to syml…

### DIFF
--- a/includes/modules/export/mpdf/class-pb-pdf.php
+++ b/includes/modules/export/mpdf/class-pb-pdf.php
@@ -139,7 +139,11 @@ class Pdf extends Export {
 		if ( ! $this->hasDependencies() ) {
 			return false; // mPDF is not installed
 		}
-		require_once( PB_MPDF_DIR . 'symbionts/mpdf/mpdf.php' );
+		if ( file_exists( PB_MPDF_DIR . 'symbionts/mpdf/mpdf.php' ) ) {
+			require_once( PB_MPDF_DIR . 'symbionts/mpdf/mpdf.php' );
+		} else {
+			require_once( PB_MPDF_DIR . 'vendor/mpdf/mpdf/mpdf.php' );
+		}
 		$this->mpdf = new \mPDF( '' );
 		$this->mpdf->SetAnchor2Bookmark( 1 );
 		$this->mpdf->ignore_invalid_utf8 = true;


### PR DESCRIPTION
…inks

In updating the mpdf plugin to use composer, the directory structure changes. Adding a symlink to deal with the different path is fine in github, fine when I browse it on WP svn repo, but does not exist when I download the plugin from the WP plugin repo. This is to deal with that shortcoming. 