### PR TITLE
Localize part string in TOC

### DIFF
--- a/assets/scss/partials/_prince-toc.scss
+++ b/assets/scss/partials/_prince-toc.scss
@@ -1,4 +1,4 @@
-// SASS MIXINS -- TABLE OF CONTENTS STYLING 
+// SASS MIXINS -- TABLE OF CONTENTS STYLING
 
 
 //=====================
@@ -6,8 +6,8 @@
 //=====================
 
 @mixin TocLeft {
- 
- /* TOC general page structure */ 
+
+ /* TOC general page structure */
 
   @page toc {
     @include blankheadandfoot;
@@ -16,24 +16,24 @@
     counter-reset: part;
     page-break-before: right;
   }
- 
+
  /* TOC Header */
 
   #toc h1 {
     @include frontmattertitle;
     margin-left: 1cm;
-    margin-top: 2cm;  
-    margin-bottom: 2cm; 
+    margin-top: 2cm;
+    margin-bottom: 2cm;
     text-align: left;
     display: block;
     padding-bottom: 1.5em;
   }
 
-/* TOC general styling */ 
+/* TOC general styling */
 
   #toc a {
     border: none;
-    color: inherit; 
+    color: inherit;
     margin-left: 0;
   }
   #toc ul, #toc li {
@@ -44,20 +44,20 @@
   #toc ul {
     counter-reset: chapter;
     line-height: 1.2;
-    margin-left: 1cm; 
+    margin-left: 1cm;
   }
   #toc li {
-    position: relative; 
+    position: relative;
   }
 
   /* TOC FRONT-MATTER/BACK-MATTER & Margins */
 
   #toc li.front-matter {
-    margin-top: 0.5em; 
+    margin-top: 0.5em;
   }
 
   #toc li.back-matter {
-    margin-top: 0.5em; 
+    margin-top: 0.5em;
   }
 
   #toc li.chapter {
@@ -97,13 +97,13 @@
 
   #toc .part {
     @include tocparttitle;
-    margin: 1.5em 0 1.5em 0; 
+    margin: 1.5em 0 1.5em 0;
     width: 80%;
     page-break-after: avoid;
   }
   #toc .part a::before {
     @include tocpartnumber;
-    content: "Part " counter(part, upper-roman) ".\A0";
+    content: $part ' ' counter(part, upper-roman) ".\A0";
     width: 80%;
     text-align: left;
     counter-increment: part;
@@ -112,7 +112,7 @@
     content:'' ;
   }
 
-  /* TOC CHAPTER STYLING */ 
+  /* TOC CHAPTER STYLING */
 
   #toc .chapter {
     margin-top: 0.3em;
@@ -140,17 +140,17 @@
     width: 75%;
   }
 
-  /* TOC CHAPTER NUMBERS */ 
+  /* TOC CHAPTER NUMBERS */
 
    #toc .chapter a::before {
     @include tocchapternumber;
     content: counter(chapter) ". ";
-    counter-increment: chapter; 
+    counter-increment: chapter;
     display: inline-block;
     vertical-align: top;
     position: relative;
-    line-height: 1.2; 
-    left: -1.5em; 
+    line-height: 1.2;
+    left: -1.5em;
     margin-right: -2em;
     width: 2em;
     text-align: right;
@@ -176,7 +176,7 @@
     text-decoration: none;
     line-height: 1.2;
   }
-  
+
   #toc .front-matter a::after {
     @include tocfrontmatterpagenumber;
     content: leader(" ") target-counter(attr(href), page, lower-roman);
@@ -192,8 +192,8 @@
 //=====================
 
 @mixin TocLeftChimero {
- 
- /* TOC general page structure */ 
+
+ /* TOC general page structure */
 
   @page toc {
     @include blankheadandfoot;
@@ -202,24 +202,24 @@
     counter-reset: part;
     page-break-before: right;
   }
- 
+
  /* TOC Header */
 
   #toc h1 {
     @include frontmattertitle;
     margin-left: 1cm;
-    margin-top: 2cm;  
-    margin-bottom: 2cm; 
+    margin-top: 2cm;
+    margin-bottom: 2cm;
     text-align: left;
     display: block;
     padding-bottom: 1.5em;
   }
 
