### PR TITLE
LaTeX Pixel Density

### DIFF
--- a/inc/modules/export/prince/class-pdf.php
+++ b/inc/modules/export/prince/class-pdf.php
@@ -95,10 +95,8 @@ class Pdf extends Export {
 	function convert() {
 
 		// Sanity check
-
 		if ( empty( $this->exportStylePath ) || ! is_file( $this->exportStylePath ) ) {
 			$this->logError( '$this->exportStylePath must be set before calling convert().' );
-
 			return false;
 		}
 
@@ -106,11 +104,14 @@ class Pdf extends Export {
 		$this->logfile = $this->createTmpFile();
 
 		// Set filename
-		$filename = $this->timestampedFileName( '.pdf' );
+		$filename = $this->generateFileName();
 		$this->outputPath = $filename;
 
 		// Fonts
 		Container::get( 'GlobalTypography' )->getFonts();
+
+		// Fix Latex DPI
+		$this->fixLatexDpi();
 
 		// CSS File
 		$css = $this->kneadCss();
@@ -177,6 +178,12 @@ class Pdf extends Export {
 		parent::logError( $message, $more_info );
 	}
 
+	/**
+	 * @return string
+	 */
+	protected function generateFileName() {
+		return $this->timestampedFileName( '.pdf' );
+	}
 
 	/**
 	 * Verify if body is actual PDF
@@ -282,6 +289,13 @@ class Pdf extends Export {
 
 	}
 
+	/**
+	 * Increase PB-LaTeX resolution to ~300 dpi
+	 */
+	protected function fixLatexDpi() {
+		$this->url .= '&pb-latex-zoom=3';
+		$this->cssOverrides .= "\n" . 'img.latex { prince-image-resolution: 300dpi; }' . "\n";
+	}
 
 	/**
 	 * Dependency check.

--- a/inc/modules/export/prince/class-pdf.php
+++ b/inc/modules/export/prince/class-pdf.php
@@ -67,8 +67,6 @@ class Pdf extends Export {
 	 */
 	function __construct( array $args ) {
 
-		// Some defaults
-
 		if ( ! defined( 'PB_PRINCE_COMMAND' ) ) {
 			define( 'PB_PRINCE_COMMAND', '/usr/bin/prince' );
 		}
@@ -84,6 +82,7 @@ class Pdf extends Export {
 		$this->url = home_url() . "/format/xhtml?timestamp={$timestamp}&hashkey={$md5}";
 
 		$this->themeOptionsOverrides();
+		$this->fixLatexDpi();
 	}
 
 
@@ -110,15 +109,14 @@ class Pdf extends Export {
 		// Fonts
 		Container::get( 'GlobalTypography' )->getFonts();
 
-		// Fix Latex DPI
-		$this->fixLatexDpi();
-
 		// CSS File
 		$css = $this->kneadCss();
 		$css_file = $this->createTmpFile();
 		file_put_contents( $css_file, $css );
 
+		// --------------------------------------------------------------------
 		// Save PDF as file in exports folder
+
 		$prince = new \PrinceXMLPhp\PrinceWrapper( PB_PRINCE_COMMAND );
 		$prince->setHTML( true );
 		$prince->setCompress( true );
@@ -150,15 +148,11 @@ class Pdf extends Export {
 	 * @return bool
 	 */
 	function validate() {
-
 		// Is this a PDF?
 		if ( ! $this->isPdf( $this->outputPath ) ) {
-
 			$this->logError( file_get_contents( $this->logfile ) );
-
 			return false;
 		}
-
 		return true;
 	}
 
@@ -306,7 +300,6 @@ class Pdf extends Export {
 		if ( false !== \Pressbooks\Utility\check_prince_install() && false !== \Pressbooks\Utility\check_xmllint_install() ) {
 			return true;
 		}
-
 		return false;
 	}
 }

--- a/inc/modules/export/prince/class-printpdf.php
+++ b/inc/modules/export/prince/class-printpdf.php
@@ -34,7 +34,6 @@ class PrintPdf extends Pdf {
 
 		if ( empty( $this->exportStylePath ) || ! is_file( $this->exportStylePath ) ) {
 			$this->logError( '$this->exportStylePath must be set before calling convert().' );
-
 			return false;
 		}
 
@@ -47,6 +46,9 @@ class PrintPdf extends Pdf {
 
 		// Fonts
 		Container::get( 'GlobalTypography' )->getFonts();
+
+		// Latex DPI
+		$this->fixLatexDpi();
 
 		// CSS File
 		$css = $this->kneadCss();
@@ -75,6 +77,14 @@ class PrintPdf extends Pdf {
 		}
 
 		return $retval;
+	}
+
+	/**
+	 * Increase PB-LaTeX resolution to ~300 dpi
+	 */
+	protected function fixLatexDpi() {
+		$this->url .= '&pb-latex-zoom=3';
+		$this->cssOverrides .= "\n" . 'img.latex { prince-image-resolution: 300dpi; }' . "\n";
 	}
 
 }

--- a/inc/modules/export/prince/class-printpdf.php
+++ b/inc/modules/export/prince/class-printpdf.php
@@ -6,8 +6,6 @@
 
 namespace Pressbooks\Modules\Export\Prince;
 
-use Pressbooks\Container;
-
 class PrintPdf extends Pdf {
 
 	/**
@@ -22,69 +20,10 @@ class PrintPdf extends Pdf {
 		$this->pdfOutputIntent = '/usr/lib/prince/icc/USWebCoatedSWOP.icc';
 	}
 
-
 	/**
-	 * Create $this->outputPath
-	 *
-	 * @return bool
+	 * @return string
 	 */
-	function convert() {
-
-		// Sanity check
-
-		if ( empty( $this->exportStylePath ) || ! is_file( $this->exportStylePath ) ) {
-			$this->logError( '$this->exportStylePath must be set before calling convert().' );
-			return false;
-		}
-
-		// Set logfile
-		$this->logfile = $this->createTmpFile();
-
-		// Set filename
-		$filename = $this->timestampedFileName( '._print.pdf' );
-		$this->outputPath = $filename;
-
-		// Fonts
-		Container::get( 'GlobalTypography' )->getFonts();
-
-		// Latex DPI
-		$this->fixLatexDpi();
-
-		// CSS File
-		$css = $this->kneadCss();
-		$css_file = $this->createTmpFile();
-		file_put_contents( $css_file, $css );
-
-		// Save PDF as file in exports folder
-		$prince = new \PrinceXMLPhp\PrinceWrapper( PB_PRINCE_COMMAND );
-		$prince->setHTML( true );
-		$prince->setCompress( true );
-		if ( defined( 'WP_ENV' ) && WP_ENV === 'development' || WP_ENV === 'staging' ) {
-			$prince->setInsecure( true );
-		}
-		$prince->setOptions( '--pdf-profile=' . $this->pdfProfile . ' --pdf-output-intent=' . $this->pdfOutputIntent );
-		$prince->addStyleSheet( $css_file );
-		if ( $this->exportScriptPath ) {
-			$prince->addScript( $this->exportScriptPath );
-		}
-		$prince->setLog( $this->logfile );
-		$retval = $prince->convert_file_to_file( $this->url, $this->outputPath, $msg );
-
-		// Prince XML is very flexible. There could be errors but Prince will still render a PDF.
-		// We want to log those errors but we won't alert the user.
-		if ( count( $msg ) ) {
-			$this->logError( file_get_contents( $this->logfile ) );
-		}
-
-		return $retval;
+	protected function generateFileName() {
+		return $this->timestampedFileName( '._print.pdf' );
 	}
-
-	/**
-	 * Increase PB-LaTeX resolution to ~300 dpi
-	 */
-	protected function fixLatexDpi() {
-		$this->url .= '&pb-latex-zoom=3';
-		$this->cssOverrides .= "\n" . 'img.latex { prince-image-resolution: 300dpi; }' . "\n";
-	}
-
 }

--- a/inc/modules/export/prince/class-printpdf.php
+++ b/inc/modules/export/prince/class-printpdf.php
@@ -12,12 +12,7 @@ class PrintPdf extends Pdf {
 	 * @param array $args
 	 */
 	function __construct( array $args ) {
-
 		parent::__construct( $args );
-
-		// Override
-		$this->pdfProfile = 'PDF/X-1a';
-		$this->pdfOutputIntent = '/usr/lib/prince/icc/USWebCoatedSWOP.icc';
 	}
 
 	/**
@@ -26,4 +21,23 @@ class PrintPdf extends Pdf {
 	protected function generateFileName() {
 		return $this->timestampedFileName( '._print.pdf' );
 	}
+
+	/**
+	 * Return the desired PDF profile.
+	 *
+	 * @return string
+	 */
+	protected function getPdfProfile() {
+		return 'PDF/X-1a:2003';
+	}
+
+	/**
+	 * Return the desired PDF output intent.
+	 *
+	 * @return string
+	 */
+	protected function getPdfOutputIntent() {
+		return '/usr/lib/prince/icc/USWebCoatedSWOP.icc';
+	}
+
 }

--- a/inc/modules/export/xhtml/class-xhtml11.php
+++ b/inc/modules/export/xhtml/class-xhtml11.php
@@ -8,6 +8,7 @@ namespace Pressbooks\Modules\Export\Xhtml;
 
 use Pressbooks\Modules\Export\Export;
 use Pressbooks\Sanitize;
+use function Pressbooks\Sanitize\clean_filename;
 
 class Xhtml11 extends Export {
 
@@ -195,12 +196,12 @@ class Xhtml11 extends Export {
 		echo '<title>' . get_bloginfo( 'name' ) . "</title>\n";
 
 		if ( ! empty( $_GET['style'] ) ) {
-			$url = \Pressbooks\Container::get( 'Sass' )->urlToUserGeneratedCss() . '/' . $_GET['style'] . '.css';
+			$url = \Pressbooks\Container::get( 'Sass' )->urlToUserGeneratedCss() . '/' . clean_filename( $_GET['style'] ) . '.css';
 			echo "<link rel='stylesheet' href='$url' type='text/css' />\n";
 		}
 
 		if ( ! empty( $_GET['script'] ) ) {
-			$url = $this->getExportScriptUrl( $_GET['script'] ) . '/script.js';
+			$url = $this->getExportScriptUrl( clean_filename( $_GET['script'] ) ) . '/script.js';
 			if ( $url ) {
 				echo "<script src='$url' type='text/javascript'></script>\n";
 			}

--- a/inc/sanitize/namespace.php
+++ b/inc/sanitize/namespace.php
@@ -444,3 +444,19 @@ function allow_post_content() {
 
 	return;
 }
+
+
+/**
+ * Sanitizer for filename
+ *
+ * @param string $file
+ *
+ * @return string
+ */
+function clean_filename( $file ) {
+	// Remove anything which isn't a word, whitespace, number or any of the following caracters -_~,;[]().
+	$file = mb_ereg_replace( '([^\w\s\d\-_~,;\[\]\(\).])', '', $file );
+	// Remove any runs of periods (thanks falstro!)
+	$file = mb_ereg_replace( '([\.]{2,})', '', $file );
+	return $file;
+}

--- a/inc/sanitize/namespace.php
+++ b/inc/sanitize/namespace.php
@@ -456,7 +456,7 @@ function allow_post_content() {
 function clean_filename( $file ) {
 	// Remove anything which isn't a word, whitespace, number or any of the following caracters -_~,;[]().
 	$file = mb_ereg_replace( '([^\w\s\d\-_~,;\[\]\(\).])', '', $file );
-	// Remove any runs of periods (thanks falstro!)
+	// Remove any runs of periods
 	$file = mb_ereg_replace( '([\.]{2,})', '', $file );
 	return $file;
 }

--- a/symbionts/pressbooks-latex/automattic-latex-wpcom.php
+++ b/symbionts/pressbooks-latex/automattic-latex-wpcom.php
@@ -1,10 +1,12 @@
 <?php
-/*
-Version: 1.1
-Copyright: Automattic, Inc.
-License: GPL2+
-*/
 
+/**
+ *
+ * This plugin is forked from the original WP Latex (c) Sidney Markowitz, Automattic, Inc.
+ * It modifies the plugin to work with Pressbooks, strips unwanted features, adds others — activated at the network level
+ *
+ * @see https://github.com/wp-plugins/wp-latex
+ */
 class Automattic_Latex_WPCOM {
 	var $latex;
 	var $bg_hex;
@@ -44,7 +46,22 @@ class Automattic_Latex_WPCOM {
 	function wrapper( $wrapper = false ) {}
 
 	function url() {
-		$this->url = 'https://s.wordpress.com/latex.php?latex=' . rawurlencode( $this->latex ) . "&bg=$this->bg_hex&fg=$this->fg_hex&s=$this->size";
+
+		if ( ! empty( $_GET['pb-latex-zoom'] ) ) {
+			$this->zoom = (int) $_GET['pb-latex-zoom'];
+		}
+
+		$this->url = add_query_arg(
+			urlencode_deep( array(
+				'latex' => $this->latex,
+				'bg' => $this->bg_hex,
+				'fg' => $this->fg_hex,
+				's' => $this->size,
+				'zoom' => $this->zoom,
+			) ),
+			( is_ssl() ? 'https' : 'http' ) . '://s0.wp.com/latex.php'
+		);
+
 		return $this->url;
 	}
 }

--- a/tests/test-sanitize.php
+++ b/tests/test-sanitize.php
@@ -233,4 +233,19 @@ class SanitizeTest extends \WP_UnitTestCase {
 		$this->assertTrue( $allowedposttags['h1']['xml:lang'] );
 	}
 
+	public function test_clean_filename() {
+
+		$file = '../../hacker.php';
+		$file = \Pressbooks\Sanitize\clean_filename( $file );
+		$this->assertEquals( $file, 'hacker.php' );
+
+		$file = '../../hacker.php;../../~more-hacks.php...';
+		$file = \Pressbooks\Sanitize\clean_filename( $file );
+		$this->assertEquals( $file, 'hacker.php;~more-hacks.php' );
+
+		$file = 'フランス語.txt'; // UTF-8
+		$file = \Pressbooks\Sanitize\clean_filename( $file );
+		$this->assertEquals( $file, 'フランス語.txt' );
+	}
+
 }


### PR DESCRIPTION
WPLaTeX API has an undocumented zoom feature. Setting zoom to 3 increases pixel density to 300, 9 increases pixel density to 900, etc.

Examples:
 + https://s.wordpress.com/latex.php?latex=e%5E%7B%5Ci%20%5Cpi%7D%20%2B%201%20%3D%200&bg=ffffff&fg=000000
+ https://s.wordpress.com/latex.php?latex=e%5E%7B%5Ci%20%5Cpi%7D%20%2B%201%20%3D%200&bg=ffffff&fg=000000&zoom=3
+ https://s.wordpress.com/latex.php?latex=e%5E%7B%5Ci%20%5Cpi%7D%20%2B%201%20%3D%200&bg=ffffff&fg=000000&zoom=9

Source code:
 + https://github.com/wp-plugins/wp-latex/commit/94c865a2faa12aac24e86b88d720ac607a89fa97

This pull request 
 + Adds detection for `$_GET['pb-latex-zoom']` in the PB LaTeX plugin
 + Changes Prince module to use the zoom feature so we can get a higher DPI in PDF exports
 + [Applies fixes found in WP-LaTeX trunk](https://github.com/wp-plugins/wp-latex/commits/master). to PB LaTeX
 + Cleans up some stuff so we can more easily extend/reuse in the Docraptor plugin.




