### PR TITLE
Import/clone full-size images (fixes #895)

### DIFF
--- a/inc/class-cloner.php
+++ b/inc/class-cloner.php
@@ -304,6 +304,9 @@ class Cloner {
 		// Set endpoint
 		$endpoint = $term['taxonomy'];
 
+		// _links key needs to be removed, pop it out into an ignored variable
+		$_links = array_pop( $term );
+
 		// Remove source-specific properties
 		$bad_keys = [ 'id', 'count', 'link', 'parent', 'taxonomy' ];
 		foreach ( $bad_keys as $bad_key ) {
@@ -618,6 +621,9 @@ class Cloner {
 				break;
 			}
 		};
+
+		// _links key needs to be removed, pop it out into an ignored variable
+		$_links = array_pop( $section );
 
 		if ( empty( $section['link'] ) ) {
 			// Doing it wrong...

--- a/inc/class-cloner.php
+++ b/inc/class-cloner.php
@@ -625,11 +625,6 @@ class Cloner {
 		// _links key needs to be removed, pop it out into an ignored variable
 		$_links = array_pop( $section );
 
-		if ( empty( $section['link'] ) ) {
-			// Doing it wrong...
-			return false;
-		}
-
 		// Get permalink
 		$permalink = $section['link'];
 

--- a/inc/class-cloner.php
+++ b/inc/class-cloner.php
@@ -130,7 +130,7 @@ class Cloner {
 	protected $targetBookTerms = [];
 
 	/**
-	 * Array of known images, format: [ Resized Filename ] => [ Fullsize URL ]
+	 * Array of known images, format: [ 2017/08/foo-bar-300x225.png ] => [ Fullsize URL ], ...
 	 *
 	 * @var array
 	 */
@@ -374,7 +374,7 @@ class Cloner {
 	}
 
 	/**
-	 * Use media endpoint to build an array of known images, format: [ Resized Filename ] => [ Fullsize URL ]
+	 * Use media endpoint to build an array of known images
 	 *
 	 * @param string $url The URL of the book.
 	 *
@@ -399,7 +399,8 @@ class Cloner {
 		foreach ( $response as $item ) {
 			$fullsize = $item['source_url'];
 			foreach ( $item['media_details']['sizes'] as $size => $info ) {
-				$known_images[ $info['file'] ] = $fullsize;
+				$attached_file = \Pressbooks\Image\strip_baseurl( $info['source_url'] ); // 2017/08/foo-bar-300x225.png
+				$known_images[ $attached_file ] = $fullsize;
 			}
 		}
 
@@ -875,10 +876,11 @@ class Cloner {
 		}
 
 		$filename = $this->basename( $url );
+		$attached_file = \Pressbooks\Image\strip_baseurl( $url );
 
-		if ( $this->sameAsSource( $url ) && isset( $this->knownImages[ $filename ] ) ) {
-			$remote_img_location = $this->knownImages[ $filename ];
-			$filename = basename( $this->knownImages[ $filename ] );
+		if ( $this->sameAsSource( $url ) && isset( $this->knownImages[ $attached_file ] ) ) {
+			$remote_img_location = $this->knownImages[ $attached_file ];
+			$filename = basename( $this->knownImages[ $attached_file ] );
 		} else {
 			$remote_img_location = $url;
 		}

--- a/inc/class-cloner.php
+++ b/inc/class-cloner.php
@@ -10,10 +10,10 @@ namespace Pressbooks;
 
 use Masterminds\HTML5;
 use Pressbooks\Admin\Network\SharingAndPrivacyOptions;
+use function Pressbooks\Image\attachment_id_from_url;
 use function Pressbooks\Image\default_cover_url;
 use function Pressbooks\Metadata\schema_to_book_information;
 use function Pressbooks\Metadata\schema_to_section_information;
-use Pressbooks\Modules\ThemeOptions\PDFOptions;
 use function \Pressbooks\Utility\getset;
 
 class Cloner {
@@ -130,6 +130,13 @@ class Cloner {
 	protected $targetBookTerms = [];
 
 	/**
+	 * Array of known images, format: [ Resized Filename ] => [ Fullsize URL ]
+	 *
+	 * @var array
+	 */
+	protected $knownImages = [];
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 4.1.0
@@ -199,6 +206,12 @@ class Cloner {
 		$this->sourceBookTerms = $this->getBookTerms( $this->sourceBookUrl );
 		if ( empty( $this->sourceBookTerms ) ) {
 			$_SESSION['pb_errors'][] = sprintf( __( 'Could not retrieve taxonomies from %s.', 'pressbooks' ), sprintf( '<em>%s</em>', $this->sourceBookMetadata['name'] ) );
+			return false;
+		}
+
+		$this->knownImages = $this->buildlistOfKnownImages( $this->sourceBookUrl );
+		if ( $this->knownImages === false ) {
+			$_SESSION['pb_errors'][] = sprintf( __( 'Could not retrieve media from %s.', 'pressbooks' ), sprintf( '<em>%s</em>', $this->sourceBookMetadata['name'] ) );
 			return false;
 		}
 
@@ -360,6 +373,39 @@ class Cloner {
 	 */
 	public function cloneBackMatter( $id ) {
 		return $this->cloneSection( $id, 'back-matter' );
+	}
+
+	/**
+	 * Use media endpoint to build an array of known images, format: [ Resized Filename ] => [ Fullsize URL ]
+	 *
+	 * @param string $url The URL of the book.
+	 *
+	 * @return bool | array False if the operation failed; known images array if succeeded.
+	 */
+	public function buildListOfKnownImages( $url ) {
+		// Handle request (local or global)
+		$params = [ 'media_type' => 'image', 'per_page' => 100 ];
+		$response = $this->handleGetRequest( $url, 'wp/v2', 'media', $params );
+
+		// Handle errors
+		if ( is_wp_error( $response ) ) {
+			$_SESSION['pb_errors'][] = sprintf(
+				'<p>%1$s</p><p>%2$s</p>',
+				__( 'The source book&rsquo;s media could not be read.', 'pressbooks' ),
+				$response->get_error_message()
+			);
+			return false;
+		}
+
+		$known_images = [];
+		foreach ( $response as $item ) {
+			$fullsize = $item['source_url'];
+			foreach ( $item['media_details']['sizes'] as $size => $info ) {
+				$known_images[ $info['file'] ] = $fullsize;
+			}
+		}
+
+		return $known_images;
 	}
 
 	/**
@@ -529,9 +575,9 @@ class Cloner {
 		$book_information = schema_to_book_information( $this->sourceBookMetadata );
 		$book_information['pb_is_based_on'] = $this->sourceBookUrl;
 		if ( strpos( $book_information['pb_cover_image'], 'plugins/pressbooks/assets/dist/images/default-book-cover.jpg' ) === false ) {
-			$new_cover = $this->fetchAndSaveUniqueImage( $book_information['pb_cover_image'] );
-			if ( $new_cover ) {
-				$book_information['pb_cover_image'] = wp_get_attachment_url( $new_cover );
+			$new_cover_id = $this->fetchAndSaveUniqueImage( $book_information['pb_cover_image'] );
+			if ( $new_cover_id ) {
+				$book_information['pb_cover_image'] = wp_get_attachment_url( $new_cover_id );
 			} else {
 				$book_information['pb_cover_image'] = default_cover_url();
 			}
@@ -724,6 +770,10 @@ class Cloner {
 				$request->set_query_params( $params );
 			}
 			$response = rest_do_request( $request );
+
+			// WordPress shows only 10-100 results. We need to paginate on $response->headers['Link']
+			// Format: <http://pressbooks.dev/pdfimages/wp-json/wp/v2/media?media_type=image&page=2>; rel="next"
+
 			if ( $switch ) {
 				restore_current_blog();
 			}
@@ -781,18 +831,25 @@ class Cloner {
 		foreach ( $images as $image ) {
 			/** @var \DOMElement $image */
 			// Fetch image, change src
-			$src = $image->getAttribute( 'src' );
+			$src_old = $image->getAttribute( 'src' );
 
-			$attachment = $this->fetchAndSaveUniqueImage( $src );
+			$attachment_id = $this->fetchAndSaveUniqueImage( $src_old );
 
-			if ( $attachment ) {
-				// Replace with new image
-				$image->setAttribute( 'src', wp_get_attachment_url( $attachment ) );
+			if ( $attachment_id ) {
+				// Replace image
+				$src_new = wp_get_attachment_url( $attachment_id );
+				if ( $this->sameAsSource( $src_old ) && $attachment_id === attachment_id_from_url( $src_old ) ) {
+					// This is a cloned image, use old filename to keep resizing
+					$basename_old = $this->basename( $src_old );
+					$basename_new = $this->basename( $src_new );
+					$src_new = \Pressbooks\Utility\str_lreplace( $basename_new, $basename_old, $src_new );
+				}
+				$image->setAttribute( 'src', $src_new );
 				// TODO Handle srcset
-				$attachments[] = $attachment;
+				$attachments[] = $attachment_id;
 			} else {
 				// Tag broken image
-				$image->setAttribute( 'src', "{$src}#fixme" );
+				$image->setAttribute( 'src', "{$src_old}#fixme" );
 			}
 		}
 
@@ -816,10 +873,17 @@ class Cloner {
 	 */
 	protected function fetchAndSaveUniqueImage( $url ) {
 		if ( ! filter_var( $url, FILTER_VALIDATE_URL ) ) {
-			return '';
+			return 0;
 		}
 
-		$remote_img_location = $url;
+		$filename = $this->basename( $url );
+
+		if ( $this->sameAsSource( $url ) && isset( $this->knownImages[ $filename ] ) ) {
+			$remote_img_location = $this->knownImages[ $filename ];
+			$filename = basename( $this->knownImages[ $filename ] );
+		} else {
+			$remote_img_location = $url;
+		}
 
 		// Cheap cache
 		static $already_done = [];
@@ -829,23 +893,17 @@ class Cloner {
 
 		/* Process */
 
-		// Basename without query string
-		$filename = explode( '?', basename( $url ) );
-		$filename = array_shift( $filename );
-		$filename = explode( '#', $filename )[0]; // Remove trailing anchors
-		$filename = sanitize_file_name( urldecode( $filename ) );
-
 		if ( ! preg_match( '/\.(jpe?g|gif|png)$/i', $filename ) ) {
 			// Unsupported image type
-			$already_done[ $remote_img_location ] = '';
-			return '';
+			$already_done[ $remote_img_location ] = 0;
+			return 0;
 		}
 
 		$tmp_name = download_url( $remote_img_location );
 		if ( is_wp_error( $tmp_name ) ) {
 			// Download failed
-			$already_done[ $remote_img_location ] = '';
-			return '';
+			$already_done[ $remote_img_location ] = 0;
+			return 0;
 		}
 
 		if ( ! \Pressbooks\Image\is_valid_image( $tmp_name, $filename ) ) {
@@ -857,9 +915,9 @@ class Cloner {
 				}
 			} catch ( \Exception $exc ) {
 				// Garbage, don't import
-				$already_done[ $remote_img_location ] = '';
-				unlink( $tmp_name );
-				return '';
+				$already_done[ $remote_img_location ] = 0;
+				@unlink( $tmp_name ); // @codingStandardsIgnoreLine
+				return 0;
 			}
 		}
 
@@ -869,11 +927,38 @@ class Cloner {
 			$pid = 0;
 		} else {
 			$this->clonedItems['media'][] = $pid;
-			$already_done[ $remote_img_location ] = $src;
+			$already_done[ $remote_img_location ] = $pid;
 		}
 		@unlink( $tmp_name ); // @codingStandardsIgnoreLine
 
 		return $pid;
+	}
+
+	/**
+	 * Get sanitized basename without query string or anchors
+	 *
+	 * @param $url
+	 *
+	 * @return array|mixed|string
+	 */
+	protected function basename( $url ) {
+		$filename = explode( '?', basename( $url ) );
+		$filename = array_shift( $filename );
+		$filename = explode( '#', $filename )[0]; // Remove trailing anchors
+		$filename = sanitize_file_name( urldecode( $filename ) );
+
+		return $filename;
+	}
+
+	/**
+	 * @param $url
+	 *
+	 * @return bool
+	 */
+	protected function sameAsSource( $url ) {
+		$same_host = ( parse_url( $this->sourceBookUrl, PHP_URL_HOST ) === parse_url( $url, PHP_URL_HOST ) );
+
+		return $same_host;
 	}
 
 	/**

--- a/inc/image/namespace.php
+++ b/inc/image/namespace.php
@@ -94,7 +94,7 @@ function thumbify( $thumb, $path ) {
 
 
 /**
- * Remove the upload path base directory from the attachment URL
+ * Returns the upload path and basename from attachment URL (ie. 2017/08/foo-bar.png), or unchanged if no match is found.
  *
  * @param string $url
  *
@@ -126,14 +126,14 @@ function attachment_id_from_url( $url ) {
 	// If this is the URL of an auto-generated thumbnail, get the URL of the original image
 	$url = preg_replace( '/-\d+x\d+(?=\.(jp?g|png|gif)$)/i', '', $url );
 
-	$url = strip_baseurl( $url );
+	$attached_file = strip_baseurl( $url );
 
 	// Get the attachment ID from the modified attachment URL
 	$id = $wpdb->get_var(
 		$wpdb->prepare(
 			"SELECT ID FROM {$wpdb->posts}
 			INNER JOIN {$wpdb->postmeta} ON {$wpdb->posts}.ID = {$wpdb->postmeta}.post_id
-			WHERE {$wpdb->posts}.post_type = 'attachment' AND {$wpdb->postmeta}.meta_key = '_wp_attached_file' AND {$wpdb->postmeta}.meta_value = '%s' ", $url
+			WHERE {$wpdb->posts}.post_type = 'attachment' AND {$wpdb->postmeta}.meta_key = '_wp_attached_file' AND {$wpdb->postmeta}.meta_value = '%s' ", $attached_file
 		)
 	);
 
@@ -255,13 +255,13 @@ function delete_attachment( $post_id ) {
 		/** @var $wpdb \wpdb */
 		global $wpdb;
 
-		$url = strip_baseurl( wp_get_attachment_url( $post->ID ) );
+		$attached_file = strip_baseurl( wp_get_attachment_url( $post->ID ) );
 
 		$id = $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT umeta_id FROM {$wpdb->usermeta} WHERE user_id = %d AND meta_key = 'pb_catalog_logo' AND meta_value REGEXP %s ",
 				$post->post_author,
-				"{$url}$" // End of string regex for URL
+				"{$attached_file}$" // End of string regex for URL
 			)
 		);
 
@@ -701,11 +701,11 @@ function maybe_swap_with_bigger( $url ) {
 	}
 
 	$upload_dir = dirname( get_attached_file( $id ) );
-	$src_base = strip_baseurl( $url );
-	$src_file = basename( $src_base );
+	$attached_file = strip_baseurl( $url );
+	$src_file = basename( $attached_file );
 
 	$meta = wp_get_attachment_metadata( $id, true );
-	if ( $meta['file'] === $src_base ) {
+	if ( $meta['file'] === $attached_file ) {
 		// This is the original image, return unchanged
 		return $url;
 	}

--- a/tests/test-image.php
+++ b/tests/test-image.php
@@ -34,6 +34,10 @@ class ImageTest extends \WP_UnitTestCase {
 		$result = \Pressbooks\Image\strip_baseurl( $test );
 		$this->assertEquals( '2017/08/foo-bar.png', $result );
 
+		$test = 'https://pressbooks.dev/upload/2017/08/foo-bar-300x225.png';
+		$result = \Pressbooks\Image\strip_baseurl( $test );
+		$this->assertEquals( '2017/08/foo-bar-300x225.png', $result );
+
 		$test = 'https://pressbooks.dev/upload/zig/zag/foo-bar.png';
 		$result = \Pressbooks\Image\strip_baseurl( $test );
 		$this->assertEquals( 'https://pressbooks.dev/upload/zig/zag/foo-bar.png', $result );


### PR DESCRIPTION
Approach:

 + Scan `/wp/v2/media` (API) or XML (WXR) for all known images and build a `[resized] => [fullsize]` list.
 + When saving `<img>` tags, if its hosted at the source, and if we find a resized match from our known images list, then download the fullsize one.
 + When we sideload the fullsize image into PB, it will recreate the same files and filenames, so it should just fit.

I did not check if images are the same because that would mean having to download the image first, then checking, then trying again if it didn't match. Maybe that's OK for a local disk, not so much over HTTP. 

We would only get the wrong image if someone changed it on the server and broke the WP conventions. It's unlikely to happen under normal circumstances Can be improved in the future.