-/* TOC general styling */ 
+/* TOC general styling */
 
   #toc a {
     border: none;
-    color: inherit; 
+    color: inherit;
     margin-left: 0;
   }
   #toc ul, #toc li {
@@ -230,20 +230,20 @@
   #toc ul {
     counter-reset: chapter;
     line-height: 1.2;
-    margin-left: 1cm; 
+    margin-left: 1cm;
   }
   #toc li {
-    position: relative; 
+    position: relative;
   }
 
   /* TOC FRONT-MATTER/BACK-MATTER & Margins */
 
   #toc li.front-matter {
-    margin-top: 0.5em; 
+    margin-top: 0.5em;
   }
 
   #toc li.back-matter {
-    margin-top: 0.5em; 
+    margin-top: 0.5em;
   }
 
   #toc li.chapter {
@@ -292,7 +292,7 @@
 
   #toc .part {
     @include tocparttitle;
-    margin: 1.5em 0 1.5em 0; 
+    margin: 1.5em 0 1.5em 0;
     width: 80%;
     page-break-after: avoid;
   }
@@ -307,7 +307,7 @@
     content:'' ;
   }
 
-  /* TOC CHAPTER STYLING */ 
+  /* TOC CHAPTER STYLING */
 
   #toc .chapter {
     margin-top: 0.3em;
@@ -335,7 +335,7 @@
     width: 75%;
   }
 
-  /* TOC CHAPTER NUMBERS */ 
+  /* TOC CHAPTER NUMBERS */
 
    #toc .chapter a::before {
     @include tocpagenumber;
@@ -344,8 +344,8 @@
     visibility: visible !important;
     vertical-align: top;
     position: relative;
-    line-height: 1.2; 
-    left: -1.5em; 
+    line-height: 1.2;
+    left: -1.5em;
     margin-right: -2em;
     width: 2em;
     text-align: right;
@@ -371,7 +371,7 @@
     display: inline-block;
     vertical-align: top;
     position: relative;
-    left: -1.5em; 
+    left: -1.5em;
     margin-right: -2em;
     width: 2em;
     text-align: right;
@@ -382,8 +382,8 @@
     display: inline-block;
     vertical-align: top;
     position: relative;
-    line-height: 1.2em; 
-    left: -1.5em; 
+    line-height: 1.2em;
+    left: -1.5em;
     margin-right: -2em;
     width: 2em;
     text-align: right;
@@ -394,8 +394,8 @@
     display: inline-block;
     vertical-align: top;
     position: relative;
-    line-height: 1.2; 
-    left: -1.5em; 
+    line-height: 1.2;
+    left: -1.5em;
     margin-right: -2em;
     width: 2em;
     text-align: right;
@@ -409,8 +409,8 @@
 
 
 @mixin TocLeftBringhurst {
- 
- /* TOC general page structure */ 
+
+ /* TOC general page structure */
 
   @page toc {
     @include blankheadandfoot;
@@ -419,24 +419,24 @@
     counter-reset: part;
     page-break-before: right;
   }
- 
+
  /* TOC Header */
 
   #toc h1 {
     @include frontmattertitle;
     margin-left: 1cm;
-    margin-top: 2cm;  
-    margin-bottom: 2cm; 
+    margin-top: 2cm;
+    margin-bottom: 2cm;
     text-align: center;
     display: block;
     padding-bottom: 1.5em;
   }
 
-/* TOC general styling */ 
+/* TOC general styling */
 
   #toc a {
     border: none;
-    color: inherit; 
+    color: inherit;
     margin-left: 0;
   }
   #toc ul, #toc li {
@@ -447,20 +447,20 @@
   #toc ul {
     counter-reset: chapter;
     line-height: 1.2;
-    margin-left: 1cm; 
+    margin-left: 1cm;
   }
   #toc li {
-    position: relative; 
+    position: relative;
   }
 
   /* TOC FRONT-MATTER/BACK-MATTER & Margins */
 
   #toc li.front-matter {
-    margin-top: 0.5em; 
+    margin-top: 0.5em;
   }
 
   #toc li.back-matter {
-    margin-top: 0.5em; 
+    margin-top: 0.5em;
   }
 
   #toc li.chapter {
