### PR TITLE
Use home_url() instead of site_url() under various circumstances

### DIFF
--- a/inc/admin/class-catalog-list-table.php
+++ b/inc/admin/class-catalog-list-table.php
@@ -67,7 +67,7 @@ class Catalog_List_Table extends \WP_List_Table {
 
 		// Build row actions
 		$actions = [
-			'visit' => sprintf( '<a href="%s">%s</a>', get_site_url( $blog_id ), __( 'Visit Book' ) ),
+			'visit' => sprintf( '<a href="%s">%s</a>', get_home_url( $blog_id ), __( 'Visit Book' ) ),
 		];
 
 		// Only include admin link if user has admin rights to the book in question
@@ -559,7 +559,7 @@ class Catalog_List_Table extends \WP_List_Table {
 			$user_login = get_userdata( get_current_user_id() )->user_login;
 		}
 
-		$view_url = network_site_url( "/catalog/$user_login" );
+		$view_url = network_home_url( "/catalog/$user_login" );
 
 		return $view_url;
 	}

--- a/inc/class-catalog.php
+++ b/inc/class-catalog.php
@@ -1249,7 +1249,7 @@ class Catalog {
 		}
 
 		$url = parse_url( \Pressbooks\Sanitize\canonicalize_url( $_REQUEST['add_book_by_url'] ) );
-		$main = parse_url( network_site_url() );
+		$main = parse_url( network_home_url() );
 
 		if ( strpos( $url['host'], $main['host'] ) === false ) {
 			$_SESSION['pb_errors'][] = __( 'Invalid URL.', 'pressbooks' );

--- a/inc/utility/namespace.php
+++ b/inc/utility/namespace.php
@@ -422,7 +422,7 @@ function check_saxonhe_install() {
 function show_experimental_features( $host = '' ) {
 
 	if ( ! $host ) {
-		$host = parse_url( network_site_url(), PHP_URL_HOST );
+		$host = parse_url( network_home_url(), PHP_URL_HOST );
 	}
 
 	// hosts where experimental features should be hidden

--- a/templates/pb-catalog.php
+++ b/templates/pb-catalog.php
@@ -121,7 +121,7 @@ function _base_url() {
 	if ( false === $base_url ) {
 		global $_current_user_id;
 		$base_url = get_userdata( $_current_user_id )->user_login;
-		$base_url = network_site_url( "/catalog/$base_url" );
+		$base_url = network_home_url( "/catalog/$base_url" );
 	}
 
 	return $base_url;
@@ -194,7 +194,7 @@ $_current_user_id = $catalog->getUserId();
 		<div id="catalog-sidebar" class="catalog-sidebar">
 	<?php endif ?>
 		<h2 class="pressbooks-logo">
-			<a href="<?php echo network_site_url(); ?>">
+			<a href="<?php echo network_home_url(); ?>">
 				<?php
 					/**
 					 * pb_catalog_title allows users to change the catalog title branding.
@@ -244,7 +244,7 @@ $_current_user_id = $catalog->getUserId();
 				<div class="book-data mix<?php echo _tag_classes( $b ); ?>">
 
 					<div class="book">
-						<a href="<?php echo get_site_url( $b['blogs_id'], '', 'http' ); ?>">
+						<a href="<?php echo get_home_url( $b['blogs_id'] ); ?>">
 						<p class="book-description"><?php echo wp_trim_words( strip_tags( pb_decode( $b['about'] ) ), 50, '...' ); ?><span class="book-link">&rarr;</span></p>
 						<img src="<?php echo $b['cover_url']['pb_cover_medium']; ?>" alt="book-cover" width="225" height="<?php echo $b['cover_height']; ?>" /></a>
 					</div><!-- end .book -->
@@ -252,7 +252,7 @@ $_current_user_id = $catalog->getUserId();
 					<div class="book-info">
 						<h2><?php echo $b['title']; ?></h2>
 
-						<p><a href="<?php echo get_site_url( $b['blogs_id'], '', 'http' ); ?>"><?php echo $b['author']; ?></a></p>
+						<p><a href="<?php echo get_home_url( $b['blogs_id'] ); ?>"><?php echo $b['author']; ?></a></p>
 					</div><!-- end book-info -->
 
 				</div><!-- end .book-data -->
@@ -264,7 +264,7 @@ $_current_user_id = $catalog->getUserId();
 
 			</div>	<!-- end .catalog-content-->
 			<div class="footer">
-				<p><a href="<?php echo network_site_url(); ?>"><?php _e( 'Pressbooks: the CMS for Books.', 'pressbooks' ); ?></a></p>
+				<p><a href="<?php echo network_home_url(); ?>"><?php _e( 'Pressbooks: the CMS for Books.', 'pressbooks' ); ?></a></p>
 			</div>
 
 		</div>	<!-- end .catalog-content-wrap -->


### PR DESCRIPTION
In a few places (notably user catalog) we use `site_url()` or `get_site_url()` or `network_site_url()` when what we really want is the front-end url, which is accessible via `home_url()` or `get_home_url()` or `network_home_url()`. Under vanilla WP conditions these two values are identical. When WordPress Core is installed in a directory (e.g. [roots/bedrock](https://github.com/roots/bedrock)), this causes issues because the `site_url` value is actually `https://pressbooks.tld/wp`.

See https://github.com/roots/bedrock/issues/250.