### PR TITLE
Book title doesn't update properly (fix #542)

### DIFF
--- a/hooks-admin.php
+++ b/hooks-admin.php
@@ -133,6 +133,7 @@ if ( \Pressbooks\Book::isBook() ) {
 	add_action( 'save_post', '\Pressbooks\Book::consolidatePost', 10, 2 );
 	add_action( 'save_post_metadata', '\Pressbooks\Admin\Metaboxes\upload_cover_image', 10, 2 );
 	add_action( 'save_post_metadata', '\Pressbooks\Admin\Metaboxes\add_required_data', 20, 2 );
+	add_action( 'added_post_meta', '\Pressbooks\Admin\Metaboxes\title_update', 10, 4 );
 	add_action( 'updated_post_meta', '\Pressbooks\Admin\Metaboxes\title_update', 10, 4 );
 	add_action( 'updated_post_meta', '\Pressbooks\L10n\install_book_locale', 10, 4 );
 	add_action( 'save_post', '\Pressbooks\Book::deleteBookObjectCache', 1000 );

--- a/includes/admin/pb-metaboxes.php
+++ b/includes/admin/pb-metaboxes.php
@@ -9,15 +9,16 @@ namespace Pressbooks\Admin\Metaboxes;
 /**
  * If the user updates the book's title, then also update the blog name
  *
- * @param int $pid
- * @param \WP_Post $post
+ * @param string|int $meta_id
+ * @param int $post_id
+ * @param string $meta_key
+ * @param string $meta_value
  */
 function title_update( $meta_id, $post_id, $meta_key, $meta_value ) {
 	if ( 'pb_title' != $meta_key ) {
-		return false;
+		return;
 	} else {
 		update_option( 'blogname', $meta_value );
-		\wp_cache_flush();
 	}
 }
 

--- a/tests/test-metaboxes.php
+++ b/tests/test-metaboxes.php
@@ -1,0 +1,27 @@
+<?php
+
+require_once( PB_PLUGIN_DIR . 'includes/admin/pb-metaboxes.php' );
+
+
+class MetaboxesTest extends \WP_UnitTestCase {
+
+	use utilsTrait;
+
+	/**
+	 * @covers \Pressbooks\Admin\Metaboxes\add_meta_boxes
+	 */
+	public function test_update_font_stacks() {
+
+		global $wp_meta_boxes;
+		$c = custom_metadata_manager::instance();
+
+		\Pressbooks\Admin\Metaboxes\add_meta_boxes();
+
+		$this->assertArrayHasKey( 'chapter', $wp_meta_boxes );
+		$this->assertArrayHasKey( 'part', $wp_meta_boxes );
+		$this->assertArrayHasKey( 'metadata', $c->metadata );
+		$this->assertArrayHasKey( 'general-book-information', $c->metadata['metadata'] );
+		$this->assertArrayHasKey( 'additional-catalogue-information', $c->metadata['metadata'] );
+	}
+
+}

--- a/tests/test-metaboxes.php
+++ b/tests/test-metaboxes.php
@@ -5,7 +5,21 @@ require_once( PB_PLUGIN_DIR . 'includes/admin/pb-metaboxes.php' );
 
 class MetaboxesTest extends \WP_UnitTestCase {
 
-	use utilsTrait;
+	/**
+	 * @covers \Pressbooks\Admin\Metaboxes\title_update
+	 */
+	public function test_title_update() {
+
+		$title = get_option( 'blogname' );
+		\Pressbooks\Admin\Metaboxes\title_update( null, null, 'pb_some_key', 'Nothing should happen' );
+		$option = get_option( 'blogname' );
+		$this->assertEquals( $option, $title );
+
+		$title = 'Hello World!';
+		\Pressbooks\Admin\Metaboxes\title_update( null, null, 'pb_title', $title );
+		$option = get_option( 'blogname' );
+		$this->assertEquals( $option, $title );
+	}
 
 	/**
 	 * @covers \Pressbooks\Admin\Metaboxes\add_meta_boxes
@@ -23,5 +37,6 @@ class MetaboxesTest extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'general-book-information', $c->metadata['metadata'] );
 		$this->assertArrayHasKey( 'additional-catalogue-information', $c->metadata['metadata'] );
 	}
+
 
 }


### PR DESCRIPTION
The custom metadata plugin calls the  function: update_metadata() in the WP Core file: web/wp/wp-includes/meta.php.

Because the title is empty, i.e. not in the postmeta table, we end up in  `return add_metadata()`. before reaching the end of the update, I.e.

```
 $meta_ids = $wpdb->get_col( $wpdb->prepare( "SELECT $id_column FROM $table WHERE meta_key = %s AND $column = %d", $meta_key, $object_id ) );
 if ( empty( $meta_ids ) ) {
  return add_metadata( $meta_type, $object_id, $raw_meta_key, $passed_value );
 }
```

The fix is to use the `added_post_meta` hook in conjunction with the `updated_post_meta` hook.