### PR TITLE
Update default EpubCheck path

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -89,7 +89,7 @@ Once installed, define the following `wp-config.php` variables. The defaults are
 
     define( 'PB_PRINCE_COMMAND', '/usr/bin/prince' );
     define( 'PB_KINDLEGEN_COMMAND', '/opt/kindlegen/kindlegen' );
-    define( 'PB_EPUBCHECK_COMMAND', '/usr/bin/java -jar /opt/epubcheck/epubcheck.jar' );
+    define( 'PB_EPUBCHECK_COMMAND', '/usr/bin/epubcheck' );
     define( 'PB_XMLLINT_COMMAND', '/usr/bin/xmllint' );
     define( 'PB_SAXON_COMMAND', '/usr/bin/java -jar /opt/saxon-he/saxon-he.jar' );
 

--- a/inc/modules/export/epub/class-epub201.php
+++ b/inc/modules/export/epub/class-epub201.php
@@ -182,7 +182,7 @@ class Epub201 extends Export {
 		}
 
 		if ( ! defined( 'PB_EPUBCHECK_COMMAND' ) ) {
-			define( 'PB_EPUBCHECK_COMMAND', '/usr/bin/java -jar /opt/epubcheck/epubcheck.jar' );
+			define( 'PB_EPUBCHECK_COMMAND', '/usr/bin/epubcheck' );
 		}
 
 		$this->tmpDir = $this->createTmpDir();

--- a/inc/utility/namespace.php
+++ b/inc/utility/namespace.php
@@ -280,7 +280,7 @@ function create_tmp_file() {
  */
 function check_epubcheck_install() {
 	if ( ! defined( 'PB_EPUBCHECK_COMMAND' ) ) { // @see wp-config.php
-		define( 'PB_EPUBCHECK_COMMAND', '/usr/bin/java -jar /opt/epubcheck/epubcheck.jar' );
+		define( 'PB_EPUBCHECK_COMMAND', '/usr/bin/epubcheck' );
 	}
 
 	$output = [];

--- a/readme.txt
+++ b/readme.txt
@@ -109,9 +109,9 @@ Once installed, define the following wp-config.php variables. The defaults are:
 
 	define( 'PB_PRINCE_COMMAND', '/usr/bin/prince' );
 	define( 'PB_KINDLEGEN_COMMAND', '/opt/kindlegen/kindlegen' );
-	define( 'PB_EPUBCHECK_COMMAND', '/usr/bin/java -jar /opt/epubcheck/epubcheck.jar' );
+	define( 'PB_EPUBCHECK_COMMAND', '/usr/bin/epubcheck' );
 	define( 'PB_XMLLINT_COMMAND', '/usr/bin/xmllint' );
-  define( 'PB_SAXON_COMMAND', '/usr/bin/java -jar /opt/saxon-he/saxon-he.jar' );
+	define( 'PB_SAXON_COMMAND', '/usr/bin/java -jar /opt/saxon-he/saxon-he.jar' );
 
 
 Example config files for a dev site hosted at http://localhost/~dac514/textopress/
@@ -151,7 +151,7 @@ Example config files for a dev site hosted at http://localhost/~dac514/textopres
 	define( 'PB_KINDLEGEN_COMMAND', '/home/dac514/bin/kindlegen' );
 	define( 'PB_EPUBCHECK_COMMAND', '/usr/bin/java -jar /home/dac514/bin/epubcheck-4.0/epubcheck-4.0.jar' );
 	define( 'PB_XMLLINT_COMMAND', '/usr/bin/xmllint' );
-  define( 'PB_SAXON_COMMAND', '/usr/bin/java -jar /home/dac514/bin/saxon-he/saxon-he.jar' );
+	define( 'PB_SAXON_COMMAND', '/usr/bin/java -jar /home/dac514/bin/saxon-he/saxon-he.jar' );
 
 	/**
 	 * Optional definitions
@@ -191,7 +191,7 @@ Once WP-CLI is installed on your server, the following shell commands executed i
 	    define( 'WP_DEFAULT_THEME', 'pressbooks-book' );
 	    define( 'PB_PRINCE_COMMAND', '/usr/bin/prince' );
 	    define( 'PB_KINDLEGEN_COMMAND', '/opt/kindlegen/kindlegen' );
-	    define( 'PB_EPUBCHECK_COMMAND', '/usr/bin/java -jar /opt/epubcheck/epubcheck.jar' );
+	    define( 'PB_EPUBCHECK_COMMAND', '/usr/bin/epubcheck' );
 	    define( 'PB_XMLLINT_COMMAND', '/usr/bin/xmllint' );
 	    define( 'PB_SAXON_COMMAND', '/usr/bin/java -jar /opt/saxon-he/saxon-he.jar' );
 	    PHP


### PR DESCRIPTION
We install epubcheck via an apt package in Trellis environments. This PR updates the default `PB_EPUBCHECK_PATH` constant to reflect it so we don't have to override this value in Bedrock.