### PR TITLE
Set viewportMargin to 5000. (fixes #940)

### DIFF
--- a/templates/admin/custom-styles.php
+++ b/templates/admin/custom-styles.php
@@ -50,11 +50,13 @@ if ( ! empty( $_GET['custom_styles_error'] ) ) {
 		lineNumbers: true,
 		matchBrackets: true,
 		readOnly: true,
+		viewportMargin: 5000,
 		mode: 'text/x-scss'
 	} );
 	var e2 = CodeMirror.fromTextArea( document.getElementById( 'your_styles' ), {
 		lineNumbers: true,
 		matchBrackets: true,
+		viewportMargin: 5000,
 		mode: 'text/x-scss'
 	} );
 </script>


### PR DESCRIPTION
The built-in browser search can be used if we increase `viewportMargin` 

We can set that property to `Infinity` but I'm going to arbitrarily select the number 5000 in the hopes it helps performance. Our transpiled CSS files are never bigger than ~3000 lines

Let's try that first, use the search plugin when it comes with WP core?

@see https://github.com/codemirror/CodeMirror/issues/4491