### PR TITLE
Add isBasedOn property to metadata (fixes #850)

### DIFF
--- a/inc/api/endpoints/controller/class-metadata.php
+++ b/inc/api/endpoints/controller/class-metadata.php
@@ -355,6 +355,13 @@ class Metadata extends \WP_REST_Controller {
 					'context' => [ 'view' ],
 					'readonly' => true,
 				],
+				'isBasedOn' => [
+					'type' => 'string',
+					'format' => 'uri',
+					'description' => __( 'A resource that was used in the creation of this resource. This term can be repeated for multiple sources.' ),
+					'context' => [ 'view' ],
+					'readonly' => true,
+				],
 			],
 		];
 
@@ -420,6 +427,7 @@ class Metadata extends \WP_REST_Controller {
 			'pb_about_50' => 'description',
 			'pb_cover_image' => 'image',
 			'pb_series_number' => 'position',
+			'pb_is_based_on' => 'isBasedOn',
 		];
 
 		foreach ( $mapped_properties as $old => $new ) {

--- a/inc/api/endpoints/controller/class-sectionmetadata.php
+++ b/inc/api/endpoints/controller/class-sectionmetadata.php
@@ -343,6 +343,13 @@ class SectionMetadata extends \WP_REST_Controller {
 					'context' => [ 'view' ],
 					'readonly' => true,
 				],
+				'isBasedOn' => [
+					'type' => 'string',
+					'format' => 'uri',
+					'description' => __( 'A resource that was used in the creation of this resource. This term can be repeated for multiple sources.' ),
+					'context' => [ 'view' ],
+					'readonly' => true,
+				],
 			],
 		];
 
@@ -418,6 +425,7 @@ class SectionMetadata extends \WP_REST_Controller {
 			'pb_title' => 'name',
 			'pb_short_title' => 'alternateName',
 			'pb_subtitle' => 'alternativeHeadline',
+			'pb_is_based_on' => 'isBasedOn',
 		];
 
 		$mapped_book_properties = [
@@ -531,6 +539,10 @@ class SectionMetadata extends \WP_REST_Controller {
 		}
 
 		$new_section_information['license'] = \Pressbooks\Metadata\get_url_for_license( $section_information['pb_section_license'] );
+
+		if ( ! isset( $section_information['pb_is_based_on'] ) && isset( $book_information['pb_is_based_on'] ) ) {
+			$new_section_information['isBasedOn'] = $book_information['pb_is_based_on'];
+		}
 
 		// TODO: educationalAlignment, educationalUse, timeRequired, typicalAgeRange, interactivityType, learningResourceType, isBasedOn, isBasedOnUrl
 

--- a/inc/metadata/namespace.php
+++ b/inc/metadata/namespace.php
@@ -53,6 +53,7 @@ function get_microdata_elements() {
 		'inLanguage' => 'pb_language',
 		'keywords' => 'pb_keywords_tags',
 		'publisher' => 'pb_publisher',
+		'isBasedOn' => 'pb_is_based_on',
 	];
 	$metadata = Book::getBookInformation();
 


### PR DESCRIPTION
This adds support for the Schema.org [isBasedOn](https://schema.org/isBasedOn) property to books and sections. The property, if populated, will be added to book and section metadata (with sections inheriting from the book if the book's property is set but the section's is not). These properties are not currently editable as they will be autofilled during a cloning operation (see #841).