### PR TITLE
Standardize license labels

### DIFF
--- a/inc/class-licensing.php
+++ b/inc/class-licensing.php
@@ -40,7 +40,7 @@ class Licensing {
 					'derivatives' => 'y',
 				],
 				'url' => 'https://creativecommons.org/publicdomain/zero/1.0/',
-				'desc' => __( 'No Rights Reserved (Public Domain)', 'pressbooks' ),
+				'desc' => __( 'Public Domain (No Rights Reserved)', 'pressbooks' ),
 			],
 			'cc-by' => [
 				'api' => [


### PR DESCRIPTION
All of the licenses are labelled something like:

CC BY-SA (Attribution ShareAlike)

For Public Domain, it's No Rights Reserved (Public Domain).

This PR just switches that one so that Public Domain is first, because reasons.