### PR TITLE
Allow overriding of wp_mail sender address and name

### DIFF
--- a/hooks.php
+++ b/hooks.php
@@ -226,7 +226,6 @@ add_filter( 'xmlrpc_enabled', '__return_false' );
 remove_action( 'wp_head', 'rsd_link' );
 remove_action( 'wp_head', 'wlwmanifest_link' );
 
-
 // -------------------------------------------------------------------------------------------------------------------
 // Override other people's plugins
 // -------------------------------------------------------------------------------------------------------------------
@@ -244,3 +243,7 @@ add_filter( 'wpmu_validate_user_signup', '\Pressbooks\Registration\validate_pass
 add_filter( 'add_signup_meta', '\Pressbooks\Registration\add_temporary_password', 99 );
 add_action( 'signup_blogform', '\Pressbooks\Registration\add_hidden_password_field' );
 add_filter( 'random_password', '\Pressbooks\Registration\override_password_generation' );
+
+// Email configuration
+add_filter( 'wp_mail_from', '\Pressbooks\Utility\mail_from' );
+add_filter( 'wp_mail_from_name', '\Pressbooks\Utility\mail_from_name' );

--- a/includes/pb-utility.php
+++ b/includes/pb-utility.php
@@ -677,3 +677,39 @@ function asset_path( $filename ) {
 		return $dist_path . $directory . $file;
 	}
 }
+
+/**
+ * Set the wp_mail sender address
+ *
+ * @since 3.9.7
+ * @param string $email The default email address
+ * @return string
+ */
+function mail_from( $email ) {
+	if ( defined( 'WP_MAIL_FROM' ) ) {
+		$email = WP_MAIL_FROM;
+	} else {
+		$sitename = strtolower( $_SERVER['SERVER_NAME'] );
+		if ( substr( $sitename, 0, 4 ) == 'www.' ) {
+			$sitename = substr( $sitename, 4 );
+		}
+		$email = 'pressbooks@' . $sitename;
+	}
+	return $email;
+}
+
+/**
+ * Set the wp_mail sender name
+ *
+ * @since 3.9.7
+ * @param string $name The default sender name
+ * @return string
+ */
+function mail_from_name( $name ) {
+	if ( defined( 'WP_MAIL_FROM_NAME' ) ) {
+		$name = WP_MAIL_FROM_NAME;
+	} else {
+		$name = 'Pressbooks';
+	}
+	return $name;
+}

--- a/tests/test-utility.php
+++ b/tests/test-utility.php
@@ -266,17 +266,33 @@ class UtilityTest extends \WP_UnitTestCase {
 		$this->assertContains( '<title>Foobar</title>', $template );
 		$this->assertNotContains( '<title></title>', $template );
 
-		$this->assertContains( "<body>Hello World!</body>", $template );
+		$this->assertContains( '<body>Hello World!</body>', $template );
 		$this->assertNotContains( '<body></body>', $template );
 
 		try {
 			\Pressbooks\Utility\template( '/tmp/file/does/not/exist' );
-		}
-		catch ( \Exception $e ) {
+		} catch ( \Exception $e ) {
 			$this->assertTrue( true );
 			return;
 		}
 		$this->fail();
 	}
 
+	/**
+	 * @covers \Pressbooks\Utility\mail_from
+	 */
+	public function test_mail_from() {
+		$this->assertEquals( 'pressbooks@example.org', \Pressbooks\Utility\mail_from() );
+		define( 'WP_MAIL_FROM', 'hi@pressbooks.org' );
+		$this->assertEquals( 'hi@pressbooks.org', \Pressbooks\Utility\mail_from() );
+	}
+
+	/**
+	 * @covers \Pressbooks\Utility\mail_from_name
+	 */
+	public function test_mail_from_name() {
+		$this->assertEquals( 'Pressbooks', \Pressbooks\Utility\mail_from_name() );
+		define( 'WP_MAIL_FROM_NAME', 'Ned' );
+		$this->assertEquals( 'Ned', \Pressbooks\Utility\mail_from_name() );
+	}
 }

--- a/tests/test-utility.php
+++ b/tests/test-utility.php
@@ -282,17 +282,17 @@ class UtilityTest extends \WP_UnitTestCase {
 	 * @covers \Pressbooks\Utility\mail_from
 	 */
 	public function test_mail_from() {
-		$this->assertEquals( 'pressbooks@example.org', \Pressbooks\Utility\mail_from() );
+		$this->assertEquals( 'pressbooks@example.org', \Pressbooks\Utility\mail_from( '' ) );
 		define( 'WP_MAIL_FROM', 'hi@pressbooks.org' );
-		$this->assertEquals( 'hi@pressbooks.org', \Pressbooks\Utility\mail_from() );
+		$this->assertEquals( 'hi@pressbooks.org', \Pressbooks\Utility\mail_from( '' ) );
 	}
 
 	/**
 	 * @covers \Pressbooks\Utility\mail_from_name
 	 */
 	public function test_mail_from_name() {
-		$this->assertEquals( 'Pressbooks', \Pressbooks\Utility\mail_from_name() );
+		$this->assertEquals( 'Pressbooks', \Pressbooks\Utility\mail_from_name( '' ) );
 		define( 'WP_MAIL_FROM_NAME', 'Ned' );
-		$this->assertEquals( 'Ned', \Pressbooks\Utility\mail_from_name() );
+		$this->assertEquals( 'Ned', \Pressbooks\Utility\mail_from_name( '' ) );
 	}
 }


### PR DESCRIPTION
This changes the default sender address for `wp_mail` from `wordpress@example.org` to `pressbooks@example.org`, and changes the default sender name to `Pressbooks`. These settings can also be overridden by the `WP_MAIL_FROM` and `WP_MAIL_FROM_NAME` constants.