### PR TITLE
Add `pb_global_components_path` filter

### DIFF
--- a/inc/class-sass.php
+++ b/inc/class-sass.php
@@ -81,7 +81,12 @@ class Sass {
 	 * @return string
 	 */
 	public function pathToGlobals() {
-		return get_theme_root( 'pressbooks-book' ) . '/pressbooks-book/assets/book/styles/';
+		/**
+		 * Filter the path to global book theme components.
+		 *
+		 * @since 4.4.0
+		 */
+		return apply_filters( 'pb_global_components_path', get_theme_root( 'pressbooks-book' ) . '/pressbooks-book/assets/book/styles/' );
 	}
 
 


### PR DESCRIPTION
This lets a book theme override the path to global components to point to its own bundled components library.