### PR TITLE
Fix custom title bug

### DIFF
--- a/assets/book/styles/components/structure/_content-strings.scss
+++ b/assets/book/styles/components/structure/_content-strings.scss
@@ -9,7 +9,7 @@ meta[name="pb-title"] {
 }
 
 meta[name="pb-short-title"] {
-  string-set: book-title attr('content');
+  string-set: short-book-title attr('content');
 }
 
 meta[name="pb-subtitle"] {

--- a/assets/book/styles/components/structure/_content-strings.scss
+++ b/assets/book/styles/components/structure/_content-strings.scss
@@ -2,34 +2,30 @@
 // Content String Settings
 //========================
 
-// Title Page
+// Metadata
 
-#title-page > {
-  .title {
-    string-set: book-title content();
-  }
+meta[name="pb-title"] {
+  string-set: book-title attr('content');
+}
 
-  .short-book-title,
-  .short-book-title {
-    visibility: hidden;
-    string-set: book-title content();
-  }
+meta[name="pb-short-title"] {
+  string-set: book-title attr('content');
+}
 
-  .subtitle {
-    string-set: book-subtitle content();
-  }
+meta[name="pb-subtitle"] {
+  string-set: book-subtitle attr('content');
+}
 
-  .author {
-    string-set: book-author content();
-  }
+meta[name="pb-author"] {
+  string-set: book-author attr('content');
+}
 
-  .publisher {
-    string-set: book-publisher content();
-  }
+meta[name="pb-publisher"] {
+  string-set: book-publisher attr('content');
+}
 
-  .publisher-city {
-    string-set: book-publisher-city content();
-  }
+meta[name="pb-publisher-city"] {
+  string-set: book-publisher-city attr('content');
 }
 
 // Parts

--- a/assets/book/styles/components/structure/_content-strings.scss
+++ b/assets/book/styles/components/structure/_content-strings.scss
@@ -28,6 +28,10 @@ meta[name="pb-publisher-city"] {
   string-set: book-publisher-city attr('content');
 }
 
+.short-book-title {
+  visibility: hidden;
+}
+
 // Parts
 
 .part-title-wrap {

--- a/assets/scss/partials/_pdf-house-style.scss
+++ b/assets/scss/partials/_pdf-house-style.scss
@@ -566,34 +566,32 @@ content: string(arbitrary-string-set-name);
 
 /* book-wide strings  */
 
-#title-page > .title {
-  string-set: book-title content();
-}
-
-#title-page > .short-book-title {
-    string-set: book-title content();
-    visibility: hidden;
+meta[name="pb-title"] {
+  string-set: book-title attr('content');
 }
 
 .short-book-title {
-    string-set: book-title content();
-    visibility: hidden;
+  visibility: hidden;
 }
 
-#title-page > .subtitle {
-  string-set: book-subtitle content();
+meta[name="pb-short-title"] {
+  string-set: book-title attr('content');
 }
 
-#title-page > .author {
-  string-set: book-author content();
+meta[name="pb-subtitle"] {
+  string-set: book-subtitle attr('content');
 }
 
-#title-page > .publisher {
-  string-set: book-publisher content();
+meta[name="pb-author"] {
+  string-set: book-author attr('content');
 }
 
-#title-page > .publisher-city {
-	string-set: book-publisher-city content();
+meta[name="pb-publisher"] {
+  string-set: book-publisher attr('content');
+}
+
+meta[name="pb-publisher-city"] {
+  string-set: book-publisher-city attr('content');
 }
 
 /* PART & CHAPTER STRINGS */

--- a/assets/scss/partials/_pdf-house-style.scss
+++ b/assets/scss/partials/_pdf-house-style.scss
@@ -575,7 +575,7 @@ meta[name="pb-title"] {
 }
 
 meta[name="pb-short-title"] {
-  string-set: book-title attr('content');
+  string-set: short-book-title attr('content');
 }
 
 meta[name="pb-subtitle"] {

--- a/includes/modules/export/xhtml/class-pb-xhtml11.php
+++ b/includes/modules/export/xhtml/class-pb-xhtml11.php
@@ -339,6 +339,9 @@ class Xhtml11 extends Export {
 	protected function queryXhtml() {
 
 		$args = array( 'timeout' => $this->timeout );
+		if ( WP_ENV == 'development' ) {
+			$args['sslverify'] = false;
+		}
 		$response = wp_remote_get( $this->url, $args );
 
 		// WordPress error?


### PR DESCRIPTION
This PR fixes an issue where content strings would not be set when a custom title page was in use. Book metadata strings are now set using the `attributes('content')` function of the corresponding `<meta>` element.