### PR TITLE
Include current `$post` with `wp_enqueue_media()`

### DIFF
--- a/symbionts/custom-metadata/custom_metadata.php
+++ b/symbionts/custom-metadata/custom_metadata.php
@@ -219,7 +219,10 @@ class custom_metadata_manager {
 	}
 
 	function enqueue_scripts() {
-		wp_enqueue_media();
+		$post = get_post();
+		wp_enqueue_media( array(
+			'post' => $post
+		) );
 		wp_enqueue_script( 'wplink' );
 		wp_enqueue_script( 'wpdialogs-popup' );
 		wp_enqueue_style( 'wp-jquery-ui-dialog' );


### PR DESCRIPTION
If editing a post (post type), this allows additional settings to be enqueued for media handling. Specifically, this allows the auto embed of content from a URL such as YouTube, which does not work at this time.

If editing a user, term, etc... `$post` will be `null`, which is the default argument in `wp_enqueue_media()`, resulting in no change.

There's a chance that the disable of auto-embed content is intentional. In that case I can find another workaround by filtering the settings. :)