@@ -496,7 +496,7 @@
 
   #toc .part {
     @include tocparttitle;
-    margin: 1.5em 0 1.5em 0; 
+    margin: 1.5em 0 1.5em 0;
     width: 80%;
     page-break-after: avoid;
   }
@@ -511,7 +511,7 @@
     content:'' ;
   }
 
-  /* TOC CHAPTER STYLING */ 
+  /* TOC CHAPTER STYLING */
 
   #toc .chapter {
     margin-top: 0.3em;
@@ -541,17 +541,17 @@
     width: 75%;
   }
 
-  /* TOC CHAPTER NUMBERS */ 
+  /* TOC CHAPTER NUMBERS */
 
    #toc .chapter a::before {
     @include tocchapternumber;
     content: counter(chapter) ". ";
-    counter-increment: chapter; 
+    counter-increment: chapter;
     display: inline-block;
     vertical-align: top;
     position: relative;
-    line-height: 1.2; 
-    left: -1.5em; 
+    line-height: 1.2;
+    left: -1.5em;
     margin-right: -2em;
     width: 2em;
     text-align: right;
@@ -589,14 +589,14 @@
 
 @mixin TocCenter {
 
-  /* TOC general page structure */ 
+  /* TOC general page structure */
 
   @page toc {
     @include blankheadandfoot;
   }
   #toc {
     counter-reset: part;
-    page-break-before: right; 
+    page-break-before: right;
     font-size: 0.9em;
     margin-left: 0.5cm;
     margin-right: 0.5cm;
@@ -611,11 +611,11 @@
     padding-bottom: 2em;
   }
 
-/* TOC general styling */ 
+/* TOC general styling */
 
   #toc a {
     border: none;
-    color: inherit; 
+    color: inherit;
   }
   #toc ul, #toc li {
     list-style: none;
@@ -627,20 +627,20 @@
   }
   #toc ul {
     counter-reset: chapter;
-    line-height: 1; 
+    line-height: 1;
   }
   #toc li {
-    position: relative; 
+    position: relative;
   }
 
  /* TOC FRONT-MATTER/BACK-MATTER & Margins */
 
   #toc li.front-matter {
-    margin-top: 0.3em; 
+    margin-top: 0.3em;
     text-align: center;
   }
   #toc li.back-matter {
-    margin-top: 0.3em; 
+    margin-top: 0.3em;
     text-align: center;
   }
   #toc li.chapter + li.back-matter {
@@ -676,24 +676,24 @@
     content: "Part " counter(part, upper-roman)".\A0";
     display: block;
     text-align: center;
-    counter-increment: part; 
+    counter-increment: part;
     page-break-after: avoid;
   }
   #toc .part a::after {
     content:'' ;
   }
 
-  /* CHAPTER NUMBERS */ 
+  /* CHAPTER NUMBERS */
 
   #toc .chapter a::before {
     @include tocchapternumber;
     content: counter(chapter) ".\A0\A0\A0";
-    counter-increment: chapter; 
+    counter-increment: chapter;
     display: inline;
     page-break-after: avoid;
   }
 
-  /* TOC CHAPTER STYLING */ 
+  /* TOC CHAPTER STYLING */
 
   #toc .chapter {
     margin-top: 0.75em;
@@ -730,6 +730,6 @@
     text-decoration: none;
     display: inline;
   }
-  
+
   /* END TOC */
 }

--- a/assets/scss/partials/_prince-toc.scss
+++ b/assets/scss/partials/_prince-toc.scss
@@ -2,16 +2,17 @@
 
 
 //=====================
-//SASS: TocLeft
+//SASS: tocleft
 //=====================
 
-@mixin TocLeft {
+@mixin tocleft {
 
  /* TOC general page structure */
 
   @page toc {
     @include blankheadandfoot;
   }
+
   #toc {
     counter-reset: part;
     page-break-before: right;
@@ -21,31 +22,35 @@
 
   #toc h1 {
     @include frontmattertitle;
-    margin-left: 1cm;
-    margin-top: 2cm;
-    margin-bottom: 2cm;
-    text-align: left;
     display: block;
     padding-bottom: 1.5em;
+    margin-top: 2cm;
+    margin-bottom: 2cm;
+    margin-left: 1cm;
+    text-align: left;
   }
 
 /* TOC general styling */
 
   #toc a {
-    border: none;
-    color: inherit;
     margin-left: 0;
+    color: inherit;
+    border: 0;
   }
