### PR TITLE
Add hash to editor style for cache busting (fix #813)

### DIFF
--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -191,9 +191,6 @@ function replace_book_admin_menu() {
 	if ( $version < $page::VERSION ) {
 		$page->upgrade( $version );
 		update_option( 'pressbooks_ecommerce_links_version', $page::VERSION, false );
-		if ( WP_DEBUG ) {
-			error_log( 'Upgraded pressbooks_ecommerce_links from version ' . $version . ' --> ' . $page::VERSION );
-		}
 	}
 
 	add_menu_page( __( 'Publish', 'pressbooks' ), __( 'Publish', 'pressbooks' ), 'edit_posts', 'pb_publish', [ $page, 'render' ], 'dashicons-products', 16 );
@@ -210,9 +207,6 @@ function replace_book_admin_menu() {
 	if ( $version < $page::VERSION ) {
 		$page->upgrade( $version );
 		update_option( 'pressbooks_export_options_version', $page::VERSION, false );
-		if ( WP_DEBUG ) {
-			error_log( 'Upgraded pressbooks_export_options from version ' . $version . ' --> ' . $page::VERSION );
-		}
 	}
 
 	add_options_page( __( 'Export Settings', 'pressbooks' ), __( 'Export', 'pressbooks' ), 'manage_options', 'pressbooks_export_options', [ $page, 'render' ] );
@@ -239,9 +233,6 @@ function network_admin_menu() {
 	if ( $version < $page::VERSION ) {
 		$page->upgrade( $version );
 		update_site_option( 'pressbooks_sharingandprivacy_options_version', $page::VERSION );
-		if ( WP_DEBUG ) {
-			error_log( 'Upgraded network pressbooks_sharingandprivacy_options from version ' . $version . ' --> ' . $page::VERSION );
-		}
 	}
 
 	add_submenu_page(

--- a/inc/editor/namespace.php
+++ b/inc/editor/namespace.php
@@ -294,7 +294,9 @@ function update_editor_style() {
 function add_editor_style() {
 
 	$sass = Container::get( 'Sass' );
-	$uri = $sass->urlToUserGeneratedCss() . '/editor.css';
+	$path = $sass->pathToUserGeneratedCss() . '/editor.css';
+	$hash = md5( filemtime( $path ) );
+	$uri = $sass->urlToUserGeneratedCss() . '/editor.css?ver=' . $hash;
 	\add_editor_style( $uri );
 }
 

--- a/inc/editor/namespace.php
+++ b/inc/editor/namespace.php
@@ -290,14 +290,21 @@ function update_editor_style() {
 
 /**
  * Adds stylesheet for MCE previewing.
+ *
+ * @return bool
  */
 function add_editor_style() {
 
 	$sass = Container::get( 'Sass' );
 	$path = $sass->pathToUserGeneratedCss() . '/editor.css';
-	$hash = md5( filemtime( $path ) );
-	$uri = $sass->urlToUserGeneratedCss() . '/editor.css?ver=' . $hash;
-	\add_editor_style( $uri );
+	if ( file_exists( $path ) ) {
+		$hash = md5( filemtime( $path ) );
+		$uri = $sass->urlToUserGeneratedCss() . '/editor.css?ver=' . $hash;
+		\add_editor_style( $uri );
+		return true;
+	}
+
+	return false;
 }
 
 

--- a/tests/test-editor.php
+++ b/tests/test-editor.php
@@ -22,6 +22,16 @@ class EditorTest extends \WP_UnitTestCase {
 		$this->assertFileExists( WP_CONTENT_DIR . '/uploads/sites/' . $blog_id . '/css/editor.css' );
 	}
 
+	public function test_add_editor_style() {
+		$this->_book( 'pressbooks-clarke' );
+		$result = Pressbooks\Editor\add_editor_style();
+		$this->assertFalse( $result );
+
+		Pressbooks\Editor\update_editor_style();
+		$result = Pressbooks\Editor\add_editor_style();
+		$this->assertTrue( $result );
+	}
+
 	public function test_add_languages() {
 
 		$array = Pressbooks\Editor\add_languages( [] );

--- a/tests/test-editor.php
+++ b/tests/test-editor.php
@@ -4,11 +4,22 @@ use Pressbooks\Editor;
 
 class EditorTest extends \WP_UnitTestCase {
 
+	use utilsTrait;
+
 	public function test_mce_valid_word_elements() {
 
 		$array = Pressbooks\Editor\mce_valid_word_elements( [] );
 
 		$this->assertArrayHasKey( 'paste_word_valid_elements', $array );
+	}
+
+	public function test_update_editor_style() {
+		$this->_book( 'pressbooks-clarke' );
+		Pressbooks\Editor\update_editor_style();
+
+		global $blog_id;
+
+		$this->assertFileExists( WP_CONTENT_DIR . '/uploads/sites/' . $blog_id . '/css/editor.css' );
 	}
 
 	public function test_add_languages() {


### PR DESCRIPTION
This PR ensures that cached versions of `editor.css` are not loaded when a new version has been generated.