### PR TITLE
Don't show dates in RSS widget. (fixes #918)

### DIFF
--- a/inc/admin/dashboard/namespace.php
+++ b/inc/admin/dashboard/namespace.php
@@ -154,7 +154,7 @@ function display_pressbooks_blog() {
 				'items' => 5,
 				'show_summary' => 1,
 				'show_author' => 0,
-				'show_date' => 1,
+				'show_date' => 0,
 			]
 		);
 		$rss = ob_get_clean();


### PR DESCRIPTION
Date is the only info run through i18n functions in `wp_widget_rss_output()`. Everything else is not.