### PR TITLE
Refactor option field display functions (closes #648)

### DIFF
--- a/includes/admin/class-pb-exportoptions.php
+++ b/includes/admin/class-pb-exportoptions.php
@@ -120,13 +120,13 @@ class ExportOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderEmailValidationLogsField( $args ) {
-		$this->renderRadioButtons(
-			'email_validation_logs',
-			$this->getSlug(),
-			'email_validation_logs',
-			@$this->options['email_validation_logs'],
-			$args
-		);
+		$this->renderRadioButtons( array(
+			'id' => 'email_validation_logs',
+			'name' => $this->getSlug(),
+			'option' => 'email_validation_logs',
+			'value' => ( isset( $this->options['email_validation_logs'] ) ) ? $this->options['email_validation_logs'] : '',
+			'choices' => $args,
+		) );
 	}
 
 	/**

--- a/includes/admin/class-pb-exportoptions.php
+++ b/includes/admin/class-pb-exportoptions.php
@@ -120,7 +120,13 @@ class ExportOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderEmailValidationLogsField( $args ) {
-		$this->renderRadioButtons( 'email_validation_logs', $this->getSlug(), 'email_validation_logs', @$this->options['email_validation_logs'], $args );
+		$this->renderRadioButtons(
+			'email_validation_logs',
+			$this->getSlug(),
+			'email_validation_logs',
+			@$this->options['email_validation_logs'],
+			$args
+		);
 	}
 
 	/**

--- a/includes/admin/class-pb-network-sharingandprivacyoptions.php
+++ b/includes/admin/class-pb-network-sharingandprivacyoptions.php
@@ -122,13 +122,13 @@ class SharingAndPrivacyOptions extends \Pressbooks\Options {
 	 */
 	function renderAllowRedistributionField( $args ) {
 		$options = get_site_option( $this->getSlug() );
-		$this->renderCheckbox(
-			'allow_redistribution',
-			$this->getSlug(),
-			'allow_redistribution',
-			@$options['allow_redistribution'],
-			$args[0]
-		);
+		$this->renderCheckbox( array(
+			'id' => 'allow_redistribution',
+			'name' => $this->getSlug(),
+			'option' => 'allow_redistribution',
+			'value' => ( isset( $options['allow_redistribution'] ) ) ? $options['allow_redistribution'] : '',
+			'description' => $args[0],
+		) );
 	}
 
 	/**

--- a/includes/admin/class-pb-network-sharingandprivacyoptions.php
+++ b/includes/admin/class-pb-network-sharingandprivacyoptions.php
@@ -122,7 +122,13 @@ class SharingAndPrivacyOptions extends \Pressbooks\Options {
 	 */
 	function renderAllowRedistributionField( $args ) {
 		$options = get_site_option( $this->getSlug() );
-		$this->renderCheckbox( 'allow_redistribution', $this->getSlug(), 'allow_redistribution', @$options['allow_redistribution'], $args[0] );
+		$this->renderCheckbox(
+			'allow_redistribution',
+			$this->getSlug(),
+			'allow_redistribution',
+			@$options['allow_redistribution'],
+			$args[0]
+		);
 	}
 
 	/**

--- a/includes/admin/class-pb-publishoptions.php
+++ b/includes/admin/class-pb-publishoptions.php
@@ -169,16 +169,14 @@ class PublishOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderAmazonField() {
-		$this->renderField(
-			'amazon',
-			$this->getSlug(),
-			'amazon',
-			@$this->options['amazon'],
-			'',
-			'',
-			'url',
-			'regular-text code'
-		);
+		$this->renderField( array(
+			'id' => 'amazon',
+			'name' => $this->getSlug(),
+			'option' => 'amazon',
+			'value' => ( isset( $this->options['amazon'] ) ) ? $this->options['amazon'] : '',
+			'type' => 'url',
+			'class' => 'regular-text code',
+		) );
 	}
 
 	/**
@@ -186,16 +184,14 @@ class PublishOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderOReillyField() {
-		$this->renderField(
-			'oreilly',
-			$this->getSlug(),
-			'oreilly',
-			@$this->options['oreilly'],
-			'',
-			'',
-			'url',
-			'regular-text code'
-		);
+		$this->renderField( array(
+			'id' => 'oreilly',
+			'name' => $this->getSlug(),
+			'option' => 'oreilly',
+			'value' => ( isset( $this->options['oreilly'] ) ) ? $this->options['oreilly'] : '',
+			'type' => 'url',
+			'class' => 'regular-text code',
+		) );
 	}
 
 	/**
@@ -203,16 +199,14 @@ class PublishOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderBarnesAndNobleField() {
-		$this->renderField(
-			'barnesandnoble',
-			$this->getSlug(),
-			'barnesandnoble',
-			@$this->options['barnesandnoble'],
-			'',
-			'',
-			'url',
-			'regular-text code'
-		);
+		$this->renderField( array(
+			'id' => 'barnesandnoble',
+			'name' => $this->getSlug(),
+			'option' => 'barnesandnoble',
+			'value' => ( isset( $this->options['barnesandnoble'] ) ) ? $this->options['barnesandnoble'] : '',
+			'type' => 'url',
+			'class' => 'regular-text code',
+		) );
 	}
 
 	/**
@@ -220,16 +214,14 @@ class PublishOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderKoboField() {
-		$this->renderField(
-			'kobo',
-			$this->getSlug(),
-			'kobo',
-			@$this->options['kobo'],
-			'',
-			'',
-			'url',
-			'regular-text code'
-		);
+		$this->renderField( array(
+			'id' => 'kobo',
+			'name' => $this->getSlug(),
+			'option' => 'kobo',
+			'value' => ( isset( $this->options['kobo'] ) ) ? $this->options['kobo'] : '',
+			'type' => 'url',
+			'class' => 'regular-text code',
+		) );
 	}
 
 	/**
@@ -237,16 +229,14 @@ class PublishOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderiBooksField() {
-		$this->renderField(
-			'ibooks',
-			$this->getSlug(),
-			'ibooks',
-			@$this->options['ibooks'],
-			'',
-			'',
-			'url',
-			'regular-text code'
-		);
+		$this->renderField( array(
+			'id' => 'ibooks',
+			'name' => $this->getSlug(),
+			'option' => 'ibooks',
+			'value' => ( isset( $this->options['ibooks'] ) ) ? $this->options['ibooks'] : '',
+			'type' => 'url',
+			'class' => 'regular-text code',
+		) );
 	}
 
 	/**
@@ -254,16 +244,14 @@ class PublishOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderOtherServiceField() {
-		$this->renderField(
-			'otherservice',
-			$this->getSlug(),
-			'otherservice',
-			@$this->options['otherservice'],
-			'',
-			'',
-			'url',
-			'regular-text code'
-		);
+		$this->renderField( array(
+			'id' => 'otherservice',
+			'name' => $this->getSlug(),
+			'option' => 'otherservice',
+			'value' => ( isset( $this->options['otherservice'] ) ) ? $this->options['otherservice'] : '',
+			'type' => 'url',
+			'class' => 'regular-text code',
+		) );
 	}
 
 	/**

--- a/includes/admin/class-pb-publishoptions.php
+++ b/includes/admin/class-pb-publishoptions.php
@@ -169,7 +169,16 @@ class PublishOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderAmazonField() {
-		$this->renderField( 'amazon', $this->getSlug(), 'amazon', @$this->options['amazon'], '', '', 'url', 'regular-text code' );
+		$this->renderField(
+			'amazon',
+			$this->getSlug(),
+			'amazon',
+			@$this->options['amazon'],
+			'',
+			'',
+			'url',
+			'regular-text code'
+		);
 	}
 
 	/**
@@ -177,7 +186,16 @@ class PublishOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderOReillyField() {
-		$this->renderField( 'oreilly', $this->getSlug(), 'oreilly', @$this->options['oreilly'], '', '', 'url', 'regular-text code' );
+		$this->renderField(
+			'oreilly',
+			$this->getSlug(),
+			'oreilly',
+			@$this->options['oreilly'],
+			'',
+			'',
+			'url',
+			'regular-text code'
+		);
 	}
 
 	/**
@@ -185,7 +203,16 @@ class PublishOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderBarnesAndNobleField() {
-		$this->renderField( 'barnesandnoble', $this->getSlug(), 'barnesandnoble', @$this->options['barnesandnoble'], '', '', 'url', 'regular-text code' );
+		$this->renderField(
+			'barnesandnoble',
+			$this->getSlug(),
+			'barnesandnoble',
+			@$this->options['barnesandnoble'],
+			'',
+			'',
+			'url',
+			'regular-text code'
+		);
 	}
 
 	/**
@@ -193,7 +220,16 @@ class PublishOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderKoboField() {
-		$this->renderField( 'kobo', $this->getSlug(), 'kobo', @$this->options['kobo'], '', '', 'url', 'regular-text code' );
+		$this->renderField(
+			'kobo',
+			$this->getSlug(),
+			'kobo',
+			@$this->options['kobo'],
+			'',
+			'',
+			'url',
+			'regular-text code'
+		);
 	}
 
 	/**
@@ -201,7 +237,16 @@ class PublishOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderiBooksField() {
-		$this->renderField( 'ibooks', $this->getSlug(), 'ibooks', @$this->options['ibooks'], '', '', 'url', 'regular-text code' );
+		$this->renderField(
+			'ibooks',
+			$this->getSlug(),
+			'ibooks',
+			@$this->options['ibooks'],
+			'',
+			'',
+			'url',
+			'regular-text code'
+		);
 	}
 
 	/**
@@ -209,7 +254,16 @@ class PublishOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderOtherServiceField() {
-		$this->renderField( 'otherservice', $this->getSlug(), 'otherservice', @$this->options['otherservice'], '', '', 'url', 'regular-text code' );
+		$this->renderField(
+			'otherservice',
+			$this->getSlug(),
+			'otherservice',
+			@$this->options['otherservice'],
+			'',
+			'',
+			'url',
+			'regular-text code'
+		);
 	}
 
 	/**

--- a/includes/class-pb-options.php
+++ b/includes/class-pb-options.php
@@ -143,81 +143,64 @@ abstract class Options {
 	/**
 	 * Render an input.
 	 *
-	 * @param string $id
-	 * @param string $name
-	 * @param string $option
-	 * @param string $value
-	 * @param string $description
-	 * @param string $append
-	 * @param string $type
-	 * @param string $size
-	 * @param bool $disabled
+	 * @param array $args
 	 */
-	static function renderField( $id, $name, $option, $value = '', $description = '', $append = '', $type = 'text', $class = 'regular-text', $disabled = false ) {
+	static function renderField( $args = array( 'id' => null, 'name' => null, 'option' => null, 'value' => '', 'description' => '', 'append' => '', 'type' => 'text', 'class' => 'regular-text', 'disabled' => false ) ) {
 		printf(
 			'<input id="%s" class="%s" name="%s[%s]" type="%s" value="%s" %s/>',
-			$id,
-			$class,
-			$name,
-			$option,
-			$type,
-			$value,
-			( $disabled ) ? ' disabled' : ''
+			$args['id'],
+			$args['class'],
+			$args['name'],
+			$args['option'],
+			$args['type'],
+			$args['value'],
+			( $args['disabled'] ) ? ' disabled' : ''
 		);
-		if ( $append ) {
-			echo ' ' . $append;
+		if ( $args['append'] ) {
+			echo ' ' . $args['append'];
 		}
 		printf(
 			'<p class="description">%s</p>',
-			$description
+			$args['description']
 		);
 	}
 
 	/**
 	 * Render a checkbox.
 	 *
-	 * @param string $id
-	 * @param string $name
-	 * @param string $option
-	 * @param string $value
-	 * @param string $description
+	 * @param array $args
 	 */
-	static function renderCheckbox( $id, $name, $option, $value = '', $description ) {
+	static function renderCheckbox( $args = array( 'id' => null, 'name' => null, 'option' => null, 'value' => '', 'description' => '' ) ) {
 		printf(
 			'<input id="%s" name="%s[%s]" type="checkbox" value="1" %s/><label for="%s">%s</label>',
-			$id,
-			$name,
-			$option,
-			checked( 1, $value, false ),
-			$id,
-			$description
+			$args['id'],
+			$args['name'],
+			$args['option'],
+			checked( 1, $args['value'], false ),
+			$args['id'],
+			$args['description']
 		);
 	}
 
 	/**
 	 * Render radio buttons.
 	 *
-	 * @param string $id
-	 * @param string $name
-	 * @param string $option
-	 * @param string $value
-	 * @param string $args
-	 * @param bool $custom
+	 * @param array $args
 	 */
-	static function renderRadioButtons( $id, $name, $option, $value = '', $args, $custom = false ) {
+	static function renderRadioButtons( $args = array( 'id' => null, 'name' => null, 'option' => null, 'value' => '', 'choices' => array(), 'custom' => false ) ) {
 		$is_custom = false;
-		if ( ! array_key_exists( $value, $args ) ) {
+		if ( ! array_key_exists( $args['value'], $args['choices'] ) ) {
 			$is_custom = true;
 		}
-		foreach ( $args as $key => $label ) {
+		foreach ( $args['choices'] as $key => $label ) {
 			printf(
 				'<label for="%s"><input type="radio" id="%s" name="%s[%s]" value="%s" %s/>%s</label><br />',
-				$id . '_' . sanitize_key( $key ),
-				$id . '_' . sanitize_key( $key ),
-				$name,
-				$option,
+				$args['id'] . '_' . sanitize_key( $key ),
+				$args['id'] . '_' . sanitize_key( $key ),
+				$args['name'],
+				$args['option'],
 				$key,
-				( $custom && $is_custom && '' == $key ) ? 'checked' : checked( $key, $value, false ),
+				( $args['custom'] && $is_custom && '' == $key ) ? 'checked' : checked( $key, $args['value'], false ),
 				$label
 			);
 		}
@@ -226,29 +209,24 @@ abstract class Options {
 	/**
 	 * Render a select element.
 	 *
-	 * @param string $id
-	 * @param string $name
-	 * @param string $option
-	 * @param string $value
-	 * @param string $args
-	 * @param boolean $multiple
+	 * @param array $args
 	 */
-	static function renderSelect( $id, $name, $option, $value = '', $args, $multiple = false ) {
+	static function renderSelect( $args = array( 'id' => null, 'name' => null, 'option' => null, 'value' => '', 'choices' => array(), 'multiple' => false ) ) {
 		$options = '';
-		foreach ( $args as $key => $label ) {
+		foreach ( $args['choices'] as $key => $label ) {
 			$options .= sprintf(
 				'<option value="%s" %s>%s</option>',
 				$key,
-				selected( $key, $value, false ),
+				selected( $key, $args['value'], false ),
 				$label
 			);
 		}
 		printf(
 			'<select name="%s[%s]" id="%s"%s>%s</select>',
-			$name,
-			$option,
-			$id,
-			( $multiple ) ? ' multiple' : '',
+			$args['name'],
+			$args['option'],
+			$args['id'],
+			( $args['multiple'] ) ? ' multiple' : '',
 			$options
 		);
 	}
@@ -256,31 +234,27 @@ abstract class Options {
 	/**
 	 * Render a custom select element.
 	 *
-	 * @param string $id
-	 * @param string $name
-	 * @param string $value
-	 * @param string $args
-	 * @param boolean $multiple
+	 * @param array $args
 	 */
-	static function renderCustomSelect( $id, $name, $value = '', $args, $multiple = false ) {
+	static function renderCustomSelect( $args = array( 'id' => null, 'name' => null, 'value' => '', 'choices' => array(), 'multiple' => false ) ) {
 		$is_custom = false;
-		if ( ! array_key_exists( $value, $args ) ) {
+		if ( ! array_key_exists( $args['value'], $args['choices'] ) ) {
 			$is_custom = true;
 		}
 		$options = '';
-		foreach ( $args as $key => $label ) {
+		foreach ( $args['choices'] as $key => $label ) {
 			$options .= sprintf(
 				'<option value="%s" %s>%s</option>',
 				$key,
-				( '' == $key && $is_custom ) ? ' selected' : selected( $key, $value, false ),
+				( '' == $key && $is_custom ) ? ' selected' : selected( $key, $args['value'], false ),
 				$label
 			);
 		}
 		printf(
 			'<select name="%s" id="%s"%s>%s</select><br />',
-			$name,
-			$id,
-			( $multiple ) ? ' multiple' : '',
+			$args['name'],
+			$args['id'],
+			( $args['multiple'] ) ? ' multiple' : '',
 			$options
 		);
 	}

--- a/includes/class-pb-options.php
+++ b/includes/class-pb-options.php
@@ -143,9 +143,35 @@ abstract class Options {
 	/**
 	 * Render an input.
 	 *
-	 * @param array $args
+	 * @param array $args {
+	 *     Arguments to render the input.
+	 *
+	 *     @type string			$id      				The id which will be assigned to the rendered field.
+	 *     @type string			$name         	The name of the field.
+	 *     @type string     $option       	The name of the option that the field is within.
+	 *     @type string     $value          The stored value of the field as retrieved from the database.
+	 *     @type string     $description		A description which will be displayed below the field.
+	 *     @type string     $append					A string which will be appended to the field (e.g. 'px').
+	 *     @type string     $type						The type property of the input. Default 'text'.
+	 *     @type string     $class					The class(es) which will be assigned to the rendered input. Default 'regular-text'.
+	 *     @type bool     	$disabled				Is the field disabled?
+ * }
 	 */
-	static function renderField( $args = array( 'id' => null, 'name' => null, 'option' => null, 'value' => '', 'description' => '', 'append' => '', 'type' => 'text', 'class' => 'regular-text', 'disabled' => false ) ) {
+	static function renderField( $args ) {
+		$defaults = array(
+			'id' => null,
+			'name' => null,
+			'option' => null,
+			'value' => '',
+			'description' => null,
+			'append' => null,
+			'type' => 'text',
+			'class' => 'regular-text',
+			'disabled' => false,
+		);
+
+		$args = wp_parse_args( $args, $defaults );
+
 		printf(
 			'<input id="%s" class="%s" name="%s[%s]" type="%s" value="%s" %s/>',
 			$args['id'],
@@ -154,15 +180,17 @@ abstract class Options {
 			$args['option'],
 			$args['type'],
 			$args['value'],
-			( $args['disabled'] ) ? ' disabled' : ''
+			( isset( $args['disabled'] ) && true == $args['disabled'] ) ? ' disabled' : ''
 		);
-		if ( $args['append'] ) {
+		if ( isset( $args['append'] ) ) {
 			echo ' ' . $args['append'];
 		}
-		printf(
-			'<p class="description">%s</p>',
-			$args['description']
-		);
+		if ( isset( $args['description'] ) ) {
+			printf(
+				'<p class="description">%s</p>',
+				$args['description']
+			);
+		}
 	}
 
 	/**
@@ -170,7 +198,17 @@ abstract class Options {
 	 *
 	 * @param array $args
 	 */
-	static function renderCheckbox( $args = array( 'id' => null, 'name' => null, 'option' => null, 'value' => '', 'description' => '' ) ) {
+	static function renderCheckbox( $args ) {
+		$defaults = array(
+			'id' => null,
+			'name' => null,
+			'option' => null,
+			'value' => '',
+			'description' => null,
+		);
+
+		$args = wp_parse_args( $args, $defaults );
+
 		printf(
 			'<input id="%s" name="%s[%s]" type="checkbox" value="1" %s/><label for="%s">%s</label>',
 			$args['id'],
@@ -187,7 +225,18 @@ abstract class Options {
 	 *
 	 * @param array $args
 	 */
-	static function renderRadioButtons( $args = array( 'id' => null, 'name' => null, 'option' => null, 'value' => '', 'choices' => array(), 'custom' => false ) ) {
+	static function renderRadioButtons( $args ) {
+		$defaults = array(
+			'id' => null,
+			'name' => null,
+			'option' => null,
+			'value' => '',
+			'choices' => array(),
+			'custom' => false,
+		);
+
+		$args = wp_parse_args( $args, $defaults );
+
 		$is_custom = false;
 		if ( ! array_key_exists( $args['value'], $args['choices'] ) ) {
 			$is_custom = true;
@@ -211,7 +260,18 @@ abstract class Options {
 	 *
 	 * @param array $args
 	 */
-	static function renderSelect( $args = array( 'id' => null, 'name' => null, 'option' => null, 'value' => '', 'choices' => array(), 'multiple' => false ) ) {
+	static function renderSelect( $args ) {
+		$defaults = array(
+			'id' => null,
+			'name' => null,
+			'option' => null,
+			'value' => '',
+			'choices' => array(),
+			'multiple' => false,
+		);
+
+		$args = wp_parse_args( $args, $defaults );
+
 		$options = '';
 		foreach ( $args['choices'] as $key => $label ) {
 			$options .= sprintf(
@@ -236,7 +296,17 @@ abstract class Options {
 	 *
 	 * @param array $args
 	 */
-	static function renderCustomSelect( $args = array( 'id' => null, 'name' => null, 'value' => '', 'choices' => array(), 'multiple' => false ) ) {
+	static function renderCustomSelect( $args ) {
+		$defaults = array(
+			'id' => null,
+			'name' => null,
+			'value' => '',
+			'choices' => array(),
+			'multiple' => false,
+		);
+
+		$args = wp_parse_args( $args, $defaults );
+
 		$is_custom = false;
 		if ( ! array_key_exists( $args['value'], $args['choices'] ) ) {
 			$is_custom = true;

--- a/includes/modules/themeoptions/class-pb-ebookoptions.php
+++ b/includes/modules/themeoptions/class-pb-ebookoptions.php
@@ -149,7 +149,13 @@ class EbookOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderParagraphSeparationField( $args ) {
-		$this->renderRadioButtons( 'ebook_paragraph_separation', 'pressbooks_theme_options_' . $this->getSlug(), 'ebook_paragraph_separation', @$this->options['ebook_paragraph_separation'], $args );
+		$this->renderRadioButtons(
+			'ebook_paragraph_separation',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'ebook_paragraph_separation',
+			@$this->options['ebook_paragraph_separation'],
+			$args
+		);
 	}
 
 	/**
@@ -157,7 +163,13 @@ class EbookOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderCompressImagesField( $args ) {
-		$this->renderCheckbox( 'ebook_compress_images', 'pressbooks_theme_options_' . $this->getSlug(), 'ebook_compress_images', @$this->options['ebook_compress_images'], $args[0] );
+		$this->renderCheckbox(
+			'ebook_compress_images',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'ebook_compress_images',
+			@$this->options['ebook_compress_images'],
+			$args[0]
+		);
 	}
 
 	/**

--- a/includes/modules/themeoptions/class-pb-ebookoptions.php
+++ b/includes/modules/themeoptions/class-pb-ebookoptions.php
@@ -149,13 +149,13 @@ class EbookOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderParagraphSeparationField( $args ) {
-		$this->renderRadioButtons(
-			'ebook_paragraph_separation',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'ebook_paragraph_separation',
-			@$this->options['ebook_paragraph_separation'],
-			$args
-		);
+		$this->renderRadioButtons( array(
+			'id' => 'ebook_paragraph_separation',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'ebook_paragraph_separation',
+			'value' => ( isset( $this->options['ebook_paragraph_separation'] ) ) ? $this->options['ebook_paragraph_separation'] : '',
+			'choices' => $args,
+		) );
 	}
 
 	/**
@@ -163,13 +163,13 @@ class EbookOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderCompressImagesField( $args ) {
-		$this->renderCheckbox(
-			'ebook_compress_images',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'ebook_compress_images',
-			@$this->options['ebook_compress_images'],
-			$args[0]
-		);
+		$this->renderCheckbox( array(
+			'id' => 'ebook_compress_images',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'ebook_compress_images',
+			'value' => ( isset( $this->options['ebook_compress_images'] ) ) ? $this->options['ebook_compress_images'] : '',
+			'description' => $args[0],
+		) );
 	}
 
 	/**

--- a/includes/modules/themeoptions/class-pb-globaloptions.php
+++ b/includes/modules/themeoptions/class-pb-globaloptions.php
@@ -202,7 +202,13 @@ class GlobalOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderChapterNumbersField( $args ) {
-		$this->renderCheckbox( 'chapter_numbers', 'pressbooks_theme_options_' . $this->getSlug(), 'chapter_numbers', $this->options['chapter_numbers'], $args[0] );
+		$this->renderCheckbox(
+			'chapter_numbers',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'chapter_numbers',
+			$this->options['chapter_numbers'],
+			$args[0]
+		);
 	}
 
 	/**
@@ -210,7 +216,13 @@ class GlobalOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderTwoLevelTOCField( $args ) {
-		$this->renderCheckbox( 'parse_subsections', 'pressbooks_theme_options_' . $this->getSlug(), 'parse_subsections', $this->options['parse_subsections'], $args[0] );
+		$this->renderCheckbox(
+			'parse_subsections',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'parse_subsections',
+			$this->options['parse_subsections'],
+			$args[0]
+		);
 	}
 
 	/**
@@ -267,7 +279,13 @@ class GlobalOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderCopyrightLicenseField( $args ) {
-		$this->renderCheckbox( 'copyright_license', 'pressbooks_theme_options_' . $this->getSlug(), 'copyright_license', $this->options['copyright_license'], $args[0] );
+		$this->renderCheckbox(
+			'copyright_license',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'copyright_license',
+			$this->options['copyright_license'],
+			$args[0]
+		);
 	}
 
 	/**

--- a/includes/modules/themeoptions/class-pb-globaloptions.php
+++ b/includes/modules/themeoptions/class-pb-globaloptions.php
@@ -202,13 +202,13 @@ class GlobalOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderChapterNumbersField( $args ) {
-		$this->renderCheckbox(
-			'chapter_numbers',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'chapter_numbers',
-			$this->options['chapter_numbers'],
-			$args[0]
-		);
+		$this->renderCheckbox( array(
+			'id' => 'chapter_numbers',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'chapter_numbers',
+			'value' => ( isset( $this->options['chapter_numbers'] ) ) ? $this->options['chapter_numbers'] : '',
+			'description' => $args[0],
+		) );
 	}
 
 	/**
@@ -216,13 +216,13 @@ class GlobalOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderTwoLevelTOCField( $args ) {
-		$this->renderCheckbox(
-			'parse_subsections',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'parse_subsections',
-			$this->options['parse_subsections'],
-			$args[0]
-		);
+		$this->renderCheckbox( array(
+			'id' => 'parse_subsections',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'parse_subsections',
+			'value' => ( isset( $this->options['parse_subsections'] ) ) ? $this->options['parse_subsections'] : '',
+			'description' => $args[0],
+		) );
 	}
 
 	/**
@@ -279,13 +279,13 @@ class GlobalOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderCopyrightLicenseField( $args ) {
-		$this->renderCheckbox(
-			'copyright_license',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'copyright_license',
-			$this->options['copyright_license'],
-			$args[0]
-		);
+		$this->renderCheckbox( array(
+			'id' => 'copyright_license',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'copyright_license',
+			'value' => ( isset( $this->options['copyright_license'] ) ) ? $this->options['copyright_license'] : '',
+			'description' => $args[0],
+		) );
 	}
 
 	/**

--- a/includes/modules/themeoptions/class-pb-pdfoptions.php
+++ b/includes/modules/themeoptions/class-pb-pdfoptions.php
@@ -660,16 +660,16 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderBodyFontSizeField( $args ) {
-		$this->renderField(
-			'pdf_body_font_size',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'pdf_body_font_size',
-			@$this->options['pdf_body_font_size'],
-			$args[0],
-			$args[1],
-			'text',
-			'small-text'
-		);
+		$this->renderField( array(
+			'id' => 'pdf_body_font_size',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'pdf_body_font_size',
+			'value' => ( isset( $this->options['pdf_body_font_size'] ) ) ? $this->options['pdf_body_font_size'] : $this->defaults['pdf_body_font_size'],
+			'description' => $args[0],
+			'append' => $args[1],
+			'type' => 'text',
+			'class' => 'small-text',
+		) );
 	}
 
 	/**
@@ -677,19 +677,16 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderBodyLineHightField( $args ) {
-		if ( ! isset( $this->options['pdf_body_line_height'] ) ) {
-			$this->options['pdf_body_line_height'] = $this->defaults['pdf_body_line_height'];
-		}
-		$this->renderField(
-			'pdf_body_line_height',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'pdf_body_line_height',
-			@$this->options['pdf_body_line_height'],
-			$args[0],
-			$args[1],
-			'text',
-			'small-text'
-		);
+		$this->renderField( array(
+			'id' => 'pdf_body_line_height',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'pdf_body_line_height',
+			'value' => ( isset( $this->options['pdf_body_line_height'] ) ) ? $this->options['pdf_body_line_height'] : $this->defaults['pdf_body_line_height'],
+			'description' => $args[0],
+			'append' => $args[1],
+			'type' => 'text',
+			'class' => 'small-text',
+		) );
 	}
 
 	/**
@@ -738,16 +735,15 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderPageWidthField( $args ) {
-		$this->renderField(
-			'pdf_page_width',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'pdf_page_width',
-			@$this->options['pdf_page_width'],
-			$args[0],
-			'',
-			'text',
-			'small-text'
-		);
+		$this->renderField( array(
+			'id' => 'pdf_page_width',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'pdf_page_width',
+			'value' => @$this->options['pdf_page_width'],
+			'description' => $args[0],
+			'type' => 'text',
+			'class' => 'small-text',
+		) );
 	}
 
 	/**
@@ -755,16 +751,15 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderPageHeightField( $args ) {
-		$this->renderField(
-			'pdf_page_height',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'pdf_page_height',
-			@$this->options['pdf_page_height'],
-			$args[0],
-			'',
-			'text',
-			'small-text'
-		);
+		$this->renderField( array(
+			'id' => 'pdf_page_height',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'pdf_page_height',
+			'value' => @$this->options['pdf_page_height'],
+			'description' => $args[0],
+			'type' => 'text',
+			'class' => 'small-text',
+		) );
 	}
 
 	/**
@@ -807,16 +802,15 @@ class PDFOptions extends \Pressbooks\Options {
 	 */
 	function renderOutsideMarginField( $args ) {
 	?>
-		<?php $this->renderField(
-			'pdf_page_margin_outside',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'pdf_page_margin_outside',
-			@$this->options['pdf_page_margin_outside'],
-			$args[0],
-			'',
-			'text',
-			'small-text'
-		);
+		<?php $this->renderField( array(
+			'id' => 'pdf_page_margin_outside',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'pdf_page_margin_outside',
+			'value' => @$this->options['pdf_page_margin_outside'],
+			'description' => $args[0],
+			'type' => 'text',
+			'class' => 'small-text',
+		) );
 	}
 
 	/**
@@ -824,16 +818,15 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderInsideMarginField( $args ) {
-		$this->renderField(
-			'pdf_page_margin_inside',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'pdf_page_margin_inside',
-			@$this->options['pdf_page_margin_inside'],
-			$args[0],
-			'',
-			'text',
-			'small-text'
-		);
+		$this->renderField( array(
+			'id' => 'pdf_page_margin_inside',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'pdf_page_margin_inside',
+			'value' => @$this->options['pdf_page_margin_inside'],
+			'description' => $args[0],
+			'type' => 'text',
+			'class' => 'small-text',
+		) );
 	}
 
 	/**
@@ -841,16 +834,15 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderTopMarginField( $args ) {
-		$this->renderField(
-			'pdf_page_margin_top',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'pdf_page_margin_top',
-			@$this->options['pdf_page_margin_top'],
-			$args[0],
-			'',
-			'text',
-			'small-text'
-		);
+		$this->renderField( array(
+			'id' => 'pdf_page_margin_top',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'pdf_page_margin_top',
+			'value' => @$this->options['pdf_page_margin_top'],
+			'description' => $args[0],
+			'type' => 'text',
+			'class' => 'small-text',
+		) );
 	}
 
 	/**
@@ -858,16 +850,15 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderBottomMarginField( $args ) {
-		$this->renderField(
-			'pdf_page_margin_bottom',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'pdf_page_margin_bottom',
-			@$this->options['pdf_page_margin_bottom'],
-			$args[0],
-			'',
-			'text',
-			'small-text'
-		);
+		$this->renderField( array(
+			'id' => 'pdf_page_margin_bottom',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'pdf_page_margin_bottom',
+			'value' => @$this->options['pdf_page_margin_bottom'],
+			'description' => $args[0],
+			'type' => 'text',
+			'class' => 'small-text',
+		) );
 	}
 
 	/**
@@ -875,13 +866,13 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderHyphenationField( $args ) {
-		$this->renderCheckbox(
-			'pdf_hyphens',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'pdf_hyphens',
-			@$this->options['pdf_hyphens'],
-			$args[0]
-		);
+		$this->renderCheckbox( array(
+			'id' => 'pdf_hyphens',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'pdf_hyphens',
+			'value' => @$this->options['pdf_hyphens'],
+			'description' => $args[0],
+		) );
 	}
 
 	/**
@@ -889,13 +880,13 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderParagraphSeparationField( $args ) {
-		$this->renderRadioButtons(
-			'pdf_paragraph_separation',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'pdf_paragraph_separation',
-			@$this->options['pdf_paragraph_separation'],
-			$args
-		);
+		$this->renderRadioButtons( array(
+			'id' => 'pdf_paragraph_separation',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'pdf_paragraph_separation',
+			'value' => @$this->options['pdf_paragraph_separation'],
+			'choices' => $args,
+		) );
 	}
 
 	/**
@@ -903,13 +894,13 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderSectionOpeningsField( $args ) {
-		$this->renderRadioButtons(
-			'pdf_sectionopenings',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'pdf_sectionopenings',
-			@$this->options['pdf_sectionopenings'],
-			$args
-		);
+		$this->renderRadioButtons( array(
+			'id' => 'pdf_sectionopenings',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'pdf_sectionopenings',
+			'value' => @$this->options['pdf_sectionopenings'],
+			'choices' => $args,
+		) );
 	}
 
 	/**
@@ -917,13 +908,13 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderTOCField( $args ) {
-		$this->renderCheckbox(
-			'pdf_toc',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'pdf_toc',
-			@$this->options['pdf_toc'],
-			$args[0]
-		);
+		$this->renderCheckbox( array(
+			'id' => 'pdf_toc',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'pdf_toc',
+			'value' => @$this->options['pdf_toc'],
+			'description' => $args[0],
+		) );
 	}
 
 	/**
@@ -931,13 +922,13 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderImageResolutionField( $args ) {
-		$this->renderRadioButtons(
-			'pdf_image_resolution',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'pdf_image_resolution',
-			@$this->options['pdf_image_resolution'],
-			$args
-		);
+		$this->renderRadioButtons( array(
+			'id' => 'pdf_image_resolution',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'pdf_image_resolution',
+			'value' => @$this->options['pdf_image_resolution'],
+			'choices' => $args,
+		) );
 	}
 
 	/**
@@ -945,13 +936,13 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 		*/
 	function renderCropMarksField( $args ) {
-		$this->renderCheckbox(
-			'pdf_crop_marks',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'pdf_crop_marks',
-			@$this->options['pdf_crop_marks'],
-			$args[0]
-		);
+		$this->renderCheckbox( array(
+			'id' => 'pdf_crop_marks',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'pdf_crop_marks',
+			'value' => @$this->options['pdf_crop_marks'],
+			'description' => $args[0],
+		) );
 	}
 
 	/**
@@ -959,13 +950,13 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderRomanizePartsField( $args ) {
-		$this->renderCheckbox(
-			'pdf_romanize_parts',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'pdf_romanize_parts',
-			@$this->options['pdf_romanize_parts'],
-			$args[0]
-		);
+		$this->renderCheckbox( array(
+			'id' => 'pdf_romanize_parts',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'pdf_romanize_parts',
+			'value' => @$this->options['pdf_romanize_parts'],
+			'description' => $args[0],
+		) );
 	}
 
 	/**
@@ -973,13 +964,13 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderFootnoteStyleField( $args ) {
-		$this->renderRadioButtons(
-			'pdf_footnotes_style',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'pdf_footnotes_style',
-			@$this->options['pdf_footnotes_style'],
-			$args
-		);
+		$this->renderRadioButtons( array(
+			'id' => 'pdf_footnotes_style',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'pdf_footnotes_style',
+			'value' => @$this->options['pdf_footnotes_style'],
+			'choices' => $args,
+		) );
 	}
 
 	/**
@@ -987,16 +978,14 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderWidowsField( $args ) {
-		$this->renderField(
-			'widows',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'widows',
-			@$this->options['widows'],
-			'',
-			'',
-			'text',
-			'small-text'
-		);
+		$this->renderField( array(
+			'id' => 'widows',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'widows',
+			'value' => @$this->options['widows'],
+			'type' => 'text',
+			'class' => 'small-text',
+		) );
 	}
 
 	/**
@@ -1004,16 +993,14 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderOrphansField( $args ) {
-		$this->renderField(
-			'orphans',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'orphans',
-			@$this->options['orphans'],
-			'',
-			'',
-			'text',
-			'small-text'
-		);
+		$this->renderField( array(
+			'id' => 'orphans',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'orphans',
+			'value' => @$this->options['orphans'],
+			'type' => 'text',
+			'class' => 'small-text',
+		) );
 	}
 
 	/**
@@ -1030,22 +1017,20 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderRunningContentFrontMatterLeftField( $args ) {
-		$this->renderCustomSelect(
-			'running_content_front_matter_left',
-			'running_content_front_matter_left',
-			@$this->options['running_content_front_matter_left'],
-			$args
-		);
-		$this->renderField(
-			'running_content_front_matter_left',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'running_content_front_matter_left',
-			@$this->options['running_content_front_matter_left'],
-			'',
-			'',
-			'text',
-			'regular-text code'
-		);
+		$this->renderCustomSelect( array(
+			'id' => 'running_content_front_matter_left',
+			'name' => 'running_content_front_matter_left',
+			'value' => @$this->options['running_content_front_matter_left'],
+			'choices' => $args,
+		) );
+		$this->renderField( array(
+			'id' => 'running_content_front_matter_left',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'running_content_front_matter_left',
+			'value' => @$this->options['running_content_front_matter_left'],
+			'type' => 'text',
+			'class' => 'regular-text code',
+		) );
 	}
 
 	/**
@@ -1053,22 +1038,20 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderRunningContentFrontMatterRightField( $args ) {
-		$this->renderCustomSelect(
-			'running_content_front_matter_right',
-			'running_content_front_matter_right',
-			@$this->options['running_content_front_matter_right'],
-			$args
-		);
-		$this->renderField(
-			'running_content_front_matter_right',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'running_content_front_matter_right',
-			@$this->options['running_content_front_matter_right'],
-			'',
-			'',
-			'text',
-			'regular-text code'
-		);
+		$this->renderCustomSelect( array(
+			'id' => 'running_content_front_matter_right',
+			'name' => 'running_content_front_matter_right',
+			'value' => @$this->options['running_content_front_matter_right'],
+			'choices' => $args,
+		) );
+		$this->renderField( array(
+			'id' => 'running_content_front_matter_right',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'running_content_front_matter_right',
+			'value' => @$this->options['running_content_front_matter_right'],
+			'type' => 'text',
+			'class' => 'regular-text code',
+		) );
 	}
 
 	/**
@@ -1076,22 +1059,20 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderRunningContentIntroductionLeftField( $args ) {
-		$this->renderCustomSelect(
-			'running_content_introduction_left',
-			'running_content_introduction_left',
-			@$this->options['running_content_introduction_left'],
-			$args
-		);
-		$this->renderField(
-			'running_content_introduction_left',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'running_content_introduction_left',
-			@$this->options['running_content_introduction_left'],
-			'',
-			'',
-			'text',
-			'regular-text code'
-		);
+		$this->renderCustomSelect( array(
+			'id' => 'running_content_introduction_left',
+			'name' => 'running_content_introduction_left',
+			'value' => @$this->options['running_content_introduction_left'],
+			'choices' => $args,
+		) );
+		$this->renderField( array(
+			'id' => 'running_content_introduction_left',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'running_content_introduction_left',
+			'value' => @$this->options['running_content_introduction_left'],
+			'type' => 'text',
+			'class' => 'regular-text code',
+		) );
 	}
 
 	/**
@@ -1099,22 +1080,20 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderRunningContentIntroductionRightField( $args ) {
-		$this->renderCustomSelect(
-			'running_content_introduction_right',
-			'running_content_introduction_right',
-			@$this->options['running_content_introduction_right'],
-			$args
-		);
-		$this->renderField(
-			'running_content_introduction_right',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'running_content_introduction_right',
-			@$this->options['running_content_introduction_right'],
-			'',
-			'',
-			'text',
-			'regular-text code'
-		);
+		$this->renderCustomSelect( array(
+			'id' => 'running_content_introduction_right',
+			'name' => 'running_content_introduction_right',
+			'value' => @$this->options['running_content_introduction_right'],
+			'choices' => $args,
+		) );
+		$this->renderField( array(
+			'id' => 'running_content_introduction_right',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'running_content_introduction_right',
+			'value' => @$this->options['running_content_introduction_right'],
+			'type' => 'text',
+			'class' => 'regular-text code',
+		) );
 	}
 
 	/**
@@ -1122,22 +1101,20 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderRunningContentPartLeftField( $args ) {
-		$this->renderCustomSelect(
-			'running_content_part_left',
-			'running_content_part_left',
-			@$this->options['running_content_part_left'],
-			$args
-		);
-		$this->renderField(
-			'running_content_part_left',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'running_content_part_left',
-			@$this->options['running_content_part_left'],
-			'',
-			'',
-			'text',
-			'regular-text code'
-		);
+		$this->renderCustomSelect( array(
+			'id' => 'running_content_part_left',
+			'name' => 'running_content_part_left',
+			'value' => @$this->options['running_content_part_left'],
+			'choices' => $args,
+		) );
+		$this->renderField( array(
+			'id' => 'running_content_part_left',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'running_content_part_left',
+			'value' => @$this->options['running_content_part_left'],
+			'type' => 'text',
+			'class' => 'regular-text code',
+		) );
 	}
 
 	/**
@@ -1145,23 +1122,20 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderRunningContentPartRightField( $args ) {
-		$this->renderCustomSelect(
-			'running_content_part_right',
-			'running_content_part_right',
-			@$this->options['running_content_part_right'],
-			$args
-		);
-		$this->renderField(
-			'running_content_part_right',
-			'pressbooks_theme_options_' .
-			$this->getSlug(),
-			'running_content_part_right',
-			@$this->options['running_content_part_right'],
-			'',
-			'',
-			'text',
-			'regular-text code'
-		);
+		$this->renderCustomSelect( array(
+			'id' => 'running_content_part_right',
+			'name' => 'running_content_part_right',
+			'value' => @$this->options['running_content_part_right'],
+			'choices' => $args,
+		) );
+		$this->renderField( array(
+			'id' => 'running_content_part_right',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'running_content_part_right',
+			'value' => @$this->options['running_content_part_right'],
+			'type' => 'text',
+			'class' => 'regular-text code',
+		) );
 	}
 
 	/**
@@ -1169,22 +1143,20 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderRunningContentChapterLeftField( $args ) {
-		$this->renderCustomSelect(
-			'running_content_chapter_left',
-			'running_content_chapter_left',
-			@$this->options['running_content_chapter_left'],
-			$args
-		);
-		$this->renderField(
-			'running_content_chapter_left',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'running_content_chapter_left',
-			@$this->options['running_content_chapter_left'],
-			'',
-			'',
-			'text',
-			'regular-text code'
-		);
+		$this->renderCustomSelect( array(
+			'id' => 'running_content_chapter_left',
+			'name' => 'running_content_chapter_left',
+			'value' => @$this->options['running_content_chapter_left'],
+			'choices' => $args,
+		) );
+		$this->renderField( array(
+			'id' => 'running_content_chapter_left',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'running_content_chapter_left',
+			'value' => @$this->options['running_content_chapter_left'],
+			'type' => 'text',
+			'class' => 'regular-text code',
+		) );
 	}
 
 	/**
@@ -1192,22 +1164,20 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderRunningContentChapterRightField( $args ) {
-		$this->renderCustomSelect(
-			'running_content_chapter_right',
-			'running_content_chapter_right',
-			@$this->options['running_content_chapter_right'],
-			$args
-		);
-		$this->renderField(
-			'running_content_chapter_right',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'running_content_chapter_right',
-			@$this->options['running_content_chapter_right'],
-			'',
-			'',
-			'text',
-			'regular-text code'
-		);
+		$this->renderCustomSelect( array(
+			'id' => 'running_content_chapter_right',
+			'name' => 'running_content_chapter_right',
+			'value' => @$this->options['running_content_chapter_right'],
+			'choices' => $args,
+		) );
+		$this->renderField( array(
+			'id' => 'running_content_chapter_right',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'running_content_chapter_right',
+			'value' => @$this->options['running_content_chapter_right'],
+			'type' => 'text',
+			'class' => 'regular-text code',
+		) );
 	}
 
 	/**
@@ -1215,22 +1185,20 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderRunningContentBackMatterLeftField( $args ) {
-		$this->renderCustomSelect(
-			'running_content_back_matter_left',
-			'running_content_back_matter_left',
-			@$this->options['running_content_back_matter_left'],
-			$args
-		);
-		$this->renderField(
-			'running_content_back_matter_left',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'running_content_back_matter_left',
-			@$this->options['running_content_back_matter_left'],
-			'',
-			'',
-			'text',
-			'regular-text code'
-		);
+		$this->renderCustomSelect( array(
+			'id' => 'running_content_back_matter_left',
+			'name' => 'running_content_back_matter_left',
+			'value' => @$this->options['running_content_back_matter_left'],
+			'choices' => $args,
+		) );
+		$this->renderField( array(
+			'id' => 'running_content_back_matter_left',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'running_content_back_matter_left',
+			'value' => @$this->options['running_content_back_matter_left'],
+			'type' => 'text',
+			'class' => 'regular-text code',
+		) );
 	}
 
 	/**
@@ -1238,22 +1206,20 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderRunningContentBackMatterRightField( $args ) {
-		$this->renderCustomSelect(
-			'running_content_back_matter_right',
-			'running_content_back_matter_right',
-			@$this->options['running_content_back_matter_right'],
-			$args
-		);
-		$this->renderField(
-			'running_content_back_matter_right',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'running_content_back_matter_right',
-			@$this->options['running_content_back_matter_right'],
-			'',
-			'',
-			'text',
-			'regular-text code'
-		);
+		$this->renderCustomSelect( array(
+			'id' => 'running_content_back_matter_right',
+			'name' => 'running_content_back_matter_right',
+			'value' => @$this->options['running_content_back_matter_right'],
+			'choices' => $args,
+		) );
+		$this->renderField( array(
+			'id' => 'running_content_back_matter_right',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'running_content_back_matter_right',
+			'value' => @$this->options['running_content_back_matter_right'],
+			'type' => 'text',
+			'class' => 'regular-text code',
+		) );
 	}
 
 	/**
@@ -1261,13 +1227,13 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderFontSizeField( $args ) {
-		$this->renderCheckbox(
-			'pdf_fontsize',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'pdf_fontsize',
-			@$this->options['pdf_fontsize'],
-			$args[0]
-		);
+		$this->renderCheckbox( array(
+			'id' => 'pdf_fontsize',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'pdf_fontsize',
+			'value' => @$this->options['pdf_fontsize'],
+			'description' => $args[0],
+		) );
 	}
 
 	/**

--- a/includes/modules/themeoptions/class-pb-pdfoptions.php
+++ b/includes/modules/themeoptions/class-pb-pdfoptions.php
@@ -660,7 +660,16 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderBodyFontSizeField( $args ) {
-		$this->renderField( 'pdf_body_font_size', 'pressbooks_theme_options_' . $this->getSlug(), 'pdf_body_font_size', @$this->options['pdf_body_font_size'], $args[0], $args[1], 'text', 'small-text' );
+		$this->renderField(
+			'pdf_body_font_size',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'pdf_body_font_size',
+			@$this->options['pdf_body_font_size'],
+			$args[0],
+			$args[1],
+			'text',
+			'small-text'
+		);
 	}
 
 	/**
@@ -671,7 +680,16 @@ class PDFOptions extends \Pressbooks\Options {
 		if ( ! isset( $this->options['pdf_body_line_height'] ) ) {
 			$this->options['pdf_body_line_height'] = $this->defaults['pdf_body_line_height'];
 		}
-		$this->renderField( 'pdf_body_line_height', 'pressbooks_theme_options_' . $this->getSlug(), 'pdf_body_line_height', @$this->options['pdf_body_line_height'], $args[0], $args[1], 'text', 'small-text' );
+		$this->renderField(
+			'pdf_body_line_height',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'pdf_body_line_height',
+			@$this->options['pdf_body_line_height'],
+			$args[0],
+			$args[1],
+			'text',
+			'small-text'
+		);
 	}
 
 	/**
@@ -720,7 +738,16 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderPageWidthField( $args ) {
-		$this->renderField( 'pdf_page_width', 'pressbooks_theme_options_' . $this->getSlug(), 'pdf_page_width', @$this->options['pdf_page_width'], $args[0], '', 'text', 'small-text' );
+		$this->renderField(
+			'pdf_page_width',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'pdf_page_width',
+			@$this->options['pdf_page_width'],
+			$args[0],
+			'',
+			'text',
+			'small-text'
+		);
 	}
 
 	/**
@@ -728,7 +755,16 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderPageHeightField( $args ) {
-		$this->renderField( 'pdf_page_height', 'pressbooks_theme_options_' . $this->getSlug(), 'pdf_page_height', @$this->options['pdf_page_height'], $args[0], '', 'text', 'small-text' );
+		$this->renderField(
+			'pdf_page_height',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'pdf_page_height',
+			@$this->options['pdf_page_height'],
+			$args[0],
+			'',
+			'text',
+			'small-text'
+		);
 	}
 
 	/**
@@ -771,7 +807,16 @@ class PDFOptions extends \Pressbooks\Options {
 	 */
 	function renderOutsideMarginField( $args ) {
 	?>
-		<?php $this->renderField( 'pdf_page_margin_outside', 'pressbooks_theme_options_' . $this->getSlug(), 'pdf_page_margin_outside', @$this->options['pdf_page_margin_outside'], $args[0], '', 'text', 'small-text' );
+		<?php $this->renderField(
+			'pdf_page_margin_outside',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'pdf_page_margin_outside',
+			@$this->options['pdf_page_margin_outside'],
+			$args[0],
+			'',
+			'text',
+			'small-text'
+		);
 	}
 
 	/**
@@ -779,7 +824,16 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderInsideMarginField( $args ) {
-		$this->renderField( 'pdf_page_margin_inside', 'pressbooks_theme_options_' . $this->getSlug(), 'pdf_page_margin_inside', @$this->options['pdf_page_margin_inside'], $args[0], '', 'text', 'small-text' );
+		$this->renderField(
+			'pdf_page_margin_inside',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'pdf_page_margin_inside',
+			@$this->options['pdf_page_margin_inside'],
+			$args[0],
+			'',
+			'text',
+			'small-text'
+		);
 	}
 
 	/**
@@ -787,7 +841,16 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderTopMarginField( $args ) {
-		$this->renderField( 'pdf_page_margin_top', 'pressbooks_theme_options_' . $this->getSlug(), 'pdf_page_margin_top', @$this->options['pdf_page_margin_top'], $args[0], '', 'text', 'small-text' );
+		$this->renderField(
+			'pdf_page_margin_top',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'pdf_page_margin_top',
+			@$this->options['pdf_page_margin_top'],
+			$args[0],
+			'',
+			'text',
+			'small-text'
+		);
 	}
 
 	/**
@@ -795,7 +858,16 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderBottomMarginField( $args ) {
-		$this->renderField( 'pdf_page_margin_bottom', 'pressbooks_theme_options_' . $this->getSlug(), 'pdf_page_margin_bottom', @$this->options['pdf_page_margin_bottom'], $args[0], '', 'text', 'small-text' );
+		$this->renderField(
+			'pdf_page_margin_bottom',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'pdf_page_margin_bottom',
+			@$this->options['pdf_page_margin_bottom'],
+			$args[0],
+			'',
+			'text',
+			'small-text'
+		);
 	}
 
 	/**
@@ -803,7 +875,13 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderHyphenationField( $args ) {
-		$this->renderCheckbox( 'pdf_hyphens', 'pressbooks_theme_options_' . $this->getSlug(), 'pdf_hyphens', @$this->options['pdf_hyphens'], $args[0] );
+		$this->renderCheckbox(
+			'pdf_hyphens',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'pdf_hyphens',
+			@$this->options['pdf_hyphens'],
+			$args[0]
+		);
 	}
 
 	/**
@@ -811,7 +889,13 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderParagraphSeparationField( $args ) {
-		$this->renderRadioButtons( 'pdf_paragraph_separation', 'pressbooks_theme_options_' . $this->getSlug(), 'pdf_paragraph_separation', @$this->options['pdf_paragraph_separation'], $args );
+		$this->renderRadioButtons(
+			'pdf_paragraph_separation',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'pdf_paragraph_separation',
+			@$this->options['pdf_paragraph_separation'],
+			$args
+		);
 	}
 
 	/**
@@ -819,7 +903,13 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderSectionOpeningsField( $args ) {
-		$this->renderRadioButtons( 'pdf_sectionopenings', 'pressbooks_theme_options_' . $this->getSlug(), 'pdf_sectionopenings', @$this->options['pdf_sectionopenings'], $args );
+		$this->renderRadioButtons(
+			'pdf_sectionopenings',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'pdf_sectionopenings',
+			@$this->options['pdf_sectionopenings'],
+			$args
+		);
 	}
 
 	/**
@@ -827,7 +917,13 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderTOCField( $args ) {
-		$this->renderCheckbox( 'pdf_toc', 'pressbooks_theme_options_' . $this->getSlug(), 'pdf_toc', @$this->options['pdf_toc'], $args[0] );
+		$this->renderCheckbox(
+			'pdf_toc',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'pdf_toc',
+			@$this->options['pdf_toc'],
+			$args[0]
+		);
 	}
 
 	/**
@@ -835,7 +931,13 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderImageResolutionField( $args ) {
-		$this->renderRadioButtons( 'pdf_image_resolution', 'pressbooks_theme_options_' . $this->getSlug(), 'pdf_image_resolution', @$this->options['pdf_image_resolution'], $args );
+		$this->renderRadioButtons(
+			'pdf_image_resolution',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'pdf_image_resolution',
+			@$this->options['pdf_image_resolution'],
+			$args
+		);
 	}
 
 	/**
@@ -843,7 +945,13 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 		*/
 	function renderCropMarksField( $args ) {
-		$this->renderCheckbox( 'pdf_crop_marks', 'pressbooks_theme_options_' . $this->getSlug(), 'pdf_crop_marks', @$this->options['pdf_crop_marks'], $args[0] );
+		$this->renderCheckbox(
+			'pdf_crop_marks',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'pdf_crop_marks',
+			@$this->options['pdf_crop_marks'],
+			$args[0]
+		);
 	}
 
 	/**
@@ -851,7 +959,13 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderRomanizePartsField( $args ) {
-		$this->renderCheckbox( 'pdf_romanize_parts', 'pressbooks_theme_options_' . $this->getSlug(), 'pdf_romanize_parts', @$this->options['pdf_romanize_parts'], $args[0] );
+		$this->renderCheckbox(
+			'pdf_romanize_parts',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'pdf_romanize_parts',
+			@$this->options['pdf_romanize_parts'],
+			$args[0]
+		);
 	}
 
 	/**
@@ -859,7 +973,13 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderFootnoteStyleField( $args ) {
-		$this->renderRadioButtons( 'pdf_footnotes_style', 'pressbooks_theme_options_' . $this->getSlug(), 'pdf_footnotes_style', @$this->options['pdf_footnotes_style'], $args );
+		$this->renderRadioButtons(
+			'pdf_footnotes_style',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'pdf_footnotes_style',
+			@$this->options['pdf_footnotes_style'],
+			$args
+		);
 	}
 
 	/**
@@ -867,7 +987,16 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderWidowsField( $args ) {
-		$this->renderField( 'widows', 'pressbooks_theme_options_' . $this->getSlug(), 'widows', @$this->options['widows'], '', '', 'text', 'small-text' );
+		$this->renderField(
+			'widows',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'widows',
+			@$this->options['widows'],
+			'',
+			'',
+			'text',
+			'small-text'
+		);
 	}
 
 	/**
@@ -875,7 +1004,16 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderOrphansField( $args ) {
-		$this->renderField( 'orphans', 'pressbooks_theme_options_' . $this->getSlug(), 'orphans', @$this->options['orphans'], '', '', 'text', 'small-text' );
+		$this->renderField(
+			'orphans',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'orphans',
+			@$this->options['orphans'],
+			'',
+			'',
+			'text',
+			'small-text'
+		);
 	}
 
 	/**
@@ -892,8 +1030,22 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderRunningContentFrontMatterLeftField( $args ) {
-		$this->renderCustomSelect( 'running_content_front_matter_left', 'running_content_front_matter_left', @$this->options['running_content_front_matter_left'], $args );
-		$this->renderField( 'running_content_front_matter_left', 'pressbooks_theme_options_' . $this->getSlug(), 'running_content_front_matter_left', @$this->options['running_content_front_matter_left'], '', '', 'text', 'regular-text code' );
+		$this->renderCustomSelect(
+			'running_content_front_matter_left',
+			'running_content_front_matter_left',
+			@$this->options['running_content_front_matter_left'],
+			$args
+		);
+		$this->renderField(
+			'running_content_front_matter_left',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'running_content_front_matter_left',
+			@$this->options['running_content_front_matter_left'],
+			'',
+			'',
+			'text',
+			'regular-text code'
+		);
 	}
 
 	/**
@@ -901,8 +1053,22 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderRunningContentFrontMatterRightField( $args ) {
-		$this->renderCustomSelect( 'running_content_front_matter_right', 'running_content_front_matter_right', @$this->options['running_content_front_matter_right'], $args );
-		$this->renderField( 'running_content_front_matter_right', 'pressbooks_theme_options_' . $this->getSlug(), 'running_content_front_matter_right', @$this->options['running_content_front_matter_right'], '', '', 'text', 'regular-text code' );
+		$this->renderCustomSelect(
+			'running_content_front_matter_right',
+			'running_content_front_matter_right',
+			@$this->options['running_content_front_matter_right'],
+			$args
+		);
+		$this->renderField(
+			'running_content_front_matter_right',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'running_content_front_matter_right',
+			@$this->options['running_content_front_matter_right'],
+			'',
+			'',
+			'text',
+			'regular-text code'
+		);
 	}
 
 	/**
@@ -910,8 +1076,22 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderRunningContentIntroductionLeftField( $args ) {
-		$this->renderCustomSelect( 'running_content_introduction_left', 'running_content_introduction_left', @$this->options['running_content_introduction_left'], $args );
-		$this->renderField( 'running_content_introduction_left', 'pressbooks_theme_options_' . $this->getSlug(), 'running_content_introduction_left', @$this->options['running_content_introduction_left'], '', '', 'text', 'regular-text code' );
+		$this->renderCustomSelect(
+			'running_content_introduction_left',
+			'running_content_introduction_left',
+			@$this->options['running_content_introduction_left'],
+			$args
+		);
+		$this->renderField(
+			'running_content_introduction_left',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'running_content_introduction_left',
+			@$this->options['running_content_introduction_left'],
+			'',
+			'',
+			'text',
+			'regular-text code'
+		);
 	}
 
 	/**
@@ -919,8 +1099,22 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderRunningContentIntroductionRightField( $args ) {
-		$this->renderCustomSelect( 'running_content_introduction_right', 'running_content_introduction_right', @$this->options['running_content_introduction_right'], $args );
-		$this->renderField( 'running_content_introduction_right', 'pressbooks_theme_options_' . $this->getSlug(), 'running_content_introduction_right', @$this->options['running_content_introduction_right'], '', '', 'text', 'regular-text code' );
+		$this->renderCustomSelect(
+			'running_content_introduction_right',
+			'running_content_introduction_right',
+			@$this->options['running_content_introduction_right'],
+			$args
+		);
+		$this->renderField(
+			'running_content_introduction_right',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'running_content_introduction_right',
+			@$this->options['running_content_introduction_right'],
+			'',
+			'',
+			'text',
+			'regular-text code'
+		);
 	}
 
 	/**
@@ -928,8 +1122,22 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderRunningContentPartLeftField( $args ) {
-		$this->renderCustomSelect( 'running_content_part_left', 'running_content_part_left', @$this->options['running_content_part_left'], $args );
-		$this->renderField( 'running_content_part_left', 'pressbooks_theme_options_' . $this->getSlug(), 'running_content_part_left', @$this->options['running_content_part_left'], '', '', 'text', 'regular-text code' );
+		$this->renderCustomSelect(
+			'running_content_part_left',
+			'running_content_part_left',
+			@$this->options['running_content_part_left'],
+			$args
+		);
+		$this->renderField(
+			'running_content_part_left',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'running_content_part_left',
+			@$this->options['running_content_part_left'],
+			'',
+			'',
+			'text',
+			'regular-text code'
+		);
 	}
 
 	/**
@@ -937,8 +1145,23 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderRunningContentPartRightField( $args ) {
-		$this->renderCustomSelect( 'running_content_part_right', 'running_content_part_right', @$this->options['running_content_part_right'], $args );
-		$this->renderField( 'running_content_part_right', 'pressbooks_theme_options_' . $this->getSlug(), 'running_content_part_right', @$this->options['running_content_part_right'], '', '', 'text', 'regular-text code' );
+		$this->renderCustomSelect(
+			'running_content_part_right',
+			'running_content_part_right',
+			@$this->options['running_content_part_right'],
+			$args
+		);
+		$this->renderField(
+			'running_content_part_right',
+			'pressbooks_theme_options_' .
+			$this->getSlug(),
+			'running_content_part_right',
+			@$this->options['running_content_part_right'],
+			'',
+			'',
+			'text',
+			'regular-text code'
+		);
 	}
 
 	/**
@@ -946,8 +1169,22 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderRunningContentChapterLeftField( $args ) {
-		$this->renderCustomSelect( 'running_content_chapter_left', 'running_content_chapter_left', @$this->options['running_content_chapter_left'], $args );
-		$this->renderField( 'running_content_chapter_left', 'pressbooks_theme_options_' . $this->getSlug(), 'running_content_chapter_left', @$this->options['running_content_chapter_left'], '', '', 'text', 'regular-text code' );
+		$this->renderCustomSelect(
+			'running_content_chapter_left',
+			'running_content_chapter_left',
+			@$this->options['running_content_chapter_left'],
+			$args
+		);
+		$this->renderField(
+			'running_content_chapter_left',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'running_content_chapter_left',
+			@$this->options['running_content_chapter_left'],
+			'',
+			'',
+			'text',
+			'regular-text code'
+		);
 	}
 
 	/**
@@ -955,8 +1192,22 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderRunningContentChapterRightField( $args ) {
-		$this->renderCustomSelect( 'running_content_chapter_right', 'running_content_chapter_right', @$this->options['running_content_chapter_right'], $args );
-		$this->renderField( 'running_content_chapter_right', 'pressbooks_theme_options_' . $this->getSlug(), 'running_content_chapter_right', @$this->options['running_content_chapter_right'], '', '', 'text', 'regular-text code' );
+		$this->renderCustomSelect(
+			'running_content_chapter_right',
+			'running_content_chapter_right',
+			@$this->options['running_content_chapter_right'],
+			$args
+		);
+		$this->renderField(
+			'running_content_chapter_right',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'running_content_chapter_right',
+			@$this->options['running_content_chapter_right'],
+			'',
+			'',
+			'text',
+			'regular-text code'
+		);
 	}
 
 	/**
@@ -964,8 +1215,22 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderRunningContentBackMatterLeftField( $args ) {
-		$this->renderCustomSelect( 'running_content_back_matter_left', 'running_content_back_matter_left', @$this->options['running_content_back_matter_left'], $args );
-		$this->renderField( 'running_content_back_matter_left', 'pressbooks_theme_options_' . $this->getSlug(), 'running_content_back_matter_left', @$this->options['running_content_back_matter_left'], '', '', 'text', 'regular-text code' );
+		$this->renderCustomSelect(
+			'running_content_back_matter_left',
+			'running_content_back_matter_left',
+			@$this->options['running_content_back_matter_left'],
+			$args
+		);
+		$this->renderField(
+			'running_content_back_matter_left',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'running_content_back_matter_left',
+			@$this->options['running_content_back_matter_left'],
+			'',
+			'',
+			'text',
+			'regular-text code'
+		);
 	}
 
 	/**
@@ -973,8 +1238,22 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderRunningContentBackMatterRightField( $args ) {
-		$this->renderCustomSelect( 'running_content_back_matter_right', 'running_content_back_matter_right', @$this->options['running_content_back_matter_right'], $args );
-		$this->renderField( 'running_content_back_matter_right', 'pressbooks_theme_options_' . $this->getSlug(), 'running_content_back_matter_right', @$this->options['running_content_back_matter_right'], '', '', 'text', 'regular-text code' );
+		$this->renderCustomSelect(
+			'running_content_back_matter_right',
+			'running_content_back_matter_right',
+			@$this->options['running_content_back_matter_right'],
+			$args
+		);
+		$this->renderField(
+			'running_content_back_matter_right',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'running_content_back_matter_right',
+			@$this->options['running_content_back_matter_right'],
+			'',
+			'',
+			'text',
+			'regular-text code'
+		);
 	}
 
 	/**
@@ -982,7 +1261,13 @@ class PDFOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderFontSizeField( $args ) {
-		$this->renderCheckbox( 'pdf_fontsize', 'pressbooks_theme_options_' . $this->getSlug(), 'pdf_fontsize', @$this->options['pdf_fontsize'], $args[0] );
+		$this->renderCheckbox(
+			'pdf_fontsize',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'pdf_fontsize',
+			@$this->options['pdf_fontsize'],
+			$args[0]
+		);
 	}
 
 	/**

--- a/includes/modules/themeoptions/class-pb-weboptions.php
+++ b/includes/modules/themeoptions/class-pb-weboptions.php
@@ -164,7 +164,13 @@ class WebOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderSocialMediaField( $args ) {
-		$this->renderCheckbox( 'social_media', 'pressbooks_theme_options_' . $this->getSlug(), 'social_media', @$this->options['social_media'], $args[0] );
+		$this->renderCheckbox(
+			'social_media',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'social_media',
+			@$this->options['social_media'],
+			$args[0]
+		);
 	}
 
 	/**
@@ -172,7 +178,13 @@ class WebOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderParagraphSeparationField( $args ) {
-		$this->renderRadioButtons( 'paragraph_separation', 'pressbooks_theme_options_' . $this->getSlug(), 'paragraph_separation', @$this->options['paragraph_separation'], $args );
+		$this->renderRadioButtons(
+			'paragraph_separation',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'paragraph_separation',
+			@$this->options['paragraph_separation'],
+			$args
+		);
 	}
 
 	/**
@@ -180,7 +192,13 @@ class WebOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderPartTitle( $args ) {
-		$this->renderCheckbox( 'part_title', 'pressbooks_theme_options_' . $this->getSlug(), 'part_title', @$this->options['part_title'], $args[0] );
+		$this->renderCheckbox(
+			'part_title',
+			'pressbooks_theme_options_' . $this->getSlug(),
+			'part_title',
+			@$this->options['part_title'],
+			$args[0]
+		);
 	}
 
 	/**

--- a/includes/modules/themeoptions/class-pb-weboptions.php
+++ b/includes/modules/themeoptions/class-pb-weboptions.php
@@ -164,13 +164,13 @@ class WebOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderSocialMediaField( $args ) {
-		$this->renderCheckbox(
-			'social_media',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'social_media',
-			@$this->options['social_media'],
-			$args[0]
-		);
+		$this->renderCheckbox( array(
+			'id' => 'social_media',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'social_media',
+			'value' => ( isset( $this->options['social_media'] ) ) ? $this->options['social_media'] : '',
+			'description' => $args[0],
+		) );
 	}
 
 	/**
@@ -178,13 +178,13 @@ class WebOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderParagraphSeparationField( $args ) {
-		$this->renderRadioButtons(
-			'paragraph_separation',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'paragraph_separation',
-			@$this->options['paragraph_separation'],
-			$args
-		);
+		$this->renderRadioButtons( array(
+			'id' => 'paragraph_separation',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'paragraph_separation',
+			'value' => ( isset( $this->options['paragraph_separation'] ) ) ? $this->options['paragraph_separation'] : '',
+			'choices' => $args,
+		) );
 	}
 
 	/**
@@ -192,13 +192,13 @@ class WebOptions extends \Pressbooks\Options {
 	 * @param array $args
 	 */
 	function renderPartTitle( $args ) {
-		$this->renderCheckbox(
-			'part_title',
-			'pressbooks_theme_options_' . $this->getSlug(),
-			'part_title',
-			@$this->options['part_title'],
-			$args[0]
-		);
+		$this->renderCheckbox( array(
+			'id' => 'part_title',
+			'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+			'option' => 'part_title',
+			'value' => ( isset( $this->options['part_title'] ) ) ? $this->options['part_title'] : '',
+			'description' => $args[0],
+		) );
 	}
 
 	/**


### PR DESCRIPTION
Render methods in `\Pressbooks\Options` now use a single parameter, `$args`, which is an array of key-value pairs, rather than individual parameters for each argument. For example:

```
renderCheckbox(
	$id = null,
	$name = null,
	$option = null,
	$value = '',
	$description = null
);
```

…becomes:

```
renderCheckbox( $args = array (
	'id' => null,
	'name' => null,
	'option' => null,
	'value' => '',
	'description' => null,
) );
```