### PR TITLE
Ebook Options tab visibility

### DIFF
--- a/includes/modules/themeoptions/class-pb-themeoptions.php
+++ b/includes/modules/themeoptions/class-pb-themeoptions.php
@@ -93,6 +93,10 @@ class ThemeOptions {
 		if ( ! \Pressbooks\Modules\Export\Prince\Pdf::hasDependencies() ) {
 			unset( $tabs['pdf'] );
 		}
+		
+		if ( ! \Pressbooks\Modules\Export\Mobi\Kindlegen::hasDependencies() && ! \Pressbooks\Modules\Export\Epub\Epub201::hasDependencies() ) {
+			unset( $tabs['ebook'] );
+		}
 
 		/**
 		 * Add a custom tab to the theme options page.

--- a/includes/modules/themeoptions/class-pb-themeoptions.php
+++ b/includes/modules/themeoptions/class-pb-themeoptions.php
@@ -93,7 +93,7 @@ class ThemeOptions {
 		if ( ! \Pressbooks\Modules\Export\Prince\Pdf::hasDependencies() ) {
 			unset( $tabs['pdf'] );
 		}
-		
+
 		if ( ! \Pressbooks\Modules\Export\Mobi\Kindlegen::hasDependencies() && ! \Pressbooks\Modules\Export\Epub\Epub201::hasDependencies() ) {
 			unset( $tabs['ebook'] );
 		}


### PR DESCRIPTION
Currently the Ebook Options tab in the Theme Options was visible all the time. Now when Kindlegen and Epub dependencies are not installed, it's not visible anymore.