### PR TITLE
Use template for pb_private() function

### DIFF
--- a/themes-book/pressbooks-book/functions.php
+++ b/themes-book/pressbooks-book/functions.php
@@ -196,30 +196,7 @@ function pb_get_links($echo=true) {
  * Prevent access by unregistered user if the book in question is private.
  */
 function pb_private() {
-	$bloginfourl = get_bloginfo( 'url' ); ?>
-  <div <?php post_class(); ?>>
-		<h2 class="entry-title denied-title"><?php _e('Access Denied', 'pressbooks'); ?></h2>
-		<!-- Table of content loop goes here. -->
-		<div class="entry-content denied-text">
-			<p><?php printf(
-				__( 'This book is private, and accessible only to registered users. If you have an account you can %s.', 'pressbooks' ),
-				sprintf(
-					'<a href="%1$s">%2$s</a>',
-					get_bloginfo( 'url' ) . '/wp-login.php',
-					__( 'login here', 'pressbooks' )
-				)
-			); ?></p>
-			<p><?php printf(
-				__( 'You can also set up your own Pressbooks book at %s.', 'pressbooks' ),
-				sprintf(
-					'<a href="%1$s">%2$s</a>',
-					apply_filters( 'pb_signup_url', 'https://pressbooks.com' ),
-					apply_filters( 'pb_signup_url', 'Pressbooks.com' )
-				)
-			); ?></p>
-		</div>
-	</div><!-- #post-## -->
-<?php
+	get_template_part('private');
 }
 
 

--- a/themes-book/pressbooks-book/private.php
+++ b/themes-book/pressbooks-book/private.php
@@ -1,0 +1,24 @@
+<?php $bloginfourl = get_bloginfo('url'); ?>
+
+	<div <?php post_class(); ?>>
+		<h2 class="entry-title denied-title"><?php _e('Access Denied', 'pressbooks'); ?></h2>
+		<!-- Table of content loop goes here. -->
+		<div class="entry-content denied-text">
+			<p><?php printf(
+				__( 'This book is private, and accessible only to registered users. If you have an account you can %s.', 'pressbooks' ),
+				sprintf(
+					'<a href="%1$s">%2$s</a>',
+					get_bloginfo( 'url' ) . '/wp-login.php',
+					__( 'login here', 'pressbooks' )
+				)
+			); ?></p>
+			<p><?php printf(
+				__( 'You can also set up your own Pressbooks book at %s.', 'pressbooks' ),
+				sprintf(
+					'<a href="%1$s">%2$s</a>',
+					apply_filters( 'pb_signup_url', 'https://pressbooks.com' ),
+					apply_filters( 'pb_signup_url', 'Pressbooks.com' )
+				)
+			); ?></p>
+		</div>
+	</div><!-- #post-## -->


### PR DESCRIPTION
This allows themes to overwrite the standard login prompt by providing their own private.php template.