-  #toc ul, #toc li {
-    list-style: none;
-    margin: 0;
+
+  #toc ul,
+  #toc li {
     padding: 0;
+    margin: 0;
+    list-style: none;
   }
+
   #toc ul {
-    counter-reset: chapter;
-    line-height: 1.2;
     margin-left: 1cm;
+    line-height: 1.2;
+    counter-reset: chapter;
   }
+
   #toc li {
     position: relative;
   }
@@ -53,11 +58,11 @@
   /* TOC FRONT-MATTER/BACK-MATTER & Margins */
 
   #toc li.front-matter {
-    margin-top: 0.5em;
+    margin-top: .5em;
   }
 
   #toc li.back-matter {
-    margin-top: 0.5em;
+    margin-top: .5em;
   }
 
   #toc li.chapter {
@@ -79,16 +84,20 @@
   #toc li.chapter + li.back-matter {
     margin-top: 1.5em;
   }
+
   #toc li.part + li.back-matter {
     margin-top: 1.5em;
   }
+
   #toc .front-matter span.toc-chapter-title {
-    display: block;
     position: relative;
+    display: block;
   }
+
   #toc .front-matter span.toc-chapter-title {
     @include tocfrontmattertitle;
   }
+
   #toc .introduction span.toc-chapter-title {
     @include tocfrontmattertitle;
   }
@@ -97,90 +106,97 @@
 
   #toc .part {
     @include tocparttitle;
-    margin: 1.5em 0 1.5em 0;
     width: 80%;
+    margin: 1.5em 0;
     page-break-after: avoid;
   }
+
   #toc .part a::before {
     @include tocpartnumber;
-    content: $part ' ' counter(part, upper-roman) ".\A0";
     width: 80%;
     text-align: left;
+    content: $part ' ' counter(part, upper-roman) '.\A0';
     counter-increment: part;
   }
+
   #toc .part a::after {
-    content:'' ;
+    content: '';
   }
 
   /* TOC CHAPTER STYLING */
 
   #toc .chapter {
-    margin-top: 0.3em;
+    margin-top: .3em;
     margin-left: 0;
   }
+
   #toc span.toc-chapter-title {
     @include tocchaptertitle;
-    display: inline-block;
-    text-indent: 0;
-    width: 80%;
-    top: 0;
     position: relative;
+    top: 0;
+    display: inline-block;
+    width: 80%;
+    text-indent: 0;
     vertical-align: top;
   }
+
   #toc span.chapter-subtitle {
     @include tocchaptersubtitle;
   }
+
   #toc span.chapter-author {
     @include tocchapterauthor;
   }
+
   #toc span.chapter-author,
   #toc span.chapter-subtitle {
     display: inline-block;
-    text-indent: 0;
     width: 75%;
+    text-indent: 0;
   }
 
   /* TOC CHAPTER NUMBERS */
 
-   #toc .chapter a::before {
+  #toc .chapter a::before {
     @include tocchapternumber;
-    content: counter(chapter) ". ";
-    counter-increment: chapter;
-    display: inline-block;
-    vertical-align: top;
     position: relative;
-    line-height: 1.2;
     left: -1.5em;
-    margin-right: -2em;
+    display: inline-block;
     width: 2em;
+    margin-right: -2em;
+    line-height: 1.2;
     text-align: right;
+    vertical-align: top;
+    content: counter(chapter) '. ';
+    counter-increment: chapter;
   }
 
   /* TOC BACK-MATTER STYLING */
 
   #toc .back-matter span.toc-chapter-title {
     @include tocbackmattertitle;
-    display: block;
     position: relative;
+    display: block;
   }
 
 /* TOC PAGE NUMBERS */
 
   #toc a::after {
     @include tocpagenumber;
-    content: target-counter(attr(href), page);
-    vertical-align: top;
     position: absolute;
-    top: 0.2em;
+    top: .2em;
     right: 0;
-    text-decoration: none;
     line-height: 1.2;
