### PR TITLE
Use `network_home_url()` instead of `PATH_CURRENT_SITE`

### DIFF
--- a/themes-book/pressbooks-book/404.php
+++ b/themes-book/pressbooks-book/404.php
@@ -1,1 +1,1 @@
-<?php wp_redirect( PATH_CURRENT_SITE, 301 ); ?>
+<?php wp_redirect( esc_url( network_home_url() ), 301 ); ?>

--- a/themes-book/pressbooks-book/archive.php
+++ b/themes-book/pressbooks-book/archive.php
@@ -1,1 +1,1 @@
-<?php wp_redirect( PATH_CURRENT_SITE, 301 ); ?>
+<?php wp_redirect( esc_url( network_home_url() ), 301 ); ?>

--- a/themes-book/pressbooks-book/category.php
+++ b/themes-book/pressbooks-book/category.php
@@ -1,1 +1,1 @@
-<?php wp_redirect( PATH_CURRENT_SITE, 301 ); ?>
+<?php wp_redirect( esc_url( network_home_url() ), 301 ); ?>

--- a/themes-book/pressbooks-book/header.php
+++ b/themes-book/pressbooks-book/header.php
@@ -74,7 +74,7 @@ if ( 1 === @$social_media['social_media'] || !isset( $social_media['social_media
 
 					    <div class="sub-nav-left">
 							<!-- Logo -->
-							<h2 class="pressbooks-logo"><a href="<?php echo PATH_CURRENT_SITE; ?>"><?php echo get_site_option('site_name'); ?></a></h2>
+							<h2 class="pressbooks-logo"><a href="<?php echo esc_url( network_home_url() ); ?>"><?php echo get_site_option('site_name'); ?></a></h2>
 					    </div> <!-- end .sub-nav-left -->
 
 			    <div class="sub-nav-right">


### PR DESCRIPTION
There are several redirects and an anchor that use `PATH_CURRENT_SITE` to generate the URL. It's possible to configure multisite without this constant, at which point PHP errors are generated in these
areas.

This makes the shift to `network_home_url()`, which uses the domain and path of the current network and provides a filter for anyone wishing to customize.