### PR TITLE
Fix WP LaTeX URL redirects

### DIFF
--- a/inc/modules/export/epub/class-epub201.php
+++ b/inc/modules/export/epub/class-epub201.php
@@ -12,6 +12,7 @@ namespace Pressbooks\Modules\Export\Epub;
 use Pressbooks\Modules\Export\Export;
 use Pressbooks\Container;
 use Pressbooks\Sanitize;
+use function Pressbooks\Utility\str_ends_with;
 
 class Epub201 extends Export {
 
@@ -1837,7 +1838,8 @@ class Epub201 extends Export {
 		$filename = explode( '?', basename( $url ) );
 
 		// isolate latex image service from WP, add file extension
-		if ( 's.wordpress.com' === parse_url( $url, PHP_URL_HOST ) && 'latex.php' === $filename[0] ) {
+		$host = parse_url( $url, PHP_URL_HOST );
+		if ( ( str_ends_with( $host, 'wordpress.com' ) || str_ends_with( $host, 'wp.com' ) ) && 'latex.php' === $filename[0] ) {
 			$filename = md5( array_pop( $filename ) );
 			// content-type = 'image/png'
 			$type = explode( '/', $response['headers']['content-type'] );

--- a/inc/modules/export/odt/class-odt.php
+++ b/inc/modules/export/odt/class-odt.php
@@ -7,6 +7,7 @@
 namespace Pressbooks\Modules\Export\Odt;
 
 use Pressbooks\Modules\Export\Export;
+use function Pressbooks\Utility\str_ends_with;
 
 class Odt extends Export {
 
@@ -341,7 +342,8 @@ class Odt extends Export {
 		$filename = explode( '?', basename( $url ) );
 
 		// isolate latex image service from WP, add file extension
-		if ( 's.wordpress.com' === parse_url( $url, PHP_URL_HOST ) && 'latex.php' === $filename[0] ) {
+		$host = parse_url( $url, PHP_URL_HOST );
+		if ( ( str_ends_with( $host, 'wordpress.com' ) || str_ends_with( $host, 'wp.com' ) ) && 'latex.php' === $filename[0] ) {
 			$filename = md5( array_pop( $filename ) );
 			// content-type = 'image/png'
 			$type = explode( '/', $response['headers']['content-type'] );

--- a/inc/utility/namespace.php
+++ b/inc/utility/namespace.php
@@ -883,3 +883,28 @@ function rcopy( $src, $dest ) {
 	}
 	return true;
 }
+
+/**
+ * @param string $haystack
+ * @param string $needle
+ *
+ * @return bool
+ */
+function str_starts_with( $haystack, $needle ) {
+	$length = strlen( $needle );
+	return ( substr( $haystack, 0, $length ) === $needle );
+}
+
+/**
+ * @param string $haystack
+ * @param string $needle
+ *
+ * @return bool
+ */
+function str_ends_with( $haystack, $needle ) {
+	$length = strlen( $needle );
+	if ( $length === 0 ) {
+		return true;
+	}
+	return ( substr( $haystack, -$length ) === $needle );
+}

--- a/tests/test-utility.php
+++ b/tests/test-utility.php
@@ -254,4 +254,16 @@ class UtilityTest extends \WP_UnitTestCase {
 		$this->assertEquals( $return, false );
 	}
 
+	public function test_str_starts_with() {
+		$this->assertTrue( \Pressbooks\Utility\str_starts_with( '', '' ) );
+		$this->assertTrue( \Pressbooks\Utility\str_starts_with( 's0.wp.com', 's0.wp' ) );
+		$this->assertFalse( \Pressbooks\Utility\str_starts_with( 's0.wp.com', 'wp.com' ) );
+	}
+
+	public function test_str_ends_with() {
+		$this->assertFalse( \Pressbooks\Utility\str_ends_with( 's0.wp.com', 's0.wp' ) );
+		$this->assertTrue( \Pressbooks\Utility\str_ends_with( 's0.wp.com', 'wp.com' ) );
+		$this->assertTrue( \Pressbooks\Utility\str_starts_with( '', '' ) );
+	}
+
 }

--- a/tests/test-utility.php
+++ b/tests/test-utility.php
@@ -255,7 +255,6 @@ class UtilityTest extends \WP_UnitTestCase {
 	}
 
 	public function test_str_starts_with() {
-		$this->assertTrue( \Pressbooks\Utility\str_starts_with( '', '' ) );
 		$this->assertTrue( \Pressbooks\Utility\str_starts_with( 's0.wp.com', 's0.wp' ) );
 		$this->assertFalse( \Pressbooks\Utility\str_starts_with( 's0.wp.com', 'wp.com' ) );
 	}
@@ -263,7 +262,6 @@ class UtilityTest extends \WP_UnitTestCase {
 	public function test_str_ends_with() {
 		$this->assertFalse( \Pressbooks\Utility\str_ends_with( 's0.wp.com', 's0.wp' ) );
 		$this->assertTrue( \Pressbooks\Utility\str_ends_with( 's0.wp.com', 'wp.com' ) );
-		$this->assertTrue( \Pressbooks\Utility\str_starts_with( '', '' ) );
 	}
 
 }


### PR DESCRIPTION
wordpress.com was changed to wp.com and breaks LaTeX detection. This PR fixes that.