### PR TITLE
Set max index length when creating `pressbooks_tags` table

### DIFF
--- a/includes/class-pb-catalog.php
+++ b/includes/class-pb-catalog.php
@@ -848,7 +848,7 @@ class Catalog {
   				users_id INT(11) NOT null,
   				tag VARCHAR(200) NOT null,
   				PRIMARY KEY  (id),
-  				UNIQUE KEY tag (tag)
+  				UNIQUE KEY tag (tag(191))
 				); ";
 		dbDelta( $sql );
 	}


### PR DESCRIPTION
MySQL has a max index length of 767 bytes. As utf8mb4 can store 4 byte characters, indexes should be restricted to a key length of 191 to fit. (4 * 191 = 767)

Before this change, a database error would be thrown when installing on a utf8mb4 MySQL instance and the table would not be created.

`Specified key was too long; max key length is 767 bytes for query`

See https://make.wordpress.org/core/2015/04/02/the-utf8mb4-upgrade/ for some more background information.

I poked around briefly for a good place to add tests, but hesitated because I'm not sure if DB schema is covered yet. Let me know if tests are necessary for this change and I can dive a little deeper.

Also, hello and thanks for Pressbooks! :smile: 