### PR TITLE
Premature optimization

### DIFF
--- a/compatibility.php
+++ b/compatibility.php
@@ -18,6 +18,12 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function pb_meets_minimum_requirements() {
 
+	// Cheap cache
+	static $is_compatible = null;
+	if ( null !== $is_compatible ) {
+		return $is_compatible;
+	}
+
 	$is_compatible = true;
 
 	// PHP Version

--- a/includes/admin/pb-analytics.php
+++ b/includes/admin/pb-analytics.php
@@ -215,7 +215,6 @@ function print_admin_analytics() {
 
 	switch_to_blog( 1 );
 	$ga_mu_uaid_network = get_option( 'ga_mu_uaid' );
-	$ga_mu_maindomain = get_option( 'ga_mu_maindomain' );
 	$ga_mu_site_specific_allowed = get_option( 'ga_mu_site_specific_allowed' );
 	restore_current_blog();
 
@@ -241,8 +240,9 @@ function print_admin_analytics() {
 		$book = false;
 	}
 
+	$html = '';
 	if ( $network || $book ) {
-		$html = "<!-- Google Analytics -->\n<script>\n(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','//www.google-analytics.com/analytics.js','ga');\n";
+		$html .= "<!-- Google Analytics -->\n<script>\n(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','//www.google-analytics.com/analytics.js','ga');\n";
 		if ( $network ) {
 			$html .= "ga('create', '" . $ga_mu_uaid_network . "', 'auto');\n";
 			$html .= "ga('send', 'pageview');\n";

--- a/includes/pb-analytics.php
+++ b/includes/pb-analytics.php
@@ -12,7 +12,6 @@ function print_analytics() {
 
 	switch_to_blog( 1 );
 	$ga_mu_uaid_network = get_option( 'ga_mu_uaid' );
-	$ga_mu_maindomain = get_option( 'ga_mu_maindomain' );
 	$ga_mu_site_specific_allowed = get_option( 'ga_mu_site_specific_allowed' );
 	restore_current_blog();
 
@@ -38,8 +37,9 @@ function print_analytics() {
 		$book = false;
 	}
 
+	$html = '';
 	if ( $network || $book ) {
-		$html = "<!-- Google Analytics -->\n<script>\n(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','//www.google-analytics.com/analytics.js','ga');\n";
+		$html .= "<!-- Google Analytics -->\n<script>\n(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','//www.google-analytics.com/analytics.js','ga');\n";
 		if ( $network ) {
 			$html .= "ga('create', '" . $ga_mu_uaid_network . "', 'auto');\n";
 			$html .= "ga('send', 'pageview');\n";

--- a/templates/admin/export.php
+++ b/templates/admin/export.php
@@ -39,60 +39,52 @@ if ( $timezone_string ) {
 
 $dependency_errors = array();
 
-if ( false == \Pressbooks\Modules\Export\Prince\Pdf::hasDependencies() ) {
-	$prince = false;
+if ( false == get_transient( 'pb_pdf_compatible' ) && false == \Pressbooks\Modules\Export\Prince\Pdf::hasDependencies() ) {
 	$dependency_errors['pdf'] = 'PDF';
 } else {
-	$prince = true;
+	set_transient( 'pb_pdf_compatible', true );
 }
 
-if ( false == \Pressbooks\Modules\Export\Prince\PrintPdf::hasDependencies() ) {
-	$prince = false;
+if ( false == get_transient( 'pb_print_pdf_compatible' ) && false == \Pressbooks\Modules\Export\Prince\PrintPdf::hasDependencies() ) {
 	$dependency_errors['print_pdf'] = 'Print PDF';
 } else {
-	$prince = true;
+	set_transient( 'pb_print_pdf_compatible', true );
 }
 
-if ( false == \Pressbooks\Modules\Export\Epub\Epub201::hasDependencies() ) {
-	$epub = false;
+if ( false == get_transient( 'pb_epub_compatible' ) && false == \Pressbooks\Modules\Export\Epub\Epub201::hasDependencies() ) {
 	$dependency_errors['epub'] = 'EPUB';
 } else {
-	$epub = true;
+	set_transient( 'pb_epub_compatible', true );
 }
 
-if ( false == \Pressbooks\Modules\Export\Mobi\Kindlegen::hasDependencies() ) {
-	$mobi = false;
+if ( false == get_transient( 'pb_mobi_compatible' ) && false == \Pressbooks\Modules\Export\Mobi\Kindlegen::hasDependencies() ) {
 	$dependency_errors['mobi'] = 'MOBI';
 } else {
-	$mobi = true;
+	set_transient( 'pb_mobi_compatible', true );
 }
 
-if ( false == \Pressbooks\Modules\Export\Epub\Epub3::hasDependencies() ) {
-	$epub3 = false;
+if ( false == get_transient( 'pb_epub3_compatible' ) && false == \Pressbooks\Modules\Export\Epub\Epub3::hasDependencies() ) {
 	$dependency_errors['epub3'] = 'EPUB3';
 } else {
-	$epub3 = true;
+	set_transient( 'pb_epub3_compatible', true );
 }
 
-if ( false == \Pressbooks\Modules\Export\Xhtml\Xhtml11::hasDependencies() ) {
-	$xhtml = false;
+if ( false == get_transient( 'pb_xhtml_compatible' ) && false == \Pressbooks\Modules\Export\Xhtml\Xhtml11::hasDependencies() ) {
 	$dependency_errors['xhtml'] = 'XHTML';
 } else {
-	$xhtml = true;
+	set_transient( 'pb_xhtml_compatible', true );
 }
 
-if ( false == \Pressbooks\Modules\Export\InDesign\Icml::hasDependencies() ) {
-	$icml = false;
+if ( false == get_transient( 'pb_icml_compatible' ) && false == \Pressbooks\Modules\Export\InDesign\Icml::hasDependencies() ) {
 	$dependency_errors['icml'] = 'ICML';
 } else {
-	$icml = true;
+	set_transient( 'pb_icml_compatible', true );
 }
 
-if ( false == \Pressbooks\Modules\Export\Odt\Odt::hasDependencies() ) {
-	$odt = false;
+if ( false == get_transient( 'pb_odt_compatible' ) && false == \Pressbooks\Modules\Export\Odt\Odt::hasDependencies() ) {
 	$dependency_errors['odt'] = 'OpenDocument';
 } else {
-	$odt = true;
+	set_transient( 'pb_odt_compatible', true );
 }
 
 if ( $dependency_errors ) {

--- a/tests/test-analytics.php
+++ b/tests/test-analytics.php
@@ -32,4 +32,30 @@ class AnalyticsTest extends \WP_UnitTestCase {
 		$this->assertInternalType( 'int', \Pressbooks\Admin\Analytics\analytics_ga_mu_site_specific_allowed_sanitize( 1 ) );
 	}
 
+	/**
+	 * @covers \Pressbooks\Analytics\print_analytics
+	 */
+	public function test_print_analytic() {
+
+		ob_start();
+		\Pressbooks\Analytics\print_analytics();
+		$buffer = ob_get_clean();
+		$this->assertContains( '<script>', $buffer );
+		$this->assertContains( 'Google', $buffer );
+		$this->assertContains( 'Analytics', $buffer );
+	}
+
+	/**
+	 * @covers \Pressbooks\Admin\Analytics\print_admin_analytics
+	 */
+	public function test_print_admin_analytics() {
+
+		ob_start();
+		\Pressbooks\Admin\Analytics\print_admin_analytics();
+		$buffer = ob_get_clean();
+		$this->assertContains( '<script>', $buffer );
+		$this->assertContains( 'Google', $buffer );
+		$this->assertContains( 'Analytics', $buffer );
+	}
+
 }

--- a/tests/test-compatibility.php
+++ b/tests/test-compatibility.php
@@ -1,0 +1,15 @@
+<?php
+
+class CompatibilityTest extends \WP_UnitTestCase {
+
+	/**
+	 * @covers \pb_meets_minimum_requirements
+	 */
+	public function test_pb_meets_minimum_requirements() {
+
+		$result = \pb_meets_minimum_requirements();
+
+		$this->assertTrue( is_bool( $result ) );
+	}
+
+}


### PR DESCRIPTION
Loading the exports page takes time because we go into multiple shells to check if all the tools are there for each page load. We only have to do this once. Optimized by using the Transients API to store true when a tool is known to be installed.

pb_meets_minimum_requirements() is called by many plugins in the same run. We only need to check once and return the same value to all the inquiring plugins. Optimized by caching the value in a static variable.

Minor fixes to the pb-analytics.php that I saw yesterday while poking around.



 