### PR TITLE
Better image cloning (fixes #895)

### DIFF
--- a/inc/class-cloner.php
+++ b/inc/class-cloner.php
@@ -10,10 +10,10 @@ namespace Pressbooks;
 
 use Masterminds\HTML5;
 use Pressbooks\Admin\Network\SharingAndPrivacyOptions;
+use function Pressbooks\Image\attachment_id_from_url;
 use function Pressbooks\Image\default_cover_url;
 use function Pressbooks\Metadata\schema_to_book_information;
 use function Pressbooks\Metadata\schema_to_section_information;
-use Pressbooks\Modules\ThemeOptions\PDFOptions;
 use function \Pressbooks\Utility\getset;
 
 class Cloner {
@@ -130,6 +130,13 @@ class Cloner {
 	protected $targetBookTerms = [];
 
 	/**
+	 * Array of known images, format: [ Resized Filename ] => [ Fullsize URL ]
+	 *
+	 * @var array
+	 */
+	protected $knownImages = [];
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 4.1.0
@@ -199,6 +206,12 @@ class Cloner {
 		$this->sourceBookTerms = $this->getBookTerms( $this->sourceBookUrl );
 		if ( empty( $this->sourceBookTerms ) ) {
 			$_SESSION['pb_errors'][] = sprintf( __( 'Could not retrieve taxonomies from %s.', 'pressbooks' ), sprintf( '<em>%s</em>', $this->sourceBookMetadata['name'] ) );
+			return false;
+		}
+
+		$this->knownImages = $this->buildlistOfKnownImages( $this->sourceBookUrl );
+		if ( $this->knownImages === false ) {
+			$_SESSION['pb_errors'][] = sprintf( __( 'Could not retrieve media from %s.', 'pressbooks' ), sprintf( '<em>%s</em>', $this->sourceBookMetadata['name'] ) );
 			return false;
 		}
 
@@ -360,6 +373,39 @@ class Cloner {
 	 */
 	public function cloneBackMatter( $id ) {
 		return $this->cloneSection( $id, 'back-matter' );
+	}
+
+	/**
+	 * Use media endpoint to build an array of known images, format: [ Resized Filename ] => [ Fullsize URL ]
+	 *
+	 * @param string $url The URL of the book.
+	 *
+	 * @return bool | array False if the operation failed; known images array if succeeded.
+	 */
+	public function buildListOfKnownImages( $url ) {
+		// Handle request (local or global)
+		$params = [ 'media_type' => 'image', 'per_page' => 100 ];
+		$response = $this->handleGetRequest( $url, 'wp/v2', 'media', $params );
+
+		// Handle errors
+		if ( is_wp_error( $response ) ) {
+			$_SESSION['pb_errors'][] = sprintf(
+				'<p>%1$s</p><p>%2$s</p>',
+				__( 'The source book&rsquo;s media could not be read.', 'pressbooks' ),
+				$response->get_error_message()
+			);
+			return false;
+		}
+
+		$known_images = [];
+		foreach ( $response as $item ) {
+			$fullsize = $item['source_url'];
+			foreach ( $item['media_details']['sizes'] as $size => $info ) {
+				$known_images[ $info['file'] ] = $fullsize;
+			}
+		}
+
+		return $known_images;
 	}
 
 	/**
@@ -529,9 +575,9 @@ class Cloner {
 		$book_information = schema_to_book_information( $this->sourceBookMetadata );
 		$book_information['pb_is_based_on'] = $this->sourceBookUrl;
 		if ( strpos( $book_information['pb_cover_image'], 'plugins/pressbooks/assets/dist/images/default-book-cover.jpg' ) === false ) {
-			$new_cover = $this->fetchAndSaveUniqueImage( $book_information['pb_cover_image'] );
-			if ( $new_cover ) {
-				$book_information['pb_cover_image'] = wp_get_attachment_url( $new_cover );
+			$new_cover_id = $this->fetchAndSaveUniqueImage( $book_information['pb_cover_image'] );
+			if ( $new_cover_id ) {
+				$book_information['pb_cover_image'] = wp_get_attachment_url( $new_cover_id );
 			} else {
 				$book_information['pb_cover_image'] = default_cover_url();
 			}
@@ -724,6 +770,10 @@ class Cloner {
 				$request->set_query_params( $params );
 			}
 			$response = rest_do_request( $request );
+
+			// WordPress shows only 10-100 results. We need to paginate on $response->headers['Link']
+			// Format: <http://pressbooks.dev/pdfimages/wp-json/wp/v2/media?media_type=image&page=2>; rel="next"
+
 			if ( $switch ) {
 				restore_current_blog();
 			}
@@ -781,18 +831,25 @@ class Cloner {
 		foreach ( $images as $image ) {
 			/** @var \DOMElement $image */
 			// Fetch image, change src
-			$src = $image->getAttribute( 'src' );
+			$src_old = $image->getAttribute( 'src' );
 
-			$attachment = $this->fetchAndSaveUniqueImage( $src );
+			$attachment_id = $this->fetchAndSaveUniqueImage( $src_old );
 
-			if ( $attachment ) {
-				// Replace with new image
-				$image->setAttribute( 'src', wp_get_attachment_url( $attachment ) );
+			if ( $attachment_id ) {
+				// Replace image
+				$src_new = wp_get_attachment_url( $attachment_id );
+				if ( $this->sameAsSource( $src_old ) && $attachment_id === attachment_id_from_url( $src_old ) ) {
+					// This is a cloned image, use old filename to keep resizing
+					$basename_old = $this->basename( $src_old );
+					$basename_new = $this->basename( $src_new );
+					$src_new = \Pressbooks\Utility\str_lreplace( $basename_new, $basename_old, $src_new );
+				}
+				$image->setAttribute( 'src', $src_new );
 				// TODO Handle srcset
-				$attachments[] = $attachment;
+				$attachments[] = $attachment_id;
 			} else {
 				// Tag broken image
-				$image->setAttribute( 'src', "{$src}#fixme" );
+				$image->setAttribute( 'src', "{$src_old}#fixme" );
 			}
 		}
 
@@ -816,10 +873,17 @@ class Cloner {
 	 */
 	protected function fetchAndSaveUniqueImage( $url ) {
 		if ( ! filter_var( $url, FILTER_VALIDATE_URL ) ) {
-			return '';
+			return 0;
 		}
 
-		$remote_img_location = $url;
+		$filename = $this->basename( $url );
+
+		if ( $this->sameAsSource( $url ) && isset( $this->knownImages[ $filename ] ) ) {
+			$remote_img_location = $this->knownImages[ $filename ];
+			$filename = basename( $this->knownImages[ $filename ] );
+		} else {
+			$remote_img_location = $url;
+		}
 
 		// Cheap cache
 		static $already_done = [];
@@ -829,23 +893,17 @@ class Cloner {
 
 		/* Process */
 
-		// Basename without query string
-		$filename = explode( '?', basename( $url ) );
-		$filename = array_shift( $filename );
-		$filename = explode( '#', $filename )[0]; // Remove trailing anchors
-		$filename = sanitize_file_name( urldecode( $filename ) );
-
 		if ( ! preg_match( '/\.(jpe?g|gif|png)$/i', $filename ) ) {
 			// Unsupported image type
-			$already_done[ $remote_img_location ] = '';
-			return '';
+			$already_done[ $remote_img_location ] = 0;
+			return 0;
 		}
 
 		$tmp_name = download_url( $remote_img_location );
 		if ( is_wp_error( $tmp_name ) ) {
 			// Download failed
-			$already_done[ $remote_img_location ] = '';
-			return '';
+			$already_done[ $remote_img_location ] = 0;
+			return 0;
 		}
 
 		if ( ! \Pressbooks\Image\is_valid_image( $tmp_name, $filename ) ) {
@@ -857,9 +915,9 @@ class Cloner {
 				}
 			} catch ( \Exception $exc ) {
 				// Garbage, don't import
-				$already_done[ $remote_img_location ] = '';
-				unlink( $tmp_name );
-				return '';
+				$already_done[ $remote_img_location ] = 0;
+				@unlink( $tmp_name ); // @codingStandardsIgnoreLine
+				return 0;
 			}
 		}
 
@@ -869,11 +927,38 @@ class Cloner {
 			$pid = 0;
 		} else {
 			$this->clonedItems['media'][] = $pid;
-			$already_done[ $remote_img_location ] = $src;
+			$already_done[ $remote_img_location ] = $pid;
 		}
 		@unlink( $tmp_name ); // @codingStandardsIgnoreLine
 
 		return $pid;
+	}
+
+	/**
+	 * Get sanitized basename without query string or anchors
+	 *
+	 * @param $url
+	 *
+	 * @return array|mixed|string
+	 */
+	protected function basename( $url ) {
+		$filename = explode( '?', basename( $url ) );
+		$filename = array_shift( $filename );
+		$filename = explode( '#', $filename )[0]; // Remove trailing anchors
+		$filename = sanitize_file_name( urldecode( $filename ) );
+
+		return $filename;
+	}
+
+	/**
+	 * @param $url
+	 *
+	 * @return bool
+	 */
+	protected function sameAsSource( $url ) {
+		$same_host = ( parse_url( $this->sourceBookUrl, PHP_URL_HOST ) === parse_url( $url, PHP_URL_HOST ) );
+
+		return $same_host;
 	}
 
 	/**


### PR DESCRIPTION
Approach:

 + Scan `/wp/v2/media` for all known images and build a `[resized] => [fullsize]` list.
 + When saving `<img>` tags, if its hosted at the source, and if we find a resized match from our known images list, then download the fullsize one.
 + When we sideload the fullsize image into PB, it will recreate the same files and filenames, so it should just fit.

I did not check if images are the same because that would mean having to download the image first, then checking, then trying again if it didn't work. Maybe that's OK for a local disk, not so much over HTTP. 

Can be improved in the future.

