### PR TITLE
Fix escapeshellcmd()

### DIFF
--- a/inc/modules/export/class-export.php
+++ b/inc/modules/export/class-export.php
@@ -539,10 +539,6 @@ abstract class Export {
 			return;
 		}
 
-		// Set locale to UTF8 so escapeshellcmd() doesn't strip valid characters.
-		setlocale( LC_CTYPE, 'UTF8', 'en_US.UTF-8' );
-		putenv( 'LC_CTYPE=en_US.UTF-8' );
-
 		// Override some WP behaviours when exporting
 		\Pressbooks\Sanitize\fix_audio_shortcode();
 

--- a/pressbooks.php
+++ b/pressbooks.php
@@ -84,6 +84,19 @@ if ( ! defined( 'PB_ROOT_THEME' ) ) {
 	define( 'PB_ROOT_THEME', 'pressbooks-publisher' );
 }
 
+/**
+ * Set locale to UTF8 so escapeshellcmd() doesn't strip valid characters
+ *
+ * @since 4.3.5
+ * @see https://bugs.php.net/bug.php?id=54391
+ *
+ * @param string $value
+ * @return string
+ */
+$pb_lc_type = apply_filters( 'pb_lc_type', 'en_US.UTF-8' );
+setlocale( LC_CTYPE, 'UTF8', $pb_lc_type );
+putenv( "LC_CTYPE={$pb_lc_type}" );
+
 // -------------------------------------------------------------------------------------------------------------------
 // Composer autoloader (if needed)
 // -------------------------------------------------------------------------------------------------------------------

--- a/pressbooks.php
+++ b/pressbooks.php
@@ -90,12 +90,12 @@ if ( ! defined( 'PB_ROOT_THEME' ) ) {
  * @since 4.3.5
  * @see https://bugs.php.net/bug.php?id=54391
  *
- * @param string $value
+ * @param string $pb_lc_ctype
  * @return string
  */
-$pb_lc_type = apply_filters( 'pb_lc_type', 'en_US.UTF-8' );
-setlocale( LC_CTYPE, 'UTF8', $pb_lc_type );
-putenv( "LC_CTYPE={$pb_lc_type}" );
+$pb_lc_ctype = apply_filters( 'pb_lc_ctype', 'en_US.UTF-8' );
+setlocale( LC_CTYPE, 'UTF8', $pb_lc_ctype );
+putenv( "LC_CTYPE={$pb_lc_ctype}" );
 
 // -------------------------------------------------------------------------------------------------------------------
 // Composer autoloader (if needed)


### PR DESCRIPTION
Fix escapeshellcmd() accross the board, add filter for those who need to change `en_US.UTF-8`