### PR TITLE
Reordering epub CSS rules to enable margins around images.

### DIFF
--- a/themes-book/fitzgerald/export/epub/style.scss
+++ b/themes-book/fitzgerald/export/epub/style.scss
@@ -310,9 +310,9 @@ img {
         max-width: 100%;
 }
 .wp-caption {
-        height: auto;
-        max-width: 100%;
-        margin: 1em 0;
+  height: auto;
+  max-width: 100%;
+  margin: 1em 0;
 }
 .alignleft {
 	float: left;

--- a/themes-book/fitzgerald/export/epub/style.scss
+++ b/themes-book/fitzgerald/export/epub/style.scss
@@ -310,9 +310,9 @@ img {
         max-width: 100%;
 }
 .wp-caption {
-	height: auto;        
-	max-width: 100%;
-	margin: 1em 0;     
+        height: auto;
+        max-width: 100%;
+        margin: 1em 0;
 }
 .alignleft {
 	float: left;

--- a/themes-book/fitzgerald/export/epub/style.scss
+++ b/themes-book/fitzgerald/export/epub/style.scss
@@ -309,6 +309,11 @@ img {
 	height: auto;
         max-width: 100%;
 }
+.wp-caption {
+	height: auto;        
+	max-width: 100%;
+	margin: 1em 0;     
+}
 .alignleft {
 	float: left;
 	margin: 1em 1em 1em 0;
@@ -331,11 +336,6 @@ img.aligncenter {
 	display: block;
 	margin: 1em auto;
 	text-align: center;      
-}
-.wp-caption {
-	height: auto;        
-	max-width: 100%;
-	margin: 1em 0;     
 }
 .wp-caption-text {
 	font-size: 0.875em;


### PR DESCRIPTION
Exported ebooks did not have appropriate margins around images due to incorrect ordering of CSS rules. This is fixed in this PR for the Fitzgerald theme; a similar change may be needed in other themes.