### PR TITLE
Remove old `latex_path` option handling

### DIFF
--- a/symbionts/pressbooks-latex/pb-latex-admin.php
+++ b/symbionts/pressbooks-latex/pb-latex-admin.php
@@ -101,14 +101,7 @@ class PBLatexAdmin extends PBLatex {
 		if ( $wrapper && ( false !== strpos( $wrapper, '%BG_COLOR_RGB%' ) || false !== strpos( $wrapper, '%FG_COLOR_RGB%' ) ) )
 				$this->errors->add( 'wrapper', __( 'PB LaTeX no longer supports ><code>%BG_COLOR_RGB%</code> or <code>%FG_COLOR_RGB</code> in the LaTeX preamble.  Please remove them.' ), $new['wrapper'] );
 
-		if ( isset( $new['latex_path'] ) ) {
-			$new['latex_path'] = trim( $new['latex_path'] );
-			if ( ( ! $new['latex_path'] || ! file_exists( $new['latex_path'] ) ) && 'Automattic_Latex_WPCOM' != $method )
-					$this->errors->add( 'latex_path', __( '<code>latex</code> path not found.', 'pb-latex' ), $new['latex_path'] );
-			else $latex_path = $new['latex_path'];
-		}
-
-		$this->options = compact( 'bg', 'fg', 'css', 'latex_path', 'wrapper', 'method' );
+		$this->options = compact( 'bg', 'fg', 'css', 'wrapper', 'method' );
 		update_option( 'pb_latex', $this->options );
 		return ! count( $this->errors->get_error_codes() );
 	}
@@ -319,15 +312,10 @@ tr.pb-latex-method-<?php echo $current_method; ?> {
 		if ( empty( $css ) )
 			$css = 'img.latex { vertical-align: middle; border: none; background: none; }';
 
-		if ( empty( $latex_path ) )
-			$latex_path = trim( @exec( 'which latex' ) );
-
-		$latex_path   = $latex_path   && @file_exists( $latex_path )   ? $latex_path   : false;
-
 		if ( empty( $wrapper ) )
 			$wrapper = false;
 
-		$this->options = compact( 'bg', 'fg', 'method', 'css', 'latex_path', 'wrapper' );
+		$this->options = compact( 'bg', 'fg', 'method', 'css', 'wrapper' );
 		update_option( 'pb_latex', $this->options );
 	}
 }

--- a/symbionts/pressbooks-latex/pb-latex.php
+++ b/symbionts/pressbooks-latex/pb-latex.php
@@ -40,8 +40,6 @@ class PBLatex {
 			'Automattic_Latex_WPCOM' => 'wpcom',
 		) );
 
-		@define( 'AUTOMATTIC_LATEX_LATEX_PATH', $this->options['latex_path'] );
-
 		add_action( 'wp_head', array( &$this, 'wpHead' ) );
 
 		add_filter( 'the_content', array( &$this, 'inlineToShortcode' ), 7 ); // Before wptexturize()


### PR DESCRIPTION
This area of code is a leftover from the WP LaTeX plugin. In that plugin, the`latex_path` option and the `AUTOMATTIC_LATEX_LATEX_PATH` constant are used only if the `Automattic_Latex_DVIPNG` class is controlling the LaTeX output. Neither of these are used in the classes used to generate LaTex via WPCOM, which Pressbooks includes.

It also appears that in the fork of that plugin, the admin form inputs that could have controlled the `latex_path` option value were removed. This results in the value always being `false`, which in turn results in `which latex` being run on the server every time the `PBLatexAdmin` class is started.

I don't believe there is any harm in removing these. Even if a custom LaTex render was being used, the `latex_path` option would likely be unavailable and managed separately.