### PR TITLE
Regex Search and Replace

### DIFF
--- a/includes/modules/searchandreplace/class-pb-search.php
+++ b/includes/modules/searchandreplace/class-pb-search.php
@@ -22,12 +22,12 @@ class Search {
 	}
 
 	function regex_error( $errno, $errstr, $errfile, $errline ) {
-		$this->regex_error = __( 'Invalid regular expression', 'pressbooks') . ': ' . preg_replace( '/(.*?):/', '', $errstr );
+		$this->regex_error = __( 'Invalid regular expression', 'pressbooks' ) . ': ' . preg_replace( '/(.*?):/', '', $errstr );
 	}
 
 	function search_and_replace( $search, $replace, $limit, $offset, $orderby, $save = false ) {
 		// escape potential backreferences when not in regex mode
-		if ( $this->regex === false ) {
+		if ( ! $this->regex ) {
 			$replace = str_replace( '\\', '\\\\', $replace );
 			$replace = str_replace( '$', '\\$', $replace );
 		}
@@ -54,7 +54,7 @@ class Search {
 				set_error_handler( array( &$this, 'regex_error' ) );
 				$valid = @preg_match( $search, '', $matches );
 				restore_error_handler();
-				if ( $valid === false ) {
+				if ( false === $valid ) {
 					return $this->regex_error;
 				}
 				return $this->find( $search, $limit, $offset, $orderby );

--- a/includes/modules/searchandreplace/class-pb-search.php
+++ b/includes/modules/searchandreplace/class-pb-search.php
@@ -24,7 +24,7 @@ class Search {
 		// evaluate expression without imput and capture potential error message
 		$regex_error = 'invalid';
 		$error_handler = function( $errno, $errstr, $errfile, $errline ) use ( &$regex_error ) {
-			$regex_error = preg_replace( '/(.*?):/', '', $errstr );
+			$regex_error = preg_replace( '/(.*?):/', '', $errstr, 1 );
 		};
 		set_error_handler( $error_handler );
 		// @codingStandardsIgnoreLine

--- a/includes/modules/searchandreplace/class-pb-search.php
+++ b/includes/modules/searchandreplace/class-pb-search.php
@@ -52,6 +52,7 @@ class Search {
 			if ( $this->regex ) {
 				// First test that the search and replace strings are valid regex
 				set_error_handler( array( &$this, 'regex_error' ) );
+				// @codingStandardsIgnoreLine
 				$valid = @preg_match( $search, '', $matches );
 				restore_error_handler();
 				if ( false === $valid ) {

--- a/includes/modules/searchandreplace/class-pb-search.php
+++ b/includes/modules/searchandreplace/class-pb-search.php
@@ -26,6 +26,11 @@ class Search {
 	}
 
 	function search_and_replace( $search, $replace, $limit, $offset, $orderby, $save = false ) {
+		// escape potential backreferences when not in regex mode
+		if ( $this->regex === false ) {
+			$replace = str_replace( '\\', '\\\\', $replace );
+			$replace = str_replace( '$', '\\$', $replace );
+		}
 		$this->replace = $replace;
 		$results = $this->search_for_pattern( $search, $limit, $offset, $orderby );
 		if ( false !== $results && $save ) {

--- a/includes/modules/searchandreplace/class-pb-searchandreplace.php
+++ b/includes/modules/searchandreplace/class-pb-searchandreplace.php
@@ -86,7 +86,7 @@ class SearchAndReplace {
 			$searcher = new $source;
 
 			// Enable regex mode
-			$searcher->regex = !empty( $_POST['regex'] );
+			$searcher->regex = ! empty( $_POST['regex'] );
 
 			// Make sure no one sneaks in with a replace
 			if ( ! current_user_can( 'administrator' ) ) {

--- a/includes/modules/searchandreplace/class-pb-searchandreplace.php
+++ b/includes/modules/searchandreplace/class-pb-searchandreplace.php
@@ -85,6 +85,9 @@ class SearchAndReplace {
 		if ( \Pressbooks\Modules\SearchAndReplace\Search::valid_search( $source ) && ( isset( $_POST['search'] ) || isset( $_POST['replace'] ) || isset( $_POST['replace_and_save'] ) ) ) {
 			$searcher = new $source;
 
+			// Enable regex mode
+			$searcher->regex = !empty( $_POST['regex'] );
+
 			// Make sure no one sneaks in with a replace
 			if ( ! current_user_can( 'administrator' ) ) {
 				unset( $_POST['replace'] );

--- a/templates/admin/search.php
+++ b/templates/admin/search.php
@@ -57,6 +57,7 @@
 				  <input class="term" type="text" name="replace_pattern" value="<?php echo esc_attr( $replace ) ?>"/><br/>
 				</td>
 			</tr>
+			<?php if ( defined( 'PB_ENABLE_REGEX_SEARCHREPLACE' ) && PB_ENABLE_REGEX_SEARCHREPLACE ) : ?>
 			<tr>
 			  <th scope="row"><?php _e( 'Regex', 'pressbooks' ) ?>:</th>
 				<td>
@@ -66,6 +67,7 @@
 					</label>
 				</td>
 			</tr>
+			<?php endif ?>
 		</table>
 		<?php wp_nonce_field( 'search', 'pressbooks-search-and-replace-nonce' ); ?>
 		<p class="submit">

--- a/templates/admin/search.php
+++ b/templates/admin/search.php
@@ -33,8 +33,12 @@
 			<tr>
 				<th scope="row"><?php _e( 'Result Order', 'pressbooks' ); ?>:</th>
 				<td>
-					<?php // @codingStandardsIgnoreLine
-					$orderby = isset( $_POST['orderby'] ) ? $_POST['orderby'] : ''; ?>
+					<?php
+					// @codingStandardsIgnoreStart
+					$orderby = isset( $_POST['orderby'] ) ? $_POST['orderby'] : '';
+					$regex = ! empty( $_POST['regex'] );
+					// @codingStandardsIgnoreEnd
+					?>
 					<select name="orderby">
 						<option <?php selected( $orderby, 'asc' ); ?>value="asc"><?php _e( 'Ascending', 'pressbooks' ); ?></option>
 						<option <?php selected( $orderby, 'desc' ); ?>value="desc"><?php _e( 'Descending', 'pressbooks' ); ?></option>
@@ -57,7 +61,7 @@
 			  <th scope="row"><?php _e( 'Regex', 'pressbooks' ) ?>:</th>
 				<td>
 					<label>
-						<input name="regex" type="checkbox" value="true"<?php if (!empty($_POST['regex'])) echo 'checked="checked"'; ?>>
+						<input name="regex" type="checkbox" value="true"<?php echo $regex ? ' checked="checked"' : ''; ?>>
 						<?php _e( 'Enable regular expressions', 'pressbooks' ) ?>
 					</label>
 				</td>

--- a/templates/admin/search.php
+++ b/templates/admin/search.php
@@ -53,6 +53,15 @@
 				  <input class="term" type="text" name="replace_pattern" value="<?php echo esc_attr( $replace ) ?>"/><br/>
 				</td>
 			</tr>
+			<tr>
+			  <th scope="row"><?php _e( 'Regex', 'pressbooks' ) ?>:</th>
+				<td>
+					<label>
+						<input name="regex" type="checkbox" value="true"<?php if (!empty($_POST['regex'])) echo 'checked="checked"'; ?>>
+						<?php _e( 'Enable regular expressions', 'pressbooks' ) ?>
+					</label>
+				</td>
+			</tr>
 		</table>
 		<?php wp_nonce_field( 'search', 'pressbooks-search-and-replace-nonce' ); ?>
 		<p class="submit">


### PR DESCRIPTION
* Add regex option to SearchAndReplace
* Escape potential backreferences when not in regex mode

The second point was a preexisting bug where a Replace With value of `a$1b` or `a\1b` would result in `ab`. 

If the regex functionality seems too confusing for existing users, I could imagine having a `PB_REGEX_SEARCH` constant to enable it conditionally, but having regex is a crucial feature in our installation.