### PR TITLE
add file extension to filename for download action

### DIFF
--- a/inc/redirect/namespace.php
+++ b/inc/redirect/namespace.php
@@ -367,6 +367,7 @@ function do_open() {
 			$files = \Pressbooks\Utility\latest_exports();
 			if ( isset( $files[ $_GET['type'] ] ) ) {
 				$filepath = \Pressbooks\Modules\Export\Export::getExportFolder() . $files[ $_GET['type'] ];
+				$file_ext = pathinfo( $filepath, PATHINFO_EXTENSION );
 				$book_title = ( get_bloginfo( 'name' ) ) ? get_bloginfo( 'name' ) : __( 'book', 'pressbooks' );
 				$book_title_slug = sanitize_file_name( $book_title );
 				$book_title_slug = str_replace( [ '+' ], '', $book_title_slug ); // Remove symbols which confuse Apache (Ie. form urlencoded spaces)
@@ -379,7 +380,7 @@ function do_open() {
 				set_time_limit( 0 );
 				header( 'Content-Description: File Transfer' );
 				header( 'Content-Type: ' . \Pressbooks\Modules\Export\Export::mimeType( $filepath ) );
-				header( 'Content-Disposition: attachment; filename="' . $book_title_slug . '"' );
+				header( 'Content-Disposition: attachment; filename="' . $book_title_slug . '.' . $file_ext . '"' );
 				header( 'Content-Transfer-Encoding: binary' );
 				header( 'Expires: 0' );
 				header( 'Cache-Control: must-revalidate, post-check=0, pre-check=0' );


### PR DESCRIPTION
In this commit https://github.com/pressbooks/pressbooks/commit/31a8160fb2ca98c129be485feeffa4bf451847b1 file extensions were removed. This adds file extensions back.