### PR TITLE
Remove sassphp dependency

### DIFF
--- a/bin/compile-scss.php
+++ b/bin/compile-scss.php
@@ -29,12 +29,13 @@ $includePaths = [
 	dirname( realpath( $input_file_name ) ),
 ];
 
+$scss = file_get_contents( $input_file_name );
+
 try {
-	// Requires: https://github.com/sensational/sassphp
-	$sass = new \Sass();
+	$sass = new \Leafo\ScssPhp\Compiler;
 	$sass->setStyle( Sass::STYLE_EXPANDED );
-	$sass->setIncludePath( implode( ':', $includePaths ) );
-	$css = $sass->compileFile( $input_file_name );
+	$sass->setImportPaths( $includePaths );
+	$css = $sass->compileFile( $scss );
 } catch ( Exception $e ) {
 	die( $e->getMessage() );
 }

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -80,7 +80,6 @@ However, we encourage you to upgrade your environment instead as [PHP 5.4 is no 
 *   For EPUB validation install [EpubCheck][9] - Version 4.0
 *   For XML validation install [xmllint][10] - Version 20800
 *   For ODT export install [Saxon-HE][11] - Version 9.7.0-10
-*   It is recommended that you install [sassphp][12] for SASS compilation; however, Pressbooks includes a bundled compiler, [scssphp][13], and will fall back to this if sassphp is absent.
 *   Certain Linux installations do not ship with the php5-xsl library enabled by default. If you attempt to export an ePub and get a either a white screen with minimal text, or a "Fatal error: Class 'XSLTProcessor' not found" error, you may need to run a command like `apt-get install php5-xsl`
 
 Unlisted versions are not supported. Upgrade/downgrade accordingly.
@@ -203,6 +202,5 @@ Note that this does not install the required libraries for export. See above (Pa
  [9]: https://github.com/idpf/epubcheck
  [10]: http://xmlsoft.org/xmllint.html
  [11]: https://sourceforge.net/projects/saxon/files/Saxon-HE/
- [12]: https://github.com/sensational/sassphp
  [13]: https://github.com/leafo/scssphp/
  [14]: https://wp-cli.org/

--- a/includes/class-pb-sass.php
+++ b/includes/class-pb-sass.php
@@ -167,20 +167,9 @@ class Sass {
 			$css = '/* Silence is golden. */'; // If no SCSS input was passed, prevent file write errors by putting a comment in the CSS output.
 
 			if ( '' !== $scss ) {
-				if ( extension_loaded( 'sass' ) ) { // use sassphp extension
-					$scss_file = array_search( 'uri', @array_flip( stream_get_meta_data( $GLOBALS[ mt_rand() ] = tmpfile() ) ) );
-					rename( $scss_file, $scss_file .= '.scss' );
-					register_shutdown_function( create_function( '', "unlink('{$scss_file}');" ) );
-					file_put_contents( $scss_file, $scss );
-					$sass = new \Sass();
-					$include_paths = implode( ':', $includes );
-					$sass->setIncludePath( $include_paths );
-					$css = $sass->compileFile( $scss_file );
-				} else { // use scssphp library
-					$sass = new \Leafo\ScssPhp\Compiler;
-					$sass->setImportPaths( $includes );
-					$css = $sass->compile( $scss );
-				}
+				$sass = new \Leafo\ScssPhp\Compiler;
+				$sass->setImportPaths( $includes );
+				$css = $sass->compile( $scss );
 			}
 		} catch ( \Exception $e ) {
 

--- a/readme.txt
+++ b/readme.txt
@@ -103,7 +103,6 @@ However, we encourage you to upgrade your environment instead as [PHP 5.4 is no 
  * For MOBI export install [KindleGen](http://www.amazon.com/gp/feature.html?docId=1000765211) - Version 2.9
  * For EPUB validation install [EpubCheck](https://github.com/idpf/epubcheck) - Version 4.0
  * For XML validation install [xmllint](http://xmlsoft.org/xmllint.html) - Version 20706
- * It is recommended that you install [sassphp](https://github.com/sensational/sassphp) for SASS compilation; however, Pressbooks includes a bundled compiler, [scssphp](https://github.com/leafo/scssphp/), and will fall back to this if sassphp is absent.
  * Certain Linux installations do not ship with the php5-xsl library enabled by default.  If you attempt to export an ePub and get a either a white screen with minimal text, or a "Fatal error: Class 'XSLTProcessor' not found" error, you may need to run a command like "apt-get install php5-xsl"
 
 Unlisted versions are not supported. Upgrade/downgrade accordingly.


### PR DESCRIPTION
It seems that https://github.com/sensational/sassphp has gone stale, and lacks some modern SASS/SCSS features. This PR removes `sassphp` support in lieu of the bundled https://github.com/leafo/scssphp library, which will allow us to ensure consistent support for SASS/SCSS features across all instances.