### PR TITLE
adding wp api rest routes, support for custom post types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
     "gridonic/princexml-php": "^1.2",
     "pimple/pimple": "^3.0",
     "leafo/scssphp": "^0.6.6",
-    "pressbooks/pb-api": "^1.1"
+    "pressbooks/pb-api": "^1.1",
+    "bccampus/rest-routes": "^1.0.3"
   },
   "require-dev": {
     "phpunit/phpunit": "~5.5",


### PR DESCRIPTION
This adds WP REST API support for custom post types. 

details here: https://packagist.org/packages/bccampus/rest-routes
