### PR TITLE
Add filter for dependency errors array

### DIFF
--- a/templates/admin/export.php
+++ b/templates/admin/export.php
@@ -102,7 +102,7 @@ if ( $dependency_errors ) {
 	 * Filter the array of dependency errors, remove unwanted formats.
 	 */
 	$dependency_messages = apply_filters( 'pb_dependency_errors', $dependency_errors );
-	if ( !empty( $dependency_messages ) ) {
+	if ( ! empty( $dependency_messages ) ) {
 		$formats = implode( ', ', $dependency_messages );
 		printf(
 			'<div class="error"><p>%s</p></div>',

--- a/templates/admin/export.php
+++ b/templates/admin/export.php
@@ -96,15 +96,23 @@ if ( false == \Pressbooks\Modules\Export\Odt\Odt::hasDependencies() ) {
 }
 
 if ( $dependency_errors ) {
-	$formats = implode( ', ', $dependency_errors );
-	printf(
-		'<div class="error"><p>%s</p></div>',
-		sprintf(
-			__( 'Some dependencies for %1$s exports could not be found. Please verify that you have completed the <a href="%2$s">installation instructions</a>.', 'pressbooks' ),
-			( $pos = strrpos( $formats, ', ' ) ) ? substr_replace( $formats, ', ' . __( 'and', 'pressbooks' ) . ' ', $pos, strlen( ', ' ) ) : $formats,
-			'http://docs.pressbooks.org/installation'
-		)
-	);
+	/**
+	 * @since 3.9.8
+	 *
+	 * Filter the array of dependency errors, remove unwanted formats.
+	 */
+	$dependency_errors = apply_filters('pb_dependency_errors', $dependency_errors);
+	if ( !empty( $dependency_errors ) ) {
+		$formats = implode( ', ', $dependency_errors );
+		printf(
+			'<div class="error"><p>%s</p></div>',
+			sprintf(
+				__( 'Some dependencies for %1$s exports could not be found. Please verify that you have completed the <a href="%2$s">installation instructions</a>.', 'pressbooks' ),
+				( $pos = strrpos( $formats, ', ' ) ) ? substr_replace( $formats, ', ' . __( 'and', 'pressbooks' ) . ' ', $pos, strlen( ', ' ) ) : $formats,
+				'http://docs.pressbooks.org/installation'
+			)
+		);
+	}
 }
 
 if ( ! empty( $_GET['export_error'] ) ) {

--- a/templates/admin/export.php
+++ b/templates/admin/export.php
@@ -101,9 +101,9 @@ if ( $dependency_errors ) {
 	 *
 	 * Filter the array of dependency errors, remove unwanted formats.
 	 */
-	$dependency_errors = apply_filters('pb_dependency_errors', $dependency_errors);
-	if ( !empty( $dependency_errors ) ) {
-		$formats = implode( ', ', $dependency_errors );
+	$dependency_messages = apply_filters( 'pb_dependency_errors', $dependency_errors );
+	if ( !empty( $dependency_messages ) ) {
+		$formats = implode( ', ', $dependency_messages );
 		printf(
 			'<div class="error"><p>%s</p></div>',
 			sprintf(


### PR DESCRIPTION
Enables administrators to filter & remove dependency errors for formats that they don't care about.