+    text-decoration: none;
+    vertical-align: top;
+    content: target-counter(attr(href), page);
   }
 
   #toc .front-matter a::after {
     @include tocfrontmatterpagenumber;
-    content: leader(" ") target-counter(attr(href), page, lower-roman);
+    content: leader(' ') target-counter(attr(href), page, lower-roman);
   }
+
   #toc .introduction a::after {
     content: leader(' ') target-counter(attr(href), page);
   }
@@ -188,16 +204,17 @@
 
 
 //=====================
-//SASS: TocLeftChimero
+//SASS: tocleftchimero
 //=====================
 
-@mixin TocLeftChimero {
+@mixin tocleftchimero {
 
  /* TOC general page structure */
 
   @page toc {
     @include blankheadandfoot;
   }
+
   #toc {
     counter-reset: part;
     page-break-before: right;
@@ -207,31 +224,35 @@
 
   #toc h1 {
     @include frontmattertitle;
-    margin-left: 1cm;
-    margin-top: 2cm;
-    margin-bottom: 2cm;
-    text-align: left;
     display: block;
     padding-bottom: 1.5em;
+    margin-top: 2cm;
+    margin-bottom: 2cm;
+    margin-left: 1cm;
+    text-align: left;
   }
 
 /* TOC general styling */
 
   #toc a {
-    border: none;
-    color: inherit;
     margin-left: 0;
+    color: inherit;
+    border: 0;
   }
-  #toc ul, #toc li {
-    list-style: none;
-    margin: 0;
+
+  #toc ul,
+  #toc li {
     padding: 0;
+    margin: 0;
+    list-style: none;
   }
+
   #toc ul {
-    counter-reset: chapter;
-    line-height: 1.2;
     margin-left: 1cm;
+    line-height: 1.2;
+    counter-reset: chapter;
   }
+
   #toc li {
     position: relative;
   }
@@ -239,11 +260,11 @@
   /* TOC FRONT-MATTER/BACK-MATTER & Margins */
 
   #toc li.front-matter {
-    margin-top: 0.5em;
+    margin-top: .5em;
   }
 
   #toc li.back-matter {
-    margin-top: 0.5em;
+    margin-top: .5em;
   }
 
   #toc li.chapter {
@@ -265,26 +286,28 @@
   #toc li.chapter + li.back-matter {
     margin-top: 1.5em;
   }
+
   #toc li.part + li.back-matter {
     margin-top: 1.5em;
   }
 
   #toc .front-matter span.toc-chapter-title {
     @include tocfrontmattertitle;
-    display: inline-block;
-    text-indent: 0;
-    width: 80%;
-    top: 0;
     position: relative;
+    top: 0;
+    display: inline-block;
+    width: 80%;
+    text-indent: 0;
     vertical-align: top;
   }
+
   #toc .introduction span.toc-chapter-title {
     @include tocfrontmattertitle;
-    display: inline-block;
-    text-indent: 0;
-    width: 80%;
-    top: 0;
     position: relative;
+    top: 0;
+    display: inline-block;
+    width: 80%;
+    text-indent: 0;
     vertical-align: top;
   }
 
@@ -292,74 +315,80 @@
 
   #toc .part {
     @include tocparttitle;
-    margin: 1.5em 0 1.5em 0;
     width: 80%;
+    margin: 1.5em 0;
     page-break-after: avoid;
   }
+
   #toc .part a::before {
     @include tocpartnumber;
-    content: "Part " counter(part, upper-roman) ".\A0";
     width: 80%;
     text-align: left;
+    content: $part ' ' counter(part, upper-roman) '.\A0';
     counter-increment: part;
   }
+
   #toc .part a::after {
-    content:'' ;
+    content: '';
   }
 
   /* TOC CHAPTER STYLING */
 
   #toc .chapter {
-    margin-top: 0.3em;
+    margin-top: .3em;
     margin-left: 0;
   }
+
   #toc span.toc-chapter-title {
     @include tocchaptertitle;
-    display: inline-block;
-    text-indent: 0;
-    width: 80%;
-    top: 0;
     position: relative;
+    top: 0;
+    display: inline-block;
+    width: 80%;
+    text-indent: 0;
     vertical-align: top;
   }
