### PR TITLE
allow for hook into setCurrentImportOptions if import is HTTP GET …

### DIFF
--- a/inc/modules/import/class-import.php
+++ b/inc/modules/import/class-import.php
@@ -430,7 +430,7 @@ abstract class Import {
 					 * Allows users to add custom import routine for custom import type
 					 * via HTTP GET requests
 					 *
-					 * @since 3.9.10
+					 * @since 4.0.0
 					 */
 					$importer = apply_filters( 'pb_initialize_import', null );
 					if ( is_object( $importer ) ) {

--- a/inc/modules/import/class-import.php
+++ b/inc/modules/import/class-import.php
@@ -385,16 +385,17 @@ abstract class Import {
 				$_SESSION['pb_errors'][] = sprintf( __( 'Your file does not appear to be a valid %s.', 'pressbooks' ), strtoupper( $_POST['type_of'] ) );
 				unlink( $upload['file'] );
 			}
-		} elseif ( isset( $_GET['import'] ) && isset( $_POST['type_of'] ) && 'html' === $_POST['type_of'] && check_admin_referer( 'pb-import' ) ) {
+			// handles file uploads via http GET requests
+		} elseif ( isset( $_GET['import'] ) && isset( $_POST['type_of'] ) && ! empty( $_POST['import_http'] ) && check_admin_referer( 'pb-import' ) ) {
 
 			// check if it's a valid url
-			if ( false === filter_var( $_POST['import_html'], FILTER_VALIDATE_URL ) ) {
+			if ( false === filter_var( $_POST['import_http'], FILTER_VALIDATE_URL ) ) {
 				$_SESSION['pb_errors'][] = __( 'Your URL does not appear to be valid', 'pressbooks' );
 				\Pressbooks\Redirect\location( $redirect_url );
 			}
 
 			// HEAD request, check for a valid response from server
-			$remote_head = wp_remote_head( $_POST['import_html'] );
+			$remote_head = wp_remote_head( $_POST['import_http'] );
 
 			// Something failed
 			if ( is_wp_error( $remote_head ) ) {
@@ -409,38 +410,37 @@ abstract class Import {
 				\Pressbooks\Redirect\location( $redirect_url );
 			}
 
-			// ensure the media type is HTML (not JSON, or something we can't deal with)
-			if ( false === strpos( $remote_head['headers']['content-type'], 'text/html' ) && false === strpos( $remote_head['headers']['content-type'], 'application/xhtml+xml' ) ) {
-				$_SESSION['pb_errors'][] = __( 'The website you are attempting to reach is not returning HTML content', 'pressbooks' );
-				\Pressbooks\Redirect\location( $redirect_url );
+			$upload = array( 'url' => $_POST['import_http'] );
+
+			switch ( $_POST['type_of'] ) {
+				case 'html':
+					// ensure the media type is HTML (not JSON, or something we can't deal with)
+					if ( false === strpos( $remote_head['headers']['content-type'], 'text/html' ) && false === strpos( $remote_head['headers']['content-type'], 'application/xhtml+xml' ) ) {
+						$_SESSION['pb_errors'][] = __( 'The website you are attempting to reach is not returning HTML content', 'pressbooks' );
+						\Pressbooks\Redirect\location( $redirect_url );
+					}
+
+					$importer = new Html\Xhtml();
+					$ok       = $importer->setCurrentImportOption( $upload );
+
+					break;
+
+				default:
+					/**
+					 * Allows users to add custom import routine for custom import type
+					 * via HTTP GET requests
+					 *
+					 * @since 3.9.10
+					 */
+					$importer = apply_filters( 'pb_initialize_import', null );
+					if ( is_object( $importer ) ) {
+						$ok = $importer->setCurrentImportOption( $upload );
+					}
 			}
-
-			// GET http request
-			$body = wp_remote_get( $_POST['import_html'] );
-
-			// check for wp error
-			if ( is_wp_error( $body ) ) {
-				$error_message = $body->get_error_message();
-				error_log( '\Pressbooks\Modules\Import::formSubmit error, import_html' . $error_message );
-				$_SESSION['pb_errors'][] = $error_message;
-				\Pressbooks\Redirect\location( $redirect_url );
-			}
-
-			// check for a successful response code on GET request
-			if ( 200 !== $body['response']['code'] ) {
-				$_SESSION['pb_errors'][] = __( 'The website you are attempting to reach is not returning a successful response on a GET request: ', 'pressbooks' ) . $body['response']['code'];
-				\Pressbooks\Redirect\location( $redirect_url );
-			}
-
-			// add our url
-			$body['url'] = $_POST['import_html'];
-
-			$importer = new Html\Xhtml();
-			$ok = $importer->setCurrentImportOption( $body );
 
 			$msg = "Tried to upload a file of type {$_POST['type_of']} and ";
 			$msg .= ( $ok ) ? 'succeeded :)' : 'failed :(';
-			self::log( $msg, $body['headers'] );
+			self::log( $msg, $upload );
 
 			if ( ! $ok ) {
 				// Not ok?

--- a/inc/modules/import/html/class-xhtml.php
+++ b/inc/modules/import/html/class-xhtml.php
@@ -452,11 +452,11 @@ class Xhtml extends Import {
 	 */
 	function setCurrentImportOption( array $upload ) {
 		// GET http request
-		$body = wp_remote_get( $upload['url'] );
+		$html = wp_remote_get( $upload['url'] );
 
 		// check for wp error
-		if ( is_wp_error( $body ) ) {
-			$error_message = $body->get_error_message();
+		if ( is_wp_error( $html ) ) {
+			$error_message = $html->get_error_message();
 			error_log( '\Pressbooks\Modules\Import\Html::setCurrentImportOption error, wp_remote_get' . $error_message );
 			$_SESSION['pb_errors'][] = $error_message;
 
@@ -464,18 +464,18 @@ class Xhtml extends Import {
 		}
 
 		// check for a successful response code on GET request
-		if ( 200 !== $body['response']['code'] ) {
-			$_SESSION['pb_errors'][] = __( 'The website you are attempting to reach is not returning a successful response on a GET request: ', 'pressbooks' ) . $body['response']['code'];
+		if ( 200 !== $html['response']['code'] ) {
+			$_SESSION['pb_errors'][] = __( 'The website you are attempting to reach is not returning a successful response on a GET request: ', 'pressbooks' ) . $html['response']['code'];
 
 			return false;
 		}
 
 		// just get the body of the array
-		$html = $body['body'];
+		$body = $html['body'];
 
 		// safety check if param (character encoding) with `;` isn't set
 		// @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.7
-		$content_type = ( false === strstr( $body['headers']['content-type'], ';' ) ) ? $content_type = $body['headers']['content-type'] : strstr( $body['headers']['content-type'], ';', true );
+		$content_type = ( false === strstr( $html['headers']['content-type'], ';' ) ) ? $html['headers']['content-type'] : strstr( $html['headers']['content-type'], ';', true );
 
 		// get the title
 		preg_match( '/<title>(.+)<\/title>/', $html, $matches );

--- a/inc/modules/import/html/class-xhtml.php
+++ b/inc/modules/import/html/class-xhtml.php
@@ -451,12 +451,31 @@ class Xhtml extends Import {
 	 * @return bool
 	 */
 	function setCurrentImportOption( array $upload ) {
+		// GET http request
+		$body = wp_remote_get( $upload['url'] );
+
+		// check for wp error
+		if ( is_wp_error( $body ) ) {
+			$error_message = $body->get_error_message();
+			error_log( '\Pressbooks\Modules\Import\Html::setCurrentImportOption error, wp_remote_get' . $error_message );
+			$_SESSION['pb_errors'][] = $error_message;
+
+			return false;
+		}
+
+		// check for a successful response code on GET request
+		if ( 200 !== $body['response']['code'] ) {
+			$_SESSION['pb_errors'][] = __( 'The website you are attempting to reach is not returning a successful response on a GET request: ', 'pressbooks' ) . $body['response']['code'];
+
+			return false;
+		}
+
 		// just get the body of the array
-		$html = $upload['body'];
+		$html = $body['body'];
 
 		// safety check if param (character encoding) with `;` isn't set
 		// @see http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.7
-		$content_type = ( false === strstr( $upload['headers']['content-type'], ';' ) ) ? $content_type = $upload['headers']['content-type'] : strstr( $upload['headers']['content-type'], ';', true );
+		$content_type = ( false === strstr( $body['headers']['content-type'], ';' ) ) ? $content_type = $body['headers']['content-type'] : strstr( $body['headers']['content-type'], ';', true );
 
 		// get the title
 		preg_match( '/<title>(.+)<\/title>/', $html, $matches );
@@ -464,10 +483,10 @@ class Xhtml extends Import {
 
 		// set the args
 		$option = [
-			'file' => $upload['url'],
+			'file'      => $upload['url'],
 			'file_type' => $content_type,
-			'type_of' => 'html',
-			'chapters' => [],
+			'type_of'   => 'html',
+			'chapters'  => [],
 		];
 
 		// there will be only one chapter

--- a/templates/admin/import.php
+++ b/templates/admin/import.php
@@ -133,25 +133,25 @@ $supported_file_extensions = implode( ', ', array_keys( $import_option_types ) )
 			jQuery(function ($) {
 				$('#pb-www').hide();
 
-				$( ".pb-html-target").change(
-					function(){
+				$(".pb-html-target").change(
+					function () {
 						var val = $('.pb-html-target').val();
 
-							if (val == 'html') {
-							$('#pb-file').hide();
-							$('#pb-www').show();
-						} else {
+						if (val == 'wxr' || val == 'epub' || val == 'odt' || val == 'docx') {
 							$('#pb-file').show();
 							$('#pb-www').hide();
 							// clear http value at input elem
 							$('.widefat').val('');
+						} else {
+							$('#pb-file').hide();
+							$('#pb-www').show();
 
 						}
 
 					});
 
 			});
-			</script>
+		</script>
 		<p>
 			<?php _e( 'Supported file extensions: ', 'pressbooks' ); echo strtoupper( $supported_file_extensions ); ?> <br />
 			<?php _e( 'Maximum file size:', 'pressbooks' );
@@ -174,7 +174,7 @@ $supported_file_extensions = implode( ', ', array_keys( $import_option_types ) )
 						</select>
 					</td>
 				</tr>
-				<tr>
+				<tr class="pb-input-types">
 					<th scope="row">
 						<label for="import_file"><?php _e( 'File', 'pressbooks' ); ?></label>
 					</th>
@@ -182,7 +182,7 @@ $supported_file_extensions = implode( ', ', array_keys( $import_option_types ) )
 						<input type="file" name="import_file" id="import_file">
 					</td>
 					<td id="pb-www">
-						<input type="text" class="widefat" name="import_html" id="import_html" placeholder="http://url-of-the-html-page-to-import.html">
+						<input type="url" class="widefat" name="import_http" id="import_http" placeholder="https://url-to-import.com">
 					</td>
 					<?php
 					/**
@@ -191,7 +191,7 @@ $supported_file_extensions = implode( ', ', array_keys( $import_option_types ) )
 					 * @since 3.9.10
 					 *
 					 */
-					echo apply_filters( 'pb_import_table_cell' );
+					echo apply_filters( 'pb_import_table_cell', null );
 					?>
 				</tr>
 

--- a/templates/admin/import.php
+++ b/templates/admin/import.php
@@ -188,7 +188,7 @@ $supported_file_extensions = implode( ', ', array_keys( $import_option_types ) )
 					/**
 					 * Allows developers to add a new input type
 					 *
-					 * @since 3.9.10
+					 * @since 4.0.0
 					 *
 					 */
 					echo apply_filters( 'pb_import_table_cell', null );


### PR DESCRIPTION
Using the hook `pb_initialize_import` to add a custom import routine which uses HTTP GET instead of a file upload, is prevented by the existing logic from ever reaching `setCurrentImportOption` because of the existing condition `'html' == $_POST['type_of']`. https://github.com/pressbooks/pressbooks/blob/dev/inc/modules/import/class-import.php#L388

The new condition checks for the existence of a generic `$_POST['import_http']` (updated in the template file as well)  instead of the more specific `$_POST['type_of']` which has been moved further down. Generic checks for valid url input, server response errors, and response code checking will apply to all HTTP GET imports. Similar to uploading a file, the switch statement now looks for `$_POST['type_of']`. HTML scraping logic/checks have been moved into the html-specific switch statement, allowing for generic checks to apply to the custom import type without requiring them, for instance, to return a content-type of `text/html`. 
