### PR TITLE
Rename hooks, deprecate old versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ cache:
   - vendor
 before_install:
 - sudo apt-get -qq update
-- sudo apt-get install -y epubcheck libxml2-utils default-jdk
+- sudo apt-get install -y epubcheck libxml2-utils
 - wget https://www.princexml.com/download/prince_11.3-1_ubuntu14.04_amd64.deb
 - sudo dpkg -i prince_11.3-1_ubuntu14.04_amd64.deb
 - rm prince_11.3-1_ubuntu14.04_amd64.deb

--- a/inc/admin/branding/namespace.php
+++ b/inc/admin/branding/namespace.php
@@ -12,20 +12,34 @@ use PressbooksMix\Assets;
 
 /**
  * Apply Color Scheme to Login Page
- * To customize this, add a filter to the 'pressbooks_login_color_scheme' hook
+ * To customize this, add a filter to the 'pb_login_color_scheme' hook
  * that returns a string containing a link tag for your own admin color scheme.
  */
 function custom_color_scheme() {
 	$assets = new Assets( 'pressbooks', 'plugin' );
 	$html = '<link rel="stylesheet" type="text/css" href="' . $assets->getPath( 'styles/colors-pb.css' ) . '" media="screen" />';
-	$html = apply_filters( 'pressbooks_login_color_scheme', $html );
+	/**
+	 * Print <link> to a custom color scheme for the login page.
+	 *
+	 * @since 4.3.0
+	 */
+	$html = apply_filters(
+		'pb_login_color_scheme',
+		/**
+		 * Print <link> to a custom color scheme for the login page.
+		 *
+		 * @since 3.5.2
+		 * @deprecated 4.3.0 Use pb_login_color_scheme instead.
+		 */
+		apply_filters( 'pressbooks_login_color_scheme', $html )
+	);
 	echo $html;
 }
 
 /**
  * Add Custom Login Graphic.
- * To customize this, add a filter to the 'pressbooks_login_logo' hook that
- * returns a string containing a style tag comparable to the one below.
+ * To customize this, add a filter to the 'pb_login_logo' hook that
+ * returns a string containing a <link> or <style> tag that supplies your custom logo.
  */
 function custom_login_logo() {
 	$html = '<style type="text/css">
@@ -41,7 +55,21 @@ function custom_login_logo() {
 	.no-svg .login h1 a {
   	background-image: url(' . PB_PLUGIN_URL . 'assets/dist//images/PB-logo.png' . '; }
 	</style>';
-	$html = apply_filters( 'pressbooks_login_logo', $html );
+	/**
+	 * Print <link> or <style> tag to add a custom logo for the login page.
+	 *
+	 * @since 4.3.0
+	 */
+	$html = apply_filters(
+		'pb_login_logo',
+		/**
+		 * Print <link> or <style> tag to add a custom logo for the login page.
+		 *
+		 * @since 3.5.2
+		 * @deprecated 4.3.0 Use pb_login_logo instead.
+		 */
+		apply_filters( 'pressbooks_login_logo', $html )
+	);
 	echo $html;
 }
 

--- a/inc/admin/class-publishoptions.php
+++ b/inc/admin/class-publishoptions.php
@@ -139,7 +139,21 @@ class PublishOptions extends \Pressbooks\Options {
 		<?php $output = ob_get_contents();
 		ob_end_clean();
 
-		echo apply_filters( 'pressbooks_publish_page', $output );
+		/**
+		* Filter the contents of the Dashboard Publish page.
+		 *
+		 * @since 4.3.0
+		 */
+		echo apply_filters(
+			'pb_publish_page',
+			/**
+			 * Filter the contents of the Dashboard Publish page.
+			 *
+			 * @since 3.9.3
+			 * @deprecated 4.3.0 Use pb_publish_page instead.
+			 */
+			apply_filters( 'pressbooks_publish_page', $output )
+		);
 	}
 
 	function render() {

--- a/inc/class-activation.php
+++ b/inc/class-activation.php
@@ -105,6 +105,14 @@ class Activation {
 		update_option( 'pressbooks_metadata_version', \Pressbooks\Metadata::VERSION );
 		flush_rewrite_rules( false );
 
+		/**
+		 * @since 4.3.0
+		 */
+		do_action( 'pb_new_blog' );
+
+		/**
+		 * @deprecated 4.3.0 Use pb_new_blog instead.
+		 */
 		do_action( 'pressbooks_new_blog' );
 
 		restore_current_blog();

--- a/inc/class-pressbooks.php
+++ b/inc/class-pressbooks.php
@@ -21,6 +21,14 @@ class Pressbooks {
 
 		$this->registerThemeDirectories();
 
+		/**
+		 * @since 4.3.0
+		 */
+		do_action( 'pb_loaded' );
+
+		/**
+		 * @deprecated 4.3.0 Use pb_loaded instead.
+		 */
 		do_action( 'pressbooks_loaded' );
 	}
 

--- a/inc/modules/export/epub/class-epub201.php
+++ b/inc/modules/export/epub/class-epub201.php
@@ -278,13 +278,16 @@ class Epub201 extends Export {
 		$return_var = 0;
 		exec( $command, $output, $return_var );
 
+		// Remove JAVA warnings that are not actually errors
+		foreach ( $output as $k => $v ) {
+			if ( strpos( $v, 'Picked up _JAVA_OPTIONS:' ) !== false ) {
+				unset( $output[ $k ] );
+			}
+		}
+
 		// Is this a valid Epub?
 		if ( ! empty( $output ) ) {
 			$this->logError( implode( "\n", $output ) );
-
-			// TODO Remove me.
-			var_dump( implode( "\n", $output ) );
-			$this->debugMe = implode( "\n", $output );
 
 			return false;
 		}

--- a/inc/modules/export/epub/class-epub201.php
+++ b/inc/modules/export/epub/class-epub201.php
@@ -282,6 +282,10 @@ class Epub201 extends Export {
 		if ( ! empty( $output ) ) {
 			$this->logError( implode( "\n", $output ) );
 
+			// TODO Remove me.
+			var_dump( implode( "\n", $output ) );
+			$this->debugMe = implode( "\n", $output );
+
 			return false;
 		}
 

--- a/inc/utility/namespace.php
+++ b/inc/utility/namespace.php
@@ -809,13 +809,41 @@ function remote_get_retry( $url, $args, $retry = 3, $attempts = 0, $response = [
 
 	$response = wp_remote_get( $url, $args );
 
-	$retry_response_codes = apply_filters( 'pressbooks_remote_get_retry_response_codes', [ 400 ] );
+	/**
+	 * Filter the array of response codes which should prompt a retry.
+	 *
+	 * @since 4.3.0
+	 */
+	$retry_response_codes = apply_filters(
+		'pb_remote_get_retry_response_codes',
+		/**
+		 * Filter the array of response codes which should prompt a retry.
+		 *
+		 * @since 3.9.6
+		 * @deprecated 4.3.0 Use pb_remote_get_retry_response_codes isntead.
+		 */
+		apply_filters( 'pressbooks_remote_get_retry_response_codes', [ 400 ] )
+	);
 
 	if ( ! is_array( $response ) || ! in_array( $response['response']['code'], $retry_response_codes, true ) ) {
 		return $response;
 	}
 
-	$sleep = apply_filters( 'pressbooks_remote_get_retry_wait_time', 1000 );
+	/**
+	 * Filter the sleep time for a retry.
+	 *
+	 * @since 4.3.0
+	 */
+	$sleep = apply_filters(
+		'pb_remote_get_retry_wait_time',
+		/**
+		 * Filter the sleep time for a retry.
+		 *
+		 * @since 3.9.6
+		 * @deprecated 4.3.0 Use pb_remote_get_retry_wait_time isntead.
+		 */
+		apply_filters( 'pressbooks_remote_get_retry_wait_time', 1000 )
+	);
 	usleep( $sleep );
 	return remote_get_retry( $url, $args, $retry, $attempts, $response );
 }

--- a/pressbooks.php
+++ b/pressbooks.php
@@ -25,7 +25,21 @@ function _pb_session_start() { // @codingStandardsIgnoreLine
 	if ( ! session_id() ) {
 		if ( ! headers_sent() ) {
 			ini_set( 'session.use_only_cookies', true );
-			apply_filters( 'pressbooks_session_configuration', false );
+			/**
+			 * Adjust session configuration as needed.
+			 *
+			 * @since 4.3.0.
+			 */
+			apply_filters(
+				'pb_session_configuration',
+				/**
+				 * Adjust session configuration as needed.
+				 *
+				 * @since 3.9.4.2
+				 * @deprecated 4.3.0 Use pb_session_configuration instead.
+				 */
+				apply_filters( 'pressbooks_session_configuration', false )
+			);
 			session_start();
 		} else {
 			error_log( 'There was a problem with _pb_session_start(), headers already sent!' );

--- a/templates/admin/export.php
+++ b/templates/admin/export.php
@@ -123,7 +123,17 @@ if ( ! empty( $_GET['export_warning'] ) && ( 1 == $exportoptions['email_validati
 ?>
 <div class="wrap">
 
-<?php do_action( 'pressbooks_top_of_export_page' ); ?>
+<?php
+/**
+ * @since 4.3.0
+ */
+do_action( 'pb_top_of_export_page' );
+
+/**
+ * @deprecated 4.3.0 Use pb_top_of_export_page instead.
+ */
+do_action( 'pressbooks_top_of_export_page' );
+?>
 
 <div id="icon-pressbooks-export" class="icon32"></div>
 <h2><?php _e( 'Export', 'pressbooks' ); ?> &ldquo;<?php bloginfo( 'name' ); ?>&rdquo;</h2>

--- a/tests/test-modules-export.php
+++ b/tests/test-modules-export.php
@@ -172,8 +172,8 @@ class Modules_ExportTest extends \WP_UnitTestCase {
 				$exporter->url = $xhtml_path;
 			}
 
-			$this->assertTrue( $exporter->convert() );
-			$this->assertTrue( $exporter->validate() );
+			$this->assertTrue( $exporter->convert(), "Could not convert with {$module}" );
+			$this->assertTrue( $exporter->validate(), "Could not validate with {$module}" );
 			$paths[] = $exporter->getOutputPath();
 
 			if ( strpos( $module, '\Xhtml\Xhtml1' ) !== false ) {

--- a/tests/test-modules-export.php
+++ b/tests/test-modules-export.php
@@ -173,7 +173,7 @@ class Modules_ExportTest extends \WP_UnitTestCase {
 			}
 
 			$this->assertTrue( $exporter->convert(), "Could not convert with {$module}" );
-			$this->assertTrue( $exporter->validate(), "Could not validate with {$module} " . ( isset( $exporter->debugMe ) ? $exporter->debugMe : '' ) ); // TODO Remove me
+			$this->assertTrue( $exporter->validate(), "Could not validate with {$module}");
 			$paths[] = $exporter->getOutputPath();
 
 			if ( strpos( $module, '\Xhtml\Xhtml11' ) !== false ) {

--- a/tests/test-modules-export.php
+++ b/tests/test-modules-export.php
@@ -173,10 +173,10 @@ class Modules_ExportTest extends \WP_UnitTestCase {
 			}
 
 			$this->assertTrue( $exporter->convert(), "Could not convert with {$module}" );
-			$this->assertTrue( $exporter->validate(), "Could not validate with {$module}" );
+			$this->assertTrue( $exporter->validate(), "Could not validate with {$module} " . ( isset( $exporter->debugMe ) ? $exporter->debugMe : '' ) ); // TODO Remove me
 			$paths[] = $exporter->getOutputPath();
 
-			if ( strpos( $module, '\Xhtml\Xhtml1' ) !== false ) {
+			if ( strpos( $module, '\Xhtml\Xhtml11' ) !== false ) {
 				$xhtml_path = $exporter->getOutputPath();
 			}
 		}


### PR DESCRIPTION
Our coding standards say that actions and filters should start with `pb_`. A few of them don't. This PR marks the old hooks as deprecated and adds new hooks that are properly named. Related to https://github.com/pressbooks/pressbooks-aldine/issues/7.

Filters:

- [x] `pressbooks_login_color_scheme`
- [x] `pressbooks_login_logo`
- [x] `pressbooks_publish_page`
- [x] `pressbooks_remote_get_retry_response_codes`
- [x] `pressbooks_remote_get_retry_wait_time`
- [x] `pressbooks_session_configuration`

Actions:

- [x] `pressbooks_new_blog`
- [x] `pressbooks_top_of_export_page`
- [x] `pressbooks_loaded`