+
   #toc span.chapter-subtitle {
     @include tocchaptersubtitle;
   }
+
   #toc span.chapter-author {
     @include tocchapterauthor;
   }
+
   #toc span.chapter-author,
   #toc span.chapter-subtitle {
     display: inline-block;
-    text-indent: 0;
     width: 75%;
+    text-indent: 0;
   }
 
   /* TOC CHAPTER NUMBERS */
 
-   #toc .chapter a::before {
+  #toc .chapter a::before {
     @include tocpagenumber;
-    content: target-counter(attr(href), page);
-    display: inline-block !important;
-    visibility: visible !important;
-    vertical-align: top;
     position: relative;
-    line-height: 1.2;
     left: -1.5em;
-    margin-right: -2em;
+    display: inline-block;
     width: 2em;
+    margin-right: -2em;
+    line-height: 1.2;
     text-align: right;
+    vertical-align: top;
+    content: target-counter(attr(href), page);
+    visibility: visible;
   }
 
   /* TOC BACK-MATTER STYLING */
 
   #toc .back-matter span.toc-chapter-title {
     @include tocbackmattertitle;
-    display: inline-block;
-    text-indent: 0;
-    width: 80%;
-    top: 0;
     position: relative;
+    top: 0;
+    display: inline-block;
+    width: 80%;
+    text-indent: 0;
     vertical-align: top;
   }
 
@@ -367,54 +396,57 @@
 
   #toc .front-matter a::before {
     @include tocfrontmatterpagenumber;
-    content: target-counter(attr(href), page, lower-roman);
-    display: inline-block;
-    vertical-align: top;
     position: relative;
     left: -1.5em;
-    margin-right: -2em;
+    display: inline-block;
     width: 2em;
+    margin-right: -2em;
     text-align: right;
+    vertical-align: top;
+    content: target-counter(attr(href), page, lower-roman);
   }
+
   #toc .introduction a::before {
     @include tocfrontmatterpagenumber;
-    content: target-counter(attr(href), page);
-    display: inline-block;
-    vertical-align: top;
     position: relative;
-    line-height: 1.2em;
     left: -1.5em;
-    margin-right: -2em;
+    display: inline-block;
     width: 2em;
+    margin-right: -2em;
+    line-height: 1.2em;
     text-align: right;
+    vertical-align: top;
+    content: target-counter(attr(href), page);
   }
+
   #toc .back-matter a::before {
     @include tocpagenumber;
-    content: target-counter(attr(href), page);
-    display: inline-block;
-    vertical-align: top;
     position: relative;
-    line-height: 1.2;
     left: -1.5em;
-    margin-right: -2em;
+    display: inline-block;
     width: 2em;
+    margin-right: -2em;
+    line-height: 1.2;
     text-align: right;
+    vertical-align: top;
+    content: target-counter(attr(href), page);
   }
 }
 
 
 //=========================
-//SASS: TocLeftBringhurst
+//SASS: tocleftbringhurst
 //==========================
 
 
-@mixin TocLeftBringhurst {
+@mixin tocleftbringhurst {
 
  /* TOC general page structure */
 
   @page toc {
     @include blankheadandfoot;
   }
+
   #toc {
     counter-reset: part;
     page-break-before: right;
@@ -424,31 +456,35 @@
 
   #toc h1 {
     @include frontmattertitle;
-    margin-left: 1cm;
-    margin-top: 2cm;
-    margin-bottom: 2cm;
-    text-align: center;
     display: block;
     padding-bottom: 1.5em;
+    margin-top: 2cm;
+    margin-bottom: 2cm;
+    margin-left: 1cm;
+    text-align: center;
   }
 
 /* TOC general styling */
 
   #toc a {
-    border: none;
-    color: inherit;
     margin-left: 0;
+    color: inherit;
+    border: 0;
   }
-  #toc ul, #toc li {
-    list-style: none;
-    margin: 0;
+
+  #toc ul,
+  #toc li {
     padding: 0;
+    margin: 0;
+    list-style: none;
   }
+
   #toc ul {
-    counter-reset: chapter;
-    line-height: 1.2;
     margin-left: 1cm;
+    line-height: 1.2;
+    counter-reset: chapter;
   }
+
   #toc li {
     position: relative;
   }
