### PR TITLE
Publication date not saving (fixes #965)

### DIFF
--- a/symbionts/custom-metadata/js/custom-metadata-manager.js
+++ b/symbionts/custom-metadata/js/custom-metadata-manager.js
@@ -177,13 +177,15 @@
 	 	// init the datepicker fields
 		$( '.custom-metadata-field.datepicker' ).find( 'input' ).datepicker({
 			changeMonth: true,
-			changeYear: true
+			changeYear: true,
+			dateFormat: 'mm/dd/yy'
 		});
 
 		// init the datetimepicker fields
 		$( '.custom-metadata-field.datetimepicker' ).find( 'input' ).datetimepicker({
 			changeMonth: true,
-			changeYear: true
+			changeYear: true,
+			dateFormat: 'mm/dd/yy'
 		});
 
 		// init the timepicker fields


### PR DESCRIPTION
The custom metadata plugin we use formats dates like: `date( 'm/d/Y', $v )`
This sometimes conflicts with `wp_localize_jquery_ui_datepicker`, espcially when not in english.