### PR TITLE
Allow editors to modify theme options and custom CSS (fix #862)

### DIFF
--- a/inc/admin/customcss/namespace.php
+++ b/inc/admin/customcss/namespace.php
@@ -16,7 +16,7 @@ use Pressbooks\CustomCss;
 function add_menu() {
 
 	if ( Book::isBook() && CustomCss::isCustomCss() ) {
-		add_theme_page( __( 'Edit CSS', 'pressbooks' ), __( 'Edit CSS', 'pressbooks' ), 'edit_theme_options', 'pb_custom_css', __NAMESPACE__ . '\display_custom_css' );
+		add_theme_page( __( 'Edit CSS', 'pressbooks' ), __( 'Edit CSS', 'pressbooks' ), 'edit_others_posts', 'pb_custom_css', __NAMESPACE__ . '\display_custom_css' );
 	}
 }
 
@@ -237,7 +237,7 @@ function render_dropdown_for_css_copy( $custom_css, $slug ) {
 function load_css_from() {
 
 	check_ajax_referer( 'pb-load-css-from' );
-	if ( empty( current_user_can( 'edit_theme_options' ) ) ) {
+	if ( empty( current_user_can( 'edit_others_posts' ) ) ) {
 		die( -1 );
 	}
 

--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -81,7 +81,7 @@ function replace_book_admin_menu() {
 	remove_menu_page( 'link-manager.php' );
 	remove_menu_page( 'edit.php?post_type=page' );
 	add_theme_page(
-		__( 'Theme Options', 'pressbooks' ), __( 'Theme Options', 'pressbooks' ), 'edit_theme_options', 'pressbooks_theme_options', [
+		__( 'Theme Options', 'pressbooks' ), __( 'Theme Options', 'pressbooks' ), 'edit_others_posts', 'pressbooks_theme_options', [
 		'\Pressbooks\Modules\ThemeOptions\ThemeOptions',
 		'render',
 		]

--- a/inc/class-customcss.php
+++ b/inc/class-customcss.php
@@ -137,7 +137,7 @@ class CustomCss {
 	 */
 	static function formSubmit() {
 
-		if ( empty( static::isFormSubmission() ) || empty( current_user_can( 'edit_theme_options' ) ) ) {
+		if ( empty( static::isFormSubmission() ) || empty( current_user_can( 'edit_others_posts' ) ) ) {
 			// Don't do anything in this function, bail.
 			return;
 		}

--- a/inc/modules/themeoptions/class-themeoptions.php
+++ b/inc/modules/themeoptions/class-themeoptions.php
@@ -30,6 +30,7 @@ class ThemeOptions {
 	 */
 	function loadTabs() {
 		foreach ( $this->tabs as $slug => $subclass ) {
+			add_filter( "option_page_capability_pressbooks_theme_options_$slug", [ $this, 'setPermissions' ], 10, 1 );
 			add_filter( 'pressbooks_theme_options_' . $slug . '_defaults', [ $subclass, 'filterDefaults' ], 10, 1 );
 			$option = get_option( 'pressbooks_theme_options_' . $slug, $subclass::getDefaults() );
 			/** @var \Pressbooks\Options $tab */
@@ -45,6 +46,18 @@ class ThemeOptions {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Modifies the capability for theme options to allow Editors to manage them.
+	 * @see https://developer.wordpress.org/reference/hooks/option_page_capability_option_page/
+	 *
+	 * @since 4.1.0
+	 * @param string $capability
+	 * @return string
+	 */
+	function setPermissions( $capability ) {
+		return 'edit_others_posts';
 	}
 
 	/**
@@ -111,4 +124,5 @@ class ThemeOptions {
 		 */
 		return apply_filters( 'pb_theme_options_tabs', $tabs );
 	}
+
 }

--- a/inc/posttype/namespace.php
+++ b/inc/posttype/namespace.php
@@ -221,12 +221,12 @@ function register_post_types() {
 		'can_export' => false,
 		'rewrite' => false,
 		'capabilities' => [
-			'edit_post' => 'edit_theme_options',
+			'edit_post' => 'edit_others_posts',
 			'read_post' => 'read',
-			'delete_post' => 'edit_theme_options',
-			'edit_posts' => 'edit_theme_options',
-			'edit_others_posts' => 'edit_theme_options',
-			'publish_posts' => 'edit_theme_options',
+			'delete_post' => 'edit_others_posts',
+			'edit_posts' => 'edit_others_posts',
+			'edit_others_posts' => 'edit_others_posts',
+			'publish_posts' => 'edit_others_posts',
 			'read_private_posts' => 'read',
 		],
 	];


### PR DESCRIPTION
In a conversation today, we identified that users who should not have Administrator privileges on a book are often given them just so they can adjust theme options/edit custom CSS. This PR allows users with Editor privileges to do these things.