@@ -456,11 +492,11 @@
   /* TOC FRONT-MATTER/BACK-MATTER & Margins */
 
   #toc li.front-matter {
-    margin-top: 0.5em;
+    margin-top: .5em;
   }
 
   #toc li.back-matter {
-    margin-top: 0.5em;
+    margin-top: .5em;
   }
 
   #toc li.chapter {
@@ -482,12 +518,15 @@
   #toc li.chapter + li.back-matter {
     margin-top: 1.5em;
   }
+
   #toc li.part + li.back-matter {
     margin-top: 1.5em;
   }
+
   #toc .front-matter span.toc-chapter-title {
     @include tocfrontmattertitle;
   }
+
   #toc .introduction span.toc-chapter-title {
     @include tocfrontmattertitle;
   }
@@ -496,65 +535,70 @@
 
   #toc .part {
     @include tocparttitle;
-    margin: 1.5em 0 1.5em 0;
     width: 80%;
+    margin: 1.5em 0;
     page-break-after: avoid;
   }
+
   #toc .part a::before {
     @include tocpartnumber;
-    content: "Part " counter(part, upper-roman) ".\A0";
     width: 80%;
     text-align: left;
+    content: $part ' ' counter(part, upper-roman) '.\A0';
     counter-increment: part;
   }
+
   #toc .part a::after {
-    content:'' ;
+    content: '';
   }
 
   /* TOC CHAPTER STYLING */
 
   #toc .chapter {
-    margin-top: 0.3em;
+    margin-top: .3em;
     margin-left: 0;
   }
+
   #toc span.toc-chapter-title {
     @include tocchaptertitle;
+    position: relative;
+    top: 0;
     display: inline-block;
     text-indent: 0;
-   /* width: 80%; */
-    top: 0;
-    position: relative;
     vertical-align: top;
   }
+
   #toc span.chapter-subtitle {
     @include tocchaptersubtitle;
     display: none;
   }
+
   #toc span.chapter-author {
     @include tocchapterauthor;
     display: none;
   }
+
   #toc span.chapter-author,
   #toc span.chapter-subtitle {
     display: none;
-    text-indent: 0;
     width: 75%;
+    text-indent: 0;
   }
 
   /* TOC CHAPTER NUMBERS */
 
-   #toc .chapter a::before {
+  #toc .chapter a::before {
     @include tocchapternumber;
-    content: counter(chapter) ". ";
-    counter-increment: chapter;
-    display: inline-block;
-    vertical-align: top;
     position: relative;
-    line-height: 1.2;
     left: -1.5em;
-    margin-right: -2em;
+    display: inline-block;
     width: 2em;
+    margin-right: -2em;
+    line-height: 1.2;
     text-align: right;
+    vertical-align: top;
+    content: counter(chapter) '. ';
+    counter-increment: chapter;
   }
 
   /* TOC BACK-MATTER STYLING */
@@ -567,16 +611,18 @@
 
   #toc a::after {
     @include tocpagenumber;
-    content: "\A0\A0\A0\A0" target-counter(attr(href), page);
     display: inline;
     text-decoration: none;
+    content: '\A0\A0\A0\A0' target-counter(attr(href), page);
   }
+
   #toc .front-matter a::after {
     @include tocfrontmatterpagenumber;
-    content: "\A0\A0\A0\A0" target-counter(attr(href), page, lower-roman);
+    content: '\A0\A0\A0\A0' target-counter(attr(href), page, lower-roman);
   }
+
   #toc .introduction a::after {
-    content: "\A0\A0\A0\A0" target-counter(attr(href), page);
+    content: '\A0\A0\A0\A0' target-counter(attr(href), page);
   }
 }
 
@@ -586,49 +632,53 @@
 //SASS: TocCenter
 //================
 
-
-@mixin TocCenter {
+@mixin toccenter {
 
   /* TOC general page structure */
 
   @page toc {
     @include blankheadandfoot;
   }
+
   #toc {
+    margin-right: .5cm;
+    margin-left: .5cm;
+    font-size: .9em;
     counter-reset: part;
     page-break-before: right;
-    font-size: 0.9em;
-    margin-left: 0.5cm;
-    margin-right: 0.5cm;
   }
 
  /* TOC Header */
 
   #toc h1 {
     @include frontmattertitle;
-    text-align: center !important;
     display: block;
     padding-bottom: 2em;
+    text-align: center;
   }
 
 /* TOC general styling */
 
   #toc a {
