### PR TITLE
Add support for custom license text (fix #934)

### DIFF
--- a/inc/api/endpoints/controller/class-metadata.php
+++ b/inc/api/endpoints/controller/class-metadata.php
@@ -355,9 +355,38 @@ class Metadata extends \WP_REST_Controller {
 					'readonly' => true,
 				],
 				'license' => [
-					'type' => 'string',
-					'format' => 'uri',
+					'type' => 'object',
 					'description' => __( 'A license document that applies to this content, typically indicated by URL.' ),
+					'properties' => [
+						'@type' => [
+							'type' => 'string',
+							'enum' => [
+								'CreativeWork',
+							],
+							'description' => __( 'The type of the thing.' ),
+							'context' => [ 'view' ],
+							'readonly' => true,
+						],
+						'url' => [
+							'type' => 'string',
+							'format' => 'uri',
+							'description' => __( 'URL of the item.' ),
+							'context' => [ 'view' ],
+							'readonly' => true,
+						],
+						'name' => [
+							'type' => 'string',
+							'description' => __( 'The name of the thing.' ),
+							'context' => [ 'view' ],
+							'readonly' => true,
+						],
+						'description' => [
+							'type' => 'string',
+							'description' => __( 'A description of the item.' ),
+							'context' => [ 'view' ],
+							'readonly' => true,
+						],
+					],
 					'context' => [ 'view' ],
 					'readonly' => true,
 				],

--- a/inc/api/endpoints/controller/class-sectionmetadata.php
+++ b/inc/api/endpoints/controller/class-sectionmetadata.php
@@ -337,9 +337,38 @@ class SectionMetadata extends \WP_REST_Controller {
 					'readonly' => true,
 				],
 				'license' => [
-					'type' => 'string',
-					'format' => 'uri',
+					'type' => 'object',
 					'description' => __( 'A license document that applies to this content, typically indicated by URL.' ),
+					'properties' => [
+						'@type' => [
+							'type' => 'string',
+							'enum' => [
+								'CreativeWork',
+							],
+							'description' => __( 'The type of the thing.' ),
+							'context' => [ 'view' ],
+							'readonly' => true,
+						],
+						'url' => [
+							'type' => 'string',
+							'format' => 'uri',
+							'description' => __( 'URL of the item.' ),
+							'context' => [ 'view' ],
+							'readonly' => true,
+						],
+						'name' => [
+							'type' => 'string',
+							'description' => __( 'The name of the thing.' ),
+							'context' => [ 'view' ],
+							'readonly' => true,
+						],
+						'description' => [
+							'type' => 'string',
+							'description' => __( 'A description of the item.' ),
+							'context' => [ 'view' ],
+							'readonly' => true,
+						],
+					],
 					'context' => [ 'view' ],
 					'readonly' => true,
 				],

--- a/inc/class-cloner.php
+++ b/inc/class-cloner.php
@@ -512,15 +512,21 @@ class Cloner {
 			'https://choosealicense.com/no-license/',
 		];
 
+		if ( is_array( $this->sourceBookMetadata['license'] ) ) {
+			$license_url = $this->sourceBookMetadata['license']['url'];
+		} else { // Backwards compatibility.
+			$license_url = $this->sourceBookMetadata['license'];
+		}
+
 		if ( ! empty( $this->sourceBookId ) ) {
 			if ( current_user_can( 'manage_network_options' ) ) {
 				return true; // Network administrators can clone local books no matter how they're licensed
-			} elseif ( ! in_array( $this->sourceBookMetadata['license'], $restrictive_licenses, true ) ) {
+			} elseif ( ! in_array( $license_url, $restrictive_licenses, true ) ) {
 				return true; // Anyone can clone local books that aren't restrictively licensed
 			} else {
 				return false;
 			}
-		} elseif ( in_array( $this->sourceBookMetadata['license'], $restrictive_licenses, true ) ) {
+		} elseif ( in_array( $license_url, $restrictive_licenses, true ) ) {
 			return false; // No one can clone global books that are restrictively licensed
 		}
 		return true;

--- a/inc/metadata/namespace.php
+++ b/inc/metadata/namespace.php
@@ -600,9 +600,21 @@ function schema_to_section_information( $section_schema, $book_schema ) {
 		$section_information['pb_section_author'] = $section_schema['author']['name'];
 	}
 
-	if ( $section_schema['license']['url'] !== $book_schema['license']['url'] ) {
+	if ( is_array( $book_schema['license'] ) ) {
+		$book_license = $book_schema['license']['url'];
+	} else {
+		$book_license = $book_schema['license'];
+	}
+
+	if ( is_array( $section_schema['license'] ) ) {
+		$section_license = $section_schema['license']['url'];
+	} else {
+		$section_license = $section_schema['license'];
+	}
+
+	if ( $section_license !== $book_license ) {
 		$licensing = new Licensing;
-		$section_information['pb_section_license'] = $licensing->getLicenseFromUrl( $section_schema['license']['url'] );
+		$section_information['pb_section_license'] = $licensing->getLicenseFromUrl( $section_license );
 	}
 
 	if ( isset( $section_schema['isBasedOn'] ) && $section_schema['isBasedOn'] !== $book_schema['isBasedOn'] ) {

--- a/inc/metadata/namespace.php
+++ b/inc/metadata/namespace.php
@@ -296,7 +296,7 @@ function book_information_to_schema( $book_information ) {
 		}
 
 		if ( ! isset( $book_information['pb_book_license'] ) ) {
-			$book_information['pb_book_license'] = '';
+			$book_information['pb_book_license'] = 'all-rights-reserved';
 		}
 
 		$licensing = new Licensing;
@@ -552,7 +552,7 @@ function section_information_to_schema( $section_information, $book_information 
 			if ( isset( $book_information['pb_license'] ) ) {
 				$section_information['pb_section_license'] = $book_information['pb_license'];
 			} else {
-				$section_information['pb_section_license'] = '';
+				$section_information['pb_section_license'] = 'all-rights-reserved';
 			}
 		}
 

--- a/inc/metadata/namespace.php
+++ b/inc/metadata/namespace.php
@@ -413,7 +413,7 @@ function schema_to_book_information( $book_schema ) {
 	$licensing = new Licensing;
 	if ( is_array( $book_schema['license'] ) ) {
 		$book_information['pb_book_license'] = $licensing->getLicenseFromUrl( $book_schema['license']['url'] );
-		if (isset( $book_schema['license']['description'] ) ) {
+		if ( isset( $book_schema['license']['description'] ) ) {
 			$book_information['pb_custom_copyright'] = $book_schema['license']['description'];
 		}
 	} else {

--- a/tests/test-metadata.php
+++ b/tests/test-metadata.php
@@ -78,6 +78,24 @@ class MetadataTest extends \WP_UnitTestCase {
 		$this->assertEquals( $result['pb_title'], 'Moby Dick' );
 		$this->assertEquals( $result['pb_author'], 'Herman Melville' );
 		$this->assertEquals( $result['pb_book_license'], 'public-domain' );
+
+		$schema = [
+			'@context' => 'http://schema.org',
+			'@type' => 'Book',
+			'author' => [
+				'@type' => 'Person',
+				'name' => 'Herman Melville',
+			],
+			'name' => 'Moby Dick',
+			'license' => [
+				'url' => 'https://creativecommons.org/publicdomain/zero/1.0/',
+				'name' => 'Public Domain (No Rights Reserved)',
+				'description' => 'Call me Ishmael.',
+			],
+		];
+
+		$result = \Pressbooks\Metadata\schema_to_book_information( $schema );
+		$this->assertEquals( $result['pb_custom_copyright'], 'Call me Ishmael.' );
 	}
 
 	public function test_section_information_to_schema() {
@@ -106,7 +124,10 @@ class MetadataTest extends \WP_UnitTestCase {
 				'name' => 'Herman Melville',
 			],
 			'name' => 'Moby Dick',
-			'license' => 'https://creativecommons.org/publicdomain/zero/1.0/',
+			'license' => [
+				'url' => 'https://creativecommons.org/publicdomain/zero/1.0/',
+				'name' => 'Public Domain (No Rights Reserved)',
+			],
 		];
 
 		$section_schema = [
@@ -117,7 +138,10 @@ class MetadataTest extends \WP_UnitTestCase {
 				'name' => 'Herman Melville',
 			],
 			'name' => 'Loomings',
-			'license' => 'https://creativecommons.org/publicdomain/zero/1.0/',
+			'license' => [
+				'url' => 'https://creativecommons.org/publicdomain/zero/1.0/',
+				'name' => 'Public Domain (No Rights Reserved)',
+			],
 		];
 
 		$result = \Pressbooks\Metadata\schema_to_section_information( $section_schema, $book_schema );

--- a/tests/test-metadata.php
+++ b/tests/test-metadata.php
@@ -147,6 +147,34 @@ class MetadataTest extends \WP_UnitTestCase {
 		$result = \Pressbooks\Metadata\schema_to_section_information( $section_schema, $book_schema );
 		$this->assertArrayNotHasKey( 'pb_section_author', $result );
 		$this->assertArrayNotHasKey( 'pb_section_license', $result );
+
+		$book_schema = [
+			'@context' => 'http://schema.org',
+			'@type' => 'Book',
+			'author' => [
+				'@type' => 'Person',
+				'name' => 'Herman Melville',
+			],
+			'name' => 'Moby Dick',
+			'license' => 'https://creativecommons.org/publicdomain/zero/1.0/',
+		];
+
+		$section_schema = [
+			'@context' => 'http://bib.schema.org',
+			'@type' => 'Chapter',
+			'author' => [
+				'@type' => 'Person',
+				'name' => 'Herman Melville',
+			],
+			'name' => 'Loomings',
+			'license' => [
+				'url' => 'https://choosealicense.com/no-license/',
+				'name' => 'All Rights Reserved',
+			],
+		];
+
+		$result = \Pressbooks\Metadata\schema_to_section_information( $section_schema, $book_schema );
+		$this->assertArrayHasKey( 'pb_section_license', $result );
 	}
 
 }


### PR DESCRIPTION
Fixes #934.

Note: the `license` key in the metadata endpoints will now be an array with the following properties:

- `url`
- `name`
- `description` (optional)

All code within Pressbooks attempts to handle this gracefully, checking for string values of `license` and assuming URLs under those circumstances.