### PR TITLE
Remove wp_filter_post_kses, this causes CSS escaping issues

### DIFF
--- a/inc/class-styles.php
+++ b/inc/class-styles.php
@@ -651,6 +651,11 @@ class Styles {
 				\Pressbooks\Redirect\location( $redirect_url . '&custom_styles_error=true' );
 			}
 
+			// Remove wp_filter_post_kses, this causes CSS escaping issues
+			remove_filter( 'content_save_pre', 'wp_filter_post_kses' );
+			remove_filter( 'content_filtered_save_pre', 'wp_filter_post_kses' );
+			remove_all_filters( 'content_save_pre' );
+
 			// Write to database
 			$my_post = [
 				'ID' => absint( $_POST['post_id'] ),


### PR DESCRIPTION
Source: https://github.com/Automattic/jetpack/blob/87ca0aff71a2ff4b42664fb03bfcb6728a44ffef/modules/custom-css/custom-css.php#L171