-    border: none;
     color: inherit;
+    border: 0;
   }
-  #toc ul, #toc li {
-    list-style: none;
-    margin-left: 0;
-    margin-right: 0;
-    padding-left: 0;
+
+  #toc ul,
+  #toc li {
     padding-right: 0;
+    padding-left: 0;
+    margin-right: 0;
+    margin-left: 0;
     text-align: center;
+    list-style: none;
   }
+
   #toc ul {
-    counter-reset: chapter;
     line-height: 1;
+    counter-reset: chapter;
   }
+
   #toc li {
     position: relative;
   }
@@ -636,23 +686,28 @@
  /* TOC FRONT-MATTER/BACK-MATTER & Margins */
 
   #toc li.front-matter {
-    margin-top: 0.3em;
+    margin-top: .3em;
     text-align: center;
   }
+
   #toc li.back-matter {
-    margin-top: 0.3em;
+    margin-top: .3em;
     text-align: center;
   }
+
   #toc li.chapter + li.back-matter {
     margin-top: 2em;
   }
+
   #toc li.part + li.back-matter {
     margin-top: 1.5em;
   }
+
   #toc .front-matter span.toc-chapter-title {
     @include tocfrontmattertitle;
     text-align: center;
   }
+
   #toc .introduction span.toc-chapter-title {
     @include tocfrontmattertitle;
     text-align: center;
@@ -667,51 +722,57 @@
 
   #toc .part {
     @include tocparttitle;
-    text-align: center;
-    page-break-after: avoid;
     margin-top: 2em;
     margin-bottom: 1.5em;
+    text-align: center;
+    page-break-after: avoid;
   }
+
   #toc .part a::before {
-    content: "Part " counter(part, upper-roman)".\A0";
     display: block;
     text-align: center;
+    content: $part ' ' counter(part, upper-roman) '.\A0';
     counter-increment: part;
     page-break-after: avoid;
   }
+
   #toc .part a::after {
-    content:'' ;
+    content: '';
   }
 
   /* CHAPTER NUMBERS */
 
   #toc .chapter a::before {
     @include tocchapternumber;
-    content: counter(chapter) ".\A0\A0\A0";
-    counter-increment: chapter;
     display: inline;
+    content: counter(chapter) '.\A0\A0\A0';
+    counter-increment: chapter;
     page-break-after: avoid;
   }
 
   /* TOC CHAPTER STYLING */
 
   #toc .chapter {
-    margin-top: 0.75em;
+    margin-top: .75em;
   }
+
   #toc span.toc-chapter-title {
     @include tocchaptertitle;
-    text-align: center;
     display: inline-block;
+    text-align: center;
     page-break-after: avoid;
   }
+
   #toc span.chapter-author,
   #toc span.chapter-subtitle {
     display: none;
     text-align: center;
   }
+
   #toc span.chapter-subtitle {
     @include tocchaptersubtitle;
   }
+
   #toc span.chapter-author {
     @include tocchapterauthor;
   }
@@ -719,16 +780,18 @@
   /* PAGE NUMBERS */
 
   #toc .front-matter a::after {
-    content: "\A0\A0\A0"  target-counter(attr(href), page, lower-roman);
+    content: '\A0\A0\A0'  target-counter(attr(href), page, lower-roman);
   }
+
   #toc .introduction a::after {
-    content: "\A0\A0\A0"  target-counter(attr(href), page);
+    content: '\A0\A0\A0'  target-counter(attr(href), page);
   }
+
   #toc a::after {
     @include tocpagenumber;
-    content: "\A0\A0\A0" target-counter(attr(href), page);
-    text-decoration: none;
     display: inline;
+    text-decoration: none;
+    content: '\A0\A0\A0' target-counter(attr(href), page);
   }
 
   /* END TOC */


### PR DESCRIPTION
This PR updates the legacy `_prince-toc.scss` partial to properly display localized text for "Part X" in the table of contents, and applies SCSS coding standards to the file..