### PR TITLE
Update composer dependencies and coding standards.

### DIFF
--- a/bin/compile-scss.php
+++ b/bin/compile-scss.php
@@ -29,7 +29,7 @@ $include_paths = [
 	dirname( realpath( $input_file_name ) ),
 ];
 
-$scss = file_get_contents( $input_file_name );
+$scss = \Pressbooks\Utility\get_contents( $input_file_name );
 
 try {
 	$sass = new \Leafo\ScssPhp\Compiler;
@@ -39,6 +39,6 @@ try {
 	die( $e->getMessage() );
 }
 
-file_put_contents( $output_file_name, $css );
+\Pressbooks\Utility\put_contents( $output_file_name, $css );
 
 echo( "$output_file_name was created successfully!\n" );

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
     "phpunit/phpunit": "~5.7",
     "doctrine/instantiator": "1.0.*",
     "humanmade/coding-standards": "dev-master",
-    "fig-r/psr2r-sniffer": "dev-master"
+    "fig-r/psr2r-sniffer": "dev-master",
+    "symfony/yaml": "^3.3"
   },
   "suggest": {
     "pressbooks/pressbooks-book":

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "composer/installers": "~1.0",
     "davidgorges/human-name-parser": "^0.2.1",
     "gridonic/princexml-php": "^1.2",
-    "leafo/scssphp": "^0.6.7",
+    "leafo/scssphp": "^0.7.1",
     "pressbooks/pb-api": "^1.1",
     "perchten/rmrdir": "^1.0",
     "sinergi/browser-detector": "^6.1",
@@ -34,14 +34,15 @@
     "pressbooks/pb-cli": "^1.5",
     "masterminds/html5": "^2.3",
     "jenssegers/imagehash": "^0.4.2",
-    "yahnis-elsts/plugin-update-checker": "4.2",
+    "yahnis-elsts/plugin-update-checker": "^4.3",
     "jenssegers/blade": "^1.1",
     "illuminate/container": "5.4.*"
   },
   "require-dev": {
     "phpunit/phpunit": "~5.7",
     "doctrine/instantiator": "1.0.*",
-    "humanmade/coding-standards": "^0.2"
+    "humanmade/coding-standards": "dev-master",
+    "fig-r/psr2r-sniffer": "dev-master"
   },
   "suggest": {
     "pressbooks/pressbooks-book":

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "1bbf30da93da2b9fa19b337f0a91ba76",
+    "content-hash": "f99a2b995ddf341888b7f4f56982310f",
     "packages": [
         {
             "name": "composer/installers",
@@ -232,60 +232,6 @@
                 "string"
             ],
             "time": "2017-07-22T12:18:28+00:00"
-        },
-        {
-            "name": "doctrine/instantiator",
-            "version": "1.0.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3,<8.0-DEV"
-            },
-            "require-dev": {
-                "athletic/athletic": "~0.1.8",
-                "ext-pdo": "*",
-                "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com",
-                    "homepage": "http://ocramius.github.com/"
-                }
-            ],
-            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://github.com/doctrine/instantiator",
-            "keywords": [
-                "constructor",
-                "instantiate"
-            ],
-            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "gridonic/princexml-php",
@@ -720,24 +666,23 @@
         },
         {
             "name": "leafo/scssphp",
-            "version": "v0.6.7",
+            "version": "v0.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/leafo/scssphp.git",
-                "reference": "562213cd803e42ea53b0735554794c4022d8db89"
+                "reference": "9eaf3a6db4d88ce2c265a89e3fc495fbec9bf7a6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/leafo/scssphp/zipball/562213cd803e42ea53b0735554794c4022d8db89",
-                "reference": "562213cd803e42ea53b0735554794c4022d8db89",
+                "url": "https://api.github.com/repos/leafo/scssphp/zipball/9eaf3a6db4d88ce2c265a89e3fc495fbec9bf7a6",
+                "reference": "9eaf3a6db4d88ce2c265a89e3fc495fbec9bf7a6",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "kherge/box": "~2.5",
-                "phpunit/phpunit": "~3.7",
+                "phpunit/phpunit": "~4.6",
                 "squizlabs/php_codesniffer": "~2.5"
             },
             "bin": [
@@ -769,7 +714,7 @@
                 "scss",
                 "stylesheet"
             ],
-            "time": "2017-02-23T05:07:33+00:00"
+            "time": "2017-10-13T15:53:00+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -1147,16 +1092,16 @@
         },
         {
             "name": "symfony/debug",
-            "version": "v3.3.13",
+            "version": "v3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "74557880e2846b5c84029faa96b834da37e29810"
+                "reference": "fb2001e5d85f95d8b6ab94ae3be5d2672df128fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/74557880e2846b5c84029faa96b834da37e29810",
-                "reference": "74557880e2846b5c84029faa96b834da37e29810",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/fb2001e5d85f95d8b6ab94ae3be5d2672df128fd",
+                "reference": "fb2001e5d85f95d8b6ab94ae3be5d2672df128fd",
                 "shasum": ""
             },
             "require": {
@@ -1167,12 +1112,12 @@
                 "symfony/http-kernel": ">=2.3,<2.3.24|~2.4.0|>=2.5,<2.5.9|>=2.6,<2.6.2"
             },
             "require-dev": {
-                "symfony/http-kernel": "~2.8|~3.0"
+                "symfony/http-kernel": "~2.8|~3.0|~4.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -1199,20 +1144,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2017-11-10T16:38:39+00:00"
+            "time": "2017-11-21T09:01:46+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.3.13",
+            "version": "v3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "138af5ec075d4b1d1bd19de08c38a34bb2d7d880"
+                "reference": "dac8d7db537bac7ad8143eb11360a8c2231f251a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/138af5ec075d4b1d1bd19de08c38a34bb2d7d880",
-                "reference": "138af5ec075d4b1d1bd19de08c38a34bb2d7d880",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/dac8d7db537bac7ad8143eb11360a8c2231f251a",
+                "reference": "dac8d7db537bac7ad8143eb11360a8c2231f251a",
                 "shasum": ""
             },
             "require": {
@@ -1221,7 +1166,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -1248,7 +1193,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2017-11-05T15:47:03+00:00"
+            "time": "2017-11-05T16:10:10+00:00"
         },
         {
             "name": "vanilla/htmlawed",
@@ -1291,16 +1236,16 @@
         },
         {
             "name": "yahnis-elsts/plugin-update-checker",
-            "version": "v4.2",
+            "version": "v4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/YahnisElsts/plugin-update-checker.git",
-                "reference": "846d11194719111c94296dabcf97a86e95b69449"
+                "reference": "22fd23a32b158ac051f09690c757f5fe509d21aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/YahnisElsts/plugin-update-checker/zipball/846d11194719111c94296dabcf97a86e95b69449",
-                "reference": "846d11194719111c94296dabcf97a86e95b69449",
+                "url": "https://api.github.com/repos/YahnisElsts/plugin-update-checker/zipball/22fd23a32b158ac051f09690c757f5fe509d21aa",
+                "reference": "22fd23a32b158ac051f09690c757f5fe509d21aa",
                 "shasum": ""
             },
             "require": {
@@ -1332,33 +1277,87 @@
                 "theme updates",
                 "wordpress"
             ],
-            "time": "2017-07-21T11:27:31+00:00"
+            "time": "2017-11-03T17:20:11+00:00"
         }
     ],
     "packages-dev": [
         {
-            "name": "fig-r/psr2r-sniffer",
-            "version": "0.3.1",
+            "name": "doctrine/instantiator",
+            "version": "1.0.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/php-fig-rectified/psr2r-sniffer.git",
-                "reference": "cdf61b2922efb225903e52c6222d7192d3b97ebf"
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig-rectified/psr2r-sniffer/zipball/cdf61b2922efb225903e52c6222d7192d3b97ebf",
-                "reference": "cdf61b2922efb225903e52c6222d7192d3b97ebf",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3,<8.0-DEV"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1.8",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "~2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://github.com/doctrine/instantiator",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "time": "2015-06-14T21:17:01+00:00"
+        },
+        {
+            "name": "fig-r/psr2r-sniffer",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig-rectified/psr2r-sniffer.git",
+                "reference": "ff4659fdb1ce8832a9e408a6e22aa05bc93efe10"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig-rectified/psr2r-sniffer/zipball/ff4659fdb1ce8832a9e408a6e22aa05bc93efe10",
+                "reference": "ff4659fdb1ce8832a9e408a6e22aa05bc93efe10",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.16",
-                "squizlabs/php_codesniffer": "~2.3"
+                "squizlabs/php_codesniffer": "^3.0"
             },
             "bin": [
                 "bin/tokenize",
                 "bin/sniff"
             ],
-            "type": "library",
+            "type": "phpcodesniffer-standard",
             "autoload": {
                 "psr-4": {
                     "PSR2R\\": "PSR2R"
@@ -1376,25 +1375,30 @@
                 }
             ],
             "description": "Code-Sniffer, Auto-Fixer and Tokenizer for PSR2-R",
-            "time": "2016-07-11T14:35:34+00:00"
+            "keywords": [
+                "codesniffer",
+                "cs"
+            ],
+            "time": "2017-08-30T10:00:39+00:00"
         },
         {
             "name": "humanmade/coding-standards",
-            "version": "0.2.2",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/humanmade/coding-standards.git",
-                "reference": "f3974696bf139eb17049ae0ced114cbee1f86b20"
+                "reference": "ccc228f92fb2914a4e32ba0acbfc7222697598d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/humanmade/coding-standards/zipball/f3974696bf139eb17049ae0ced114cbee1f86b20",
-                "reference": "f3974696bf139eb17049ae0ced114cbee1f86b20",
+                "url": "https://api.github.com/repos/humanmade/coding-standards/zipball/ccc228f92fb2914a4e32ba0acbfc7222697598d9",
+                "reference": "ccc228f92fb2914a4e32ba0acbfc7222697598d9",
                 "shasum": ""
             },
             "require": {
-                "fig-r/psr2r-sniffer": "^0.3.1",
-                "wp-coding-standards/wpcs": "^0.10.0"
+                "fig-r/psr2r-sniffer": "dev-master",
+                "squizlabs/php_codesniffer": "^3.1",
+                "wp-coding-standards/wpcs": "^0.13.1"
             },
             "type": "project",
             "notification-url": "https://packagist.org/downloads/",
@@ -1402,7 +1406,7 @@
                 "GPL-2.0"
             ],
             "description": "Human Made coding standards",
-            "time": "2017-08-31T03:33:08+00:00"
+            "time": "2017-11-23T01:42:09+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1505,29 +1509,35 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "4.1.1",
+            "version": "4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "2d3d238c433cf69caeb4842e97a3223a116f94b2"
+                "reference": "66465776cfc249844bde6d117abff1d22e06c2da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/2d3d238c433cf69caeb4842e97a3223a116f94b2",
-                "reference": "2d3d238c433cf69caeb4842e97a3223a116f94b2",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/66465776cfc249844bde6d117abff1d22e06c2da",
+                "reference": "66465776cfc249844bde6d117abff1d22e06c2da",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0",
-                "phpdocumentor/reflection-common": "^1.0@dev",
+                "phpdocumentor/reflection-common": "^1.0.0",
                 "phpdocumentor/type-resolver": "^0.4.0",
                 "webmozart/assert": "^1.0"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.4"
+                "doctrine/instantiator": "~1.0.5",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^6.4"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "phpDocumentor\\Reflection\\": [
@@ -1546,7 +1556,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-08-30T18:51:59+00:00"
+            "time": "2017-11-27T17:38:31+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -1597,16 +1607,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.7.2",
+            "version": "1.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6"
+                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
-                "reference": "c9b8c6088acd19d769d4cc0ffa60a9fe34344bd6",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
+                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
                 "shasum": ""
             },
             "require": {
@@ -1618,7 +1628,7 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8 || ^5.6.5"
+                "phpunit/phpunit": "^4.8.35 || ^5.7"
             },
             "type": "library",
             "extra": {
@@ -1656,7 +1666,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-09-04T11:05:03+00:00"
+            "time": "2017-11-24T13:59:53+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1723,16 +1733,16 @@
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.2",
+            "version": "1.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
                 "shasum": ""
             },
             "require": {
@@ -1766,7 +1776,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03T07:40:28+00:00"
+            "time": "2017-11-27T13:52:08+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -1860,16 +1870,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "9a02332089ac48e704c70f6cefed30c224e3c0b0"
+                "reference": "791198a2c6254db10131eecfe8c06670700904db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/9a02332089ac48e704c70f6cefed30c224e3c0b0",
-                "reference": "9a02332089ac48e704c70f6cefed30c224e3c0b0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
+                "reference": "791198a2c6254db10131eecfe8c06670700904db",
                 "shasum": ""
             },
             "require": {
@@ -1905,7 +1915,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-08-20T05:47:52+00:00"
+            "time": "2017-11-27T05:48:46+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -2563,63 +2573,36 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.9.1",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62"
+                "reference": "d667e245d5dcd4d7bf80f26f2c947d476b66213e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dcbed1074f8244661eecddfc2a675430d8d33f62",
-                "reference": "dcbed1074f8244661eecddfc2a675430d8d33f62",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d667e245d5dcd4d7bf80f26f2c947d476b66213e",
+                "reference": "d667e245d5dcd4d7bf80f26f2c947d476b66213e",
                 "shasum": ""
             },
             "require": {
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": ">=5.1.2"
+                "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0"
             },
             "bin": [
-                "scripts/phpcs",
-                "scripts/phpcbf"
+                "bin/phpcs",
+                "bin/phpcbf"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-master": "3.x-dev"
                 }
-            },
-            "autoload": {
-                "classmap": [
-                    "CodeSniffer.php",
-                    "CodeSniffer/CLI.php",
-                    "CodeSniffer/Exception.php",
-                    "CodeSniffer/File.php",
-                    "CodeSniffer/Fixer.php",
-                    "CodeSniffer/Report.php",
-                    "CodeSniffer/Reporting.php",
-                    "CodeSniffer/Sniff.php",
-                    "CodeSniffer/Tokens.php",
-                    "CodeSniffer/Reports/",
-                    "CodeSniffer/Tokenizers/",
-                    "CodeSniffer/DocGenerators/",
-                    "CodeSniffer/Standards/AbstractPatternSniff.php",
-                    "CodeSniffer/Standards/AbstractScopeSniff.php",
-                    "CodeSniffer/Standards/AbstractVariableSniff.php",
-                    "CodeSniffer/Standards/IncorrectPatternException.php",
-                    "CodeSniffer/Standards/Generic/Sniffs/",
-                    "CodeSniffer/Standards/MySource/Sniffs/",
-                    "CodeSniffer/Standards/PEAR/Sniffs/",
-                    "CodeSniffer/Standards/PSR1/Sniffs/",
-                    "CodeSniffer/Standards/PSR2/Sniffs/",
-                    "CodeSniffer/Standards/Squiz/Sniffs/",
-                    "CodeSniffer/Standards/Zend/Sniffs/"
-                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2637,27 +2620,30 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-05-22T02:43:20+00:00"
+            "time": "2017-10-16T22:40:25+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.3.13",
+            "version": "v4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "0938408c4faa518d95230deabb5f595bf0de31b9"
+                "reference": "7be8741ce5dce9943f41a9269f6828b66e726776"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/0938408c4faa518d95230deabb5f595bf0de31b9",
-                "reference": "0938408c4faa518d95230deabb5f595bf0de31b9",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/7be8741ce5dce9943f41a9269f6828b66e726776",
+                "reference": "7be8741ce5dce9943f41a9269f6828b66e726776",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": "^7.1.3"
+            },
+            "conflict": {
+                "symfony/console": "<3.4"
             },
             "require-dev": {
-                "symfony/console": "~2.8|~3.0"
+                "symfony/console": "~3.4|~4.0"
             },
             "suggest": {
                 "symfony/console": "For validating YAML files using the lint command"
@@ -2665,7 +2651,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2692,7 +2678,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-11-10T18:26:04+00:00"
+            "time": "2017-11-29T13:42:03+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -2746,22 +2732,26 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "0.10.0",
+            "version": "0.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
-                "reference": "b39490465f6fd7375743a395019cd597e12119c9"
+                "reference": "1f64b1a0b5b789822d0303436ee4e30e0135e4dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/b39490465f6fd7375743a395019cd597e12119c9",
-                "reference": "b39490465f6fd7375743a395019cd597e12119c9",
+                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/1f64b1a0b5b789822d0303436ee4e30e0135e4dc",
+                "reference": "1f64b1a0b5b789822d0303436ee4e30e0135e4dc",
                 "shasum": ""
             },
             "require": {
-                "squizlabs/php_codesniffer": "^2.6"
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.9.0 || ^3.0.2"
             },
-            "type": "library",
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1"
+            },
+            "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
@@ -2778,12 +2768,15 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2016-08-29T20:04:47+00:00"
+            "time": "2017-08-05T16:08:58+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "humanmade/coding-standards": 20,
+        "fig-r/psr2r-sniffer": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "f99a2b995ddf341888b7f4f56982310f",
+    "content-hash": "b4f94271be4763c2c01d8f57fabd0729",
     "packages": [
         {
             "name": "composer/installers",
@@ -2624,20 +2624,20 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v4.0.0",
+            "version": "v3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "7be8741ce5dce9943f41a9269f6828b66e726776"
+                "reference": "b3d0c9c11be3831b84825967dc6b52b5a7b84e04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/7be8741ce5dce9943f41a9269f6828b66e726776",
-                "reference": "7be8741ce5dce9943f41a9269f6828b66e726776",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/b3d0c9c11be3831b84825967dc6b52b5a7b84e04",
+                "reference": "b3d0c9c11be3831b84825967dc6b52b5a7b84e04",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3"
+                "php": "^5.5.9|>=7.0.8"
             },
             "conflict": {
                 "symfony/console": "<3.4"
@@ -2651,7 +2651,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -2678,7 +2678,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-11-29T13:42:03+00:00"
+            "time": "2017-11-29T13:28:14+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/hooks-admin.php
+++ b/hooks-admin.php
@@ -142,17 +142,22 @@ if ( ! $is_book ) {
 // Posts, Meta Boxes
 // -------------------------------------------------------------------------------------------------------------------
 
-add_action('init', function() { // replace default title filtering with our custom one that allows certain tags
-	remove_filter( 'title_save_pre', 'wp_filter_kses' );
-	add_filter( 'title_save_pre', 'Pressbooks\Sanitize\filter_title' );
-});
+add_action(
+	'init', function() {
+		// replace default title filtering with our custom one that allows certain tags
+		remove_filter( 'title_save_pre', 'wp_filter_kses' );
+		add_filter( 'title_save_pre', 'Pressbooks\Sanitize\filter_title' );
+	}
+);
 
-add_action( 'admin_menu', function () {
-	remove_meta_box( 'pageparentdiv', 'chapter', 'normal' );
-	remove_meta_box( 'submitdiv', 'metadata', 'normal' );
-	remove_meta_box( 'submitdiv', 'author', 'normal' );
-	remove_meta_box( 'submitdiv', 'part', 'normal' );
-} );
+add_action(
+	'admin_menu', function () {
+		remove_meta_box( 'pageparentdiv', 'chapter', 'normal' );
+		remove_meta_box( 'submitdiv', 'metadata', 'normal' );
+		remove_meta_box( 'submitdiv', 'author', 'normal' );
+		remove_meta_box( 'submitdiv', 'part', 'normal' );
+	}
+);
 
 add_action( 'custom_metadata_manager_init_metadata', '\Pressbooks\Admin\Metaboxes\add_meta_boxes' );
 
@@ -213,12 +218,14 @@ if ( $is_book ) {
 	add_action( 'after_switch_theme', '\Pressbooks\Admin\Fonts\update_font_stacks' );
 
 	// Posts, Meta Boxes
-	add_action( 'updated_postmeta', function ( $meta_id, $object_id, $meta_key, $meta_value ) {
-		if ( 'pb_language' === $meta_key ) {
-			\Pressbooks\Book::deleteBookObjectCache();
-			\Pressbooks\Admin\Fonts\update_font_stacks();
-		}
-	}, 10, 4 );
+	add_action(
+		'updated_postmeta', function ( $meta_id, $object_id, $meta_key, $meta_value ) {
+			if ( 'pb_language' === $meta_key ) {
+				\Pressbooks\Book::deleteBookObjectCache();
+				\Pressbooks\Admin\Fonts\update_font_stacks();
+			}
+		}, 10, 4
+	);
 
 	// Init
 	add_action( 'admin_init', '\Pressbooks\Admin\Fonts\fix_missing_font_stacks' );
@@ -245,43 +252,55 @@ add_action( 'init', '\Pressbooks\Cloner::formSubmit', 50 );
 
 if ( $is_book ) {
 
-	add_action( 'post_edit_form_tag', function () {
-		echo ' enctype="multipart/form-data"';
-	} );
+	add_action(
+		'post_edit_form_tag', function () {
+			echo ' enctype="multipart/form-data"';
+		}
+	);
 
 	// Disable all pointers (i.e. tooltips) all the time, see \WP_Internal_Pointers()
-	add_action( 'admin_init', function () {
-		remove_action( 'admin_enqueue_scripts', [ 'WP_Internal_Pointers', 'enqueue_scripts' ] );
-	} );
+	add_action(
+		'admin_init', function () {
+			remove_action( 'admin_enqueue_scripts', [ 'WP_Internal_Pointers', 'enqueue_scripts' ] );
+		}
+	);
 
 	// Fix for "are you sure you want to leave page" message when editing a part
-	add_action( 'admin_enqueue_scripts', function () {
-		if ( 'part' === get_post_type() ) {
-			wp_dequeue_script( 'autosave' );
+	add_action(
+		'admin_enqueue_scripts', function () {
+			if ( 'part' === get_post_type() ) {
+				wp_dequeue_script( 'autosave' );
+			}
 		}
-	} );
+	);
 
 	// Hide welcome screen
-	add_action( 'load-index.php', function () {
-		$user_id = get_current_user_id();
-		if ( get_user_meta( $user_id, 'show_welcome_panel', true ) ) {
-			update_user_meta( $user_id, 'show_welcome_panel', 0 );
+	add_action(
+		'load-index.php', function () {
+			$user_id = get_current_user_id();
+			if ( get_user_meta( $user_id, 'show_welcome_panel', true ) ) {
+				update_user_meta( $user_id, 'show_welcome_panel', 0 );
+			}
 		}
-	} );
+	);
 
 	// Disable live preview
-	add_filter( 'theme_action_links', function ( $actions ) {
-		unset( $actions['preview'] );
-		return $actions;
-	} );
+	add_filter(
+		'theme_action_links', function ( $actions ) {
+			unset( $actions['preview'] );
+			return $actions;
+		}
+	);
 
 }
 
 // Hide WP update nag
-add_action( 'admin_menu', function () {
-	remove_action( 'admin_notices', 'update_nag', 3 );
-	remove_filter( 'update_footer', 'core_update_footer' );
-} );
+add_action(
+	'admin_menu', function () {
+		remove_action( 'admin_notices', 'update_nag', 3 );
+		remove_filter( 'update_footer', 'core_update_footer' );
+	}
+);
 
 // Plugin Recommendations
 add_filter( 'install_plugins_tabs', '\Pressbooks\Utility\install_plugins_tabs' );

--- a/hooks-admin.php
+++ b/hooks-admin.php
@@ -34,7 +34,7 @@ $is_book = Book::isBook();
 // -------------------------------------------------------------------------------------------------------------------
 
 if ( ! $is_book ) {
-	$updater = new \Puc_v4p2_Vcs_PluginUpdateChecker(
+	$updater = new \Puc_v4p3_Vcs_PluginUpdateChecker(
 		new \Pressbooks\Updater( 'https://github.com/pressbooks/pressbooks/' ),
 		__DIR__ . '/pressbooks.php', // Fully qualified path to the main plugin file
 		'pressbooks',

--- a/hooks.php
+++ b/hooks.php
@@ -145,22 +145,26 @@ if ( $is_book ) {
 // -------------------------------------------------------------------------------------------------------------------
 
 if ( is_admin() === false ) {
-	add_action( 'init', function () {
-		wp_deregister_script( 'admin-bar' );
-		wp_deregister_style( 'admin-bar' );
-		remove_action( 'init', '_wp_admin_bar_init' );
-		remove_action( 'wp_footer', 'wp_admin_bar_render', 1000 );
-		remove_action( 'admin_footer', 'wp_admin_bar_render', 1000 );
-	}, 0 );
+	add_action(
+		'init', function () {
+			wp_deregister_script( 'admin-bar' );
+			wp_deregister_style( 'admin-bar' );
+			remove_action( 'init', '_wp_admin_bar_init' );
+			remove_action( 'wp_footer', 'wp_admin_bar_render', 1000 );
+			remove_action( 'admin_footer', 'wp_admin_bar_render', 1000 );
+		}, 0
+	);
 }
 
 // -------------------------------------------------------------------------------------------------------------------
 // The following is used when a REGISTERED USER creates a NEW BLOG
 // -------------------------------------------------------------------------------------------------------------------
 
-add_action( 'wpmu_new_blog', function ( $b, $u ) {
-	( new \Pressbooks\Activation() )->wpmuNewBlog( $b, $u );
-}, 9, 2 );
+add_action(
+	'wpmu_new_blog', function ( $b, $u ) {
+		( new \Pressbooks\Activation() )->wpmuNewBlog( $b, $u );
+	}, 9, 2
+);
 
 // Force PB colors
 add_action( 'wp_login', '\Pressbooks\Activation::forcePbColors', 10, 2 );
@@ -208,13 +212,15 @@ add_filter( 'the_content', 'wpautop' , 12 ); // execute wpautop after shortcode 
 // -------------------------------------------------------------------------------------------------------------------
 
 if ( $is_book ) {
-	add_action( 'init', function () {
-		$meta_version = get_option( 'pressbooks_metadata_version', 0 );
-		if ( $meta_version < \Pressbooks\Metadata::VERSION ) {
-			( new \Pressbooks\Metadata() )->upgrade( $meta_version );
-			update_option( 'pressbooks_metadata_version', \Pressbooks\Metadata::VERSION );
-		}
-	}, 1000 );
+	add_action(
+		'init', function () {
+			$meta_version = get_option( 'pressbooks_metadata_version', 0 );
+			if ( $meta_version < \Pressbooks\Metadata::VERSION ) {
+				( new \Pressbooks\Metadata() )->upgrade( $meta_version );
+				update_option( 'pressbooks_metadata_version', \Pressbooks\Metadata::VERSION );
+			}
+		}, 1000
+	);
 }
 
 // -------------------------------------------------------------------------------------------------------------------
@@ -224,26 +230,30 @@ if ( $is_book ) {
 // TODO: Before this commit, we were updating 'pressbooks_taxonomy_version' with \Pressbooks\Metadata::VERSION (bug)
 
 if ( $is_book ) {
-	add_action( 'init', function () {
-		$taxonomy_version = get_option( 'pressbooks_taxonomy_version', 0 );
-		if ( $taxonomy_version < \Pressbooks\Taxonomy::VERSION ) {
-			( new \Pressbooks\Taxonomy() )->upgrade( $taxonomy_version );
-			update_option( 'pressbooks_taxonomy_version', \Pressbooks\Taxonomy::VERSION );
-		}
-	}, 1000 );
+	add_action(
+		'init', function () {
+			$taxonomy_version = get_option( 'pressbooks_taxonomy_version', 0 );
+			if ( $taxonomy_version < \Pressbooks\Taxonomy::VERSION ) {
+				( new \Pressbooks\Taxonomy() )->upgrade( $taxonomy_version );
+				update_option( 'pressbooks_taxonomy_version', \Pressbooks\Taxonomy::VERSION );
+			}
+		}, 1000
+	);
 }
 
 // -------------------------------------------------------------------------------------------------------------------
 // Upgrade Catalog
 // -------------------------------------------------------------------------------------------------------------------
 
-add_action( 'init', function () {
-	$catalog_version = get_site_option( 'pressbooks_catalog_version', 0 );
-	if ( $catalog_version < \Pressbooks\Catalog::VERSION ) {
-		( new \Pressbooks\Catalog() )->upgrade( $catalog_version );
-		update_site_option( 'pressbooks_catalog_version', \Pressbooks\Catalog::VERSION );
-	}
-}, 1000 );
+add_action(
+	'init', function () {
+		$catalog_version = get_site_option( 'pressbooks_catalog_version', 0 );
+		if ( $catalog_version < \Pressbooks\Catalog::VERSION ) {
+			( new \Pressbooks\Catalog() )->upgrade( $catalog_version );
+			update_site_option( 'pressbooks_catalog_version', \Pressbooks\Catalog::VERSION );
+		}
+	}, 1000
+);
 
 // -------------------------------------------------------------------------------------------------------------------
 // Migrate Themes
@@ -256,17 +266,22 @@ add_action( 'init', '\Pressbooks\Theme\update_template_root' );
 // Regenerate stylesheets
 // -------------------------------------------------------------------------------------------------------------------
 
-add_action( 'init', function() {
-	Container::get( 'Styles' )->maybeUpdateStylesheets();
-} );
+add_action(
+	'init', function() {
+		Container::get( 'Styles' )->maybeUpdateStylesheets();
+	}
+);
 
 // -------------------------------------------------------------------------------------------------------------------
 // Force Flush
 // -------------------------------------------------------------------------------------------------------------------
 
 if ( ! empty( $GLOBALS['PB_SECRET_SAUCE']['FORCE_FLUSH'] ) ) {
-	add_action( 'init', function () { flush_rewrite_rules( false );
-	}, 9999 );
+	add_action(
+		'init', function () {
+			flush_rewrite_rules( false );
+		}, 9999
+	);
 } else {
 	add_action( 'init', '\Pressbooks\Redirect\flusher', 9999 );
 }

--- a/inc/admin/analytics/namespace.php
+++ b/inc/admin/analytics/namespace.php
@@ -169,7 +169,8 @@ function display_network_analytics_settings() {
 	?>
 	<div class="wrap">
 		<h2><?php _e( 'Google Analytics', 'pressbooks' ); ?></h2>
-		<?php $nonce = ( ! empty( $_REQUEST['_wpnonce'] ) ) ? $_REQUEST['_wpnonce'] : '';
+		<?php
+		$nonce = ( ! empty( $_REQUEST['_wpnonce'] ) ) ? $_REQUEST['_wpnonce'] : '';
 		if ( ! empty( $_POST ) ) {
 			if ( ! wp_verify_nonce( $nonce, 'pb_network_analytics-options' ) ) {
 				wp_die( 'Security check' );
@@ -183,17 +184,23 @@ function display_network_analytics_settings() {
 					update_option( 'ga_mu_site_specific_allowed', $_REQUEST['ga_mu_site_specific_allowed'] );
 				} else {
 					delete_option( 'ga_mu_site_specific_allowed' );
-				} ?>
+				}
+				?>
 				<div id="message" class="updated notice is-dismissible"><p><strong><?php _e( 'Settings saved.', 'pressbooks' ); ?></strong></div>
-			<?php }
-		} ?>
+			<?php
+			}
+		}
+		?>
 		<form method="POST" action="">
-			<?php settings_fields( 'pb_network_analytics' );
-			do_settings_sections( 'pb_network_analytics' ); ?>
+			<?php
+			settings_fields( 'pb_network_analytics' );
+			do_settings_sections( 'pb_network_analytics' );
+			?>
 			<?php submit_button(); ?>
 		</form>
 	</div>
-<?php }
+<?php
+}
 
 /**
  * Display Analytics settings (book)
@@ -203,8 +210,10 @@ function display_analytics_settings() {
 	<div class="wrap">
 		<h2><?php _e( 'Google Analytics', 'pressbooks' ); ?></h2>
 		<form method="POST" action="options.php">
-			<?php settings_fields( 'pb_analytics' );
-			do_settings_sections( 'pb_analytics' ); ?>
+			<?php
+			settings_fields( 'pb_analytics' );
+			do_settings_sections( 'pb_analytics' );
+			?>
 			<?php submit_button(); ?>
 		</form>
 	</div>

--- a/inc/admin/class-catalog-list-table.php
+++ b/inc/admin/class-catalog-list-table.php
@@ -242,8 +242,8 @@ class Catalog_List_Table extends \WP_List_Table {
 		} else {
 			$data = wp_list_sort(
 				$data, [
-				'status' => 'desc',
-				'title' => 'asc',
+					'status' => 'desc',
+					'title' => 'asc',
 				]
 			);
 		}
@@ -482,14 +482,20 @@ class Catalog_List_Table extends \WP_List_Table {
 			<form id="books-search" method="get" action="<?php echo $url; ?>">
 				<?php wp_nonce_field( 'pb_catalog_search', 'pb_catalog_search', false ); ?>
 				<input type="hidden" name="page" value="<?php echo esc_attr( $_REQUEST['page'] ); ?>"/>
-				<?php if ( ! empty( $_REQUEST['user_id'] ) ) : ?><input type="hidden" name="user_id"
+				<?php
+				if ( ! empty( $_REQUEST['user_id'] ) ) :
+?>
+<input type="hidden" name="user_id"
 																										 value="<?php echo esc_attr( $_REQUEST['user_id'] ); ?>" /><?php endif; ?>
 				<?php $list_table->search_box( __( 'Search', 'pressbooks' ), 'search_id' ); ?>
 			</form>
 
 			<form id="books-filter" method="post" action="<?php echo $url; ?>">
 				<input type="hidden" name="page" value="<?php echo esc_attr( $_REQUEST['page'] ); ?>"/>
-				<?php if ( ! empty( $_REQUEST['user_id'] ) ) : ?><input type="hidden" name="user_id"
+				<?php
+				if ( ! empty( $_REQUEST['user_id'] ) ) :
+?>
+<input type="hidden" name="user_id"
 																										 value="<?php echo esc_attr( $_REQUEST['user_id'] ); ?>" /><?php endif; ?>
 				<div id="add-by-url">
 					<input type="text" id="add_book_by_url" name="add_book_by_url"/><label for="add_book_by_url">
@@ -498,7 +504,7 @@ class Catalog_List_Table extends \WP_List_Table {
 					&nbsp;
 				</div>
 
-				<?php $list_table->display() ?>
+				<?php $list_table->display(); ?>
 			</form>
 
 		</div>

--- a/inc/admin/class-exportoptions.php
+++ b/inc/admin/class-exportoptions.php
@@ -50,7 +50,8 @@ class ExportOptions extends \Pressbooks\Options {
 	 * Configure the export options page using the settings API.
 	 */
 	function init() {
-		$_page = $_option = $this->getSlug();
+		$_option = $this->getSlug();
+		$_page = $_option;
 		$_section = $this->getSlug() . '_section';
 
 		add_settings_section(

--- a/inc/admin/class-exportoptions.php
+++ b/inc/admin/class-exportoptions.php
@@ -104,11 +104,14 @@ class ExportOptions extends \Pressbooks\Options {
 		<div class="wrap">
 			<h1><?php echo $this->getTitle(); ?></h1>
 			<form method="post" action="options.php">
-				<?php settings_fields( $this->getSlug() );
+				<?php
+				settings_fields( $this->getSlug() );
 				do_settings_sections( $this->getSlug() );
-				submit_button(); ?>
+				submit_button();
+				?>
 			</form>
-		</div> <?php
+		</div> 
+		<?php
 	}
 
 	function upgrade( $version ) {

--- a/inc/admin/class-publishoptions.php
+++ b/inc/admin/class-publishoptions.php
@@ -136,7 +136,8 @@ class PublishOptions extends \Pressbooks\Options {
 		<h3><?php _e( 'Adding BUY Links to Your Pressbooks Web Book', 'pressbooks' ); ?></h3>
 		<p><?php _e( 'If you would like to add <strong>BUY</strong> links to your Pressbooks web book, add the links to your book at the different retailers below:', 'pressbooks' ); ?></p>
 
-		<?php $output = ob_get_contents();
+		<?php
+		$output = ob_get_contents();
 		ob_end_clean();
 
 		/**
@@ -163,11 +164,14 @@ class PublishOptions extends \Pressbooks\Options {
 		<div class="wrap">
 			<h1><?php echo $this->getTitle(); ?></h1>
 			<form method="post" action="options.php">
-				<?php settings_fields( $this->getSlug() );
+				<?php
+				settings_fields( $this->getSlug() );
 				do_settings_sections( $this->getSlug() );
-				submit_button(); ?>
+				submit_button();
+				?>
 			</form>
-		</div> <?php
+		</div> 
+		<?php
 	}
 
 	function upgrade( $version ) {

--- a/inc/admin/class-publishoptions.php
+++ b/inc/admin/class-publishoptions.php
@@ -50,7 +50,8 @@ class PublishOptions extends \Pressbooks\Options {
 	 * Configure the publish options page using the settings API.
 	 */
 	function init() {
-		$_page = $_option = $this->getSlug();
+		$_option = $this->getSlug();
+		$_page = $_option;
 		$_section = $this->getSlug() . '_section';
 
 		add_settings_section(

--- a/inc/admin/dashboard/namespace.php
+++ b/inc/admin/dashboard/namespace.php
@@ -177,7 +177,10 @@ function display_users_widget() {
 
 	echo '<table>';
 	foreach ( $users as $user ) {
-		$meta = unserialize( $user->meta_value );
+		$meta = unserialize( $user->meta_value ); // @codingStandardsIgnoreLine
+		if ( is_object( $meta ) ) {
+			continue; // Hack attempt?
+		}
 		$u = get_userdata( $user->user_id );
 		echo '<tr><td>' . get_avatar( $user->user_id, 32 ) . '</td><td>' . $u->display_name . ' - ' . ucfirst( key( $meta ) ) . '</td></tr>';
 	}

--- a/inc/admin/dashboard/namespace.php
+++ b/inc/admin/dashboard/namespace.php
@@ -267,7 +267,8 @@ function dashboard_options_init() {
 function dashboard_feed_callback( $args ) {
 	?>
 	<p><?php __( 'Adjust settings for your dashboard RSS feed widget below.', 'pressbooks' ); ?></p>
-<?php }
+<?php
+}
 
 function display_feed_callback( $args ) {
 	$options = get_site_option(

--- a/inc/admin/delete/class-book.php
+++ b/inc/admin/delete/class-book.php
@@ -60,7 +60,8 @@ class Book {
 	public function deleteBookEmailContent( $content ) {
 
 		/* translators: Do not translate USERNAME, URL_DELETE, SITE_NAME: those are placeholders. */
-		$content = __( "Howdy ###USERNAME###,
+		$content = __(
+			"Howdy ###USERNAME###,
 
 You recently clicked the 'Delete Book' link on your book and filled in a
 form on that page.
@@ -74,7 +75,8 @@ some time in the future! (But remember your current book
 is gone forever.)
 
 Thanks for using Pressbooks,
-###SITE_NAME###", 'pressbooks' );
+###SITE_NAME###", 'pressbooks'
+		);
 
 		return $content;
 	}

--- a/inc/admin/diagnostics/namespace.php
+++ b/inc/admin/diagnostics/namespace.php
@@ -38,7 +38,8 @@ function render_page() {
 		<p><?php _e( 'Please submit this information with any bug reports.', 'pressbooks' ); ?></p>
 		<textarea style="width: 800px; max-width: 100%; height: 600px; background: #fff; font-family: monospace;" readonly="readonly" onclick="this.focus(); this.select()"
 				  title="<?php _e( 'To copy the system info, click below then press Ctrl + C (PC) or Cmd + C (Mac).', 'pressbooks' ); ?>">
-<?php $output = "### System Information\n\n";
+<?php
+$output = "### System Information\n\n";
 if ( \Pressbooks\Book::isBook() ) {
 	$output .= "#### Book Info\n\n";
 	$output .= 'Book ID: ' . get_current_blog_id() . "\n";
@@ -166,6 +167,9 @@ if ( function_exists( 'curl_init' ) && function_exists( 'curl_version' ) ) {
 }
 $output .= 'imagick: ' . ( extension_loaded( 'imagick' ) ? 'Installed' : 'Not Installed' ) . "\n";
 $output .= 'xsl: ' . ( extension_loaded( 'xsl' ) ? 'Installed' : 'Not Installed' );
-echo $output; ?></textarea>
+echo $output;
+?>
+</textarea>
 	</div>
-<?php }
+<?php
+}

--- a/inc/admin/diagnostics/namespace.php
+++ b/inc/admin/diagnostics/namespace.php
@@ -162,7 +162,7 @@ if ( $opcache ) {
 $output .= 'XDebug: ' . ( extension_loaded( 'xdebug' ) ? 'Enabled' : 'Disabled' ) . "\n";
 $output .= 'cURL: ' . ( function_exists( 'curl_init' ) ? 'Supported' : 'Not Supported' ) . "\n";
 if ( function_exists( 'curl_init' ) && function_exists( 'curl_version' ) ) {
-	$curl_values = curl_version();
+	$curl_values = curl_version(); // @codingStandardsIgnoreLine
 	$output .= 'cURL Version: ' . $curl_values['version'] . "\n";
 }
 $output .= 'imagick: ' . ( extension_loaded( 'imagick' ) ? 'Installed' : 'Not Installed' ) . "\n";

--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -97,15 +97,15 @@ function replace_book_admin_menu() {
 				wp_enqueue_script( 'pb-organize' );
 				wp_localize_script(
 					'pb-organize', 'PB_OrganizeToken', [
-					// Ajax nonces
-					'orderNonce' => wp_create_nonce( 'pb-update-book-order' ),
-					'exportNonce' => wp_create_nonce( 'pb-update-book-export' ),
-					'wordCountNonce' => wp_create_nonce( 'pb-update-word-count-for-export' ),
-					'showTitleNonce' => wp_create_nonce( 'pb-update-book-show-title' ),
-					'privacyNonce' => wp_create_nonce( 'pb-update-book-privacy' ),
-					'private' => __( 'Private', 'pressbooks' ),
-					'published' => __( 'Published', 'pressbooks' ),
-					'public' => __( 'Public', 'pressbooks' ),
+						// Ajax nonces
+						'orderNonce' => wp_create_nonce( 'pb-update-book-order' ),
+						'exportNonce' => wp_create_nonce( 'pb-update-book-export' ),
+						'wordCountNonce' => wp_create_nonce( 'pb-update-word-count-for-export' ),
+						'showTitleNonce' => wp_create_nonce( 'pb-update-book-show-title' ),
+						'privacyNonce' => wp_create_nonce( 'pb-update-book-privacy' ),
+						'private' => __( 'Private', 'pressbooks' ),
+						'published' => __( 'Published', 'pressbooks' ),
+						'public' => __( 'Public', 'pressbooks' ),
 					]
 				);
 			}
@@ -179,7 +179,7 @@ function replace_book_admin_menu() {
 				wp_enqueue_script( 'pb-export' );
 				wp_localize_script(
 					'pb-export', 'PB_ExportToken', [
-					'mobiConfirm' => __( 'EPUB is required for MOBI export. Would you like to reenable it?', 'pressbooks' ),
+						'mobiConfirm' => __( 'EPUB is required for MOBI export. Would you like to reenable it?', 'pressbooks' ),
 					]
 				);
 			}
@@ -217,21 +217,25 @@ function replace_book_admin_menu() {
 
 	// Import
 	$import_page = add_management_page( __( 'Import', 'pressbooks' ), __( 'Import', 'pressbooks' ), 'edit_posts', 'pb_import', __NAMESPACE__ . '\display_import' );
-	add_action( 'admin_enqueue_scripts', function ( $hook ) use ( $import_page ) {
-		if ( $hook === $import_page ) {
-			wp_enqueue_script( 'pb-import' );
+	add_action(
+		'admin_enqueue_scripts', function ( $hook ) use ( $import_page ) {
+			if ( $hook === $import_page ) {
+				wp_enqueue_script( 'pb-import' );
+			}
 		}
-	} );
+	);
 
 	// Clone a Book
 	if ( \Pressbooks\Cloner::isEnabled() ) {
 		$cloner_page = add_submenu_page( 'options.php', __( 'Clone a Book', 'pressbooks' ), __( 'Clone a Book', 'pressbooks' ), 'edit_posts', 'pb_cloner', __NAMESPACE__ . '\display_cloner' );
-		add_action( 'admin_enqueue_scripts', function ( $hook ) use ( $cloner_page ) {
-			if ( $hook === $cloner_page ) {
-				wp_enqueue_style( 'pb-cloner' );
-				wp_enqueue_script( 'pb-cloner' );
+		add_action(
+			'admin_enqueue_scripts', function ( $hook ) use ( $cloner_page ) {
+				if ( $hook === $cloner_page ) {
+					wp_enqueue_style( 'pb-cloner' );
+					wp_enqueue_script( 'pb-cloner' );
+				}
 			}
-		} );
+		);
 	}
 
 	// Catalog
@@ -287,8 +291,8 @@ function network_admin_menu() {
 
 	add_submenu_page(
 		'settings.php', __( 'Sharing and Privacy Settings', 'pressbooks' ), __( 'Sharing &amp; Privacy', 'pressbooks' ), 'manage_network', 'pressbooks_sharingandprivacy_options', [
-		$page,
-		'render',
+			$page,
+			'render',
 		]
 	);
 }
@@ -680,7 +684,7 @@ function transform_category_selection_box() {
 		jQuery('input:checkbox[id^="in-chapter-type"]').each(function () {
 			jQuery(this).replaceWith(jQuery(this).clone(true).attr('type', 'radio'));
 		});
-		<?php if ( isset( $term ) ) :  ?>
+		<?php if ( isset( $term ) ) : ?>
 		jQuery('input:radio[id="in-front-matter-type-<?php echo $term->term_id; ?>"]').attr('checked', 'checked');
 		jQuery('input:radio[id="in-back-matter-type-<?php echo $term->term_id; ?>"]').attr('checked', 'checked');
 		jQuery('input:radio[id="in-chapter-type-<?php echo $term->term_id; ?>"]').attr('checked', 'checked');
@@ -708,10 +712,10 @@ function init_css_js() {
 	wp_admin_css_color(
 		'pb_colors', 'Pressbooks', $assets->getPath( 'styles/colors-pb.css' ), apply_filters(
 			'pressbooks_admin_colors', [
-			'#b40026',
-			'#d4002d',
-			'#e9e9e9',
-			'#dfdfdf',
+				'#b40026',
+				'#d4002d',
+				'#e9e9e9',
+				'#dfdfdf',
 			]
 		)
 	);
@@ -738,8 +742,8 @@ function init_css_js() {
 		wp_enqueue_script( 'pressbooks/theme-lock', $assets->getPath( 'scripts/theme-lock.js' ), [ 'jquery' ] );
 		wp_localize_script(
 			'pressbooks/theme-lock', 'PB_ThemeLockToken', [
-			// Strings
-			'confirmation' => __( 'Are you sure you want to unlock your theme? This will update your book to the most recent version of your selected theme, which may change your book&rsquo;s appearance and page count. Once you save your settings on this page, this action will NOT be reversable!', 'pressbooks' ),
+				// Strings
+				'confirmation' => __( 'Are you sure you want to unlock your theme? This will update your book to the most recent version of your selected theme, which may change your book&rsquo;s appearance and page count. Once you save your settings on this page, this action will NOT be reversable!', 'pressbooks' ),
 			]
 		);
 	}
@@ -886,7 +890,8 @@ function privacy_permissive_private_content_callback( $args ) {
 		$subscriber->remove_cap( 'read_private_posts' );
 		$contributor->remove_cap( 'read_private_posts' );
 		$author->remove_cap( 'read_private_posts' );
-	} ?>
+	}
+	?>
 	<p><?php _e( 'Who can see private front matter, chapters and back matter?', 'pressbooks' ); ?></p>
 	<fieldgroup>
 		<input type="radio" id="standard-private-content" name="permissive_private_content" value="0" <?php checked( $permissive_private_content, 0 ); ?>/>
@@ -894,7 +899,8 @@ function privacy_permissive_private_content_callback( $args ) {
 		<input type="radio" id="permissive-private-content" name="permissive_private_content" value="1" <?php checked( $permissive_private_content, 1 ); ?>/>
 		<label for="permissive-private-content"><?php _e( 'All logged in users including subscribers.', 'pressbooks' ); ?></label>
 	</fieldgroup>
-<?php }
+<?php
+}
 
 /**
  * Privacy settings, disable_comments field callback
@@ -902,7 +908,11 @@ function privacy_permissive_private_content_callback( $args ) {
  * @param $args
  */
 function privacy_disable_comments_callback( $args ) {
-	$options = get_option( 'pressbooks_sharingandprivacy_options', [ 'disable_comments' => 1 ] );
+	$options = get_option(
+		'pressbooks_sharingandprivacy_options', [
+			'disable_comments' => 1,
+		]
+	);
 	$html = '<input type="radio" id="disable-comments" name="pressbooks_sharingandprivacy_options[disable_comments]" value="1" ';
 	if ( $options['disable_comments'] ) {
 		$html .= 'checked="checked" ';
@@ -994,8 +1004,10 @@ function display_privacy_settings() {
 	<div class="wrap">
 		<h2><?php _e( 'Sharing and Privacy Settings', 'pressbooks' ); ?></h2>
 		<form method="post" action="options.php">
-			<?php settings_fields( 'privacy_settings' );
-			do_settings_sections( 'privacy_settings' ); ?>
+			<?php
+			settings_fields( 'privacy_settings' );
+			do_settings_sections( 'privacy_settings' );
+			?>
 			<?php submit_button(); ?>
 		</form>
 	</div>
@@ -1057,47 +1069,47 @@ function sites_to_books( $translated_text, $untranslated_text, $domain ) {
 	global $pagenow;
 
 	switch ( $untranslated_text ) {
-		case 'Sites' :
+		case 'Sites':
 			$translated_text = __( 'Books', 'pressbooks' );
 			break;
-		case 'All Sites' :
+		case 'All Sites':
 			$translated_text = __( 'All Books', 'pressbooks' );
 			break;
 	}
 
 	if ( $pagenow === 'sites.php' ) {
 		switch ( $untranslated_text ) {
-			case 'Sites' :
+			case 'Sites':
 				$translated_text = __( 'Books', 'pressbooks' );
 				break;
-			case 'Search Sites' :
+			case 'Search Sites':
 				$translated_text = __( 'Search Books', 'pressbooks' );
 				break;
 		}
 	} elseif ( $pagenow === 'site-info.php' ) {
 		switch ( $untranslated_text ) {
-			case 'Edit Site: %s' :
+			case 'Edit Site: %s':
 				$translated_text = __( 'Edit Book: %s', 'pressbooks' );
 				break;
-			case 'Site Address (URL)' :
+			case 'Site Address (URL)':
 				$translated_text = __( 'Book Address (URL)', 'pressbooks' );
 				break;
 		}
 	} elseif ( $pagenow === 'site-new.php' ) {
 		switch ( $untranslated_text ) {
-			case 'Add New Site' :
+			case 'Add New Site':
 				$translated_text = __( 'Add New Book', 'pressbooks' );
 				break;
-			case 'Site Address (URL)' :
+			case 'Site Address (URL)':
 				$translated_text = __( 'Book Address (URL)', 'pressbooks' );
 				break;
-			case 'Site Title' :
+			case 'Site Title':
 				$translated_text = __( 'Book Title', 'pressbooks' );
 				break;
-			case 'Site Language' :
+			case 'Site Language':
 				$translated_text = __( 'Book Language', 'pressbooks' );
 				break;
-			case 'Add Site' :
+			case 'Add Site':
 				$translated_text = __( 'Add Book', 'pressbooks' );
 				break;
 		}

--- a/inc/admin/metaboxes/namespace.php
+++ b/inc/admin/metaboxes/namespace.php
@@ -61,8 +61,16 @@ function upload_cover_image( $pid, $post ) {
 		return; // Bail
 	}
 
-	$allowed_file_types = [ 'jpg' => 'image/jpeg', 'jpeg' => 'image/jpeg', 'gif' => 'image/gif', 'png' => 'image/png' ];
-	$overrides = [ 'test_form' => false, 'mimes' => $allowed_file_types ];
+	$allowed_file_types = [
+		'jpg' => 'image/jpeg',
+		'jpeg' => 'image/jpeg',
+		'gif' => 'image/gif',
+		'png' => 'image/png',
+	];
+	$overrides = [
+		'test_form' => false,
+		'mimes' => $allowed_file_types,
+	];
 	$image = wp_handle_upload( $_FILES['pb_cover_image'], $overrides );
 
 	if ( ! empty( $image['error'] ) ) {
@@ -119,7 +127,9 @@ function add_metadata_styles( $hook ) {
 		} elseif ( 'part' === $post_type ) {
 			add_filter(
 				'page_attributes_dropdown_pages_args', function () {
-					return [ 'post_type' => '__GARBAGE__' ];
+					return [
+						'post_type' => '__GARBAGE__',
+					];
 				}
 			); // Hide this dropdown by querying for garbage
 		}
@@ -155,212 +165,214 @@ function add_meta_boxes() {
 
 	x_add_metadata_group(
 		'general-book-information', 'metadata', [
-		'label' => __( 'General Book Information', 'pressbooks' ),
-		'priority' => 'high',
+			'label' => __( 'General Book Information', 'pressbooks' ),
+			'priority' => 'high',
 		]
 	);
 
 	x_add_metadata_field(
 		'pb_title', 'metadata', [
-		'group' => 'general-book-information',
-		'label' => 'Title',
+			'group' => 'general-book-information',
+			'label' => 'Title',
 		]
 	);
 
 	x_add_metadata_field(
 		'pb_short_title', 'metadata', [
-		'group' => 'general-book-information',
-		'label' => __( 'Short Title', 'pressbooks' ),
-		'description' => __( 'In case of long titles that might be truncated in running heads in the PDF export.', 'pressbooks' ),
+			'group' => 'general-book-information',
+			'label' => __( 'Short Title', 'pressbooks' ),
+			'description' => __( 'In case of long titles that might be truncated in running heads in the PDF export.', 'pressbooks' ),
 		]
 	);
 
 	x_add_metadata_field(
 		'pb_subtitle', 'metadata', [
-		'group' => 'general-book-information',
-		'label' => __( 'Subtitle', 'pressbooks' ),
+			'group' => 'general-book-information',
+			'label' => __( 'Subtitle', 'pressbooks' ),
 		]
 	);
 
 	x_add_metadata_field(
 		'pb_author', 'metadata', [
-		'group' => 'general-book-information',
-		'label' => __( 'Author', 'pressbooks' ),
+			'group' => 'general-book-information',
+			'label' => __( 'Author', 'pressbooks' ),
 		]
 	);
 
 	if ( $show_expanded_metadata ) {
 		x_add_metadata_field(
 			'pb_author_file_as', 'metadata', [
-			'group' => 'general-book-information',
-			'label' => __( 'Author, file as', 'pressbooks' ),
-			'description' => __( 'This ensures that your ebook will sort properly in ebook stores, by the author\'s last name.', 'pressbooks' ),
+				'group' => 'general-book-information',
+				'label' => __( 'Author, file as', 'pressbooks' ),
+				'description' => __( 'This ensures that your ebook will sort properly in ebook stores, by the author\'s last name.', 'pressbooks' ),
 			]
 		);
 	}
 
 	x_add_metadata_field(
 		'pb_contributing_authors', 'metadata', [
-		'group' => 'general-book-information',
-		'label' => __( 'Contributing Author(s)', 'pressbooks' ),
-		'multiple' => true,
-		'description' => __( 'This may be used when more than one person shares the responsibility for the intellectual content of a book.', 'pressbooks' ),
+			'group' => 'general-book-information',
+			'label' => __( 'Contributing Author(s)', 'pressbooks' ),
+			'multiple' => true,
+			'description' => __( 'This may be used when more than one person shares the responsibility for the intellectual content of a book.', 'pressbooks' ),
 		]
 	);
 
 	x_add_metadata_field(
 		'pb_editor', 'metadata', [
-		'group' => 'general-book-information',
-		'label' => __( 'Editor(s)', 'pressbooks' ),
-		'multiple' => true,
+			'group' => 'general-book-information',
+			'label' => __( 'Editor(s)', 'pressbooks' ),
+			'multiple' => true,
 		]
 	);
 
 	x_add_metadata_field(
 		'pb_translator', 'metadata', [
-		'group' => 'general-book-information',
-		'label' => __( 'Translator(s)', 'pressbooks' ),
-		'multiple' => true,
+			'group' => 'general-book-information',
+			'label' => __( 'Translator(s)', 'pressbooks' ),
+			'multiple' => true,
 		]
 	);
 
 	x_add_metadata_field(
 		'pb_publisher', 'metadata', [
-		'group' => 'general-book-information',
-		'label' => __( 'Publisher', 'pressbooks' ),
-		'description' => __( 'This text appears on the title page of your book.', 'pressbooks' ),
+			'group' => 'general-book-information',
+			'label' => __( 'Publisher', 'pressbooks' ),
+			'description' => __( 'This text appears on the title page of your book.', 'pressbooks' ),
 		]
 	);
 
 	x_add_metadata_field(
 		'pb_publisher_city', 'metadata', [
-		'group' => 'general-book-information',
-		'label' => __( 'Publisher City', 'pressbooks' ),
-		'description' => __( 'This text appears on the title page of your book.', 'pressbooks' ),
+			'group' => 'general-book-information',
+			'label' => __( 'Publisher City', 'pressbooks' ),
+			'description' => __( 'This text appears on the title page of your book.', 'pressbooks' ),
 		]
 	);
 
 	x_add_metadata_field(
 		'pb_publication_date', 'metadata', [
-		'field_type' => 'datepicker',
-		'group' => 'general-book-information',
-		'label' => __( 'Publication Date', 'pressbooks' ),
-		'description' => __( 'This is added to the metadata in your ebook.', 'pressbooks' ),
+			'field_type' => 'datepicker',
+			'group' => 'general-book-information',
+			'label' => __( 'Publication Date', 'pressbooks' ),
+			'description' => __( 'This is added to the metadata in your ebook.', 'pressbooks' ),
 		]
 	);
 
 	if ( $show_expanded_metadata ) {
 		x_add_metadata_field(
 			'pb_onsale_date', 'metadata', [
-			'field_type' => 'datepicker',
-			'group' => 'general-book-information',
-			'label' => __( 'On-Sale Date', 'pressbooks' ),
-			'description' => __( 'This is added to the metadata in your ebook.', 'pressbooks' ),
+				'field_type' => 'datepicker',
+				'group' => 'general-book-information',
+				'label' => __( 'On-Sale Date', 'pressbooks' ),
+				'description' => __( 'This is added to the metadata in your ebook.', 'pressbooks' ),
 			]
 		);
 	}
 
 	x_add_metadata_field(
 		'pb_ebook_isbn', 'metadata', [
-		'group' => 'general-book-information',
-		'label' => __( 'Ebook ISBN', 'pressbooks' ),
-		'description' => __( 'ISBN is the International Standard Book Number, and you\'ll need one if you want to sell your book in some online ebook stores. This is added to the metadata in your ebook.', 'pressbooks' ),
+			'group' => 'general-book-information',
+			'label' => __( 'Ebook ISBN', 'pressbooks' ),
+			'description' => __( 'ISBN is the International Standard Book Number, and you\'ll need one if you want to sell your book in some online ebook stores. This is added to the metadata in your ebook.', 'pressbooks' ),
 		]
 	);
 
 	x_add_metadata_field(
 		'pb_print_isbn', 'metadata', [
-		'group' => 'general-book-information',
-		'label' => __( 'Print ISBN', 'pressbooks' ),
-		'description' => __( 'ISBN is the International Standard Book Number, and you\'ll need one if you want to sell your book in online and physical book stores.', 'pressbooks' ),
+			'group' => 'general-book-information',
+			'label' => __( 'Print ISBN', 'pressbooks' ),
+			'description' => __( 'ISBN is the International Standard Book Number, and you\'ll need one if you want to sell your book in online and physical book stores.', 'pressbooks' ),
 		]
 	);
 
 	x_add_metadata_field(
 		'pb_language', 'metadata', [
-		'group' => 'general-book-information',
-		'field_type' => 'select',
-		'values' => \Pressbooks\L10n\supported_languages(),
-		'select2' => true,
-		'label' => __( 'Language', 'pressbooks' ),
-		'description' => __( 'This sets metadata in your ebook, making it easier to find in some stores. It also changes some system generated content for supported languages, such as the "Contents" header.', 'pressbooks' ) . '<br />' . sprintf( '<a href="https://www.transifex.com/pressbooks/pressbooks/">%s</a>', __( 'Help translate Pressbooks into your language!', 'pressbooks' ) ),
+			'group' => 'general-book-information',
+			'field_type' => 'select',
+			'values' => \Pressbooks\L10n\supported_languages(),
+			'select2' => true,
+			'label' => __( 'Language', 'pressbooks' ),
+			'description' => __( 'This sets metadata in your ebook, making it easier to find in some stores. It also changes some system generated content for supported languages, such as the "Contents" header.', 'pressbooks' ) . '<br />' . sprintf( '<a href="https://www.transifex.com/pressbooks/pressbooks/">%s</a>', __( 'Help translate Pressbooks into your language!', 'pressbooks' ) ),
 		]
 	);
 
 	x_add_metadata_group(
 		'copyright', 'metadata', [
-		'label' => __( 'Copyright', 'pressbooks' ),
-		'priority' => 'low',
+			'label' => __( 'Copyright', 'pressbooks' ),
+			'priority' => 'low',
 		]
 	);
 
 	if ( $show_expanded_metadata ) {
 		x_add_metadata_field(
 			'pb_copyright_year', 'metadata', [
-			'group' => 'copyright',
-			'label' => __( 'Copyright Year', 'pressbooks' ),
-			'description' => __( 'Year that the book is/was published.', 'pressbooks' ),
+				'group' => 'copyright',
+				'label' => __( 'Copyright Year', 'pressbooks' ),
+				'description' => __( 'Year that the book is/was published.', 'pressbooks' ),
 			]
 		);
 	}
 
 	x_add_metadata_field(
 		'pb_copyright_holder', 'metadata', [
-		'group' => 'copyright',
-		'label' => __( 'Copyright Holder', 'pressbooks' ),
-		'description' => __( 'Name of the copyright holder.', 'pressbooks' ),
+			'group' => 'copyright',
+			'label' => __( 'Copyright Holder', 'pressbooks' ),
+			'description' => __( 'Name of the copyright holder.', 'pressbooks' ),
 		]
 	);
 
 	x_add_metadata_field(
 		'pb_book_license', 'metadata', [
-		'group' => 'copyright',
-		'field_type' => 'select',
-		'values' => [ '' => __( 'Select a License', 'pressbooks' ) ] + $licenses,
-		'label' => __( 'Copyright License', 'pressbooks' ),
-		'description' => __( 'You can select various licenses including Creative Commons.', 'pressbooks' ),
+			'group' => 'copyright',
+			'field_type' => 'select',
+			'values' => [
+				'' => __( 'Select a License', 'pressbooks' ),
+			] + $licenses,
+			'label' => __( 'Copyright License', 'pressbooks' ),
+			'description' => __( 'You can select various licenses including Creative Commons.', 'pressbooks' ),
 		]
 	);
 
 	x_add_metadata_field(
 		'pb_custom_copyright', 'metadata', [
-		'field_type' => 'wysiwyg',
-		'group' => 'copyright',
-		'label' => __( 'Copyright Notice', 'pressbooks' ),
-		'description' => __( 'Enter a custom copyright notice, with whatever information you like. This will override the auto-generated copyright notice if All Rights Reserved or no license is selected, and will be inserted after the title page. If you select a Creative Commons license, the custom notice will appear after the license text in both the webbook and your exports.', 'pressbooks' ),
+			'field_type' => 'wysiwyg',
+			'group' => 'copyright',
+			'label' => __( 'Copyright Notice', 'pressbooks' ),
+			'description' => __( 'Enter a custom copyright notice, with whatever information you like. This will override the auto-generated copyright notice if All Rights Reserved or no license is selected, and will be inserted after the title page. If you select a Creative Commons license, the custom notice will appear after the license text in both the webbook and your exports.', 'pressbooks' ),
 		]
 	);
 
 	x_add_metadata_group(
 		'about-the-book', 'metadata', [
-		'label' => 'About the Book',
-		'priority' => 'low',
+			'label' => 'About the Book',
+			'priority' => 'low',
 		]
 	);
 
 	x_add_metadata_field(
 		'pb_about_140', 'metadata', [
-		'group' => 'about-the-book',
-		'label' => __( 'Book Tagline', 'pressbooks' ),
-		'description' => __( 'A very short description of your book. It should fit in a Twitter post, and encapsulate your book in the briefest sentence.', 'pressbooks' ),
+			'group' => 'about-the-book',
+			'label' => __( 'Book Tagline', 'pressbooks' ),
+			'description' => __( 'A very short description of your book. It should fit in a Twitter post, and encapsulate your book in the briefest sentence.', 'pressbooks' ),
 		]
 	);
 
 	x_add_metadata_field(
 		'pb_about_50', 'metadata', [
-		'field_type' => 'textarea',
-		'group' => 'about-the-book',
-		'label' => __( 'Short Description', 'pressbooks' ),
-		'description' => __( 'A short paragraph about your book, for catalogs, reviewers etc. to quote.', 'pressbooks' ),
+			'field_type' => 'textarea',
+			'group' => 'about-the-book',
+			'label' => __( 'Short Description', 'pressbooks' ),
+			'description' => __( 'A short paragraph about your book, for catalogs, reviewers etc. to quote.', 'pressbooks' ),
 		]
 	);
 
 	x_add_metadata_field(
 		'pb_about_unlimited', 'metadata', [
-		'field_type' => 'wysiwyg',
-		'group' => 'about-the-book',
-		'label' => __( 'Long Description', 'pressbooks' ),
-		'description' => __( 'The full description of your book.', 'pressbooks' ),
+			'field_type' => 'wysiwyg',
+			'group' => 'about-the-book',
+			'label' => __( 'Long Description', 'pressbooks' ),
+			'description' => __( 'The full description of your book.', 'pressbooks' ),
 		]
 	);
 
@@ -369,88 +381,88 @@ function add_meta_boxes() {
 	if ( $show_expanded_metadata ) {
 		x_add_metadata_group(
 			'additional-catalog-information', 'metadata', [
-			'label' => __( 'Additional Catalog Information', 'pressbooks' ),
-			'priority' => 'low',
+				'label' => __( 'Additional Catalog Information', 'pressbooks' ),
+				'priority' => 'low',
 			]
 		);
 
 		x_add_metadata_field(
 			'pb_series_title', 'metadata', [
-			'group' => 'additional-catalog-information',
-			'label' => __( 'Series Title', 'pressbooks' ),
-			'description' => __( 'Add if your book is part of a series.', 'pressbooks' ),
+				'group' => 'additional-catalog-information',
+				'label' => __( 'Series Title', 'pressbooks' ),
+				'description' => __( 'Add if your book is part of a series.', 'pressbooks' ),
 			]
 		);
 
 		x_add_metadata_field(
 			'pb_series_number', 'metadata', [
-			'group' => 'additional-catalog-information',
-			'label' => __( 'Series Number', 'pressbooks' ),
-			'description' => __( 'Add if your book is part of a series.', 'pressbooks' ),
+				'group' => 'additional-catalog-information',
+				'label' => __( 'Series Number', 'pressbooks' ),
+				'description' => __( 'Add if your book is part of a series.', 'pressbooks' ),
 			]
 		);
 
 		x_add_metadata_field(
 			'pb_keywords_tags', 'metadata', [
-			'group' => 'additional-catalog-information',
-			'label' => __( 'Keywords', 'pressbooks' ),
-			'multiple' => true,
-			'description' => __( 'These are added to your webbook cover page, and in your ebook metadata. Keywords are used by online book stores and search engines.', 'pressbooks' ),
+				'group' => 'additional-catalog-information',
+				'label' => __( 'Keywords', 'pressbooks' ),
+				'multiple' => true,
+				'description' => __( 'These are added to your webbook cover page, and in your ebook metadata. Keywords are used by online book stores and search engines.', 'pressbooks' ),
 			]
 		);
 
 		x_add_metadata_field(
 			'pb_hashtag', 'metadata', [
-			'group' => 'additional-catalog-information',
-			'label' => __( 'Hashtag', 'pressbooks' ),
-			'description' => __( 'These are added to your webbook cover page. For those of you who like Twitter.', 'pressbooks' ),
+				'group' => 'additional-catalog-information',
+				'label' => __( 'Hashtag', 'pressbooks' ),
+				'description' => __( 'These are added to your webbook cover page. For those of you who like Twitter.', 'pressbooks' ),
 			]
 		);
 
 		x_add_metadata_field(
 			'pb_list_price_print', 'metadata', [
-			'group' => 'additional-catalog-information',
-			'label' => __( 'List Price (Print)', 'pressbooks' ),
-			'description' => __( 'The list price of your book in print.', 'pressbooks' ),
+				'group' => 'additional-catalog-information',
+				'label' => __( 'List Price (Print)', 'pressbooks' ),
+				'description' => __( 'The list price of your book in print.', 'pressbooks' ),
 			]
 		);
 
 		x_add_metadata_field(
 			'pb_list_price_pdf', 'metadata', [
-			'group' => 'additional-catalog-information',
-			'label' => __( 'List Price (PDF)', 'pressbooks' ),
-			'description' => __( 'The list price of your book in PDF format.', 'pressbooks' ),
+				'group' => 'additional-catalog-information',
+				'label' => __( 'List Price (PDF)', 'pressbooks' ),
+				'description' => __( 'The list price of your book in PDF format.', 'pressbooks' ),
 			]
 		);
 
 		x_add_metadata_field(
 			'pb_list_price_epub', 'metadata', [
-			'group' => 'additional-catalog-information',
-			'label' => __( 'List Price (ebook)', 'pressbooks' ),
-			'description' => __( 'The list price of your book in Ebook formats.', 'pressbooks' ),
+				'group' => 'additional-catalog-information',
+				'label' => __( 'List Price (ebook)', 'pressbooks' ),
+				'description' => __( 'The list price of your book in Ebook formats.', 'pressbooks' ),
 			]
 		);
 
 		x_add_metadata_field(
 			'pb_list_price_web', 'metadata', [
-			'group' => 'additional-catalog-information',
-			'label' => __( 'List Price (Web)', 'pressbooks' ),
-			'description' => __( 'The list price of your webbook.', 'pressbooks' ),
+				'group' => 'additional-catalog-information',
+				'label' => __( 'List Price (Web)', 'pressbooks' ),
+				'description' => __( 'The list price of your webbook.', 'pressbooks' ),
 			]
 		);
 
 		x_add_metadata_field(
 			'pb_audience', 'metadata', [
-			'group' => 'additional-catalog-information',
-			'field_type' => 'select',
-			'values' => [
-				'' => __( 'Choose an audience&hellip;', 'pressbooks' ),
-				'juvenile' => __( 'Juvenile', 'pressbooks' ),
-				'young-adult' => __( 'Young Adult', 'pressbooks' ),
-				'adult' => __( 'Adult', 'pressbooks' ),
-			],
-			'label' => __( 'Audience', 'pressbooks' ),
-			'description' => __( 'The target audience for your book.', 'pressbooks' ),
+				'group' => 'additional-catalog-information',
+				'field_type' => 'select',
+				'values' => [
+					'' => __( 'Choose an audience&hellip;', 'pressbooks' ),
+					'juvenile' => __( 'Juvenile', 'pressbooks' ),
+					'young-adult' => __( 'Young Adult', 'pressbooks' ),
+					'adult' => __( 'Adult', 'pressbooks' ),
+				],
+				'label' => __( 'Audience', 'pressbooks' ),
+				'description' => __( 'The target audience for your book.', 'pressbooks' ),
 			]
 		);
 
@@ -460,12 +472,14 @@ function add_meta_boxes() {
 			 *
 			 * @since 4.0.0
 			 */
-			'pb_bisac_subject', 'metadata', apply_filters( 'pb_bisac_subject_field_args', [
-				'group' => 'additional-catalog-information',
-				'label' => __( 'BISAC Subject(s)', 'pressbooks' ),
-				'multiple' => true,
-				'description' => __( 'BISAC Subject Headings help libraries and (e)book stores properly classify your book.', 'pressbooks' ),
-			] )
+			'pb_bisac_subject', 'metadata', apply_filters(
+				'pb_bisac_subject_field_args', [
+					'group' => 'additional-catalog-information',
+					'label' => __( 'BISAC Subject(s)', 'pressbooks' ),
+					'multiple' => true,
+					'description' => __( 'BISAC Subject Headings help libraries and (e)book stores properly classify your book.', 'pressbooks' ),
+				]
+			)
 		);
 
 		x_add_metadata_field(
@@ -474,11 +488,13 @@ function add_meta_boxes() {
 			 *
 			 * @since 4.0.0
 			 */
-			'pb_bisac_regional_theme', 'metadata', apply_filters( 'pb_bisac_regional_theme_field_args', [
-				'group' => 'additional-catalog-information',
-				'label' => __( 'BISAC Regional Theme', 'pressbooks' ),
-				'description' => __( 'BISAC Regional Themes help libraries and (e)book stores properly classify your book.', 'pressbooks' ),
-			] )
+			'pb_bisac_regional_theme', 'metadata', apply_filters(
+				'pb_bisac_regional_theme_field_args', [
+					'group' => 'additional-catalog-information',
+					'label' => __( 'BISAC Regional Theme', 'pressbooks' ),
+					'description' => __( 'BISAC Regional Themes help libraries and (e)book stores properly classify your book.', 'pressbooks' ),
+				]
+			)
 		);
 	}
 
@@ -486,37 +502,39 @@ function add_meta_boxes() {
 
 	x_add_metadata_group(
 		'chapter-metadata', 'chapter', [
-		'label' => __( 'Chapter Metadata', 'pressbooks' ),
+			'label' => __( 'Chapter Metadata', 'pressbooks' ),
 		]
 	);
 
 	x_add_metadata_field(
 		'pb_short_title', 'chapter', [
-		'group' => 'chapter-metadata',
-		'label' => __( 'Chapter Short Title (appears in the PDF running header)', 'pressbooks' ),
+			'group' => 'chapter-metadata',
+			'label' => __( 'Chapter Short Title (appears in the PDF running header)', 'pressbooks' ),
 		]
 	);
 
 	x_add_metadata_field(
 		'pb_subtitle', 'chapter', [
-		'group' => 'chapter-metadata',
-		'label' => __( 'Chapter Subtitle (appears in the Web/ebook/PDF output)', 'pressbooks' ),
+			'group' => 'chapter-metadata',
+			'label' => __( 'Chapter Subtitle (appears in the Web/ebook/PDF output)', 'pressbooks' ),
 		]
 	);
 
 	x_add_metadata_field(
 		'pb_section_author', 'chapter', [
-		'group' => 'chapter-metadata',
-		'label' => __( 'Chapter Author (appears in Web/ebook/PDF output)', 'pressbooks' ),
+			'group' => 'chapter-metadata',
+			'label' => __( 'Chapter Author (appears in Web/ebook/PDF output)', 'pressbooks' ),
 		]
 	);
 
 	x_add_metadata_field(
 		'pb_section_license', 'chapter', [
-		'group' => 'chapter-metadata',
-		'field_type' => 'select',
-		'values' => [ '' => __( 'Select a License', 'pressbooks' ) ] + $licenses,
-		'label' => __( 'Chapter Copyright License (overrides book license on this page)', 'pressbooks' ),
+			'group' => 'chapter-metadata',
+			'field_type' => 'select',
+			'values' => [
+				'' => __( 'Select a License', 'pressbooks' ),
+			] + $licenses,
+			'label' => __( 'Chapter Copyright License (overrides book license on this page)', 'pressbooks' ),
 		]
 	);
 
@@ -524,9 +542,9 @@ function add_meta_boxes() {
 
 	x_add_metadata_group(
 		'chapter-parent', 'chapter', [
-		'label' => __( 'Part', 'pressbooks' ),
-		'context' => 'side',
-		'priority' => 'high',
+			'label' => __( 'Part', 'pressbooks' ),
+			'context' => 'side',
+			'priority' => 'high',
 		]
 	);
 
@@ -534,33 +552,33 @@ function add_meta_boxes() {
 
 	x_add_metadata_group(
 		'export', [ 'chapter', 'front-matter', 'back-matter' ], [
-		'label' => __( 'Export Settings', 'pressbooks' ),
-		'context' => 'side',
-		'priority' => 'high',
+			'label' => __( 'Export Settings', 'pressbooks' ),
+			'context' => 'side',
+			'priority' => 'high',
 		]
 	);
 
 	x_add_metadata_field(
 		'pb_export', [ 'chapter', 'front-matter', 'back-matter' ], [
-		'group' => 'export',
-		'field_type' => 'checkbox',
-		'label' => __( 'Include in exports', 'pressbooks' ),
+			'group' => 'export',
+			'field_type' => 'checkbox',
+			'label' => __( 'Include in exports', 'pressbooks' ),
 		]
 	);
 
 	x_add_metadata_field(
 		'pb_show_title', [ 'chapter', 'front-matter', 'back-matter' ], [
-		'group' => 'export',
-		'field_type' => 'checkbox',
-		'label' => __( 'Show title in exports', 'pressbooks' ),
+			'group' => 'export',
+			'field_type' => 'checkbox',
+			'label' => __( 'Show title in exports', 'pressbooks' ),
 		]
 	);
 
 	x_add_metadata_field(
 		'pb_ebook_start', [ 'chapter', 'front-matter', 'back-matter' ], [
-		'group' => 'export',
-		'field_type' => 'checkbox',
-		'label' => __( 'Set as ebook start-point', 'pressbooks' ),
+			'group' => 'export',
+			'field_type' => 'checkbox',
+			'label' => __( 'Set as ebook start-point', 'pressbooks' ),
 		]
 	);
 
@@ -568,37 +586,39 @@ function add_meta_boxes() {
 
 	x_add_metadata_group(
 		'front-matter-metadata', 'front-matter', [
-		'label' => __( 'Front Matter Metadata', 'pressbooks' ),
+			'label' => __( 'Front Matter Metadata', 'pressbooks' ),
 		]
 	);
 
 	x_add_metadata_field(
 		'pb_short_title', 'front-matter', [
-		'group' => 'front-matter-metadata',
-		'label' => __( 'Front Matter Short Title (appears in the PDF running header)', 'pressbooks' ),
+			'group' => 'front-matter-metadata',
+			'label' => __( 'Front Matter Short Title (appears in the PDF running header)', 'pressbooks' ),
 		]
 	);
 
 	x_add_metadata_field(
 		'pb_subtitle', 'front-matter', [
-		'group' => 'front-matter-metadata',
-		'label' => __( 'Front Matter Subtitle (appears in the Web/ebook/PDF output)', 'pressbooks' ),
+			'group' => 'front-matter-metadata',
+			'label' => __( 'Front Matter Subtitle (appears in the Web/ebook/PDF output)', 'pressbooks' ),
 		]
 	);
 
 	x_add_metadata_field(
 		'pb_section_author', 'front-matter', [
-		'group' => 'front-matter-metadata',
-		'label' => __( 'Front Matter Author (appears in Web/ebook/PDF output)', 'pressbooks' ),
+			'group' => 'front-matter-metadata',
+			'label' => __( 'Front Matter Author (appears in Web/ebook/PDF output)', 'pressbooks' ),
 		]
 	);
 
 	x_add_metadata_field(
 		'pb_section_license', 'front-matter', [
-		'group' => 'front-matter-metadata',
-		'field_type' => 'select',
-		'values' => [ '' => __( 'Select a License', 'pressbooks' ) ] + $licenses,
-		'label' => __( 'Front Matter Copyright License (overrides book license on this page)', 'pressbooks' ),
+			'group' => 'front-matter-metadata',
+			'field_type' => 'select',
+			'values' => [
+				'' => __( 'Select a License', 'pressbooks' ),
+			] + $licenses,
+			'label' => __( 'Front Matter Copyright License (overrides book license on this page)', 'pressbooks' ),
 		]
 	);
 
@@ -606,37 +626,39 @@ function add_meta_boxes() {
 
 	x_add_metadata_group(
 		'back-matter-metadata', 'back-matter', [
-		'label' => __( 'Back Matter Metadata', 'pressbooks' ),
+			'label' => __( 'Back Matter Metadata', 'pressbooks' ),
 		]
 	);
 
 	x_add_metadata_field(
 		'pb_short_title', 'back-matter', [
-		'group' => 'back-matter-metadata',
-		'label' => __( 'Back Matter Short Title (appears in the PDF running header)', 'pressbooks' ),
+			'group' => 'back-matter-metadata',
+			'label' => __( 'Back Matter Short Title (appears in the PDF running header)', 'pressbooks' ),
 		]
 	);
 
 	x_add_metadata_field(
 		'pb_subtitle', 'back-matter', [
-		'group' => 'back-matter-metadata',
-		'label' => __( 'Back Matter Subtitle (appears in the Web/ebook/PDF output)', 'pressbooks' ),
+			'group' => 'back-matter-metadata',
+			'label' => __( 'Back Matter Subtitle (appears in the Web/ebook/PDF output)', 'pressbooks' ),
 		]
 	);
 
 	x_add_metadata_field(
 		'pb_section_author', 'back-matter', [
-		'group' => 'back-matter-metadata',
-		'label' => __( 'Back Matter Author (appears in Web/ebook/PDF output)', 'pressbooks' ),
+			'group' => 'back-matter-metadata',
+			'label' => __( 'Back Matter Author (appears in Web/ebook/PDF output)', 'pressbooks' ),
 		]
 	);
 
 	x_add_metadata_field(
 		'pb_section_license', 'back-matter', [
-		'group' => 'back-matter-metadata',
-		'field_type' => 'select',
-		'values' => [ '' => __( 'Select a License', 'pressbooks' ) ] + $licenses,
-		'label' => __( 'Back Matter Copyright License (overrides book license on this page)', 'pressbooks' ),
+			'group' => 'back-matter-metadata',
+			'field_type' => 'select',
+			'values' => [
+				'' => __( 'Select a License', 'pressbooks' ),
+			] + $licenses,
+			'label' => __( 'Back Matter Copyright License (overrides book license on this page)', 'pressbooks' ),
 		]
 	);
 
@@ -742,7 +764,8 @@ function part_save_box( $post ) {
 	<?php } else { ?>
 		<input name="original_publish" type="hidden" id="original_publish" value="Publish"/>
 		<input name="publish" id="publish" type="submit" class="button button-primary button-large" value="Save" tabindex="5" accesskey="p"/>
-	<?php }
+	<?php
+}
 }
 
 
@@ -752,13 +775,15 @@ function part_save_box( $post ) {
  * @param \WP_Post $post
  */
 function metadata_save_box( $post ) {
-	if ( 'publish' === $post->post_status ) { ?>
+	if ( 'publish' === $post->post_status ) {
+	?>
 		<input name="original_publish" type="hidden" id="original_publish" value="Update"/>
 		<input name="save" type="submit" class="button button-primary button-large" id="publish" accesskey="p" value="Save"/>
 	<?php } else { ?>
 		<input name="original_publish" type="hidden" id="original_publish" value="Publish"/>
 		<input name="publish" id="publish" type="submit" class="button button-primary button-large" value="Save" tabindex="5" accesskey="p"/>
-	<?php }
+	<?php
+}
 }
 
 /**
@@ -774,7 +799,8 @@ function metadata_subject_box( $post ) {
 	$pb_additional_subjects = get_post_meta( $post->ID, 'pb_additional_subjects' );
 	if ( ! $pb_additional_subjects ) {
 		$pb_additional_subjects = [];
-	} ?>
+	}
+	?>
 	<div class="custom-metadata-field select">
 		<label for="pb_primary_subject"><?php _e( 'Primary Subject', 'pressbooks' ); ?></label>
 		<select id="primary-subject" name="pb_primary_subject">

--- a/inc/admin/network/class-sharingandprivacyoptions.php
+++ b/inc/admin/network/class-sharingandprivacyoptions.php
@@ -112,7 +112,8 @@ class SharingAndPrivacyOptions extends \Pressbooks\Options {
 		?>
 		<div class="wrap">
 			<h1><?php echo $this->getTitle(); ?></h1>
-			<?php $nonce = ( ! empty( $_REQUEST['_wpnonce'] ) ) ? $_REQUEST['_wpnonce'] : '';
+			<?php
+			$nonce = ( ! empty( $_REQUEST['_wpnonce'] ) ) ? $_REQUEST['_wpnonce'] : '';
 			if ( ! empty( $_POST ) ) {
 				if ( ! wp_verify_nonce( $nonce, $_option . '-options' ) ) {
 					wp_die( 'Security check' );
@@ -125,14 +126,19 @@ class SharingAndPrivacyOptions extends \Pressbooks\Options {
 					update_site_option( $_option, $options );
 					?>
 					<div id="message" class="updated notice is-dismissible"><p><strong><?php _e( 'Settings saved.', 'pressbooks' ); ?></strong></div>
-				<?php }
-			} ?>
+				<?php
+				}
+			}
+			?>
 			<form method="post" action="">
-				<?php settings_fields( $this->getSlug() );
+				<?php
+				settings_fields( $this->getSlug() );
 				do_settings_sections( $this->getSlug() );
-				submit_button(); ?>
+				submit_button();
+				?>
 			</form>
-		</div> <?php
+		</div> 
+		<?php
 	}
 
 	/**

--- a/inc/admin/network/class-sharingandprivacyoptions.php
+++ b/inc/admin/network/class-sharingandprivacyoptions.php
@@ -50,7 +50,8 @@ class SharingAndPrivacyOptions extends \Pressbooks\Options {
 	 * Configure the network export options page using the settings API.
 	 */
 	function init() {
-		$_page = $_option = $this->getSlug();
+		$_option = $this->getSlug();
+		$_page = $_option;
 		$_section = $this->getSlug() . '_section';
 
 		add_settings_section(

--- a/inc/admin/networkmanagers/namespace.php
+++ b/inc/admin/networkmanagers/namespace.php
@@ -33,7 +33,7 @@ function admin_enqueues() {
 	wp_enqueue_script( 'pb-network-managers', $assets->getPath( 'scripts/network-managers.js' ), [ 'jquery' ] );
 	wp_localize_script(
 		'pb-network-managers', 'PB_NetworkManagerToken', [
-		'networkManagerNonce' => wp_create_nonce( 'pb-network-managers' ),
+			'networkManagerNonce' => wp_create_nonce( 'pb-network-managers' ),
 		]
 	);
 }
@@ -91,7 +91,8 @@ function options() {
 		<p><?php _e( 'Network administrators&rsquo; access to network admininistration menus can be restricted to leave only sites and users visible to them.', 'pressbooks' ); ?></p>
 		<?php $superadmins->display(); ?>
 	</div>
-<?php }
+<?php
+}
 
 
 /**

--- a/inc/admin/networkmanagers/namespace.php
+++ b/inc/admin/networkmanagers/namespace.php
@@ -59,7 +59,8 @@ function update_admin_status() {
 				$restricted[] = $id;
 			}
 		} elseif ( 0 === absint( $_POST['status'] ) ) {
-			if ( ( $key = array_search( absint( $id ), $restricted, true ) ) !== false ) {
+			$key = array_search( absint( $id ), $restricted, true );
+			if ( $key !== false ) {
 				unset( $restricted[ $key ] );
 			}
 		}
@@ -181,7 +182,7 @@ function restrict_access() {
 		$restricted = [];
 	}
 
-	$check_against_url = parse_url( ( is_ssl() ? 'http://' : 'https://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'], PHP_URL_PATH );
+	$check_against_url = wp_parse_url( ( is_ssl() ? 'http://' : 'https://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'], PHP_URL_PATH );
 	$redirect_url = get_site_url() . '/wp-admin/network/';
 
 	// ---------------------------------------------------------------------------------------------------------------

--- a/inc/api/endpoints/controller/class-books.php
+++ b/inc/api/endpoints/controller/class-books.php
@@ -62,32 +62,40 @@ class Books extends \WP_REST_Controller {
 	 */
 	public function register_routes() {
 
-		register_rest_route( $this->namespace, '/' . $this->rest_base, [
-			[
-				'methods' => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_items' ],
-				'permission_callback' => [ $this, 'get_items_permissions_check' ],
-				'args' => $this->get_collection_params(),
-			],
-			'schema' => [ $this, 'get_public_item_schema' ],
-		] );
+		register_rest_route(
+			$this->namespace, '/' . $this->rest_base, [
+				[
+					'methods' => \WP_REST_Server::READABLE,
+					'callback' => [ $this, 'get_items' ],
+					'permission_callback' => [ $this, 'get_items_permissions_check' ],
+					'args' => $this->get_collection_params(),
+				],
+				'schema' => [ $this, 'get_public_item_schema' ],
+			]
+		);
 
-		register_rest_route( $this->namespace, '/' . $this->rest_base . '/(?P<id>[\d]+)', [
-			'args' => [
-				'id' => [
-					'description' => __( 'Unique identifier for the object.' ),
-					'type' => 'integer',
-				],
-			],
-			[
-				'methods' => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_item' ],
-				'permission_callback' => [ $this, 'get_item_permissions_check' ],
+		register_rest_route(
+			$this->namespace, '/' . $this->rest_base . '/(?P<id>[\d]+)', [
 				'args' => [
-					'context' => $this->get_context_param( [ 'default' => 'view' ] ),
+					'id' => [
+						'description' => __( 'Unique identifier for the object.' ),
+						'type' => 'integer',
+					],
 				],
-			],
-		] );
+				[
+					'methods' => \WP_REST_Server::READABLE,
+					'callback' => [ $this, 'get_item' ],
+					'permission_callback' => [ $this, 'get_item_permissions_check' ],
+					'args' => [
+						'context' => $this->get_context_param(
+							[
+								'default' => 'view',
+							]
+						),
+					],
+				],
+			]
+		);
 	}
 
 	public function get_item_schema() {
@@ -286,20 +294,30 @@ class Books extends \WP_REST_Controller {
 			'toc' => $this->prepare_response_for_collection( $response_toc ),
 		];
 
-		$this->linkCollector['api'][] = [ 'href' => get_rest_url( $id ) ];
+		$this->linkCollector['api'][] = [
+			'href' => get_rest_url( $id ),
+		];
 
 		restore_current_blog();
 
-		$this->linkCollector['metadata'][] = [ 'href' => $item['metadata']['_links']['self'][0]['href'] ];
+		$this->linkCollector['metadata'][] = [
+			'href' => $item['metadata']['_links']['self'][0]['href'],
+		];
 		unset( $item['metadata']['_links'] );
 
-		$this->linkCollector['toc'][] = [ 'href' => $item['toc']['_links']['self'][0]['href'] ];
+		$this->linkCollector['toc'][] = [
+			'href' => $item['toc']['_links']['self'][0]['href'],
+		];
 		foreach ( $item['toc']['_links']['metadata'] as $v ) {
-			$this->linkCollector['metadata'][] = [ 'href' => $v['href'] ];
+			$this->linkCollector['metadata'][] = [
+				'href' => $v['href'],
+			];
 		}
 		unset( $item['toc']['_links'] );
 
-		$this->linkCollector['self'][] = [ 'href' => rest_url( sprintf( '%s/%s/%d', $this->namespace, $this->rest_base, $id ) ) ];
+		$this->linkCollector['self'][] = [
+			'href' => rest_url( sprintf( '%s/%s/%d', $this->namespace, $this->rest_base, $id ) ),
+		];
 
 		return $item;
 	}
@@ -502,7 +520,7 @@ class Books extends \WP_REST_Controller {
 		$searched_books = 0;
 		$found_books = 0;
 		$results = [];
-		while ( $found_books < $request['per_page']  ) {
+		while ( $found_books < $request['per_page'] ) {
 			$book_ids = $this->searchBookIds( $request );
 			foreach ( $book_ids as $id ) {
 				$node = $this->renderBook( $id, $request['search'] );

--- a/inc/api/endpoints/controller/class-metadata.php
+++ b/inc/api/endpoints/controller/class-metadata.php
@@ -25,17 +25,23 @@ class Metadata extends \WP_REST_Controller {
 	 */
 	public function register_routes() {
 
-		register_rest_route( $this->namespace, '/' . $this->rest_base, [
-			[
-				'methods' => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_item' ],
-				'permission_callback' => [ $this, 'get_item_permissions_check' ],
-				'args' => [
-					'context' => $this->get_context_param( [ 'default' => 'view' ] ),
+		register_rest_route(
+			$this->namespace, '/' . $this->rest_base, [
+				[
+					'methods' => \WP_REST_Server::READABLE,
+					'callback' => [ $this, 'get_item' ],
+					'permission_callback' => [ $this, 'get_item_permissions_check' ],
+					'args' => [
+						'context' => $this->get_context_param(
+							[
+								'default' => 'view',
+							]
+						),
+					],
 				],
-			],
-			'schema' => [ $this, 'get_public_item_schema' ],
-		] );
+				'schema' => [ $this, 'get_public_item_schema' ],
+			]
+		);
 	}
 
 	/**
@@ -433,7 +439,9 @@ class Metadata extends \WP_REST_Controller {
 		$meta = $this->buildMetadata( $meta );
 
 		$response = rest_ensure_response( $meta );
-		$this->linkCollector['self'] = [ 'href' => rest_url( sprintf( '%s/%s', $this->namespace, $this->rest_base ) ) ];
+		$this->linkCollector['self'] = [
+			'href' => rest_url( sprintf( '%s/%s', $this->namespace, $this->rest_base ) ),
+		];
 		$response->add_links( $this->linkCollector );
 
 		return $response;

--- a/inc/api/endpoints/controller/class-search.php
+++ b/inc/api/endpoints/controller/class-search.php
@@ -17,15 +17,17 @@ class Search extends Books {
 	 */
 	public function register_routes() {
 
-		register_rest_route( $this->namespace, '/' . $this->rest_base, [
-			[
-				'methods' => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_items' ],
-				'permission_callback' => [ $this, 'get_items_permissions_check' ],
-				'args' => $this->get_collection_params(),
-			],
-			'schema' => [ $this, 'get_public_item_schema' ],
-		] );
+		register_rest_route(
+			$this->namespace, '/' . $this->rest_base, [
+				[
+					'methods' => \WP_REST_Server::READABLE,
+					'callback' => [ $this, 'get_items' ],
+					'permission_callback' => [ $this, 'get_items_permissions_check' ],
+					'args' => $this->get_collection_params(),
+				],
+				'schema' => [ $this, 'get_public_item_schema' ],
+			]
+		);
 	}
 
 	/**
@@ -60,7 +62,9 @@ class Search extends Books {
 		// Override search request
 		$search = $request->get_query_params();
 		unset( $search['per_page'], $search['next'] );
-		$request['search'] = ! empty( $search ) ? $search : [ null => null ]; // Set some weird value that means abort
+		$request['search'] = ! empty( $search ) ? $search : [
+			null => null,
+		]; // Set some weird value that means abort
 
 		$response = rest_ensure_response( $this->searchBooks( $request ) );
 		unset( $request['search'] );
@@ -83,7 +87,9 @@ class Search extends Books {
 			wp_die( 'LogicException: $search should be a [meta_key => val] array' );
 		}
 
-		if ( $search === [ null => null ] ) {
+		if ( $search === [
+			null => null,
+		] ) {
 			return false; // Abort search
 		}
 

--- a/inc/api/endpoints/controller/class-sectionmetadata.php
+++ b/inc/api/endpoints/controller/class-sectionmetadata.php
@@ -54,24 +54,30 @@ class SectionMetadata extends \WP_REST_Controller {
 	 */
 	public function register_routes() {
 
-		register_rest_route( $this->namespace, '/' . $this->parent_base . '/(?P<parent>[\d]+)/' . $this->rest_base, [
-			'args' => [
-				'parent' => [
-					'required' => true,
-					'description' => __( 'The ID for the parent of the object.' ),
-					'type' => 'integer',
-				],
-			],
-			[
-				'methods' => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_item' ],
-				'permission_callback' => [ $this, 'get_item_permissions_check' ],
+		register_rest_route(
+			$this->namespace, '/' . $this->parent_base . '/(?P<parent>[\d]+)/' . $this->rest_base, [
 				'args' => [
-					'context' => $this->get_context_param( [ 'default' => 'view' ] ),
+					'parent' => [
+						'required' => true,
+						'description' => __( 'The ID for the parent of the object.' ),
+						'type' => 'integer',
+					],
 				],
-			],
-			'schema' => [ $this, 'get_public_item_schema' ],
-		] );
+				[
+					'methods' => \WP_REST_Server::READABLE,
+					'callback' => [ $this, 'get_item' ],
+					'permission_callback' => [ $this, 'get_item_permissions_check' ],
+					'args' => [
+						'context' => $this->get_context_param(
+							[
+								'default' => 'view',
+							]
+						),
+					],
+				],
+				'schema' => [ $this, 'get_public_item_schema' ],
+			]
+		);
 	}
 
 	/**
@@ -410,8 +416,18 @@ class SectionMetadata extends \WP_REST_Controller {
 	 * @return \WP_Error|\WP_REST_Response Response object on success, or WP_Error object on failure.
 	 */
 	public function get_item( $request ) {
-		$posts = get_posts( [ 'p' => $request['parent'], 'post_type' => $this->post_type, 'post_status' => 'any' ] );
-		$error = new \WP_Error( 'rest_post_invalid_id', __( 'Invalid post ID.' ), [ 'status' => 404 ] );
+		$posts = get_posts(
+			[
+				'p' => $request['parent'],
+				'post_type' => $this->post_type,
+				'post_status' => 'any',
+			]
+		);
+		$error = new \WP_Error(
+			'rest_post_invalid_id', __( 'Invalid post ID.' ), [
+				'status' => 404,
+			]
+		);
 		if ( empty( $posts ) ) {
 			return $error;
 		}
@@ -430,8 +446,12 @@ class SectionMetadata extends \WP_REST_Controller {
 		$section_meta = $this->buildMetadata( $section_meta, $book_meta );
 
 		$response = rest_ensure_response( $section_meta );
-		$this->linkCollector['self'] = [ 'href' => rest_url( sprintf( '%s/%s/%d/%s', $this->namespace, $this->parent_base, $request['parent'], 'metadata' ) ) ];
-		$this->linkCollector[ $this->post_type ] = [ 'href' => rest_url( sprintf( '%s/%s/%d', $this->namespace, $this->parent_base, $request['parent'] ) ) ];
+		$this->linkCollector['self'] = [
+			'href' => rest_url( sprintf( '%s/%s/%d/%s', $this->namespace, $this->parent_base, $request['parent'], 'metadata' ) ),
+		];
+		$this->linkCollector[ $this->post_type ] = [
+			'href' => rest_url( sprintf( '%s/%s/%d', $this->namespace, $this->parent_base, $request['parent'] ) ),
+		];
 		$response->add_links( $this->linkCollector );
 
 		return $response;

--- a/inc/api/endpoints/controller/class-toc.php
+++ b/inc/api/endpoints/controller/class-toc.php
@@ -43,17 +43,23 @@ class Toc extends \WP_REST_Controller {
 	 */
 	public function register_routes() {
 
-		register_rest_route( $this->namespace, '/' . $this->rest_base, [
-			[
-				'methods' => \WP_REST_Server::READABLE,
-				'callback' => [ $this, 'get_item' ],
-				'permission_callback' => [ $this, 'get_item_permissions_check' ],
-				'args' => [
-					'context' => $this->get_context_param( [ 'default' => 'view' ] ),
+		register_rest_route(
+			$this->namespace, '/' . $this->rest_base, [
+				[
+					'methods' => \WP_REST_Server::READABLE,
+					'callback' => [ $this, 'get_item' ],
+					'permission_callback' => [ $this, 'get_item_permissions_check' ],
+					'args' => [
+						'context' => $this->get_context_param(
+							[
+								'default' => 'view',
+							]
+						),
+					],
 				],
-			],
-			'schema' => [ $this, 'get_public_item_schema' ],
-		] );
+				'schema' => [ $this, 'get_public_item_schema' ],
+			]
+		);
 	}
 
 	/**
@@ -103,7 +109,13 @@ class Toc extends \WP_REST_Controller {
 			'status' => [
 				'description' => __( 'A named status for the object.' ),
 				'type' => 'string',
-				'enum' => array_keys( get_post_stati( [ 'internal' => false ] ) ),
+				'enum' => array_keys(
+					get_post_stati(
+						[
+							'internal' => false,
+						]
+					)
+				),
 				'context' => [ 'view' ],
 				'readonly' => true,
 			],
@@ -133,37 +145,43 @@ class Toc extends \WP_REST_Controller {
 		];
 
 		$fm_meta_data = $this->frontMatterMetadata->get_item_schema();
-		$fm_item = array_merge( $item, [
-			'metadata' => [
-				'description' => __( 'Metadata', 'pressbooks' ),
-				'type' => 'object',
-				'properties' => $fm_meta_data['properties'],
-				'context' => [ 'view' ],
-				'readonly' => true,
-			],
-		]);
+		$fm_item = array_merge(
+			$item, [
+				'metadata' => [
+					'description' => __( 'Metadata', 'pressbooks' ),
+					'type' => 'object',
+					'properties' => $fm_meta_data['properties'],
+					'context' => [ 'view' ],
+					'readonly' => true,
+				],
+			]
+		);
 
 		$bm_meta_data = $this->backMatterMetadata->get_item_schema();
-		$bm_item = array_merge( $item, [
-			'metadata' => [
-				'description' => __( 'Metadata', 'pressbooks' ),
-				'type' => 'object',
-				'properties' => $bm_meta_data['properties'],
-				'context' => [ 'view' ],
-				'readonly' => true,
-			],
-		]);
+		$bm_item = array_merge(
+			$item, [
+				'metadata' => [
+					'description' => __( 'Metadata', 'pressbooks' ),
+					'type' => 'object',
+					'properties' => $bm_meta_data['properties'],
+					'context' => [ 'view' ],
+					'readonly' => true,
+				],
+			]
+		);
 
 		$ch_meta_data = $this->chapterMetadata->get_item_schema();
-		$ch_item = array_merge( $item, [
-			'metadata' => [
-				'description' => __( 'Metadata', 'pressbooks' ),
-				'type' => 'object',
-				'properties' => $ch_meta_data['properties'],
-				'context' => [ 'view' ],
-				'readonly' => true,
-			],
-		]);
+		$ch_item = array_merge(
+			$item, [
+				'metadata' => [
+					'description' => __( 'Metadata', 'pressbooks' ),
+					'type' => 'object',
+					'properties' => $ch_meta_data['properties'],
+					'context' => [ 'view' ],
+					'readonly' => true,
+				],
+			]
+		);
 
 		$schema = [
 			'$schema' => 'http://json-schema.org/schema#',
@@ -185,18 +203,20 @@ class Toc extends \WP_REST_Controller {
 					'type' => 'array',
 					'items' => [
 						'type' => 'object',
-						'properties' => array_merge( $item, [
-							'chapters' => [
-								'description' => __( 'Chapter', 'pressbooks' ),
-								'type' => 'array',
-								'items' => [
-									'type' => 'object',
-									'properties' => $ch_item,
+						'properties' => array_merge(
+							$item, [
+								'chapters' => [
+									'description' => __( 'Chapter', 'pressbooks' ),
+									'type' => 'array',
+									'items' => [
+										'type' => 'object',
+										'properties' => $ch_item,
+									],
 								],
-							],
-							'context' => [ 'view' ],
-							'readonly' => true,
-						] ),
+								'context' => [ 'view' ],
+								'readonly' => true,
+							]
+						),
 					],
 					'context' => [ 'view' ],
 					'readonly' => true,
@@ -250,7 +270,9 @@ class Toc extends \WP_REST_Controller {
 		$struct = $this->fixBookStructure( $struct, current_user_can( 'edit_posts' ) );
 
 		$response = rest_ensure_response( $struct );
-		$this->linkCollector['self'] = [ 'href' => rest_url( sprintf( '%s/%s', $this->namespace, $this->rest_base ) ) ];
+		$this->linkCollector['self'] = [
+			'href' => rest_url( sprintf( '%s/%s', $this->namespace, $this->rest_base ) ),
+		];
 		$response->add_links( $this->linkCollector );
 
 		return $response;
@@ -313,14 +335,23 @@ class Toc extends \WP_REST_Controller {
 					$new_fm[ $new_key ] = $val;
 				}
 				$new_fm['link'] = get_permalink( $new_fm['id'] );
-				$new_fm['front-matter-type'] = wp_get_object_terms( $new_fm['id'], 'front-matter-type', [ 'fields' => 'ids' ] );
-				$this->linkCollector['front-matter'][] = [ 'href' => trailingslashit( $rest_url ) . $new_fm['id'], 'embeddable' => true ];
+				$new_fm['front-matter-type'] = wp_get_object_terms(
+					$new_fm['id'], 'front-matter-type', [
+						'fields' => 'ids',
+					]
+				);
+				$this->linkCollector['front-matter'][] = [
+					'href' => trailingslashit( $rest_url ) . $new_fm['id'],
+					'embeddable' => true,
+				];
 
 				// Metadata
 				$request_metadata = new \WP_REST_Request( 'GET', "/pressbooks/v2/{$base}/{$new_fm['id']}/metadata" );
 				$response_metadata = rest_do_request( $request_metadata );
 				$new_fm['metadata'] = $this->prepare_response_for_collection( $response_metadata );
-				$this->linkCollector['metadata'][] = [ 'href' => trailingslashit( $rest_url ) . "{$new_fm['id']}/metadata" ];
+				$this->linkCollector['metadata'][] = [
+					'href' => trailingslashit( $rest_url ) . "{$new_fm['id']}/metadata",
+				];
 				unset( $new_fm['metadata']['_links'] );
 
 				$front_matter[] = $new_fm;
@@ -360,14 +391,23 @@ class Toc extends \WP_REST_Controller {
 						$new_ch[ $new_key ] = $val;
 					}
 					$new_ch['link'] = get_permalink( $new_ch['id'] );
-					$new_ch['chapter-type'] = wp_get_object_terms( $new_ch['id'], 'chapter-type', [ 'fields' => 'ids' ] );
-					$this->linkCollector['chapter'][] = [ 'href' => trailingslashit( $chapter_rest_url ) . $new_ch['id'], 'embeddable' => true ];
+					$new_ch['chapter-type'] = wp_get_object_terms(
+						$new_ch['id'], 'chapter-type', [
+							'fields' => 'ids',
+						]
+					);
+					$this->linkCollector['chapter'][] = [
+						'href' => trailingslashit( $chapter_rest_url ) . $new_ch['id'],
+						'embeddable' => true,
+					];
 
 					// Metadata
 					$request_metadata = new \WP_REST_Request( 'GET', "/pressbooks/v2/{$chapter_base}/{$new_ch['id']}/metadata" );
 					$response_metadata = rest_do_request( $request_metadata );
 					$new_ch['metadata'] = $this->prepare_response_for_collection( $response_metadata );
-					$this->linkCollector['metadata'][] = [ 'href' => trailingslashit( $chapter_rest_url ) . "{$new_ch['id']}/metadata" ];
+					$this->linkCollector['metadata'][] = [
+						'href' => trailingslashit( $chapter_rest_url ) . "{$new_ch['id']}/metadata",
+					];
 					unset( $new_ch['metadata']['_links'] );
 
 					$chapters[] = $new_ch;
@@ -375,7 +415,10 @@ class Toc extends \WP_REST_Controller {
 			}
 			$new_p['chapters'] = $chapters;
 			$new_p['link'] = get_permalink( $new_p['id'] );
-			$this->linkCollector['part'][] = [ 'href' => trailingslashit( $part_rest_url ) . $new_p['id'], 'embeddable' => true ];
+			$this->linkCollector['part'][] = [
+				'href' => trailingslashit( $part_rest_url ) . $new_p['id'],
+				'embeddable' => true,
+			];
 			$part[] = $new_p;
 		}
 
@@ -403,14 +446,23 @@ class Toc extends \WP_REST_Controller {
 					$new_bm[ $new_key ] = $val;
 				}
 				$new_bm['link'] = get_permalink( $new_bm['id'] );
-				$new_bm['back-matter-type'] = wp_get_object_terms( $new_bm['id'], 'back-matter-type', [ 'fields' => 'ids' ] );
-				$this->linkCollector['back-matter'][] = [ 'href' => trailingslashit( $rest_url ) . $new_bm['id'], 'embeddable' => true ];
+				$new_bm['back-matter-type'] = wp_get_object_terms(
+					$new_bm['id'], 'back-matter-type', [
+						'fields' => 'ids',
+					]
+				);
+				$this->linkCollector['back-matter'][] = [
+					'href' => trailingslashit( $rest_url ) . $new_bm['id'],
+					'embeddable' => true,
+				];
 
 				// Metadata
 				$request_metadata = new \WP_REST_Request( 'GET', "/pressbooks/v2/{$base}/{$new_bm['id']}/metadata" );
 				$response_metadata = rest_do_request( $request_metadata );
 				$new_bm['metadata'] = $this->prepare_response_for_collection( $response_metadata );
-				$this->linkCollector['metadata'][] = [ 'href' => trailingslashit( $rest_url ) . "{$new_bm['id']}/metadata" ];
+				$this->linkCollector['metadata'][] = [
+					'href' => trailingslashit( $rest_url ) . "{$new_bm['id']}/metadata",
+				];
 				unset( $new_bm['metadata']['_links'] );
 
 				$back_matter[] = $new_bm;

--- a/inc/api/namespace.php
+++ b/inc/api/namespace.php
@@ -59,17 +59,19 @@ function init_book() {
 
 	// Add Part ID to chapters
 	// We disable hierarchical mode but still want to use `post_parent`
-	register_rest_field( 'chapter', 'part', [
-		'get_callback' => function ( $post_arr ) {
-			return (int) get_post( $post_arr['id'] )->post_parent;
-		},
-		'update_callback' => __NAMESPACE__ . '\update_part_id',
-		'schema' => [
-			'description' => __( 'Part ID.', 'pressbooks' ),
-			'type' => 'integer',
-			'context' => [ 'view', 'edit', 'embed' ],
-		],
-	] );
+	register_rest_field(
+		'chapter', 'part', [
+			'get_callback' => function ( $post_arr ) {
+				return (int) get_post( $post_arr['id'] )->post_parent;
+			},
+			'update_callback' => __NAMESPACE__ . '\update_part_id',
+			'schema' => [
+				'description' => __( 'Part ID.', 'pressbooks' ),
+				'type' => 'integer',
+				'context' => [ 'view', 'edit', 'embed' ],
+			],
+		]
+	);
 }
 
 /**
@@ -159,15 +161,32 @@ function update_part_id( $part_id, $post_obj ) {
 
 	$part = get_post( $part_id );
 	if ( $part === null ) {
-		return new \WP_Error( 'rest_chapter_part_failed', __( 'Part does not exist', 'pressbooks' ), [ 'status' => 500 ] );
+		return new \WP_Error(
+			'rest_chapter_part_failed', __( 'Part does not exist', 'pressbooks' ), [
+				'status' => 500,
+			]
+		);
 	}
 	if ( $part->post_type !== 'part' ) {
-		return new \WP_Error( 'rest_chapter_part_failed', __( 'ID is not a part', 'pressbooks' ), [ 'status' => 500 ] );
+		return new \WP_Error(
+			'rest_chapter_part_failed', __( 'ID is not a part', 'pressbooks' ), [
+				'status' => 500,
+			]
+		);
 	}
 
-	$ret = wp_update_post( [ 'ID' => $post_obj->ID, 'post_parent' => $part_id ] );
+	$ret = wp_update_post(
+		[
+			'ID' => $post_obj->ID,
+			'post_parent' => $part_id,
+		]
+	);
 	if ( false === $ret ) {
-		return new \WP_Error( 'rest_chapter_part_failed', __( 'Failed to update chapter part', 'pressbooks' ), [ 'status' => 500 ] );
+		return new \WP_Error(
+			'rest_chapter_part_failed', __( 'Failed to update chapter part', 'pressbooks' ), [
+				'status' => 500,
+			]
+		);
 	}
 
 	return true;

--- a/inc/class-activation.php
+++ b/inc/class-activation.php
@@ -270,8 +270,16 @@ class Activation {
 		 */
 		$posts = apply_filters( 'pb_default_book_content', $posts );
 
-		$part = [ 'post_status' => 'publish', 'comment_status' => 'closed', 'post_author' => $this->user_id ];
-		$post = [ 'post_status' => 'publish', 'comment_status' => 'open', 'post_author' => $this->user_id ];
+		$part = [
+			'post_status' => 'publish',
+			'comment_status' => 'closed',
+			'post_author' => $this->user_id,
+		];
+		$post = [
+			'post_status' => 'publish',
+			'comment_status' => 'open',
+			'post_author' => $this->user_id,
+		];
 		$page = [
 			'post_status' => 'publish',
 			'comment_status' => 'closed',
@@ -300,9 +308,9 @@ class Activation {
 			$exists = $wpdb->get_var(
 				$wpdb->prepare(
 					"SELECT ID FROM {$wpdb->posts} WHERE post_title = %s AND post_type = %s AND post_name = %s AND post_status = 'publish' ", [
-					$item['post_title'],
-					$item['post_type'],
-					$item['post_name'],
+						$item['post_title'],
+						$item['post_type'],
+						$item['post_name'],
 					]
 				)
 			);

--- a/inc/class-activation.php
+++ b/inc/class-activation.php
@@ -359,8 +359,8 @@ class Activation {
 						$locale = get_option( 'WPLANG' );
 						if ( ! empty( $locale ) ) {
 							$locale = array_search( $locale, \Pressbooks\L10n\wplang_codes(), true );
-						} elseif ( $locale = get_site_option( 'WPLANG' ) ) {
-							$locale = array_search( $locale, \Pressbooks\L10n\wplang_codes(), true );
+						} elseif ( get_site_option( 'WPLANG' ) ) {
+							$locale = array_search( get_site_option( 'WPLANG' ), \Pressbooks\L10n\wplang_codes(), true );
 						} else {
 							$locale = 'en';
 						}

--- a/inc/class-book.php
+++ b/inc/class-book.php
@@ -548,7 +548,7 @@ class Book {
 			$section->setAttribute( 'class', 'section-header' );
 		}
 		$xpath = new \DOMXPath( $dom );
-		while ( ( $nodes = $xpath->query( '//*[not(text() or node() or self::br or self::hr or self::img)]' ) ) && $nodes->length > 0 ) {
+		while ( ( $nodes = $xpath->query( '//*[not(text() or node() or self::br or self::hr or self::img)]' ) ) && $nodes->length > 0 ) { // @codingStandardsIgnoreLine
 			foreach ( $nodes as $node ) {
 				/** @var $node \DOMElement */
 				$node->appendChild( new \DOMText( '' ) );

--- a/inc/class-book.php
+++ b/inc/class-book.php
@@ -308,7 +308,10 @@ class Book {
 			foreach ( $book_structure[ $type ] as $i => $struct ) {
 				unset( $book_structure[ $type ][ $i ]['post_parent'] );
 				if ( 'part' !== $type ) {
-					$book_structure['__order'][ $struct['ID'] ] = [ 'export' => $struct['export'], 'post_status' => $struct['post_status'] ];
+					$book_structure['__order'][ $struct['ID'] ] = [
+						'export' => $struct['export'],
+						'post_status' => $struct['post_status'],
+					];
 					if ( $struct['export'] ) {
 						$book_structure['__export_lookup'][ $struct['post_name'] ] = $type;
 					}
@@ -316,9 +319,15 @@ class Book {
 					foreach ( $struct['chapters'] as $j => $chapter ) {
 						unset( $book_structure[ $type ][ $i ]['chapters'][ $j ]['post_parent'] );
 						if ( $struct['has_post_content'] && get_post_meta( $struct['ID'], 'pb_part_invisible', true ) !== 'on' ) {
-							$book_structure['__order'][ $struct['ID'] ] = [ 'export' => $struct['export'], 'post_status' => $struct['post_status'] ];
+							$book_structure['__order'][ $struct['ID'] ] = [
+								'export' => $struct['export'],
+								'post_status' => $struct['post_status'],
+							];
 						}
-						$book_structure['__order'][ $chapter['ID'] ] = [ 'export' => $chapter['export'], 'post_status' => $chapter['post_status'] ];
+						$book_structure['__order'][ $chapter['ID'] ] = [
+							'export' => $chapter['export'],
+							'post_status' => $chapter['post_status'],
+						];
 						if ( $chapter['export'] ) {
 							$book_structure['__export_lookup'][ $chapter['post_name'] ] = 'chapter';
 						}
@@ -526,7 +535,11 @@ class Book {
 			return false;
 		}
 
-		$doc = new HTML5( [ 'disable_html_ns' => true ] ); // Disable default namespace for \DOMXPath compatibility
+		$doc = new HTML5(
+			[
+				'disable_html_ns' => true,
+			]
+		); // Disable default namespace for \DOMXPath compatibility
 		$dom = $doc->loadHTML( $content );
 		$sections = $dom->getElementsByTagName( 'h1' );
 		foreach ( $sections as $section ) {
@@ -576,7 +589,13 @@ class Book {
 						if ( 'chapter' === $key ) {
 							foreach ( $values as $position => $id ) {
 								$position += 1; // array is 0-indexed, but we want it to start from 1
-								$wpdb->update( $wpdb->posts, [ 'menu_order' => $position ], [ 'ID' => $id ] );
+								$wpdb->update(
+									$wpdb->posts, [
+										'menu_order' => $position,
+									], [
+										'ID' => $id,
+									]
+								);
 								clean_post_cache( $id );
 							}
 						}
@@ -590,7 +609,13 @@ class Book {
 					if ( 'chapter' === $key ) {
 						foreach ( $values as $position => $id ) {
 							$position += 1; // array is 0-indexed, but we want it to start from 1
-							$wpdb->update( $wpdb->posts, [ 'menu_order' => $position ], [ 'ID' => $id ] );
+							$wpdb->update(
+								$wpdb->posts, [
+									'menu_order' => $position,
+								], [
+									'ID' => $id,
+								]
+							);
 							clean_post_cache( $id );
 						}
 					}
@@ -622,7 +647,13 @@ class Book {
 					if ( 'front-matter' === $key ) {
 						foreach ( $values as $position => $id ) {
 							$position += 1;
-							$wpdb->update( $wpdb->posts, [ 'menu_order' => $position ], [ 'ID' => $id ] );
+							$wpdb->update(
+								$wpdb->posts, [
+									'menu_order' => $position,
+								], [
+									'ID' => $id,
+								]
+							);
 							clean_post_cache( $id );
 						}
 					}
@@ -650,7 +681,13 @@ class Book {
 					if ( 'back-matter' === $key ) {
 						foreach ( $values as $position => $id ) {
 							$position += 1;
-							$wpdb->update( $wpdb->posts, [ 'menu_order' => $position ], [ 'ID' => $id ] );
+							$wpdb->update(
+								$wpdb->posts, [
+									'menu_order' => $position,
+								], [
+									'ID' => $id,
+								]
+							);
 							clean_post_cache( $id );
 						}
 					}

--- a/inc/class-catalog.php
+++ b/inc/class-catalog.php
@@ -1315,8 +1315,8 @@ class Catalog {
 			$redirect_url = get_admin_url( get_current_blog_id(), '/index.php?page=pb_catalog' );
 		}
 
-		$url = parse_url( \Pressbooks\Sanitize\canonicalize_url( $_REQUEST['add_book_by_url'] ) );
-		$main = parse_url( network_home_url() );
+		$url = wp_parse_url( \Pressbooks\Sanitize\canonicalize_url( $_REQUEST['add_book_by_url'] ) );
+		$main = wp_parse_url( network_home_url() );
 
 		if ( strpos( $url['host'], $main['host'] ) === false ) {
 			$_SESSION['pb_errors'][] = __( 'Invalid URL.', 'pressbooks' );

--- a/inc/class-catalog.php
+++ b/inc/class-catalog.php
@@ -373,9 +373,19 @@ class Catalog {
 		global $wpdb;
 
 		if ( $for_real ) {
-			return $wpdb->delete( $this->dbTable, [ 'users_id' => $this->userId ], [ '%d' ] );
+			return $wpdb->delete(
+				$this->dbTable, [
+					'users_id' => $this->userId,
+				], [ '%d' ]
+			);
 		} else {
-			return $wpdb->update( $this->dbTable, [ 'deleted' => 1 ], [ 'users_id' => $this->userId ], [ '%d' ], [ '%d' ] );
+			return $wpdb->update(
+				$this->dbTable, [
+					'deleted' => 1,
+				], [
+					'users_id' => $this->userId,
+				], [ '%d' ], [ '%d' ]
+			);
 		}
 	}
 
@@ -429,8 +439,16 @@ class Catalog {
 
 		unset( $item['users_id'], $item['blogs_id'], $item['deleted'] ); // Don't allow spoofing
 
-		$data = [ 'users_id' => $this->userId, 'blogs_id' => $blog_id, 'deleted' => 0 ];
-		$format = [ 'users_id' => $this->dbColumns['users_id'], 'blogs_id' => $this->dbColumns['blogs_id'], 'deleted' => $this->dbColumns['deleted'] ];
+		$data = [
+			'users_id' => $this->userId,
+			'blogs_id' => $blog_id,
+			'deleted' => 0,
+		];
+		$format = [
+			'users_id' => $this->dbColumns['users_id'],
+			'blogs_id' => $this->dbColumns['blogs_id'],
+			'deleted' => $this->dbColumns['deleted'],
+		];
 
 		foreach ( $item as $key => $val ) {
 			if ( isset( $this->dbColumns[ $key ] ) ) {
@@ -487,9 +505,21 @@ class Catalog {
 		global $wpdb;
 
 		if ( $for_real ) {
-			return $wpdb->delete( $this->dbTable, [ 'users_id' => $this->userId, 'blogs_id' => $blog_id ], [ '%d', '%d' ] );
+			return $wpdb->delete(
+				$this->dbTable, [
+					'users_id' => $this->userId,
+					'blogs_id' => $blog_id,
+				], [ '%d', '%d' ]
+			);
 		} else {
-			return $wpdb->update( $this->dbTable, [ 'deleted' => 1 ], [ 'users_id' => $this->userId, 'blogs_id' => $blog_id ], [ '%d' ], [ '%d', '%d' ] );
+			return $wpdb->update(
+				$this->dbTable, [
+					'deleted' => 1,
+				], [
+					'users_id' => $this->userId,
+					'blogs_id' => $blog_id,
+				], [ '%d' ], [ '%d', '%d' ]
+			);
 		}
 	}
 
@@ -608,14 +638,27 @@ class Catalog {
 		}
 
 		if ( $for_real && is_super_admin() ) {
-			$wpdb->delete( $this->dbLinkTable, [ 'tags_id' => $tag_id ], [ '%d' ] );
-			$wpdb->delete( $this->dbTagsTable, [ 'id' => $tag_id ], [ '%d' ] );
+			$wpdb->delete(
+				$this->dbLinkTable, [
+					'tags_id' => $tag_id,
+				], [ '%d' ]
+			);
+			$wpdb->delete(
+				$this->dbTagsTable, [
+					'id' => $tag_id,
+				], [ '%d' ]
+			);
 			$result = 1;
 		} else {
 			$result = $wpdb->delete(
 				$this->dbLinkTable,
-				[ 'users_id' => $this->userId, 'blogs_id' => $blog_id, 'tags_id' => $tag_id, 'tags_group' => $tag_group ],
-				[ '%d',  '%d',  '%d', '%d' ]
+				[
+					'users_id' => $this->userId,
+					'blogs_id' => $blog_id,
+					'tags_id' => $tag_id,
+					'tags_group' => $tag_group,
+				],
+				[ '%d', '%d', '%d', '%d' ]
 			);
 		}
 
@@ -642,7 +685,13 @@ class Catalog {
 		/** @var $wpdb \wpdb */
 		global $wpdb;
 
-		$result = $wpdb->delete( $this->dbLinkTable, [ 'users_id' => $this->userId, 'blogs_id' => $blog_id, 'tags_group' => $tag_group ], [ '%d', '%d', '%d' ] );
+		$result = $wpdb->delete(
+			$this->dbLinkTable, [
+				'users_id' => $this->userId,
+				'blogs_id' => $blog_id,
+				'tags_group' => $tag_group,
+			], [ '%d', '%d', '%d' ]
+		);
 
 		// TODO:
 		// Optimize the links table: $wpdb->query( "OPTIMIZE TABLE {$this->dbLinkTable} " );
@@ -732,8 +781,16 @@ class Catalog {
 
 		switch_to_blog( $book->blog_id );
 
-		$allowed_file_types = [ 'jpg' => 'image/jpeg', 'jpeg' => 'image/jpeg', 'gif' => 'image/gif', 'png' => 'image/png' ];
-		$overrides = [ 'test_form' => false, 'mimes' => $allowed_file_types ];
+		$allowed_file_types = [
+			'jpg' => 'image/jpeg',
+			'jpeg' => 'image/jpeg',
+			'gif' => 'image/gif',
+			'png' => 'image/png',
+		];
+		$overrides = [
+			'test_form' => false,
+			'mimes' => $allowed_file_types,
+		];
 		$image = wp_handle_upload( $_FILES[ $meta_key ], $overrides );
 
 		if ( ! empty( $image['error'] ) ) {
@@ -1180,7 +1237,11 @@ class Catalog {
 		/* Go! */
 		$catalog = new static( $user_id );
 		$featured = ( isset( $_REQUEST['featured'] ) ) ? absint( $_REQUEST['featured'] ) : 0;
-		$catalog->saveBook( $blog_id, [ 'featured' => $featured ] );
+		$catalog->saveBook(
+			$blog_id, [
+				'featured' => $featured,
+			]
+		);
 
 		// Tags
 		for ( $i = 1; $i <= self::MAX_TAGS_GROUP; ++$i ) {

--- a/inc/class-cloner.php
+++ b/inc/class-cloner.php
@@ -97,7 +97,13 @@ class Cloner {
 	 *
 	 * @var array
 	 */
-	protected $itemsToClone = [ 'terms' => 0, 'front-matter' => 0, 'back-matter' => 0, 'parts' => 0, 'chapters' => 0 ];
+	protected $itemsToClone = [
+		'terms' => 0,
+		'front-matter' => 0,
+		'back-matter' => 0,
+		'parts' => 0,
+		'chapters' => 0,
+	];
 	/**
 	 * An array of cloned items.
 	 *
@@ -123,7 +129,9 @@ class Cloner {
 	 *
 	 * @var array
 	 */
-	protected $requestArgs = [ 'timeout' => 30 ];
+	protected $requestArgs = [
+		'timeout' => 30,
+	];
 
 	/**
 	 * @var array
@@ -387,7 +395,10 @@ class Cloner {
 	 */
 	public function buildListOfKnownImages( $url ) {
 		// Handle request (local or global)
-		$params = [ 'media_type' => 'image', 'per_page' => 100 ];
+		$params = [
+			'media_type' => 'image',
+			'per_page' => 100,
+		];
 		$response = $this->handleGetRequest( $url, 'wp/v2', 'media', $params );
 
 		// Handle errors
@@ -448,7 +459,11 @@ class Cloner {
 	 */
 	public function getBookStructure( $url ) {
 		// Handle request (local or global)
-		$response = $this->handleGetRequest( $url , 'pressbooks/v2', 'toc', [ '_embed' => 1 ] );
+		$response = $this->handleGetRequest(
+			$url , 'pressbooks/v2', 'toc', [
+				'_embed' => 1,
+			]
+		);
 
 		// Handle errors
 		if ( is_wp_error( $response ) ) {
@@ -477,7 +492,11 @@ class Cloner {
 
 		foreach ( [ 'front-matter-type', 'chapter-type', 'back-matter-type' ] as $taxonomy ) {
 			// Handle request (local or global)
-			$response = $this->handleGetRequest( $url, 'pressbooks/v2', "$taxonomy", [ 'per_page' => 25 ] );
+			$response = $this->handleGetRequest(
+				$url, 'pressbooks/v2', "$taxonomy", [
+					'per_page' => 25,
+				]
+			);
 
 			// Bail on error
 			if ( is_wp_error( $response ) ) {
@@ -553,9 +572,11 @@ class Cloner {
 		$title = $this->sourceBookMetadata['name'];
 		$user_id = get_current_user_id();
 		 // Disable automatic redirect to new book dashboard
-		 add_filter( 'pb_redirect_to_new_book', function () {
-			 return false;
-		 } );
+		add_filter(
+			'pb_redirect_to_new_book', function () {
+				return false;
+			}
+		);
 		 // Remove default content so that the book only contains the results of the clone operation
 		 add_filter( 'pb_default_book_content', [ $this, 'removeDefaultBookContent' ] );
 		$result = wpmu_create_blog( $domain, $path, $title, $user_id );
@@ -707,10 +728,12 @@ class Cloner {
 		}
 
 		foreach ( $attachments as $attachment ) {
-			wp_update_post( [
-				'ID' => $attachment,
-				'post_parent' => $response['id'],
-			] );
+			wp_update_post(
+				[
+					'ID' => $attachment,
+					'post_parent' => $response['id'],
+				]
+			);
 		}
 
 		return $response['id'];
@@ -927,7 +950,12 @@ class Cloner {
 			}
 		}
 
-		$pid = media_handle_sideload( [ 'name' => $filename, 'tmp_name' => $tmp_name ], 0 );
+		$pid = media_handle_sideload(
+			[
+				'name' => $filename,
+				'tmp_name' => $tmp_name,
+			], 0
+		);
 		$src = wp_get_attachment_url( $pid );
 		if ( ! $src ) {
 			$pid = 0;
@@ -1021,7 +1049,11 @@ class Cloner {
 		// Check for taxonomies introduced in Pressbooks 4.1
 		// We specifically check for 404 Not Found.
 		// If we get another kind of error it will be caught later because we want to know what went wrong.
-		$response = $this->handleGetRequest( $url, 'pressbooks/v2', 'chapter-type', [ 'per_page' => 1 ] );
+		$response = $this->handleGetRequest(
+			$url, 'pressbooks/v2', 'chapter-type', [
+				'per_page' => 1,
+			]
+		);
 		if ( is_wp_error( $response ) && in_array( (int) $response->get_error_code(), [ 404 ], true ) ) {
 			$_SESSION['pb_errors'][] = __( 'You can only clone from a book hosted by Pressbooks 4.1 or later. Please ensure that your source book meets these requirements.', 'pressbooks' );
 			return false;

--- a/inc/class-customcss.php
+++ b/inc/class-customcss.php
@@ -68,7 +68,11 @@ class CustomCss {
 		if ( ! file_exists( $filename ) ) {
 			return false;
 		}
-		$theme = get_file_data( $filename, [ 'ThemeURI' => 'Theme URI' ] );
+		$theme = get_file_data(
+			$filename, [
+				'ThemeURI' => 'Theme URI',
+			]
+		);
 		$theme_slug = str_replace( [ 'http://pressbooks.com/themes/', 'https://pressbooks.com/themes/' ], [ '', '' ], $theme['ThemeURI'] );
 
 		return untrailingslashit( $theme_slug );
@@ -104,7 +108,10 @@ class CustomCss {
 			],
 		];
 
-		$post = [ 'post_status' => 'publish', 'post_author' => wp_get_current_user()->ID ];
+		$post = [
+			'post_status' => 'publish',
+			'post_author' => wp_get_current_user()->ID,
+		];
 
 		foreach ( $posts as $item ) {
 			$exists = $wpdb->get_var(

--- a/inc/class-globaltypography.php
+++ b/inc/class-globaltypography.php
@@ -70,7 +70,7 @@ class GlobalTypography {
 		$fullpath = $this->sass->pathToUserGeneratedSass() . "/_font-stack-{$type}.scss";
 
 		if ( is_file( $fullpath ) ) {
-			$return_value = file_get_contents( $fullpath );
+			$return_value = \Pressbooks\Utility\get_contents( $fullpath );
 		}
 
 		return $return_value;
@@ -256,7 +256,7 @@ class GlobalTypography {
 
 		$dir = $this->sass->pathToUserGeneratedSass();
 		$file = $dir . "/_font-stack-{$type}.scss";
-		file_put_contents( $file, $scss );
+		\Pressbooks\Utility\put_contents( $file, $scss );
 	}
 
 	/**

--- a/inc/class-licensing.php
+++ b/inc/class-licensing.php
@@ -6,6 +6,8 @@
 
 namespace Pressbooks;
 
+use function \Pressbooks\Utility\debug_error_log;
+
 class Licensing {
 
 	/**
@@ -288,7 +290,7 @@ class Licensing {
 					if ( ! is_wp_error( $xml ) ) {
 						$xml = $xml['body'];
 					} else {
-						\error_log( '\Pressbooks\Licensing::getLicenseXml() error: ' . $xml->get_error_message() );
+						debug_error_log( '\Pressbooks\Licensing::getLicenseXml() error: ' . $xml->get_error_message() );
 						$xml = '';
 					}
 				}

--- a/inc/class-licensing.php
+++ b/inc/class-licensing.php
@@ -214,7 +214,13 @@ class Licensing {
 
 			set_transient(
 				$transient_id,
-				[ $license => $html, $copyright_holder => 1, $title => 1, $lang => 1, $copyright_year => 1 ]
+				[
+					$license => $html,
+					$copyright_holder => 1,
+					$title => 1,
+					$lang => 1,
+					$copyright_year => 1,
+				]
 			);
 
 		} else {

--- a/inc/class-licensing.php
+++ b/inc/class-licensing.php
@@ -274,7 +274,7 @@ class Licensing {
 
 				$url =
 					$endpoint . $key[0] . '/' . $val[0] . '/get?' . $key[1] . '=' . $val[1] . '&' . $key[2] . '=' . $val[2] .
-					'&creator=' . urlencode( $copyright_holder ) . '&attribution_url=' . urlencode( $src_url ) . '&title=' . urlencode( $title ) . '&locale=' . $lang;
+					'&creator=' . rawurlencode( $copyright_holder ) . '&attribution_url=' . rawurlencode( $src_url ) . '&title=' . rawurlencode( $title ) . '&locale=' . $lang;
 				if ( $year ) {
 					$url .= '&year=' . (int) $year;
 				}

--- a/inc/class-metadata.php
+++ b/inc/class-metadata.php
@@ -454,11 +454,13 @@ class Metadata implements \JsonSerializable {
 		foreach ( $parts as $part ) {
 			$pb_part_content = trim( get_post_meta( $part->ID, 'pb_part_content', true ) );
 			if ( $pb_part_content ) {
-				$success = wp_update_post( [
-					'ID' => $part->ID,
-					'post_content' => $pb_part_content,
-					'comment_status' => 'closed',
-				] );
+				$success = wp_update_post(
+					[
+						'ID' => $part->ID,
+						'post_content' => $pb_part_content,
+						'comment_status' => 'closed',
+					]
+				);
 				if ( $success === $part->ID ) {
 					delete_post_meta( $part->ID, 'pb_part_content' );
 				}

--- a/inc/class-sass.php
+++ b/inc/class-sass.php
@@ -309,18 +309,16 @@ class Sass {
 	 * @param string $css
 	 * @param string $scss
 	 * @param string $filename
-	 *
-	 * @param string $filename
 	 */
 	public function debug( $css, $scss, $filename ) {
 
 		$debug_dir = $this->pathToDebugDir();
 
 		$css_debug_file = $debug_dir . "/{$filename}.css";
-		file_put_contents( $css_debug_file, $css );
+		\Pressbooks\Utility\put_contents( $css_debug_file, $css );
 
 		$scss_debug_file = $debug_dir . "/{$filename}.scss";
-		file_put_contents( $scss_debug_file, $scss );
+		\Pressbooks\Utility\put_contents( $scss_debug_file, $scss );
 	}
 
 	/**

--- a/inc/class-sass.php
+++ b/inc/class-sass.php
@@ -191,10 +191,11 @@ class Sass {
 			}
 		} catch ( \Exception $e ) {
 
+			$error_message = print_r( $sass->getParsedFiles(), true ); // @codingStandardsIgnoreLine
 			$_SESSION['pb_errors'][] = sprintf(
 				__( 'There was a problem with SASS. Contact your site administrator. Error: %1$s %2$s', 'pressbooks' ),
 				$e->getMessage(),
-				'<pre>' . print_r( $sass->getParsedFiles(), true ) . '</pre>'
+				"<pre>{$error_message}</pre>"
 			);
 
 			$this->logException( $e );
@@ -293,7 +294,7 @@ class Sass {
 			],
 		];
 
-		$message = print_r( array_merge( $info ), true );
+		$message = print_r( array_merge( $info ), true ); // @codingStandardsIgnoreLine
 
 		\Pressbooks\Utility\email_error_log(
 			$this->errorsEmail,

--- a/inc/class-styles.php
+++ b/inc/class-styles.php
@@ -6,6 +6,8 @@
 
 namespace Pressbooks;
 
+use function \Pressbooks\Utility\debug_error_log;
+
 /**
  * Custom Styles Feature(s)
  */
@@ -643,12 +645,12 @@ class Styles {
 			$redirect_url = get_admin_url( get_current_blog_id(), '/themes.php?page=' . $this::PAGE . '&slug=' . $slug );
 
 			if ( ! isset( $_POST['post_id'], $_POST['post_id_integrity'] ) ) {
-				error_log( __METHOD__ . ' error: Missing post ID' );
+				debug_error_log( __METHOD__ . ' error: Missing post ID' );
 				\Pressbooks\Redirect\location( $redirect_url . '&custom_styles_error=true' );
 			}
 			if ( md5( NONCE_KEY . $_POST['post_id'] ) !== $_POST['post_id_integrity'] ) {
 				// A hacker trying to overwrite posts?.
-				error_log( __METHOD__ . ' error: unexpected value for post_id_integrity' );
+				debug_error_log( __METHOD__ . ' error: unexpected value for post_id_integrity' );
 				\Pressbooks\Redirect\location( $redirect_url . '&custom_styles_error=true' );
 			}
 
@@ -666,7 +668,7 @@ class Styles {
 
 			if ( is_wp_error( $response ) ) {
 				// Something went wrong?
-				error_log( __METHOD__ . ' error, wp_update_post(): ' . $response->get_error_message() );
+				debug_error_log( __METHOD__ . ' error, wp_update_post(): ' . $response->get_error_message() );
 				\Pressbooks\Redirect\location( $redirect_url . '&custom_styles_error=true' );
 			}
 

--- a/inc/class-styles.php
+++ b/inc/class-styles.php
@@ -352,7 +352,7 @@ class Styles {
 	public function customizeWeb( $overrides = [] ) {
 		$path = $this->getPathToWebScss();
 		if ( $path ) {
-			return $this->customize( 'web', file_get_contents( $path ), $overrides );
+			return $this->customize( 'web', \Pressbooks\Utility\get_contents( $path ), $overrides );
 		}
 		return '';
 	}
@@ -365,7 +365,7 @@ class Styles {
 	public function customizePrince( $overrides = [] ) {
 		$path = $this->getPathToPrinceScss();
 		if ( $path ) {
-			return $this->customize( 'prince', file_get_contents( $path ), $overrides );
+			return $this->customize( 'prince', \Pressbooks\Utility\get_contents( $path ), $overrides );
 		}
 		return '';
 	}
@@ -378,7 +378,7 @@ class Styles {
 	public function customizeEpub( $overrides = [] ) {
 		$path = $this->getPathToEpubScss();
 		if ( $path ) {
-			return $this->customize( 'epub', file_get_contents( $path ), $overrides );
+			return $this->customize( 'epub', \Pressbooks\Utility\get_contents( $path ), $overrides );
 		}
 		return '';
 	}
@@ -468,7 +468,7 @@ class Styles {
 
 		foreach ( $scan as $token => $replace_with ) {
 			if ( is_file( $replace_with ) ) {
-				$css = str_replace( $token, file_get_contents( $replace_with ), $css );
+				$css = str_replace( $token, \Pressbooks\Utility\get_contents( $replace_with ), $css );
 			}
 		}
 
@@ -488,9 +488,9 @@ class Styles {
 		$scss = '$url-base: \'' . get_stylesheet_directory_uri() . "/';\n";
 
 		if ( $this->isCurrentThemeCompatible( 1 ) ) {
-			$scss .= file_get_contents( realpath( get_stylesheet_directory() . '/style.scss' ) );
+			$scss .= \Pressbooks\Utility\get_contents( realpath( get_stylesheet_directory() . '/style.scss' ) );
 		} elseif ( $this->isCurrentThemeCompatible( 2 ) ) {
-			$scss .= file_get_contents( realpath( get_stylesheet_directory() . '/assets/styles/web/style.scss' ) );
+			$scss .= \Pressbooks\Utility\get_contents( realpath( get_stylesheet_directory() . '/assets/styles/web/style.scss' ) );
 		} else {
 			return;
 		}
@@ -505,7 +505,7 @@ class Styles {
 		$css = \Pressbooks\Sanitize\normalize_css_urls( $css );
 
 		$css_file = $this->sass->pathToUserGeneratedCss() . '/style.css';
-		file_put_contents( $css_file, $css );
+		\Pressbooks\Utility\put_contents( $css_file, $css );
 	}
 
 	/**
@@ -561,8 +561,8 @@ class Styles {
 	 * @return string
 	 */
 	public function renderDropdownForSlugs( $slug ) {
-
-		$select_id = $select_name = 'slug';
+		$select_name = 'slug';
+		$select_id = $select_name;
 		$redirect_url = get_admin_url( get_current_blog_id(), '/themes.php?page=' . $this::PAGE . '&slug=' );
 		$html = '';
 

--- a/inc/class-styles.php
+++ b/inc/class-styles.php
@@ -71,14 +71,18 @@ class Styles {
 			);
 		}
 
-		add_action( 'init', function () {
-			// Admin Menu
-			add_action( 'admin_menu', function () {
-				add_theme_page( __( 'Custom Styles', 'pressbooks' ), __( 'Custom Styles', 'pressbooks' ), 'edit_others_posts', $this::PAGE, [ $this, 'editor' ] );
-			}, 11 );
-			// Register Post Types
-			$this->registerPosts();
-		} );
+		add_action(
+			'init', function () {
+				// Admin Menu
+				add_action(
+					'admin_menu', function () {
+						add_theme_page( __( 'Custom Styles', 'pressbooks' ), __( 'Custom Styles', 'pressbooks' ), 'edit_others_posts', $this::PAGE, [ $this, 'editor' ] );
+					}, 11
+				);
+				// Register Post Types
+				$this->registerPosts();
+			}
+		);
 
 		// Catch form submission
 		add_action( 'init', [ $this, 'formSubmit' ], 50 );
@@ -110,7 +114,10 @@ class Styles {
 			],
 		];
 
-		$post = [ 'post_status' => 'publish', 'post_author' => wp_get_current_user()->ID ];
+		$post = [
+			'post_status' => 'publish',
+			'post_author' => wp_get_current_user()->ID,
+		];
 
 		foreach ( $posts as $item ) {
 			$exists = $wpdb->get_var(

--- a/inc/class-taxonomy.php
+++ b/inc/class-taxonomy.php
@@ -65,7 +65,9 @@ class Taxonomy {
 				'show_ui' => true,
 				'show_in_rest' => true,
 				'query_var' => true,
-				'rewrite' => [ 'slug' => 'front-matter-type' ],
+				'rewrite' => [
+					'slug' => 'front-matter-type',
+				],
 			]
 		);
 
@@ -106,7 +108,9 @@ class Taxonomy {
 				'show_ui' => true,
 				'show_in_rest' => true,
 				'query_var' => true,
-				'rewrite' => [ 'slug' => 'back-matter-type' ],
+				'rewrite' => [
+					'slug' => 'back-matter-type',
+				],
 			]
 		);
 
@@ -147,7 +151,9 @@ class Taxonomy {
 				'show_ui' => true,
 				'show_in_rest' => true,
 				'query_var' => true,
-				'rewrite' => [ 'slug' => 'chapter-type' ],
+				'rewrite' => [
+					'slug' => 'chapter-type',
+				],
 			]
 		);
 	}
@@ -162,57 +168,241 @@ class Taxonomy {
 		}
 
 		// Front Matter
-		wp_insert_term( 'Abstract', 'front-matter-type', [ 'slug' => 'abstracts' ] );
-		wp_insert_term( 'Acknowledgements', 'front-matter-type', [ 'slug' => 'acknowledgements' ] );
-		wp_insert_term( 'Before Title Page', 'front-matter-type', [ 'slug' => 'before-title' ] );
-		wp_insert_term( 'Chronology, Timeline', 'front-matter-type', [ 'slug' => 'chronology-timeline' ] );
-		wp_insert_term( 'Dedication', 'front-matter-type', [ 'slug' => 'dedication' ] );
-		wp_insert_term( 'Disclaimer', 'front-matter-type', [ 'slug' => 'disclaimer' ] );
-		wp_insert_term( 'Epigraph', 'front-matter-type', [ 'slug' => 'epigraph' ] );
-		wp_insert_term( 'Foreword', 'front-matter-type', [ 'slug' => 'foreword' ] );
-		wp_insert_term( 'Genealogy, Family Tree', 'front-matter-type', [ 'slug' => 'genealogy-family-tree' ] );
-		wp_insert_term( 'Image credits', 'front-matter-type', [ 'slug' => 'image-credits' ] );
-		wp_insert_term( 'Introduction', 'front-matter-type', [ 'slug' => 'introduction' ] );
-		wp_insert_term( 'List of Abbreviations', 'front-matter-type', [ 'slug' => 'list-of-abbreviations' ] );
-		wp_insert_term( 'List of Characters', 'front-matter-type', [ 'slug' => 'list-of-characters' ] );
-		wp_insert_term( 'List of Illustrations', 'front-matter-type', [ 'slug' => 'list-of-illustrations' ] );
-		wp_insert_term( 'List of Tables', 'front-matter-type', [ 'slug' => 'list-of-tables' ] );
-		wp_insert_term( 'Miscellaneous', 'front-matter-type', [ 'slug' => 'miscellaneous' ] );
-		wp_insert_term( 'Other Books by Author', 'front-matter-type', [ 'slug' => 'other-books' ] );
-		wp_insert_term( 'Preface', 'front-matter-type', [ 'slug' => 'preface' ] );
-		wp_insert_term( 'Prologue', 'front-matter-type', [ 'slug' => 'prologue' ] );
-		wp_insert_term( 'Recommended citation', 'front-matter-type', [ 'slug' => 'recommended-citation' ] );
-		wp_insert_term( 'Title Page', 'front-matter-type', [ 'slug' => 'title-page' ] );
+		wp_insert_term(
+			'Abstract', 'front-matter-type', [
+				'slug' => 'abstracts',
+			]
+		);
+		wp_insert_term(
+			'Acknowledgements', 'front-matter-type', [
+				'slug' => 'acknowledgements',
+			]
+		);
+		wp_insert_term(
+			'Before Title Page', 'front-matter-type', [
+				'slug' => 'before-title',
+			]
+		);
+		wp_insert_term(
+			'Chronology, Timeline', 'front-matter-type', [
+				'slug' => 'chronology-timeline',
+			]
+		);
+		wp_insert_term(
+			'Dedication', 'front-matter-type', [
+				'slug' => 'dedication',
+			]
+		);
+		wp_insert_term(
+			'Disclaimer', 'front-matter-type', [
+				'slug' => 'disclaimer',
+			]
+		);
+		wp_insert_term(
+			'Epigraph', 'front-matter-type', [
+				'slug' => 'epigraph',
+			]
+		);
+		wp_insert_term(
+			'Foreword', 'front-matter-type', [
+				'slug' => 'foreword',
+			]
+		);
+		wp_insert_term(
+			'Genealogy, Family Tree', 'front-matter-type', [
+				'slug' => 'genealogy-family-tree',
+			]
+		);
+		wp_insert_term(
+			'Image credits', 'front-matter-type', [
+				'slug' => 'image-credits',
+			]
+		);
+		wp_insert_term(
+			'Introduction', 'front-matter-type', [
+				'slug' => 'introduction',
+			]
+		);
+		wp_insert_term(
+			'List of Abbreviations', 'front-matter-type', [
+				'slug' => 'list-of-abbreviations',
+			]
+		);
+		wp_insert_term(
+			'List of Characters', 'front-matter-type', [
+				'slug' => 'list-of-characters',
+			]
+		);
+		wp_insert_term(
+			'List of Illustrations', 'front-matter-type', [
+				'slug' => 'list-of-illustrations',
+			]
+		);
+		wp_insert_term(
+			'List of Tables', 'front-matter-type', [
+				'slug' => 'list-of-tables',
+			]
+		);
+		wp_insert_term(
+			'Miscellaneous', 'front-matter-type', [
+				'slug' => 'miscellaneous',
+			]
+		);
+		wp_insert_term(
+			'Other Books by Author', 'front-matter-type', [
+				'slug' => 'other-books',
+			]
+		);
+		wp_insert_term(
+			'Preface', 'front-matter-type', [
+				'slug' => 'preface',
+			]
+		);
+		wp_insert_term(
+			'Prologue', 'front-matter-type', [
+				'slug' => 'prologue',
+			]
+		);
+		wp_insert_term(
+			'Recommended citation', 'front-matter-type', [
+				'slug' => 'recommended-citation',
+			]
+		);
+		wp_insert_term(
+			'Title Page', 'front-matter-type', [
+				'slug' => 'title-page',
+			]
+		);
 
 		// Back Matter
-		wp_insert_term( 'About the Author', 'back-matter-type', [ 'slug' => 'about-the-author' ] );
-		wp_insert_term( 'About the Publisher', 'back-matter-type', [ 'slug' => 'about-the-publisher' ] );
-		wp_insert_term( 'Acknowledgements', 'back-matter-type', [ 'slug' => 'acknowledgements' ] );
-		wp_insert_term( 'Afterword', 'back-matter-type', [ 'slug' => 'afterword' ] );
-		wp_insert_term( 'Appendix', 'back-matter-type', [ 'slug' => 'appendix' ] );
-		wp_insert_term( "Author's Note", 'back-matter-type', [ 'slug' => 'authors-note' ] );
-		wp_insert_term( 'Back of Book Ad', 'back-matter-type', [ 'slug' => 'back-of-book-ad' ] );
-		wp_insert_term( 'Bibliography', 'back-matter-type', [ 'slug' => 'bibliography' ] );
-		wp_insert_term( 'Biographical Note', 'back-matter-type', [ 'slug' => 'biographical-note' ] );
-		wp_insert_term( 'Colophon', 'back-matter-type', [ 'slug' => 'colophon' ] );
-		wp_insert_term( 'Conclusion', 'back-matter-type', [ 'slug' => 'conclusion' ] );
-		wp_insert_term( 'Credits', 'back-matter-type', [ 'slug' => 'credits' ] );
-		wp_insert_term( 'Dedication', 'back-matter-type', [ 'slug' => 'dedication' ] );
-		wp_insert_term( 'Epilogue', 'back-matter-type', [ 'slug' => 'epilogue' ] );
-		wp_insert_term( 'Glossary', 'back-matter-type', [ 'slug' => 'glossary' ] );
-		wp_insert_term( 'Index', 'back-matter-type', [ 'slug' => 'index' ] );
-		wp_insert_term( 'Miscellaneous', 'back-matter-type', [ 'slug' => 'miscellaneous' ] );
-		wp_insert_term( 'Notes', 'back-matter-type', [ 'slug' => 'notes' ] );
-		wp_insert_term( 'Other Books by Author', 'back-matter-type', [ 'slug' => 'other-books' ] );
-		wp_insert_term( 'Permissions', 'back-matter-type', [ 'slug' => 'permissions' ] );
-		wp_insert_term( 'Reading Group Guide', 'back-matter-type', [ 'slug' => 'reading-group-guide' ] );
+		wp_insert_term(
+			'About the Author', 'back-matter-type', [
+				'slug' => 'about-the-author',
+			]
+		);
+		wp_insert_term(
+			'About the Publisher', 'back-matter-type', [
+				'slug' => 'about-the-publisher',
+			]
+		);
+		wp_insert_term(
+			'Acknowledgements', 'back-matter-type', [
+				'slug' => 'acknowledgements',
+			]
+		);
+		wp_insert_term(
+			'Afterword', 'back-matter-type', [
+				'slug' => 'afterword',
+			]
+		);
+		wp_insert_term(
+			'Appendix', 'back-matter-type', [
+				'slug' => 'appendix',
+			]
+		);
+		wp_insert_term(
+			"Author's Note", 'back-matter-type', [
+				'slug' => 'authors-note',
+			]
+		);
+		wp_insert_term(
+			'Back of Book Ad', 'back-matter-type', [
+				'slug' => 'back-of-book-ad',
+			]
+		);
+		wp_insert_term(
+			'Bibliography', 'back-matter-type', [
+				'slug' => 'bibliography',
+			]
+		);
+		wp_insert_term(
+			'Biographical Note', 'back-matter-type', [
+				'slug' => 'biographical-note',
+			]
+		);
+		wp_insert_term(
+			'Colophon', 'back-matter-type', [
+				'slug' => 'colophon',
+			]
+		);
+		wp_insert_term(
+			'Conclusion', 'back-matter-type', [
+				'slug' => 'conclusion',
+			]
+		);
+		wp_insert_term(
+			'Credits', 'back-matter-type', [
+				'slug' => 'credits',
+			]
+		);
+		wp_insert_term(
+			'Dedication', 'back-matter-type', [
+				'slug' => 'dedication',
+			]
+		);
+		wp_insert_term(
+			'Epilogue', 'back-matter-type', [
+				'slug' => 'epilogue',
+			]
+		);
+		wp_insert_term(
+			'Glossary', 'back-matter-type', [
+				'slug' => 'glossary',
+			]
+		);
+		wp_insert_term(
+			'Index', 'back-matter-type', [
+				'slug' => 'index',
+			]
+		);
+		wp_insert_term(
+			'Miscellaneous', 'back-matter-type', [
+				'slug' => 'miscellaneous',
+			]
+		);
+		wp_insert_term(
+			'Notes', 'back-matter-type', [
+				'slug' => 'notes',
+			]
+		);
+		wp_insert_term(
+			'Other Books by Author', 'back-matter-type', [
+				'slug' => 'other-books',
+			]
+		);
+		wp_insert_term(
+			'Permissions', 'back-matter-type', [
+				'slug' => 'permissions',
+			]
+		);
+		wp_insert_term(
+			'Reading Group Guide', 'back-matter-type', [
+				'slug' => 'reading-group-guide',
+			]
+		);
 		wp_insert_term( 'Resources', 'back-matter-type', [ 'slug', 'resources' ] );
-		wp_insert_term( 'Sources', 'back-matter-type', [ 'slug' => 'sources' ] );
-		wp_insert_term( 'Suggested Reading', 'back-matter-type', [ 'slug' => 'suggested-reading' ] );
+		wp_insert_term(
+			'Sources', 'back-matter-type', [
+				'slug' => 'sources',
+			]
+		);
+		wp_insert_term(
+			'Suggested Reading', 'back-matter-type', [
+				'slug' => 'suggested-reading',
+			]
+		);
 
 		// Chapter
-		wp_insert_term( 'Standard', 'chapter-type', [ 'slug' => 'standard' ] );
-		wp_insert_term( 'Numberless', 'chapter-type', [ 'slug' => 'numberless' ] );
+		wp_insert_term(
+			'Standard', 'chapter-type', [
+				'slug' => 'standard',
+			]
+		);
+		wp_insert_term(
+			'Numberless', 'chapter-type', [
+				'slug' => 'numberless',
+			]
+		);
 	}
 
 	/**
@@ -308,7 +498,12 @@ class Taxonomy {
 		$type_5 = get_term_by( 'slug', 'type-5', 'chapter-type' );
 
 		if ( $type_1 ) {
-			wp_update_term( $type_1->term_id, 'chapter-type', [ 'name' => 'Standard', 'slug' => 'standard' ] );
+			wp_update_term(
+				$type_1->term_id, 'chapter-type', [
+					'name' => 'Standard',
+					'slug' => 'standard',
+				]
+			);
 		}
 
 		if ( $type_2 ) {

--- a/inc/class-updater.php
+++ b/inc/class-updater.php
@@ -13,10 +13,10 @@ namespace Pressbooks;
  * @see https://github.com/YahnisElsts/plugin-update-checker/issues/93
  * @see https://api.github.com/repos/pressbooks/pressbooks/releases
  */
-class Updater extends \Puc_v4p2_Vcs_GitHubApi {
+class Updater extends \Puc_v4p3_Vcs_GitHubApi {
 
 	/**
-	 * @return null|\Puc_v4p2_Vcs_Reference
+	 * @return null|\Puc_v4p3_Vcs_Reference
 	 */
 	public function getLatestRelease() {
 		$reference = parent::getLatestRelease();

--- a/inc/editor/namespace.php
+++ b/inc/editor/namespace.php
@@ -146,7 +146,7 @@ function mce_before_init_insert_formats( $init_array ) {
 
 	$style_formats = apply_filters( 'pressbooks_editor_custom_styles', $style_formats );
 
-	$init_array['style_formats'] = json_encode( $style_formats );
+	$init_array['style_formats'] = wp_json_encode( $style_formats );
 
 	$init_array['table_toolbar'] = false;
 
@@ -239,11 +239,11 @@ function mce_table_editor_options( $settings ) {
 	$row_classes = apply_filters( 'pressbooks_editor_row_classes', $row_classes );
 
 	$settings['table_advtab'] = false;
-	$settings['table_class_list'] = json_encode( $table_classes );
+	$settings['table_class_list'] = wp_json_encode( $table_classes );
 	$settings['table_cell_advtab'] = false;
-	$settings['table_cell_class_list'] = json_encode( $cell_classes );
+	$settings['table_cell_class_list'] = wp_json_encode( $cell_classes );
 	$settings['table_row_advtab'] = false;
-	$settings['table_row_class_list'] = json_encode( $row_classes );
+	$settings['table_row_class_list'] = wp_json_encode( $row_classes );
 	$settings['table_appearance_options'] = false;
 	return $settings;
 }
@@ -258,13 +258,13 @@ function update_editor_style() {
 	$sass = Container::get( 'Sass' );
 
 	if ( $styles->isCurrentThemeCompatible( 1 ) ) {
-		$scss = file_get_contents( $sass->pathToPartials() . '/_editor-with-custom-fonts.scss' );
+		$scss = \Pressbooks\Utility\get_contents( $sass->pathToPartials() . '/_editor-with-custom-fonts.scss' );
 		$css = $styles->customize( 'web', $scss );
 	} elseif ( $styles->isCurrentThemeCompatible( 2 ) ) {
-		$scss = file_get_contents( $sass->pathToGlobals() . '/editor/_editor.scss' );
+		$scss = \Pressbooks\Utility\get_contents( $sass->pathToGlobals() . '/editor/_editor.scss' );
 		$css = $styles->customize( 'web', $scss );
 	} else {
-		$scss = file_get_contents( $sass->pathToPartials() . '/_editor.scss' );
+		$scss = \Pressbooks\Utility\get_contents( $sass->pathToPartials() . '/_editor.scss' );
 		$css = $sass->compile(
 			$scss,
 			[
@@ -279,7 +279,7 @@ function update_editor_style() {
 	$css = normalize_css_urls( $css );
 
 	$output = $sass->pathToUserGeneratedCss() . '/editor.css';
-	file_put_contents( $output, $css );
+	\Pressbooks\Utility\put_contents( $output, $css );
 }
 
 
@@ -327,7 +327,7 @@ function customize_wp_link_query_args( $query ) {
  */
 function add_anchors_to_wp_link_query( $results, $query ) {
 
-	$url = parse_url( $_SERVER['HTTP_REFERER'] );
+	$url = wp_parse_url( $_SERVER['HTTP_REFERER'] );
 	parse_str( $url['query'], $query );
 
 	if ( ! isset( $query['post'] ) ) {

--- a/inc/editor/namespace.php
+++ b/inc/editor/namespace.php
@@ -167,13 +167,13 @@ function metadata_manager_default_editor_args( $args ) {
 	// Precedence when using the + operator to merge arrays is from left to right
 
 	$args = [
-				'media_buttons' => false,
-				'tinymce' => [
-					'theme_advanced_buttons1' => 'bold,italic,underline,strikethrough,|,link,unlink,|,numlist,bullist,|,undo,redo,pastetext,pasteword,|',
-					'theme_advanced_buttons2' => '',
-					'theme_advanced_buttons3' => '',
-				],
-			] + $args;
+		'media_buttons' => false,
+		'tinymce' => [
+			'theme_advanced_buttons1' => 'bold,italic,underline,strikethrough,|,link,unlink,|,numlist,bullist,|,undo,redo,pastetext,pasteword,|',
+			'theme_advanced_buttons2' => '',
+			'theme_advanced_buttons3' => '',
+		],
+	] + $args;
 
 	return $args;
 }

--- a/inc/image/namespace.php
+++ b/inc/image/namespace.php
@@ -174,9 +174,21 @@ function thumbnail_from_url( $url, $size ) {
 function intermediate_image_sizes( array $image_sizes = [] ) {
 
 	$our_sizes = [
-		'pb_cover_small' => [ 'width' => 65, 'height' => 0, 'crop' => false ],
-		'pb_cover_medium' => [ 'width' => 225, 'height' => 0, 'crop' => false ],
-		'pb_cover_large' => [ 'width' => 350, 'height' => 0, 'crop' => false ],
+		'pb_cover_small' => [
+			'width' => 65,
+			'height' => 0,
+			'crop' => false,
+		],
+		'pb_cover_medium' => [
+			'width' => 225,
+			'height' => 0,
+			'crop' => false,
+		],
+		'pb_cover_large' => [
+			'width' => 350,
+			'height' => 0,
+			'crop' => false,
+		],
 	];
 
 	if ( empty( $image_sizes ) ) {
@@ -372,7 +384,7 @@ function render_cover_image_box( $form_id, $cover_pid, $image_url, $ajax_action,
 							action: '<?php echo $ajax_action; ?>',
 							filename: image_file,
 							pid: pid,
-							_ajax_nonce: '<?php echo $nonce ?>'
+							_ajax_nonce: '<?php echo $nonce; ?>'
 						},
 						success: function (data) {
 							jQuery('#delete_cover_button').remove();
@@ -399,7 +411,10 @@ function render_cover_image_box( $form_id, $cover_pid, $image_url, $ajax_action,
 				<p><img id="cover_image_preview" src="<?php echo \Pressbooks\Image\default_cover_url(); ?>" style="width:auto;height:100px;" alt="cover_image"/></p>
 				<p><input type="file" name="<?php echo $form_id; ?>" value="<?php echo $image_url; ?>" id="<?php echo $form_id; ?>"/></p>
 			<?php } ?>
-			<?php if ( $description ) : ?><span class="description"><?php echo $description; ?></span><?php endif; ?>
+			<?php
+			if ( $description ) :
+?>
+<span class="description"><?php echo $description; ?></span><?php endif; ?>
 		</div>
 	</div>
 	<?php

--- a/inc/image/namespace.php
+++ b/inc/image/namespace.php
@@ -64,7 +64,7 @@ function is_valid_image( $file, $filename, $is_stream = false ) {
 
 	if ( $is_stream ) {
 		$tmp_image_path = \Pressbooks\Utility\create_tmp_file();
-		file_put_contents( $tmp_image_path, $file );
+		\Pressbooks\Utility\put_contents( $tmp_image_path, $file );
 		$file = $tmp_image_path;
 	}
 

--- a/inc/l10n/namespace.php
+++ b/inc/l10n/namespace.php
@@ -520,7 +520,21 @@ function romanize( $integer ) {
 
 	$integer = absint( $integer );
 
-	$table = [ 'M' => 1000, 'CM' => 900, 'D' => 500, 'CD' => 400, 'C' => 100, 'XC' => 90, 'L' => 50, 'XL' => 40, 'X' => 10, 'IX' => 9, 'V' => 5, 'IV' => 4, 'I' => 1 ];
+	$table = [
+		'M' => 1000,
+		'CM' => 900,
+		'D' => 500,
+		'CD' => 400,
+		'C' => 100,
+		'XC' => 90,
+		'L' => 50,
+		'XL' => 40,
+		'X' => 10,
+		'IX' => 9,
+		'V' => 5,
+		'IV' => 4,
+		'I' => 1,
+	];
 	$return = '';
 	while ( $integer > 0 ) {
 		foreach ( $table as $rom => $arb ) {

--- a/inc/metadata/namespace.php
+++ b/inc/metadata/namespace.php
@@ -660,7 +660,7 @@ function schema_to_section_information( $section_schema, $book_schema ) {
  * @return array
  */
 function get_thema_subjects( $include_qualifiers = false ) {
-	$json = file_get_contents( PB_PLUGIN_DIR . 'symbionts/thema/Thema_v1.2_en.json' );
+	$json = \Pressbooks\Utility\get_contents( PB_PLUGIN_DIR . 'symbionts/thema/Thema_v1.2_en.json' );
 	$values = json_decode( $json );
 	$subjects = [];
 	foreach ( $values->CodeList->Code as $code ) {

--- a/inc/metadata/namespace.php
+++ b/inc/metadata/namespace.php
@@ -211,8 +211,8 @@ function book_information_to_schema( $book_information ) {
 
 		if ( isset( $book_information['pb_primary_subject'] ) ) {
 			$book_schema['about'][] = [
-			 '@type' => 'Thing',
-			 'identifier' => $book_information['pb_primary_subject'],
+				'@type' => 'Thing',
+				'identifier' => $book_information['pb_primary_subject'],
 			];
 		}
 
@@ -220,8 +220,8 @@ function book_information_to_schema( $book_information ) {
 			$additional_subjects = explode( ', ', $book_information['pb_additional_subjects'] );
 			foreach ( $additional_subjects as $additional_subject ) {
 				$book_schema['about'][] = [
-				 '@type' => 'Thing',
-				 'identifier' => $additional_subject,
+					'@type' => 'Thing',
+					'identifier' => $additional_subject,
 				];
 			}
 		}
@@ -230,16 +230,16 @@ function book_information_to_schema( $book_information ) {
 			$bisac_subjects = explode( ', ', $book_information['pb_bisac_subject'] );
 			foreach ( $bisac_subjects as $bisac_subject ) {
 				$book_schema['about'][] = [
-				 '@type' => 'Thing',
-				 'identifier' => $bisac_subject,
+					'@type' => 'Thing',
+					'identifier' => $bisac_subject,
 				];
 			}
 		}
 
 		if ( isset( $book_information['pb_author'] ) ) {
 			$book_schema['author'] = [
-			 '@type' => 'Person',
-			 'name' => $book_information['pb_author'],
+				'@type' => 'Person',
+				'name' => $book_information['pb_author'],
 			];
 
 			if ( isset( $book_information['pb_author_file_as'] ) ) {
@@ -251,8 +251,8 @@ function book_information_to_schema( $book_information ) {
 			$contributing_authors = explode( ', ', $book_information['pb_contributing_authors'] );
 			foreach ( $contributing_authors as $contributor ) {
 				$book_schema['contributor'][] = [
-				 '@type' => 'Person',
-				 'name' => $contributor,
+					'@type' => 'Person',
+					'name' => $contributor,
 				];
 			}
 		}
@@ -261,8 +261,8 @@ function book_information_to_schema( $book_information ) {
 			$editors = explode( ', ', $book_information['pb_editor'] );
 			foreach ( $editors as $editor ) {
 				$book_schema['editor'][] = [
-				 '@type' => 'Person',
-				 'name' => $editor,
+					'@type' => 'Person',
+					'name' => $editor,
 				];
 			}
 		}
@@ -271,30 +271,30 @@ function book_information_to_schema( $book_information ) {
 			$translators = explode( ', ', $book_information['pb_translator'] );
 			foreach ( $translators as $translator ) {
 				$book_schema['translator'][] = [
-				 '@type' => 'Person',
-				 'name' => $translator,
+					'@type' => 'Person',
+					'name' => $translator,
 				];
 			}
 		}
 
 		if ( isset( $book_information['pb_publisher'] ) ) {
 			$book_schema['publisher'] = [
-			 '@type' => 'Organization',
-			 'name' => $book_information['pb_publisher'],
+				'@type' => 'Organization',
+				'name' => $book_information['pb_publisher'],
 			];
 
 			if ( isset( $book_information['pb_publisher_city'] ) ) {
 				$book_schema['publisher']['address'] = [
-				 '@type' => 'PostalAddress',
-				 'addressLocality' => $book_information['pb_publisher_city'],
+					'@type' => 'PostalAddress',
+					'addressLocality' => $book_information['pb_publisher_city'],
 				];
 			}
 		}
 
 		if ( isset( $book_information['pb_audience'] ) ) {
 			$book_schema['audience'] = [
-			 '@type' => 'Audience',
-			 'name' => $book_information['pb_audience'],
+				'@type' => 'Audience',
+				'name' => $book_information['pb_audience'],
 			];
 		}
 
@@ -308,8 +308,8 @@ function book_information_to_schema( $book_information ) {
 
 		if ( isset( $book_information['pb_copyright_holder'] ) ) { // TODO: Person or Organization?
 			$book_schema['copyrightHolder'] = [
-			 '@type' => 'Organization',
-			 'name' => $book_information['pb_copyright_holder'],
+				'@type' => 'Organization',
+				'name' => $book_information['pb_copyright_holder'],
 			];
 		}
 
@@ -495,13 +495,13 @@ function section_information_to_schema( $section_information, $book_information 
 
 		if ( isset( $section_information['pb_section_author'] ) ) {
 			$section_schema['author'] = [
-			 '@type' => 'Person',
-			 'name' => $section_information['pb_section_author'],
+				'@type' => 'Person',
+				'name' => $section_information['pb_section_author'],
 			];
 		} elseif ( isset( $book_information['pb_author'] ) ) {
 			$section_schema['author'] = [
-			 '@type' => 'Person',
-			 'name' => $book_information['pb_author'],
+				'@type' => 'Person',
+				'name' => $book_information['pb_author'],
 			];
 
 			if ( isset( $book_information['pb_author_file_as'] ) ) {
@@ -513,8 +513,8 @@ function section_information_to_schema( $section_information, $book_information 
 			$contributing_authors = explode( ', ', $book_information['pb_contributing_authors'] );
 			foreach ( $contributing_authors as $contributor ) {
 				$section_schema['contributor'][] = [
-				 '@type' => 'Person',
-				 'name' => $contributor,
+					'@type' => 'Person',
+					'name' => $contributor,
 				];
 			}
 		}
@@ -523,8 +523,8 @@ function section_information_to_schema( $section_information, $book_information 
 			$editors = explode( ', ', $book_information['pb_editor'] );
 			foreach ( $editors as $editor ) {
 				$section_schema['editor'][] = [
-				 '@type' => 'Person',
-				 'name' => $editor,
+					'@type' => 'Person',
+					'name' => $editor,
 				];
 			}
 		}
@@ -533,29 +533,29 @@ function section_information_to_schema( $section_information, $book_information 
 			$translators = explode( ', ', $book_information['pb_translator'] );
 			foreach ( $translators as $translator ) {
 				$section_schema['translator'][] = [
-				 '@type' => 'Person',
-				 'name' => $translator,
+					'@type' => 'Person',
+					'name' => $translator,
 				];
 			}
 		}
 
 		if ( isset( $book_information['pb_audience'] ) ) {
 			$section_schema['audience'] = [
-			 '@type' => 'Audience',
-			 'name' => $book_information['pb_audience'],
+				'@type' => 'Audience',
+				'name' => $book_information['pb_audience'],
 			];
 		}
 
 		if ( isset( $book_information['pb_publisher'] ) ) {
 			$section_schema['publisher'] = [
-			 '@type' => 'Organization',
-			 'name' => $book_information['pb_publisher'],
+				'@type' => 'Organization',
+				'name' => $book_information['pb_publisher'],
 			];
 
 			if ( isset( $book_information['pb_publisher_city'] ) ) {
 				$section_schema['publisher']['address'] = [
-				 '@type' => 'PostalAddress',
-				 'addressLocality' => $book_information['pb_publisher_city'],
+					'@type' => 'PostalAddress',
+					'addressLocality' => $book_information['pb_publisher_city'],
 				];
 			}
 		}
@@ -569,8 +569,8 @@ function section_information_to_schema( $section_information, $book_information 
 
 		if ( isset( $book_information['pb_copyright_holder'] ) ) { // TODO: Person or Organization?
 			$section_schema['copyrightHolder'] = [
-			 '@type' => 'Organization',
-			 'name' => $book_information['pb_copyright_holder'],
+				'@type' => 'Organization',
+				'name' => $book_information['pb_copyright_holder'],
 			];
 		}
 
@@ -666,7 +666,9 @@ function get_thema_subjects( $include_qualifiers = false ) {
 	foreach ( $values->CodeList->Code as $code ) {
 		if ( ctype_alpha( substr( $code->CodeValue, 0, 1 ) ) || $include_qualifiers && ctype_digit( substr( $code->CodeValue, 0, 1 ) ) ) {
 			if ( strlen( $code->CodeValue ) === 1 ) {
-				$subjects[ $code->CodeValue ] = [ 'label' => $code->CodeDescription ];
+				$subjects[ $code->CodeValue ] = [
+					'label' => $code->CodeDescription,
+				];
 				if ( ctype_alpha( $code->CodeValue ) ) {
 					$subjects[ $code->CodeValue ]['children'][ $code->CodeValue ] = $code->CodeDescription;
 				}

--- a/inc/modules/export/class-export.php
+++ b/inc/modules/export/class-export.php
@@ -211,7 +211,7 @@ abstract class Export {
 			'theme' => '' . wp_get_theme(), // Stringify by appending to empty string
 		];
 
-		$message = print_r( array_merge( $info, $more_info ), true ) . $message;
+		$message = print_r( array_merge( $info, $more_info ), true ) . $message; // @codingStandardsIgnoreLine
 		$exportoptions = get_option( 'pressbooks_export_options' );
 		if ( $current_user->user_email && isset( $exportoptions['email_validation_logs'] ) && 1 === absint( $exportoptions['email_validation_logs'] ) ) {
 			$this->errorsEmail[] = $current_user->user_email;

--- a/inc/modules/export/class-export.php
+++ b/inc/modules/export/class-export.php
@@ -819,7 +819,11 @@ abstract class Export {
 		$filepath = static::getExportFolder() . $filename;
 		if ( ! is_readable( $filepath ) ) {
 			// Cannot read file
-			wp_die( __( 'File not found', 'pressbooks' ) . ": $filename", '', [ 'response' => 404 ] );
+			wp_die(
+				__( 'File not found', 'pressbooks' ) . ": $filename", '', [
+					'response' => 404,
+				]
+			);
 		}
 
 		// Force download

--- a/inc/modules/export/class-export.php
+++ b/inc/modules/export/class-export.php
@@ -520,7 +520,7 @@ abstract class Export {
 		$path_to_htaccess = $path . '.htaccess';
 		if ( ! file_exists( $path_to_htaccess ) ) {
 			// Restrict access
-			file_put_contents( $path_to_htaccess, "deny from all\n" );
+			\Pressbooks\Utility\put_contents( $path_to_htaccess, "deny from all\n" );
 		}
 
 		return $path;
@@ -827,7 +827,8 @@ abstract class Export {
 		}
 
 		// Force download
-		@set_time_limit( 0 ); // @codingStandardsIgnoreLine
+		// @codingStandardsIgnoreStart
+		@set_time_limit( 0 );
 		header( 'Content-Description: File Transfer' );
 		header( 'Content-Type: ' . static::mimeType( $filepath ) );
 		if ( $inline ) {
@@ -840,11 +841,12 @@ abstract class Export {
 		header( 'Cache-Control: must-revalidate, post-check=0, pre-check=0' );
 		header( 'Pragma: public' );
 		header( 'Content-Length: ' . filesize( $filepath ) );
-		@ob_clean(); // @codingStandardsIgnoreLine
+		@ob_clean();
 		flush();
-		while ( @ob_end_flush() ) { // @codingStandardsIgnoreLine
+		while ( @ob_end_flush() ) {
 			// Fix out-of-memory problem
 		}
 		readfile( $filepath );
+		// @codingStandardsIgnoreEnd
 	}
 }

--- a/inc/modules/export/epub/class-epub201.php
+++ b/inc/modules/export/epub/class-epub201.php
@@ -525,7 +525,7 @@ class Epub201 extends Export {
 	 */
 	protected function createContainer() {
 
-		file_put_contents(
+		\Pressbooks\Utility\put_contents(
 			$this->tmpDir . '/mimetype',
 			utf8_decode( 'application/epub+zip' )
 		);
@@ -534,12 +534,12 @@ class Epub201 extends Export {
 		mkdir( $this->tmpDir . '/OEBPS' );
 		mkdir( $this->tmpDir . '/OEBPS/assets' );
 
-		file_put_contents(
+		\Pressbooks\Utility\put_contents(
 			$this->tmpDir . '/META-INF/container.xml',
 			$this->loadTemplate( $this->dir . '/templates/epub201/container.php' )
 		);
 
-		file_put_contents(
+		\Pressbooks\Utility\put_contents(
 			$this->tmpDir . '/META-INF/com.apple.ibooks.display-options.xml',
 			$this->loadTemplate( $this->dir . '/templates/epub201/ibooks.php' )
 		);
@@ -605,7 +605,7 @@ class Epub201 extends Export {
 		$path_to_tmp_stylesheet = $this->tmpDir . "/OEBPS/{$this->stylesheet}";
 
 		// Copy stylesheet
-		file_put_contents(
+		\Pressbooks\Utility\put_contents(
 			$path_to_tmp_stylesheet,
 			$this->loadTemplate( $this->exportStylePath )
 		);
@@ -624,7 +624,7 @@ class Epub201 extends Export {
 
 		$styles = Container::get( 'Styles' );
 
-		$scss = file_get_contents( $path_to_copy_of_stylesheet );
+		$scss = \Pressbooks\Utility\get_contents( $path_to_copy_of_stylesheet );
 
 		if ( $this->extraCss ) {
 			$scss .= "\n" . $this->loadTemplate( $this->extraCss );
@@ -643,7 +643,7 @@ class Epub201 extends Export {
 		$css = $this->normalizeCssUrls( $css, $scss_dir, $path_to_epub_assets );
 
 		// Overwrite the new file with new info
-		file_put_contents( $path_to_copy_of_stylesheet, $css );
+		\Pressbooks\Utility\put_contents( $path_to_copy_of_stylesheet, $css );
 
 		if ( WP_DEBUG ) {
 			Container::get( 'Sass' )->debug( $css, $scss, 'epub' );
@@ -792,7 +792,7 @@ class Epub201 extends Export {
 		$file_id = 'front-cover';
 		$filename = "{$file_id}.{$this->filext}";
 
-		file_put_contents(
+		\Pressbooks\Utility\put_contents(
 			$this->tmpDir . "/OEBPS/$filename",
 			$this->loadTemplate( $this->dir . '/templates/epub201/html.php', $vars )
 		);
@@ -858,7 +858,7 @@ class Epub201 extends Export {
 				$file_id = 'front-matter-' . sprintf( '%03s', $i );
 				$filename = "{$file_id}-{$slug}.{$this->filext}";
 
-				file_put_contents(
+				\Pressbooks\Utility\put_contents(
 					$this->tmpDir . "/OEBPS/$filename",
 					$this->loadTemplate( $this->dir . '/templates/epub201/html.php', $vars )
 				);
@@ -933,7 +933,7 @@ class Epub201 extends Export {
 		$file_id = 'title-page';
 		$filename = "{$file_id}.{$this->filext}";
 
-		file_put_contents(
+		\Pressbooks\Utility\put_contents(
 			$this->tmpDir . "/OEBPS/$filename",
 			$this->loadTemplate( $this->dir . '/templates/epub201/html.php', $vars )
 		);
@@ -1021,7 +1021,7 @@ class Epub201 extends Export {
 		$file_id = 'copyright';
 		$filename = "{$file_id}.{$this->filext}";
 
-		file_put_contents(
+		\Pressbooks\Utility\put_contents(
 			$this->tmpDir . "/OEBPS/$filename",
 			$this->loadTemplate( $this->dir . '/templates/epub201/html.php', $vars )
 		);
@@ -1088,7 +1088,7 @@ class Epub201 extends Export {
 				$file_id = 'front-matter-' . sprintf( '%03s', $i );
 				$filename = "{$file_id}-{$slug}.{$this->filext}";
 
-				file_put_contents(
+				\Pressbooks\Utility\put_contents(
 					$this->tmpDir . "/OEBPS/$filename",
 					$this->loadTemplate( $this->dir . '/templates/epub201/html.php', $vars )
 				);
@@ -1196,7 +1196,7 @@ class Epub201 extends Export {
 			$file_id = 'front-matter-' . sprintf( '%03s', $i );
 			$filename = "{$file_id}-{$slug}.{$this->filext}";
 
-			file_put_contents(
+			\Pressbooks\Utility\put_contents(
 				$this->tmpDir . "/OEBPS/$filename",
 				$this->loadTemplate( $this->dir . '/templates/epub201/html.php', $vars )
 			);
@@ -1234,7 +1234,7 @@ class Epub201 extends Export {
 				'lang' => $this->lang,
 			];
 
-			file_put_contents(
+			\Pressbooks\Utility\put_contents(
 				$this->tmpDir . "/OEBPS/$filename",
 				$this->loadTemplate( $this->dir . '/templates/epub201/html.php', $vars )
 			);
@@ -1273,7 +1273,10 @@ class Epub201 extends Export {
 		];
 
 		// Parts, Chapters
-		$i = $j = $c = $p = 1;
+		$i = 1;
+		$j = 1;
+		$c = 1;
+		$p = 1;
 		foreach ( $book_contents['part'] as $part ) {
 
 			$invisibility = ( get_post_meta( $part['ID'], 'pb_part_invisible', true ) === 'on' ) ? 'invisible' : '';
@@ -1359,7 +1362,7 @@ class Epub201 extends Export {
 				$file_id = 'chapter-' . sprintf( '%03s', $j );
 				$filename = "{$file_id}-{$slug}.{$this->filext}";
 
-				file_put_contents(
+				\Pressbooks\Utility\put_contents(
 					$this->tmpDir . "/OEBPS/$filename",
 					$this->loadTemplate( $this->dir . '/templates/epub201/html.php', $vars )
 				);
@@ -1395,7 +1398,7 @@ class Epub201 extends Export {
 				$file_id = 'part-' . sprintf( '%03s', $i );
 				$filename = "{$file_id}-{$slug}.{$this->filext}";
 
-				file_put_contents(
+				\Pressbooks\Utility\put_contents(
 					$this->tmpDir . "/OEBPS/$filename",
 					$this->loadTemplate( $this->dir . '/templates/epub201/html.php', $vars )
 				);
@@ -1430,7 +1433,7 @@ class Epub201 extends Export {
 					$file_id = 'part-' . sprintf( '%03s', $i );
 					$filename = "{$file_id}-{$slug}.{$this->filext}";
 
-					file_put_contents(
+					\Pressbooks\Utility\put_contents(
 						$this->tmpDir . "/OEBPS/$filename",
 						$this->loadTemplate( $this->dir . '/templates/epub201/html.php', $vars )
 					);
@@ -1465,7 +1468,7 @@ class Epub201 extends Export {
 						$file_id = 'part-' . sprintf( '%03s', $i );
 						$filename = "{$file_id}-{$slug}.{$this->filext}";
 
-						file_put_contents(
+						\Pressbooks\Utility\put_contents(
 							$this->tmpDir . "/OEBPS/$filename",
 							$this->loadTemplate( $this->dir . '/templates/epub201/html.php', $vars )
 						);
@@ -1572,7 +1575,7 @@ class Epub201 extends Export {
 			$file_id = 'back-matter-' . sprintf( '%03s', $i );
 			$filename = "{$file_id}-{$slug}.{$this->filext}";
 
-			file_put_contents(
+			\Pressbooks\Utility\put_contents(
 				$this->tmpDir . "/OEBPS/$filename",
 				$this->loadTemplate( $this->dir . '/templates/epub201/html.php', $vars )
 			);
@@ -1711,7 +1714,7 @@ class Epub201 extends Export {
 
 		$vars['post_content'] = $html;
 
-		file_put_contents(
+		\Pressbooks\Utility\put_contents(
 			$this->tmpDir . "/OEBPS/$filename",
 			$this->loadTemplate( $this->dir . '/templates/epub201/html.php', $vars )
 		);
@@ -1779,7 +1782,7 @@ class Epub201 extends Export {
 
 		// Make sure empty tags (e.g. <b></b>) don't get turned into self-closing versions by adding an empty text node to them.
 		$xpath = new \DOMXPath( $dom );
-		while ( ( $nodes = $xpath->query( '//*[not(text() or node() or self::br or self::hr or self::img)]' ) ) && $nodes->length > 0 ) {
+		while ( ( $nodes = $xpath->query( '//*[not(text() or node() or self::br or self::hr or self::img)]' ) ) && $nodes->length > 0 ) { // @codingStandardsIgnoreLine
 			foreach ( $nodes as $node ) {
 				/** @var \DOMElement $node */
 				$node->appendChild( new \DOMText( '' ) );
@@ -1892,7 +1895,7 @@ class Epub201 extends Export {
 		$filename = explode( '?', basename( $url ) );
 
 		// isolate latex image service from WP, add file extension
-		$host = parse_url( $url, PHP_URL_HOST );
+		$host = wp_parse_url( $url, PHP_URL_HOST );
 		if ( ( str_ends_with( $host, 'wordpress.com' ) || str_ends_with( $host, 'wp.com' ) ) && 'latex.php' === $filename[0] ) {
 			$filename = md5( array_pop( $filename ) );
 			// content-type = 'image/png'
@@ -1907,7 +1910,7 @@ class Epub201 extends Export {
 		}
 
 		$tmp_file = \Pressbooks\Utility\create_tmp_file();
-		file_put_contents( $tmp_file, wp_remote_retrieve_body( $response ) );
+		\Pressbooks\Utility\put_contents( $tmp_file, wp_remote_retrieve_body( $response ) );
 
 		if ( ! \Pressbooks\Image\is_valid_image( $tmp_file, $filename ) ) {
 			$this->fetchedImageCache[ $url ] = '';
@@ -1924,7 +1927,7 @@ class Epub201 extends Export {
 		// Check for duplicates, save accordingly
 		if ( ! file_exists( "$fullpath/$filename" ) ) {
 			copy( $tmp_file, "$fullpath/$filename" );
-		} elseif ( md5( file_get_contents( $tmp_file ) ) !== md5( file_get_contents( "$fullpath/$filename" ) ) ) {
+		} elseif ( md5( \Pressbooks\Utility\get_contents( $tmp_file ) ) !== md5( \Pressbooks\Utility\get_contents( "$fullpath/$filename" ) ) ) {
 			$filename = wp_unique_filename( $fullpath, $filename );
 			copy( $tmp_file, "$fullpath/$filename" );
 		}
@@ -1970,7 +1973,7 @@ class Epub201 extends Export {
 		$filename = Sanitize\force_ascii( $filename );
 
 		$tmp_file = \Pressbooks\Utility\create_tmp_file();
-		file_put_contents( $tmp_file, wp_remote_retrieve_body( $response ) );
+		\Pressbooks\Utility\put_contents( $tmp_file, wp_remote_retrieve_body( $response ) );
 
 		// TODO: Validate that this is actually a font
 		// TODO: Refactor fetchAndSaveUniqueImage() and fetchAndSaveUniqueFont() into a single method, but "inject" different validation
@@ -1978,7 +1981,7 @@ class Epub201 extends Export {
 		// Check for duplicates, save accordingly
 		if ( ! file_exists( "$fullpath/$filename" ) ) {
 			copy( $tmp_file, "$fullpath/$filename" );
-		} elseif ( md5( file_get_contents( $tmp_file ) ) !== md5( file_get_contents( "$fullpath/$filename" ) ) ) {
+		} elseif ( md5( \Pressbooks\Utility\get_contents( $tmp_file ) ) !== md5( \Pressbooks\Utility\get_contents( "$fullpath/$filename" ) ) ) {
 			$filename = wp_unique_filename( $fullpath, $filename );
 			copy( $tmp_file, "$fullpath/$filename" );
 		}
@@ -2120,11 +2123,11 @@ class Epub201 extends Export {
 		$url = trim( $url );
 		$url = rtrim( $url, '/' );
 
-		$domain = parse_url( $url );
+		$domain = wp_parse_url( $url );
 		$domain = ( isset( $domain['host'] ) ) ? $domain['host'] : false;
 
 		if ( $domain ) {
-			$domain2 = parse_url( wp_guess_url() );
+			$domain2 = wp_parse_url( wp_guess_url() );
 			$domain2 = ( isset( $domain2['host'] ) ) ? $domain2['host'] : false;
 			if ( $domain2 !== $domain ) {
 				return false; // If there is a domain name and it =/= ours, bail.
@@ -2222,7 +2225,7 @@ class Epub201 extends Export {
 		$vars['meta'] = $metadata;
 
 		// Put contents
-		file_put_contents(
+		\Pressbooks\Utility\put_contents(
 			$this->tmpDir . '/book.opf',
 			$this->loadTemplate( $this->dir . '/templates/epub201/opf.php', $vars )
 		);
@@ -2295,7 +2298,7 @@ class Epub201 extends Export {
 			'lang' => $this->lang,
 		];
 
-		file_put_contents(
+		\Pressbooks\Utility\put_contents(
 			$this->tmpDir . '/toc.ncx',
 			$this->loadTemplate( $this->dir . '/templates/epub201/ncx.php', $vars )
 		);

--- a/inc/modules/export/epub/class-epub201.php
+++ b/inc/modules/export/epub/class-epub201.php
@@ -15,6 +15,7 @@ use Pressbooks\Container;
 use Pressbooks\Sanitize;
 use function \Pressbooks\Sanitize\sanitize_xml_attribute;
 use function \Pressbooks\Utility\str_ends_with;
+use function \Pressbooks\Utility\debug_error_log;
 
 class Epub201 extends Export {
 
@@ -1885,8 +1886,7 @@ class Epub201 extends Export {
 				}
 			} catch ( \Exception $exc ) {
 				$this->fetchedImageCache[ $url ] = '';
-				error_log( '\PressBooks\Export\Epub201\fetchAndSaveUniqueImage wp_error on wp_remote_get() - ' . $response->get_error_message() . ' - ' . $exc->getMessage() );
-
+				debug_error_log( '\PressBooks\Export\Epub201\fetchAndSaveUniqueImage wp_error on wp_remote_get() - ' . $response->get_error_message() . ' - ' . $exc->getMessage() );
 				return '';
 			}
 		}
@@ -1914,7 +1914,7 @@ class Epub201 extends Export {
 
 		if ( ! \Pressbooks\Image\is_valid_image( $tmp_file, $filename ) ) {
 			$this->fetchedImageCache[ $url ] = '';
-			error_log( '\PressBooks\Export\Epub201\fetchAndSaveUniqueImage is_valid_image, not a valid image ' );
+			debug_error_log( '\PressBooks\Export\Epub201\fetchAndSaveUniqueImage is_valid_image, not a valid image ' );
 			return ''; // Not an image
 		}
 

--- a/inc/modules/export/epub/class-epub201.php
+++ b/inc/modules/export/epub/class-epub201.php
@@ -1402,12 +1402,12 @@ class Epub201 extends Export {
 
 				// Insert into correct pos
 				$this->manifest = array_slice( $this->manifest, 0, $array_pos, true ) + [
-						$file_id => [
-							'ID' => $part['ID'],
-							'post_title' => $part['post_title'],
-							'filename' => $filename,
-						],
-					] + array_slice( $this->manifest, $array_pos, count( $this->manifest ) - 1, true );
+					$file_id => [
+						'ID' => $part['ID'],
+						'post_title' => $part['post_title'],
+						'filename' => $filename,
+					],
+				] + array_slice( $this->manifest, $array_pos, count( $this->manifest ) - 1, true );
 
 				++$i;
 				if ( 'invisible' !== $invisibility ) {
@@ -1437,12 +1437,12 @@ class Epub201 extends Export {
 
 					// Insert into correct pos
 					$this->manifest = array_slice( $this->manifest, 0, $array_pos, true ) + [
-							$file_id => [
-								'ID' => $part['ID'],
-								'post_title' => $part['post_title'],
-								'filename' => $filename,
-							],
-						] + array_slice( $this->manifest, $array_pos, count( $this->manifest ) - 1, true );
+						$file_id => [
+							'ID' => $part['ID'],
+							'post_title' => $part['post_title'],
+							'filename' => $filename,
+						],
+					] + array_slice( $this->manifest, $array_pos, count( $this->manifest ) - 1, true );
 
 					++$i;
 					if ( 'invisible' !== $invisibility ) {
@@ -1472,12 +1472,12 @@ class Epub201 extends Export {
 
 						// Insert into correct pos
 						$this->manifest = array_slice( $this->manifest, 0, $array_pos, true ) + [
-								$file_id => [
-									'ID' => $part['ID'],
-									'post_title' => $part['post_title'],
-									'filename' => $filename,
-								],
-							] + array_slice( $this->manifest, $array_pos, count( $this->manifest ) - 1, true );
+							$file_id => [
+								'ID' => $part['ID'],
+								'post_title' => $part['post_title'],
+								'filename' => $filename,
+							],
+						] + array_slice( $this->manifest, $array_pos, count( $this->manifest ) - 1, true );
 
 						++$i;
 						if ( 'invisible' !== $invisibility ) {
@@ -1613,12 +1613,12 @@ class Epub201 extends Export {
 		$vars['post_title'] = __( 'Table Of Contents', 'pressbooks' );
 
 		$this->manifest = array_slice( $this->manifest, 0, $array_pos + 1, true ) + [
-				$file_id => [
-					'ID' => -1,
-					'post_title' => $vars['post_title'],
-					'filename' => $filename,
-				],
-			] + array_slice( $this->manifest, $array_pos + 1, count( $this->manifest ) - 1, true );
+			$file_id => [
+				'ID' => -1,
+				'post_title' => $vars['post_title'],
+				'filename' => $filename,
+			],
+		] + array_slice( $this->manifest, $array_pos + 1, count( $this->manifest ) - 1, true );
 
 		// HTML
 
@@ -1761,7 +1761,11 @@ class Epub201 extends Export {
 	 */
 	protected function kneadHtml( $html, $type, $pos = 0 ) {
 
-		$doc = new HTML5( [ 'disable_html_ns' => true ] ); // Disable default namespace for \DOMXPath compatibility
+		$doc = new HTML5(
+			[
+				'disable_html_ns' => true,
+			]
+		); // Disable default namespace for \DOMXPath compatibility
 		$dom = $doc->loadHTML( $html );
 
 		// Download images, change to relative paths
@@ -1849,7 +1853,11 @@ class Epub201 extends Export {
 			return $this->fetchedImageCache[ $url ];
 		}
 
-		$response = \Pressbooks\Utility\remote_get_retry( $url, [ 'timeout' => $this->timeout ] );
+		$response = \Pressbooks\Utility\remote_get_retry(
+			$url, [
+				'timeout' => $this->timeout,
+			]
+		);
 
 		// WordPress error?
 		if ( is_wp_error( $response ) ) {
@@ -1864,7 +1872,11 @@ class Epub201 extends Export {
 						$url = 'http:' . $url;
 					}
 				}
-				$response = wp_remote_get( $url, [ 'timeout' => $this->timeout ] );
+				$response = wp_remote_get(
+					$url, [
+						'timeout' => $this->timeout,
+					]
+				);
 				if ( is_wp_error( $response ) ) {
 					throw new \Exception( 'Bad URL: ' . $url );
 				}
@@ -1874,7 +1886,6 @@ class Epub201 extends Export {
 
 				return '';
 			}
-
 		}
 
 		// Basename without query string
@@ -1938,7 +1949,11 @@ class Epub201 extends Export {
 			return $this->fetchedFontCache[ $url ];
 		}
 
-		$response = wp_remote_get( $url, [ 'timeout' => $this->timeout ] );
+		$response = wp_remote_get(
+			$url, [
+				'timeout' => $this->timeout,
+			]
+		);
 
 		// WordPress error?
 		if ( is_wp_error( $response ) ) {

--- a/inc/modules/export/epub/class-epub3.php
+++ b/inc/modules/export/epub/class-epub3.php
@@ -324,7 +324,11 @@ class Epub3 extends Epub201 {
 			return $this->fetchedMediaCache[ $url ];
 		}
 
-		$response = wp_remote_get( $url, [ 'timeout' => $this->timeout ] );
+		$response = wp_remote_get(
+			$url, [
+				'timeout' => $this->timeout,
+			]
+		);
 
 		// WordPress error?
 		if ( is_wp_error( $response ) ) {
@@ -339,7 +343,11 @@ class Epub3 extends Epub201 {
 						$url = 'http:' . $url;
 					}
 				}
-				$response = wp_remote_get( $url, [ 'timeout' => $this->timeout ] );
+				$response = wp_remote_get(
+					$url, [
+						'timeout' => $this->timeout,
+					]
+				);
 				if ( is_wp_error( $response ) ) {
 					throw new \Exception( 'Bad URL: ' . $url );
 				}

--- a/inc/modules/export/epub/class-epub3.php
+++ b/inc/modules/export/epub/class-epub3.php
@@ -9,6 +9,7 @@ namespace Pressbooks\Modules\Export\Epub;
 
 use Pressbooks\Sanitize;
 use function \Pressbooks\Sanitize\sanitize_xml_attribute;
+use function \Pressbooks\Utility\debug_error_log;
 
 class Epub3 extends Epub201 {
 
@@ -236,7 +237,7 @@ class Epub3 extends Epub201 {
 				}
 			}
 		} catch ( \Exception $e ) {
-			error_log( $e );
+			debug_error_log( $e );
 		}
 
 		return false;
@@ -353,8 +354,7 @@ class Epub3 extends Epub201 {
 				}
 			} catch ( \Exception $exc ) {
 				$this->fetchedImageCache[ $url ] = '';
-				error_log( '\PressBooks\Export\Epub3\fetchAndSaveUniqueMedia wp_error on wp_remote_get() - ' . $response->get_error_message() . ' - ' . $exc->getMessage() );
-
+				debug_error_log( '\PressBooks\Export\Epub3\fetchAndSaveUniqueMedia wp_error on wp_remote_get() - ' . $response->get_error_message() . ' - ' . $exc->getMessage() );
 				return '';
 			}
 		}

--- a/inc/modules/export/epub/class-epub3.php
+++ b/inc/modules/export/epub/class-epub3.php
@@ -173,7 +173,7 @@ class Epub3 extends Epub201 {
 	 */
 	protected function getProperties( $html_file ) {
 
-		$html = file_get_contents( $html_file );
+		$html = \Pressbooks\Utility\get_contents( $html_file );
 		$properties = [];
 
 		if ( empty( $html ) ) {
@@ -367,7 +367,7 @@ class Epub3 extends Epub201 {
 		$filename = Sanitize\force_ascii( $filename );
 
 		$tmp_file = \Pressbooks\Utility\create_tmp_file();
-		file_put_contents( $tmp_file, wp_remote_retrieve_body( $response ) );
+		\Pressbooks\Utility\put_contents( $tmp_file, wp_remote_retrieve_body( $response ) );
 
 		if ( ! \Pressbooks\Media\is_valid_media( $tmp_file, $filename ) ) {
 			$this->fetchedMediaCache[ $url ] = '';
@@ -377,7 +377,7 @@ class Epub3 extends Epub201 {
 		// Check for duplicates, save accordingly
 		if ( ! file_exists( "$fullpath/$filename" ) ) {
 			copy( $tmp_file, "$fullpath/$filename" );
-		} elseif ( md5( file_get_contents( $tmp_file ) ) !== md5( file_get_contents( "$fullpath/$filename" ) ) ) {
+		} elseif ( md5( \Pressbooks\Utility\get_contents( $tmp_file ) ) !== md5( \Pressbooks\Utility\get_contents( "$fullpath/$filename" ) ) ) {
 			$filename = wp_unique_filename( $fullpath, $filename );
 			copy( $tmp_file, "$fullpath/$filename" );
 		}
@@ -468,7 +468,7 @@ class Epub3 extends Epub201 {
 		$vars['meta'] = $metadata;
 
 		// Put contents
-		file_put_contents(
+		\Pressbooks\Utility\put_contents(
 			$this->tmpDir . '/book.opf',
 			$this->loadTemplate( $this->dir . '/templates/epub3/opf.php', $vars )
 		);
@@ -497,13 +497,13 @@ class Epub3 extends Epub201 {
 			'lang' => $this->lang,
 		];
 
-		file_put_contents(
+		\Pressbooks\Utility\put_contents(
 			$this->tmpDir . '/toc.xhtml',
 			$this->loadTemplate( $this->dir . '/templates/epub3/toc.php', $vars )
 		);
 
 		// For backwards compatibility
-		file_put_contents(
+		\Pressbooks\Utility\put_contents(
 			$this->tmpDir . '/toc.ncx',
 			$this->loadTemplate( $this->dir . '/templates/epub201/ncx.php', $vars )
 		);

--- a/inc/modules/export/epub/templates/epub201/html.php
+++ b/inc/modules/export/epub/templates/epub201/html.php
@@ -16,7 +16,10 @@ echo '<?xml version="1.0" encoding="UTF-8" ?>' . "\n";
 	<meta name="EPB-UUID" content="<?php echo $isbn; ?>" />
 
 	<?php
-	if ( ! empty( $stylesheet ) ) :  ?><link rel="stylesheet" href="<?php echo $stylesheet; ?>" type="text/css" /><?php endif; ?>
+	if ( ! empty( $stylesheet ) ) :
+
+	?>
+	<link rel="stylesheet" href="<?php echo $stylesheet; ?>" type="text/css" /><?php endif; ?>
 
 </head>
 <body>

--- a/inc/modules/export/epub/templates/epub201/ncx.php
+++ b/inc/modules/export/epub/templates/epub201/ncx.php
@@ -29,7 +29,7 @@ if ( $enable_external_identifier ) {
 		<text><?php bloginfo( 'name' ); ?></text>
 	</docTitle>
 
-	<?php if ( ! empty( $author ) ) :  ?>
+	<?php if ( ! empty( $author ) ) : ?>
 	<docAuthor>
 		<text><?php echo $author; ?></text>
 	</docAuthor>
@@ -50,14 +50,17 @@ if ( $enable_external_identifier ) {
 			if ( get_post_meta( $v['ID'], 'pb_part_invisible', true ) !== 'on' ) {
 
 				$text = strip_tags( \Pressbooks\Sanitize\decode( $v['post_title'] ) );
-				if ( ! $text ) { $text = ' ';
+				if ( ! $text ) {
+					$text = ' ';
 				}
 
-				printf( '
+				printf(
+					'
 					<navPoint id="%s" playOrder="%s">
 					<navLabel><text>%s</text></navLabel>
 					<content src="OEBPS/%s" />
-					', $k, $i, $text, $v['filename'] );
+					', $k, $i, $text, $v['filename']
+				);
 
 				if ( preg_match( '/^part-/', $k ) ) {
 					$part_open = true;

--- a/inc/modules/export/epub/templates/epub201/opf.php
+++ b/inc/modules/export/epub/templates/epub201/opf.php
@@ -50,7 +50,7 @@ echo '<?xml version="1.0" encoding="UTF-8" ?>' . "\n";
 			echo ' opf:file-as="' . $meta['pb_author_file_as'] . '"';
 		} else {
 			$nameparser = new Parser();
-			try	{
+			try {
 				$author = $nameparser->parse( $meta['pb_author'] );
 				$author_file_as = $author->getLastName() . ', ' . $author->getFirstName();
 			} catch ( NameParsingException $e ) {
@@ -101,17 +101,17 @@ echo '<?xml version="1.0" encoding="UTF-8" ?>' . "\n";
 		foreach ( $meta as $key => $val ) {
 			switch ( $key ) {
 
-				case 'pb_publisher' :
+				case 'pb_publisher':
 					echo "<dc:publisher>$val</dc:publisher>\n";
 					break;
 
-				case 'pb_publication_date' :
+				case 'pb_publication_date':
 					echo '<dc:date opf:event="publication">';
 					echo date( 'Y-m-d', (int) $val );
 					echo "</dc:date>\n";
 					break;
 
-				case 'pb_bisac_subject' :
+				case 'pb_bisac_subject':
 					$subjects = explode( ',', $val );
 					foreach ( $subjects as $subject ) {
 						echo '<dc:subject>' . trim( $subject ) . "</dc:subject>\n";
@@ -139,7 +139,10 @@ echo '<?xml version="1.0" encoding="UTF-8" ?>' . "\n";
 		echo $manifest_assets;
 		?>
 		<item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml" />
-		<?php if ( ! empty( $stylesheet ) ) :  ?><item id="stylesheet" href="OEBPS/<?php echo $stylesheet; ?>"  media-type="text/css" /><?php endif; ?>
+		<?php
+		if ( ! empty( $stylesheet ) ) :
+?>
+<item id="stylesheet" href="OEBPS/<?php echo $stylesheet; ?>"  media-type="text/css" /><?php endif; ?>
 	</manifest>
 
 

--- a/inc/modules/export/epub/templates/epub3/html.php
+++ b/inc/modules/export/epub/templates/epub3/html.php
@@ -15,7 +15,10 @@ echo '<?xml version="1.0" encoding="UTF-8" ?>' . "\n";
 	<meta name="EPB-UUID" content="<?php echo $isbn; ?>" />
 
 	<?php
-	if ( ! empty( $stylesheet ) ) :  ?><link rel="stylesheet" href="<?php echo $stylesheet; ?>" type="text/css" /><?php endif; ?>
+	if ( ! empty( $stylesheet ) ) :
+
+	?>
+	<link rel="stylesheet" href="<?php echo $stylesheet; ?>" type="text/css" /><?php endif; ?>
 
 </head>
 <body>

--- a/inc/modules/export/epub/templates/epub3/opf.php
+++ b/inc/modules/export/epub/templates/epub3/opf.php
@@ -73,7 +73,7 @@ echo '<?xml version="1.0" encoding="UTF-8" ?>' . "\n";
 			echo $meta['pb_author_file_as'];
 		} elseif ( ! empty( $meta['pb_author'] ) ) {
 			$nameparser = new Parser();
-			try	{
+			try {
 				$author = $nameparser->parse( $meta['pb_author'] );
 				echo $author->getLastName() . ', ' . $author->getFirstName();
 			} catch ( NameParsingException $e ) {
@@ -111,17 +111,17 @@ echo '<?xml version="1.0" encoding="UTF-8" ?>' . "\n";
 		foreach ( $meta as $key => $val ) {
 			switch ( $key ) {
 
-				case 'pb_publisher' :
+				case 'pb_publisher':
 					echo "<dc:publisher>$val</dc:publisher>\n";
 					break;
 
-				case 'pb_publication_date' :
+				case 'pb_publication_date':
 					echo '<dc:date>';
 					echo date( 'Y-m-d', (int) $val );
 					echo "</dc:date>\n";
 					break;
 
-				case 'pb_bisac_subject' :
+				case 'pb_bisac_subject':
 					$subjects = explode( ',', $val );
 					foreach ( $subjects as $subject ) {
 						echo '<dc:subject>' . trim( $subject ) . "</dc:subject>\n";
@@ -147,7 +147,7 @@ echo '<?xml version="1.0" encoding="UTF-8" ?>' . "\n";
 		?>
 		<item id="toc" properties="nav" href="toc.xhtml" media-type="application/xhtml+xml"/>
 		<item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml" />
-		<?php if ( ! empty( $stylesheet ) ) :  ?>
+		<?php if ( ! empty( $stylesheet ) ) : ?>
 		<item id="stylesheet" href="OEBPS/<?php echo $stylesheet; ?>"  media-type="text/css" />
 		<?php endif; ?>
 	</manifest>

--- a/inc/modules/export/epub/templates/epub3/toc.php
+++ b/inc/modules/export/epub/templates/epub3/toc.php
@@ -15,7 +15,10 @@ echo '<?xml version="1.0" encoding="UTF-8" ?>' . "\n";
 		<meta http-equiv="default-style" content="text/html; charset=utf-8"/>
 		<title><?php bloginfo( 'name' ); ?> </title>
 		<?php
-		if ( ! empty( $stylesheet ) ) :  ?><link rel="stylesheet" href="<?php echo $stylesheet; ?>" type="text/css" /><?php endif; ?>
+		if ( ! empty( $stylesheet ) ) :
+
+		?>
+		<link rel="stylesheet" href="<?php echo $stylesheet; ?>" type="text/css" /><?php endif; ?>
 	</head>
 
 	<body>
@@ -34,7 +37,8 @@ echo '<?xml version="1.0" encoding="UTF-8" ?>' . "\n";
 
 					if ( get_post_meta( $v['ID'], 'pb_part_invisible', true ) !== 'on' ) {
 						$text = strip_tags( \Pressbooks\Sanitize\decode( $v['post_title'] ) );
-						if ( ! $text ) { $text = ' ';
+						if ( ! $text ) {
+							$text = ' ';
 						}
 
 						if ( preg_match( '/^part-/', $k ) ) {

--- a/inc/modules/export/indesign/class-icml.php
+++ b/inc/modules/export/indesign/class-icml.php
@@ -47,7 +47,7 @@ class Icml extends Export {
 		// Save ICML as file in exports folder
 
 		$filename = $this->timestampedFileName( '.icml' );
-		file_put_contents( $filename, $content );
+		\Pressbooks\Utility\put_contents( $filename, $content );
 		$this->outputPath = $filename;
 
 		if ( ! filesize( $this->outputPath ) ) {
@@ -110,7 +110,7 @@ class Icml extends Export {
 		$message .= 'Analysis of $book_html follows: ' . "\n\n";
 
 		$book_html_path = $this->createTmpFile();
-		file_put_contents( $book_html_path, $book_html );
+		\Pressbooks\Utility\put_contents( $book_html_path, $book_html );
 
 		// Xmllint params
 		$command = PB_XMLLINT_COMMAND . ' --html --valid --noout ' . escapeshellcmd( $book_html_path ) . ' 2>&1';

--- a/inc/modules/export/indesign/templates/xhtml.php
+++ b/inc/modules/export/indesign/templates/xhtml.php
@@ -23,11 +23,11 @@ echo '<?xml version="1.0" encoding="utf-8" ?>' . "\n";
 <h1><?php bloginfo( 'name' ); ?></h1>
 
 <h2>by</h2>
-<?php if ( isset( $meta['pb_author'] ) ) {  ?>
+<?php if ( isset( $meta['pb_author'] ) ) { ?>
 	<h2><?php echo $meta['pb_author']; ?></h2>
 <?php } ?>
 
-<?php if ( isset( $meta['pb_contributing_authors'] ) ) {  ?>
+<?php if ( isset( $meta['pb_contributing_authors'] ) ) { ?>
 	<h3><?php echo $meta['pb_contributing_authors']; ?></h3>
 <?php } ?>
 
@@ -44,7 +44,7 @@ echo '<?xml version="1.0" encoding="utf-8" ?>' . "\n";
 		<p class="publisher"><strong>Publisher</strong>: <?php echo $meta['pb_publisher']; ?></p>
 	<?php } ?>
 
-	<?php if ( isset( $meta['pb_copyright_year'] ) || isset( $meta['pb_copyright_holder'] )  ) { ?>
+	<?php if ( isset( $meta['pb_copyright_year'] ) || isset( $meta['pb_copyright_holder'] ) ) { ?>
 		<p class="copyright_notice"><strong>Copyright</strong>:
 			<?php
 			if ( ! empty( $meta['pb_copyright_year'] ) ) {

--- a/inc/modules/export/odt/class-odt.php
+++ b/inc/modules/export/odt/class-odt.php
@@ -95,9 +95,9 @@ class Odt extends Export {
 		$source = $content_path['dirname'] . '/source.xhtml';
 
 		if ( defined( 'WP_TESTS_MULTISITE' ) ) {
-			file_put_contents( $source, file_get_contents( $this->url ) );
+			\Pressbooks\Utility\put_contents( $source, \Pressbooks\Utility\get_contents( $this->url ) );
 		} else {
-			file_put_contents( $source, $this->queryXhtml() );
+			\Pressbooks\Utility\put_contents( $source, $this->queryXhtml() );
 		}
 
 		$xslt = PB_PLUGIN_DIR . 'inc/modules/export/odt/xhtml2odt.xsl';
@@ -113,7 +113,7 @@ class Odt extends Export {
 			$this->deleteDirectory( $mediafolder );
 		}
 
-		$urlcontent = file_get_contents( $source );
+		$urlcontent = \Pressbooks\Utility\get_contents( $source );
 		$urlcontent = preg_replace( '/xmlns\="http\:\/\/www\.w3\.org\/1999\/xhtml"/i', '', $urlcontent );
 
 		if ( empty( $urlcontent ) ) {
@@ -177,7 +177,7 @@ class Odt extends Export {
 			}
 		}
 
-		file_put_contents( $source, $doc->saveXML() );
+		\Pressbooks\Utility\put_contents( $source, $doc->saveXML() );
 
 		$errors = libxml_get_errors(); // TODO: Handle errors gracefully
 		libxml_clear_errors();
@@ -298,7 +298,7 @@ class Odt extends Export {
 		// Is this an ODT?
 		if ( ! $this->isOdt( $this->outputPath ) ) {
 
-			$this->logError( file_get_contents( $this->logfile ) );
+			$this->logError( \Pressbooks\Utility\get_contents( $this->logfile ) );
 
 			return false;
 		}
@@ -371,7 +371,7 @@ class Odt extends Export {
 		$filename = explode( '?', basename( $url ) );
 
 		// isolate latex image service from WP, add file extension
-		$host = parse_url( $url, PHP_URL_HOST );
+		$host = wp_parse_url( $url, PHP_URL_HOST );
 		if ( ( str_ends_with( $host, 'wordpress.com' ) || str_ends_with( $host, 'wp.com' ) ) && 'latex.php' === $filename[0] ) {
 			$filename = md5( array_pop( $filename ) );
 			// content-type = 'image/png'
@@ -386,7 +386,7 @@ class Odt extends Export {
 		}
 
 		$tmp_file = \Pressbooks\Utility\create_tmp_file();
-		file_put_contents( $tmp_file, wp_remote_retrieve_body( $response ) );
+		\Pressbooks\Utility\put_contents( $tmp_file, wp_remote_retrieve_body( $response ) );
 
 		if ( ! \Pressbooks\Image\is_valid_image( $tmp_file, $filename ) ) {
 			$already_done[ $url ] = '';
@@ -402,7 +402,7 @@ class Odt extends Export {
 		// Check for duplicates, save accordingly
 		if ( ! file_exists( "$fullpath/$filename" ) ) {
 			copy( $tmp_file, "$fullpath/$filename" );
-		} elseif ( md5( file_get_contents( $tmp_file ) ) !== md5( file_get_contents( "$fullpath/$filename" ) ) ) {
+		} elseif ( md5( \Pressbooks\Utility\get_contents( $tmp_file ) ) !== md5( \Pressbooks\Utility\get_contents( "$fullpath/$filename" ) ) ) {
 			$filename = wp_unique_filename( $fullpath, $filename );
 			copy( $tmp_file, "$fullpath/$filename" );
 		}

--- a/inc/modules/export/odt/class-odt.php
+++ b/inc/modules/export/odt/class-odt.php
@@ -64,7 +64,11 @@ class Odt extends Export {
 		$md5 = $this->nonce( $timestamp );
 		$this->url = home_url() . "/format/xhtml?timestamp={$timestamp}&hashkey={$md5}";
 		if ( ! empty( $_REQUEST['preview'] ) ) {
-			$this->url .= '&' . http_build_query( [ 'preview' => $_REQUEST['preview'] ] );
+			$this->url .= '&' . http_build_query(
+				[
+					'preview' => $_REQUEST['preview'],
+				]
+			);
 		}
 
 	}
@@ -259,7 +263,9 @@ class Odt extends Export {
 	 */
 	protected function queryXhtml() {
 
-		$args = [ 'timeout' => $this->timeout ];
+		$args = [
+			'timeout' => $this->timeout,
+		];
 		if ( defined( 'WP_ENV' ) && WP_ENV === 'development' ) {
 			$args['sslverify'] = false;
 		}
@@ -348,7 +354,11 @@ class Odt extends Export {
 			return $already_done[ $url ];
 		}
 
-		$response = wp_remote_get( $url, [ 'timeout' => $this->timeout ] );
+		$response = wp_remote_get(
+			$url, [
+				'timeout' => $this->timeout,
+			]
+		);
 
 		// WordPress error?
 		if ( is_wp_error( $response ) ) {

--- a/inc/modules/export/prince/class-pdf.php
+++ b/inc/modules/export/prince/class-pdf.php
@@ -119,7 +119,7 @@ class Pdf extends Export {
 		// CSS File
 		$css = $this->kneadCss();
 		$css_file = $this->createTmpFile();
-		file_put_contents( $css_file, $css );
+		\Pressbooks\Utility\put_contents( $css_file, $css );
 
 		// --------------------------------------------------------------------
 		// Save PDF as file in exports folder
@@ -145,7 +145,7 @@ class Pdf extends Export {
 		// Prince XML is very flexible. There could be errors but Prince will still render a PDF.
 		// We want to log those errors but we won't alert the user.
 		if ( count( $msg ) ) {
-			$this->logError( file_get_contents( $this->logfile ) );
+			$this->logError( \Pressbooks\Utility\get_contents( $this->logfile ) );
 		}
 
 		return $retval;
@@ -159,7 +159,7 @@ class Pdf extends Export {
 	function validate() {
 		// Is this a PDF?
 		if ( ! $this->isPdf( $this->outputPath ) ) {
-			$this->logError( file_get_contents( $this->logfile ) );
+			$this->logError( \Pressbooks\Utility\get_contents( $this->logfile ) );
 			return false;
 		}
 		return true;
@@ -231,7 +231,7 @@ class Pdf extends Export {
 
 		$styles = Container::get( 'Styles' );
 
-		$scss = file_get_contents( $this->exportStylePath );
+		$scss = \Pressbooks\Utility\get_contents( $this->exportStylePath );
 
 		$custom_styles = $styles->getPrincePost();
 		if ( $custom_styles && ! empty( $custom_styles->post_content ) ) {

--- a/inc/modules/export/prince/class-pdf.php
+++ b/inc/modules/export/prince/class-pdf.php
@@ -81,7 +81,11 @@ class Pdf extends Export {
 		$md5 = $this->nonce( $timestamp );
 		$this->url = home_url() . "/format/xhtml?timestamp={$timestamp}&hashkey={$md5}";
 		if ( ! empty( $_REQUEST['preview'] ) ) {
-			$this->url .= '&' . http_build_query( [ 'preview' => $_REQUEST['preview'] ] );
+			$this->url .= '&' . http_build_query(
+				[
+					'preview' => $_REQUEST['preview'],
+				]
+			);
 		}
 
 		$this->themeOptionsOverrides();
@@ -123,7 +127,7 @@ class Pdf extends Export {
 		$prince = new \PrinceXMLPhp\PrinceWrapper( PB_PRINCE_COMMAND );
 		$prince->setHTML( true );
 		$prince->setCompress( true );
-		if ( defined( 'WP_ENV' ) && ( WP_ENV === 'development' || WP_ENV === 'staging' )  ) {
+		if ( defined( 'WP_ENV' ) && ( WP_ENV === 'development' || WP_ENV === 'staging' ) ) {
 			$prince->setInsecure( true );
 		}
 		if ( $this->pdfProfile && $this->pdfOutputIntent ) {

--- a/inc/modules/export/wordpress/class-vanillawxr.php
+++ b/inc/modules/export/wordpress/class-vanillawxr.php
@@ -109,7 +109,7 @@ class VanillaWxr extends Wxr {
 
 		// save wxr as file in exports folder
 		$filename = $this->timestampedFileName( '._vanilla.xml' );
-		file_put_contents( $filename, $output );
+		\Pressbooks\Utility\put_contents( $filename, $output );
 		$this->outputPath = $filename;
 
 		return true;

--- a/inc/modules/export/wordpress/class-vanillawxr.php
+++ b/inc/modules/export/wordpress/class-vanillawxr.php
@@ -34,7 +34,7 @@ class VanillaWxr extends Wxr {
 
 		// check for errors
 		if ( ! $success ) {
-			throw new \Exception( print_r( libxml_get_errors(), true ) );
+			throw new \Exception( print_r( libxml_get_errors(), true ) ); // @codingStandardsIgnoreLine
 		}
 
 		for ( $i = 0; $i < $post_type->length; $i++ ) {
@@ -78,7 +78,7 @@ class VanillaWxr extends Wxr {
 
 		// sanity
 		if ( ! $xml ) {
-			throw new \Exception( print_r( libxml_get_errors(), true ) );
+			throw new \Exception( print_r( libxml_get_errors(), true ) ); // @codingStandardsIgnoreLine
 		}
 
 		$category = $xml->xpath( '/rss/channel/item/category' );

--- a/inc/modules/export/wordpress/class-wxr.php
+++ b/inc/modules/export/wordpress/class-wxr.php
@@ -36,7 +36,7 @@ class Wxr extends Export {
 		// Save WXR as file in exports folder
 
 		$filename = $this->timestampedFileName( '.xml' );
-		file_put_contents( $filename, $output );
+		\Pressbooks\Utility\put_contents( $filename, $output );
 		$this->outputPath = $filename;
 
 		return true;

--- a/inc/modules/export/xhtml/class-xhtml11.php
+++ b/inc/modules/export/xhtml/class-xhtml11.php
@@ -118,7 +118,7 @@ class Xhtml11 extends Export {
 		// Save XHTML as file in exports folder
 
 		$filename = $this->timestampedFileName( '.html' );
-		file_put_contents( $filename, $output );
+		\Pressbooks\Utility\put_contents( $filename, $output );
 		$this->outputPath = $filename;
 
 		return true;
@@ -1073,7 +1073,8 @@ class Xhtml11 extends Export {
 		$chapter_printf .= '<div class="ugc chapter-ugc">%s</div>%s%s';
 		$chapter_printf .= '</div>';
 
-		$i = $j = 1;
+		$i = 1;
+		$j = 1;
 		foreach ( $book_contents['part'] as $part ) {
 
 			$invisibility = ( get_post_meta( $part['ID'], 'pb_part_invisible', true ) === 'on' ) ? 'invisible' : '';
@@ -1228,7 +1229,7 @@ class Xhtml11 extends Export {
 		$back_matter_printf .= '<div class="ugc back-matter-ugc">%s</div>%s%s';
 		$back_matter_printf .= '</div>';
 
-		$i = $s = 1;
+		$i = 1;
 		foreach ( $book_contents['back-matter'] as $back_matter ) {
 
 			if ( ! $back_matter['export'] ) {

--- a/inc/modules/export/xhtml/class-xhtml11.php
+++ b/inc/modules/export/xhtml/class-xhtml11.php
@@ -77,7 +77,11 @@ class Xhtml11 extends Export {
 		$md5 = $this->nonce( $timestamp );
 		$this->url = home_url() . "/format/xhtml?timestamp={$timestamp}&hashkey={$md5}";
 		if ( ! empty( $_REQUEST['preview'] ) ) {
-			$this->url .= '&' . http_build_query( [ 'preview' => $_REQUEST['preview'] ] );
+			$this->url .= '&' . http_build_query(
+				[
+					'preview' => $_REQUEST['preview'],
+				]
+			);
 		}
 
 		// Append endnotes to URL?

--- a/inc/modules/import/class-import.php
+++ b/inc/modules/import/class-import.php
@@ -7,6 +7,7 @@
 namespace Pressbooks\Modules\Import;
 
 use function \Pressbooks\Utility\getset;
+use function \Pressbooks\Utility\debug_error_log;
 
 abstract class Import {
 
@@ -400,7 +401,7 @@ abstract class Import {
 
 			// Something failed
 			if ( is_wp_error( $remote_head ) ) {
-				error_log( '\Pressbooks\Modules\Import::formSubmit html import error, wp_remote_head()' . $remote_head->get_error_message() );
+				debug_error_log( '\Pressbooks\Modules\Import::formSubmit html import error, wp_remote_head()' . $remote_head->get_error_message() );
 				$_SESSION['pb_errors'][] = $remote_head->get_error_message();
 				\Pressbooks\Redirect\location( $redirect_url );
 			}
@@ -509,7 +510,7 @@ abstract class Import {
 			'blog_id' => get_current_blog_id(),
 		];
 
-		$message = print_r( array_merge( $info, $more_info ), true ) . $message;
+		$message = print_r( array_merge( $info, $more_info ), true ) . $message; // @codingStandardsIgnoreLine
 
 		\Pressbooks\Utility\email_error_log( self::$logsEmail, $subject, $message );
 	}

--- a/inc/modules/import/class-import.php
+++ b/inc/modules/import/class-import.php
@@ -320,14 +320,18 @@ abstract class Import {
 			 */
 			$allowed_file_types = apply_filters(
 				'pb_import_file_types', [
-				'epub' => 'application/epub+zip',
-				'xml' => 'application/xml',
-				'odt' => 'application/vnd.oasis.opendocument.text',
-				'docx' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+					'epub' => 'application/epub+zip',
+					'xml' => 'application/xml',
+					'odt' => 'application/vnd.oasis.opendocument.text',
+					'docx' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
 				]
 			);
 
-			$overrides = [ 'test_form' => false, 'test_type' => false, 'mimes' => $allowed_file_types ];
+			$overrides = [
+				'test_form' => false,
+				'test_type' => false,
+				'mimes' => $allowed_file_types,
+			];
 
 			if ( ! function_exists( 'wp_handle_upload' ) ) {
 				require_once( ABSPATH . 'wp-admin/includes/file.php' );
@@ -407,7 +411,9 @@ abstract class Import {
 				\Pressbooks\Redirect\location( $redirect_url );
 			}
 
-			$upload = [ 'url' => $_POST['import_http'] ];
+			$upload = [
+				'url' => $_POST['import_http'],
+			];
 
 			switch ( $_POST['type_of'] ) {
 				case 'html':

--- a/inc/modules/import/epub/class-epub201.php
+++ b/inc/modules/import/epub/class-epub201.php
@@ -554,7 +554,12 @@ class Epub201 extends Import {
 			}
 		}
 
-		$pid = media_handle_sideload( [ 'name' => $filename, 'tmp_name' => $tmp_name ], 0 );
+		$pid = media_handle_sideload(
+			[
+				'name' => $filename,
+				'tmp_name' => $tmp_name,
+			], 0
+		);
 		$src = wp_get_attachment_url( $pid );
 		if ( ! $src ) {
 			$src = ''; // Change false to empty string
@@ -609,9 +614,9 @@ class Epub201 extends Import {
 			}
 
 			$this->manifest[ $id ] = [
-					'type' => $type,
-					'herf' => $href,
-					];
+				'type' => $type,
+				'herf' => $href,
+			];
 		}
 
 	}

--- a/inc/modules/import/epub/class-epub201.php
+++ b/inc/modules/import/epub/class-epub201.php
@@ -537,7 +537,7 @@ class Epub201 extends Import {
 		}
 
 		$tmp_name = $this->createTmpFile();
-		file_put_contents( $tmp_name, $image_content );
+		\Pressbooks\Utility\put_contents( $tmp_name, $image_content );
 
 		if ( ! \Pressbooks\Image\is_valid_image( $tmp_name, $filename ) ) {
 
@@ -597,7 +597,9 @@ class Epub201 extends Import {
 		foreach ( $xml->manifest->children() as $item ) {
 			/** @var \SimpleXMLElement $item */
 			// Get attributes
-			$id = $title = $type = $href = '';
+			$id = '';
+			$type = '';
+			$href = '';
 			foreach ( $item->attributes() as $key => $val ) {
 				if ( 'id' === $key ) {
 					$id = (string) $val;

--- a/inc/modules/import/html/class-xhtml.php
+++ b/inc/modules/import/html/class-xhtml.php
@@ -46,7 +46,7 @@ class Xhtml extends Import {
 
 		}
 
-		$url = parse_url( $current_import['file'] );
+		$url = wp_parse_url( $current_import['file'] );
 		// get parent directory (with forward slash e.g. /parent)
 		$path = dirname( $url['path'] );
 
@@ -144,7 +144,7 @@ class Xhtml extends Import {
 			return $license;
 		}
 		// look for creativecommons domain
-		$parts = parse_url( $url );
+		$parts = wp_parse_url( $url );
 
 		if ( 'http' === $parts['scheme'] && 'creativecommons.org' === $parts['host'] ) {
 			// extract the license information from it

--- a/inc/modules/import/html/class-xhtml.php
+++ b/inc/modules/import/html/class-xhtml.php
@@ -10,6 +10,7 @@ namespace Pressbooks\Modules\Import\Html;
 use Masterminds\HTML5;
 use Pressbooks\Modules\Import\Import;
 use Pressbooks\Book;
+use function \Pressbooks\Utility\debug_error_log;
 
 class Xhtml extends Import {
 
@@ -38,7 +39,7 @@ class Xhtml extends Import {
 		// Something failed
 		if ( is_wp_error( $html ) ) {
 			$redirect_url = get_admin_url( get_current_blog_id(), '/tools.php?page=pb_import' );
-			error_log( '\PressBooks\Import\Html import error, wp_remote_get() ' . $html->get_error_message() );
+			debug_error_log( '\PressBooks\Import\Html import error, wp_remote_get() ' . $html->get_error_message() );
 			$_SESSION['pb_errors'][] = $html->get_error_message();
 
 			$this->revokeCurrentImport();
@@ -447,7 +448,7 @@ class Xhtml extends Import {
 		// check for wp error
 		if ( is_wp_error( $html ) ) {
 			$error_message = $html->get_error_message();
-			error_log( '\Pressbooks\Modules\Import\Html::setCurrentImportOption error, wp_remote_get' . $error_message );
+			debug_error_log( '\Pressbooks\Modules\Import\Html::setCurrentImportOption error, wp_remote_get' . $error_message );
 			$_SESSION['pb_errors'][] = $error_message;
 
 			return false;

--- a/inc/modules/import/html/class-xhtml.php
+++ b/inc/modules/import/html/class-xhtml.php
@@ -418,7 +418,12 @@ class Xhtml extends Import {
 			}
 		}
 
-		$pid = media_handle_sideload( [ 'name' => $filename, 'tmp_name' => $tmp_name ], 0 );
+		$pid = media_handle_sideload(
+			[
+				'name' => $filename,
+				'tmp_name' => $tmp_name,
+			], 0
+		);
 		$src = wp_get_attachment_url( $pid );
 		if ( ! $src ) {
 			$src = ''; // Change false to empty string

--- a/inc/modules/import/odf/class-odt.php
+++ b/inc/modules/import/odf/class-odt.php
@@ -258,7 +258,12 @@ class Odt extends Import {
 			}
 		}
 
-		$pid = media_handle_sideload( [ 'name' => $filename, 'tmp_name' => $tmp_name ], 0 );
+		$pid = media_handle_sideload(
+			[
+				'name' => $filename,
+				'tmp_name' => $tmp_name,
+			], 0
+		);
 		$src = wp_get_attachment_url( $pid );
 		if ( ! $src ) {
 			$src = ''; // Change false to empty string

--- a/inc/modules/import/odf/class-odt.php
+++ b/inc/modules/import/odf/class-odt.php
@@ -240,7 +240,7 @@ class Odt extends Import {
 		}
 
 		$tmp_name = $this->createTmpFile();
-		file_put_contents( $tmp_name, $image_content );
+		\Pressbooks\Utility\put_contents( $tmp_name, $image_content );
 
 		if ( ! \Pressbooks\Image\is_valid_image( $tmp_name, $filename ) ) {
 

--- a/inc/modules/import/ooxml/class-docx.php
+++ b/inc/modules/import/ooxml/class-docx.php
@@ -373,7 +373,7 @@ class Docx extends Import {
 		}
 
 		$tmp_name = $this->createTmpFile();
-		file_put_contents( $tmp_name, $image_content );
+		\Pressbooks\Utility\put_contents( $tmp_name, $image_content );
 
 		if ( ! \Pressbooks\Image\is_valid_image( $tmp_name, $filename ) ) {
 

--- a/inc/modules/import/ooxml/class-docx.php
+++ b/inc/modules/import/ooxml/class-docx.php
@@ -391,7 +391,12 @@ class Docx extends Import {
 			}
 		}
 
-		$pid = media_handle_sideload( [ 'name' => $filename, 'tmp_name' => $tmp_name ], 0 );
+		$pid = media_handle_sideload(
+			[
+				'name' => $filename,
+				'tmp_name' => $tmp_name,
+			], 0
+		);
 		$src = wp_get_attachment_url( $pid );
 		if ( ! $src ) {
 			$src = ''; // Change false to empty string

--- a/inc/modules/import/wordpress/class-parser.php
+++ b/inc/modules/import/wordpress/class-parser.php
@@ -46,17 +46,19 @@ class Parser {
 		}
 		libxml_disable_entity_loader( $old_value );
 
+		// @codingStandardsIgnoreStart
 		if ( ! $success || isset( $dom->doctype ) ) {
 			throw new \Exception( print_r( libxml_get_errors(), true ) );
 		}
 
-		$xml = @simplexml_import_dom( $dom ); // @codingStandardsIgnoreLine
+		$xml = @simplexml_import_dom( $dom );
 		unset( $dom );
 
 		// halt if loading produces an error
 		if ( ! $xml ) {
 			throw new \Exception( print_r( libxml_get_errors(), true ) );
 		}
+		// @codingStandardsIgnoreEnd
 
 		$wxr_version = $xml->xpath( '/rss/channel/wp:wxr_version' );
 		if ( ! $wxr_version ) {

--- a/inc/modules/import/wordpress/class-parser.php
+++ b/inc/modules/import/wordpress/class-parser.php
@@ -25,13 +25,18 @@ class Parser {
 		// Setup & sanity check
 		// ------------------------------------------------------------------------------------------------------------
 
-		$authors = $posts = $categories = $tags = $terms = [];
+		$authors = [];
+		$posts = [];
+		$categories = [];
+		$tags = [];
+		$terms = [];
+
 		libxml_use_internal_errors( true );
 
 		$old_value = libxml_disable_entity_loader( true );
 		$dom = new \DOMDocument;
 		$dom->recover = true; // Try to parse non-well formed documents
-		$success = $dom->loadXML( file_get_contents( $file ) );
+		$success = $dom->loadXML( \Pressbooks\Utility\get_contents( $file ) );
 		foreach ( $dom->childNodes as $child ) {
 			if ( XML_DOCUMENT_TYPE_NODE === $child->nodeType ) {
 				// Invalid XML: Detected use of disallowed DOCTYPE

--- a/inc/modules/import/wordpress/class-wxr.php
+++ b/inc/modules/import/wordpress/class-wxr.php
@@ -407,7 +407,10 @@ class Wxr extends Import {
 			foreach ( $meta_to_update as $meta_key ) {
 				$meta_val = $this->searchForMetaValue( $meta_key, $p['postmeta'] );
 				if ( is_serialized( $meta_val ) ) {
-					$meta_val = unserialize( $meta_val );
+					$meta_val = unserialize( $meta_val ); // @codingStandardsIgnoreLine
+					if ( is_object( $meta_val ) ) {
+						continue; // Hack attempt?
+					}
 				}
 				if ( $meta_val ) {
 					update_post_meta( $pid, $meta_key, $meta_val );

--- a/inc/modules/import/wordpress/class-wxr.php
+++ b/inc/modules/import/wordpress/class-wxr.php
@@ -246,7 +246,11 @@ class Wxr extends Import {
 	 */
 	protected function pbCheck( array $xml ) {
 
-		$pt = $ch = $fm = $bm = $meta = 0;
+		$pt = 0;
+		$ch = 0;
+		$fm = 0;
+		$bm = 0;
+		$meta = 0;
 
 		foreach ( $xml['posts'] as $p ) {
 

--- a/inc/modules/import/wordpress/class-wxr.php
+++ b/inc/modules/import/wordpress/class-wxr.php
@@ -635,7 +635,12 @@ class Wxr extends Import {
 			}
 		}
 
-		$pid = media_handle_sideload( [ 'name' => $filename, 'tmp_name' => $tmp_name ], 0 );
+		$pid = media_handle_sideload(
+			[
+				'name' => $filename,
+				'tmp_name' => $tmp_name,
+			], 0
+		);
 		$src = wp_get_attachment_url( $pid );
 		if ( ! $src ) {
 			$pid = 0;

--- a/inc/modules/searchandreplace/class-search.php
+++ b/inc/modules/searchandreplace/class-search.php
@@ -55,9 +55,11 @@ abstract class Search {
 		$error_handler = function( $errno, $errstr, $errfile, $errline ) use ( &$regex_error ) {
 			$regex_error = preg_replace( '/(.*?):/', '', $errstr, 1 );
 		};
+		// @codingStandardsIgnoreStart
 		set_error_handler( $error_handler );
-		$valid = @preg_match( $expr, null, $matches ); // @codingStandardsIgnoreLine
+		$valid = @preg_match( $expr, null, $matches );
 		restore_error_handler();
+		// @codingStandardsIgnoreEnd
 		if ( false === $valid ) {
 			return $regex_error;
 		}

--- a/inc/modules/searchandreplace/class-search.php
+++ b/inc/modules/searchandreplace/class-search.php
@@ -56,8 +56,7 @@ abstract class Search {
 			$regex_error = preg_replace( '/(.*?):/', '', $errstr, 1 );
 		};
 		set_error_handler( $error_handler );
-		// @codingStandardsIgnoreLine
-		$valid = @preg_match( $expr, null, $matches );
+		$valid = @preg_match( $expr, null, $matches ); // @codingStandardsIgnoreLine
 		restore_error_handler();
 		if ( false === $valid ) {
 			return $regex_error;

--- a/inc/modules/searchandreplace/class-searchandreplace.php
+++ b/inc/modules/searchandreplace/class-searchandreplace.php
@@ -84,7 +84,8 @@ class SearchAndReplace {
 			return;
 		}
 
-		$search_pattern = $replace_pattern = '';
+		$search_pattern = '';
+		$replace_pattern = '';
 
 		if ( isset( $_POST['search_pattern'] ) ) {
 			$search_pattern  = stripslashes( $_POST['search_pattern'] );

--- a/inc/modules/searchandreplace/class-searchandreplace.php
+++ b/inc/modules/searchandreplace/class-searchandreplace.php
@@ -55,7 +55,7 @@ class SearchAndReplace {
 	 */
 	public function getL10n() {
 		return [
-		  'warning_text' => __( 'Once you&rsquo;ve pressed &lsquo;Replace & Save&rsquo; there is no going back! Have you checked &lsquo;Preview Replacements&rsquo; to make sure this will do what you want it to do?', 'pressbooks' ),
+			'warning_text' => __( 'Once you&rsquo;ve pressed &lsquo;Replace & Save&rsquo; there is no going back! Have you checked &lsquo;Preview Replacements&rsquo; to make sure this will do what you want it to do?', 'pressbooks' ),
 		];
 	}
 
@@ -136,16 +136,35 @@ class SearchAndReplace {
 			} elseif ( isset( $_POST['replace_and_save'] ) ) {
 	?>
 		  <div class="updated" id="message" onclick="this.parentNode.removeChild (this)">
-		   <p><?php printf( _n( '%d occurrence replaced.', '%d occurrences replaced.', count( $results ) ), count( $results ) ) ?></p>
+		   <p><?php printf( _n( '%d occurrence replaced.', '%d occurrences replaced.', count( $results ) ), count( $results ) ); ?></p>
 		  </div>
 <?php
 			}
-			$this->render( 'search', [ 'search' => $search_pattern, 'replace' => $replace_pattern, 'searches' => $searches, 'source' => $source ] );
+			$this->render(
+				'search', [
+					'search' => $search_pattern,
+					'replace' => $replace_pattern,
+					'searches' => $searches,
+					'source' => $source,
+				]
+			);
 			if ( is_array( $results ) && ! isset( $_POST['replace_and_save'] ) ) {
-				$this->render( 'results', [ 'search' => $searcher, 'results' => $results ] );
+				$this->render(
+					'results', [
+						'search' => $searcher,
+						'results' => $results,
+					]
+				);
 			}
 		} else {
-			$this->render( 'search', [ 'search' => $search_pattern, 'replace' => $replace_pattern, 'searches' => $searches, 'source' => $source ] );
+			$this->render(
+				'search', [
+					'search' => $search_pattern,
+					'replace' => $replace_pattern,
+					'searches' => $searches,
+					'source' => $source,
+				]
+			);
 		}
 	}
 
@@ -162,7 +181,7 @@ class SearchAndReplace {
 	public function renderError( $message ) {
 		?>
 	<div class="fade error" id="message">
-		<p><?php echo $message ?></p>
+		<p><?php echo $message; ?></p>
 	</div>
 	<?php
 	}

--- a/inc/modules/searchandreplace/types/class-content.php
+++ b/inc/modules/searchandreplace/types/class-content.php
@@ -33,7 +33,8 @@ class Content extends \Pressbooks\Modules\SearchAndReplace\Search {
 
 		if ( count( $posts ) > 0 ) {
 			foreach ( $posts as $key => $post ) {
-				if ( ( $matches = $this->matches( $pattern, $post->post_content, $post->ID ) ) ) {
+				$matches = $this->matches( $pattern, $post->post_content, $post->ID );
+				if ( $matches ) {
 					foreach ( $matches as $match ) {
 						$match->title = $post->post_title;
 					}

--- a/inc/modules/themeoptions/class-ebookoptions.php
+++ b/inc/modules/themeoptions/class-ebookoptions.php
@@ -55,7 +55,8 @@ class EbookOptions extends \Pressbooks\Options {
 	 * Configure the ebook options tab using the settings API.
 	 */
 	function init() {
-		$_page = $_option = 'pressbooks_theme_options_' . $this->getSlug();
+		$_option = 'pressbooks_theme_options_' . $this->getSlug();
+		$_page = $_option;
 		$_section = $this->getSlug() . '_options_section';
 
 		if ( false === get_option( $_option ) ) {

--- a/inc/modules/themeoptions/class-ebookoptions.php
+++ b/inc/modules/themeoptions/class-ebookoptions.php
@@ -214,8 +214,8 @@ class EbookOptions extends \Pressbooks\Options {
 		 */
 		return apply_filters(
 			'pb_theme_options_ebook_defaults', [
-			'ebook_paragraph_separation' => 'indent',
-			'ebook_compress_images' => 0,
+				'ebook_paragraph_separation' => 'indent',
+				'ebook_compress_images' => 0,
 			]
 		);
 	}
@@ -246,7 +246,7 @@ class EbookOptions extends \Pressbooks\Options {
 		 */
 		return apply_filters(
 			'pb_theme_options_ebook_booleans', [
-			'ebook_compress_images',
+				'ebook_compress_images',
 			]
 		);
 	}
@@ -314,7 +314,7 @@ class EbookOptions extends \Pressbooks\Options {
 		 */
 		return apply_filters(
 			'pb_theme_options_ebook_predefined', [
-			'ebook_paragraph_separation',
+				'ebook_paragraph_separation',
 			]
 		);
 	}
@@ -340,9 +340,11 @@ class EbookOptions extends \Pressbooks\Options {
 
 		if ( ! $options['chapter_numbers'] ) {
 			if ( $v2_compatible ) {
-				$styles->getSass()->setVariables( [
-					'chapter-number-display' => 'none',
-				] );
+				$styles->getSass()->setVariables(
+					[
+						'chapter-number-display' => 'none',
+					]
+				);
 			} else {
 				$scss .= "div.part-title-wrap > .part-number, div.chapter-title-wrap > .chapter-number { display: none !important; } \n";
 			}
@@ -356,19 +358,23 @@ class EbookOptions extends \Pressbooks\Options {
 		// Indent paragraphs?
 		if ( 'skiplines' === $options['ebook_paragraph_separation'] ) {
 			if ( $v2_compatible ) {
-				$styles->getSass()->setVariables( [
-					'para-margin-top' => '1em',
-					'para-indent' => '0',
-				] );
+				$styles->getSass()->setVariables(
+					[
+						'para-margin-top' => '1em',
+						'para-indent' => '0',
+					]
+				);
 			} else {
 				$scss .= "p + p, .indent, div.ugc p.indent { text-indent: 0; margin-top: 1em; } \n";
 			}
 		} else {
 			if ( $v2_compatible ) {
-				$styles->getSass()->setVariables( [
-					'para-margin-top' => '0',
-					'para-indent' => '1em',
-				] );
+				$styles->getSass()->setVariables(
+					[
+						'para-margin-top' => '0',
+						'para-indent' => '1em',
+					]
+				);
 			} else {
 				$scss .= "p + p, .indent, div.ugc p.indent { text-indent: 1em; margin-top: 0em; } \n";
 			}

--- a/inc/modules/themeoptions/class-globaloptions.php
+++ b/inc/modules/themeoptions/class-globaloptions.php
@@ -341,9 +341,9 @@ class GlobalOptions extends \Pressbooks\Options {
 		 */
 		return apply_filters(
 			'pb_theme_options_global_defaults', [
-			'chapter_numbers' => 1,
-			'parse_subsections' => 0,
-			'copyright_license' => 0,
+				'chapter_numbers' => 1,
+				'parse_subsections' => 0,
+				'copyright_license' => 0,
 			]
 		);
 	}
@@ -374,8 +374,8 @@ class GlobalOptions extends \Pressbooks\Options {
 		 */
 		return apply_filters(
 			'pb_theme_options_global_booleans', [
-			'chapter_numbers',
-			'parse_subsections',
+				'chapter_numbers',
+				'parse_subsections',
 			]
 		);
 	}

--- a/inc/modules/themeoptions/class-globaloptions.php
+++ b/inc/modules/themeoptions/class-globaloptions.php
@@ -58,7 +58,8 @@ class GlobalOptions extends \Pressbooks\Options {
 	 * Configure the global options tab using the settings API.
 	 */
 	function init() {
-		$_page = $_option = 'pressbooks_theme_options_' . $this->getSlug();
+		$_option = 'pressbooks_theme_options_' . $this->getSlug();
+		$_page = $_option;
 		$_section = $this->getSlug() . '_options_section';
 
 		if ( false === get_option( $_option ) ) {

--- a/inc/modules/themeoptions/class-pdfoptions.php
+++ b/inc/modules/themeoptions/class-pdfoptions.php
@@ -806,7 +806,8 @@ class PDFOptions extends \Pressbooks\Options {
 		<p>
 			<strong><?php _e( 'IMPORTANT: If you plan to use a print-on-demand service, margins under 2cm on any side can cause your file to be rejected.', 'pressbooks' ); ?></strong>
 		</p>
-	<?php }
+	<?php
+	}
 
 	/**
 	 * Render the pdf_page_margin_outside input.
@@ -815,7 +816,8 @@ class PDFOptions extends \Pressbooks\Options {
 	 */
 	function renderOutsideMarginField( $args ) {
 		?>
-		<?php $this->renderField(
+		<?php
+		$this->renderField(
 			[
 				'id' => 'pdf_page_margin_outside',
 				'name' => 'pressbooks_theme_options_' . $this->getSlug(),
@@ -1048,7 +1050,8 @@ class PDFOptions extends \Pressbooks\Options {
 	function renderRunningContentField( $args ) {
 		?>
 		<p class="description"><?php echo $args[0]; ?></p>
-	<?php }
+	<?php
+	}
 
 	/**
 	 * Render the running_content_front_matter_left input.
@@ -1358,34 +1361,34 @@ class PDFOptions extends \Pressbooks\Options {
 		 */
 		return apply_filters(
 			'pb_theme_options_pdf_defaults', [
-			'pdf_body_font_size' => '11',
-			'pdf_body_line_height' => '1.4',
-			'pdf_page_width' => '5.5in',
-			'pdf_page_height' => '8.5in',
-			'pdf_page_margin_outside' => '2cm',
-			'pdf_page_margin_inside' => '2cm',
-			'pdf_page_margin_top' => '2cm',
-			'pdf_page_margin_bottom' => '2cm',
-			'pdf_hyphens' => 0,
-			'pdf_paragraph_separation' => 'indent',
-			'pdf_sectionopenings' => 'openauto',
-			'pdf_toc' => 1,
-			'pdf_crop_marks' => 0,
-			'pdf_romanize_parts' => 1,
-			'pdf_footnotes_style' => 'footnotes',
-			'widows' => 2,
-			'orphans' => 1,
-			'running_content_front_matter_left' => '%book_title%',
-			'running_content_front_matter_right' => '%section_title%',
-			'running_content_introduction_left' => '%book_title%',
-			'running_content_introduction_right' => '%section_title%',
-			'running_content_part_left' => '%book_title%',
-			'running_content_part_right' => '%part_title%',
-			'running_content_chapter_left' => '%book_title%',
-			'running_content_chapter_right' => '%section_title%',
-			'running_content_back_matter_left' => '%book_title%',
-			'running_content_back_matter_right' => '%section_title%',
-			'pdf_fontsize' => 0,
+				'pdf_body_font_size' => '11',
+				'pdf_body_line_height' => '1.4',
+				'pdf_page_width' => '5.5in',
+				'pdf_page_height' => '8.5in',
+				'pdf_page_margin_outside' => '2cm',
+				'pdf_page_margin_inside' => '2cm',
+				'pdf_page_margin_top' => '2cm',
+				'pdf_page_margin_bottom' => '2cm',
+				'pdf_hyphens' => 0,
+				'pdf_paragraph_separation' => 'indent',
+				'pdf_sectionopenings' => 'openauto',
+				'pdf_toc' => 1,
+				'pdf_crop_marks' => 0,
+				'pdf_romanize_parts' => 1,
+				'pdf_footnotes_style' => 'footnotes',
+				'widows' => 2,
+				'orphans' => 1,
+				'running_content_front_matter_left' => '%book_title%',
+				'running_content_front_matter_right' => '%section_title%',
+				'running_content_introduction_left' => '%book_title%',
+				'running_content_introduction_right' => '%section_title%',
+				'running_content_part_left' => '%book_title%',
+				'running_content_part_right' => '%part_title%',
+				'running_content_chapter_left' => '%book_title%',
+				'running_content_chapter_right' => '%section_title%',
+				'running_content_back_matter_left' => '%book_title%',
+				'running_content_back_matter_right' => '%section_title%',
+				'pdf_fontsize' => 0,
 			]
 		);
 	}
@@ -1508,11 +1511,11 @@ class PDFOptions extends \Pressbooks\Options {
 		 */
 		return apply_filters(
 			'pb_theme_options_pdf_booleans', [
-			'pdf_hyphens',
-			'pdf_toc',
-			'pdf_crop_marks',
-			'pdf_romanize_parts',
-			'pdf_fontsize',
+				'pdf_hyphens',
+				'pdf_toc',
+				'pdf_crop_marks',
+				'pdf_romanize_parts',
+				'pdf_fontsize',
 			]
 		);
 	}
@@ -1532,22 +1535,22 @@ class PDFOptions extends \Pressbooks\Options {
 		 */
 		return apply_filters(
 			'pb_theme_options_pdf_strings', [
-			'pdf_page_width',
-			'pdf_page_height',
-			'pdf_page_margin_outside',
-			'pdf_page_margin_inside',
-			'pdf_page_margin_top',
-			'pdf_page_margin_bottom',
-			'running_content_front_matter_left',
-			'running_content_front_matter_right',
-			'running_content_introduction_left',
-			'running_content_introduction_right',
-			'running_content_part_left',
-			'running_content_part_right',
-			'running_content_chapter_left',
-			'running_content_chapter_right',
-			'running_content_back_matter_left',
-			'running_content_back_matter_right',
+				'pdf_page_width',
+				'pdf_page_height',
+				'pdf_page_margin_outside',
+				'pdf_page_margin_inside',
+				'pdf_page_margin_top',
+				'pdf_page_margin_bottom',
+				'running_content_front_matter_left',
+				'running_content_front_matter_right',
+				'running_content_introduction_left',
+				'running_content_introduction_right',
+				'running_content_part_left',
+				'running_content_part_right',
+				'running_content_chapter_left',
+				'running_content_chapter_right',
+				'running_content_back_matter_left',
+				'running_content_back_matter_right',
 			]
 		);
 	}
@@ -1567,8 +1570,8 @@ class PDFOptions extends \Pressbooks\Options {
 		 */
 		return apply_filters(
 			'pb_theme_options_pdf_integers', [
-			'widows',
-			'orphans',
+				'widows',
+				'orphans',
 			]
 		);
 	}
@@ -1609,9 +1612,9 @@ class PDFOptions extends \Pressbooks\Options {
 		 */
 		return apply_filters(
 			'pb_theme_options_pdf_predefined', [
-			'pdf_paragraph_separation',
-			'pdf_sectionopenings',
-			'pdf_footnotes_style',
+				'pdf_paragraph_separation',
+				'pdf_sectionopenings',
+				'pdf_footnotes_style',
 			]
 		);
 	}
@@ -1718,12 +1721,14 @@ class PDFOptions extends \Pressbooks\Options {
 		// Should we display chapter numbers? True (default) or false.
 		if ( ! $options['chapter_numbers'] ) {
 			if ( $v2_compatible ) {
-				$styles->getSass()->setVariables( [
-					'chapter-number-display' => 'none',
-					'part-number-display' => 'none',
-					'toc-chapter-number-display' => 'none',
-					'toc-part-number-display' => 'none',
-				] );
+				$styles->getSass()->setVariables(
+					[
+						'chapter-number-display' => 'none',
+						'part-number-display' => 'none',
+						'toc-chapter-number-display' => 'none',
+						'toc-part-number-display' => 'none',
+					]
+				);
 			} else {
 				$scss .= "div.part-title-wrap > .part-number, div.chapter-title-wrap > .chapter-number, #toc .part a::before, #toc .chapter a::before { display: none !important; } \n";  // TODO: NO
 			}
@@ -1737,17 +1742,21 @@ class PDFOptions extends \Pressbooks\Options {
 		// Change body font size
 		if ( $v2_compatible && isset( $options['pdf_body_font_size'] ) ) {
 			$fontsize = $options['pdf_body_font_size'] . 'pt';
-			$styles->getSass()->setVariables( [
-				'body-font-size' => "(epub: medium, prince: $fontsize, web: 14pt)",
-			] );
+			$styles->getSass()->setVariables(
+				[
+					'body-font-size' => "(epub: medium, prince: $fontsize, web: 14pt)",
+				]
+			);
 		}
 
 		// Change body line height
 		if ( $v2_compatible && isset( $options['pdf_body_line_height'] ) ) {
 			$lineheight = $options['pdf_body_line_height'] . 'em';
-				$styles->getSass()->setVariables( [
-					'body-line-height' => "(epub: 1.4em, prince: $lineheight, web: 1.8em)",
-				] );
+				$styles->getSass()->setVariables(
+					[
+						'body-line-height' => "(epub: 1.4em, prince: $lineheight, web: 1.8em)",
+					]
+				);
 		}
 
 		// Page dimensions
@@ -1755,30 +1764,36 @@ class PDFOptions extends \Pressbooks\Options {
 		$height = $options['pdf_page_height'];
 
 		if ( $v2_compatible ) {
-			$styles->getSass()->setVariables( [
-				'page-width' => $width,
-				'page-height' => $height,
-			] );
+			$styles->getSass()->setVariables(
+				[
+					'page-width' => $width,
+					'page-height' => $height,
+				]
+			);
 		} else {
 			$scss .= "@page { size: $width $height; } \n";
 		}
 
 		// Margins
 		if ( $v2_compatible ) {
-			$styles->getSass()->setVariables( [
-				'page-margin-top' => ( isset( $options['pdf_page_margin_top'] ) ) ? $options['pdf_page_margin_top'] : '2cm',
-				'page-margin-inside' => ( isset( $options['pdf_page_margin_inside'] ) ) ? $options['pdf_page_margin_inside'] : '2cm',
-				'page-margin-bottom' => ( isset( $options['pdf_page_margin_bottom'] ) ) ? $options['pdf_page_margin_bottom'] : '2cm',
-				'page-margin-outside' => ( isset( $options['pdf_page_margin_outside'] ) ) ? $options['pdf_page_margin_outside'] : '2cm',
-			] );
+			$styles->getSass()->setVariables(
+				[
+					'page-margin-top' => ( isset( $options['pdf_page_margin_top'] ) ) ? $options['pdf_page_margin_top'] : '2cm',
+					'page-margin-inside' => ( isset( $options['pdf_page_margin_inside'] ) ) ? $options['pdf_page_margin_inside'] : '2cm',
+					'page-margin-bottom' => ( isset( $options['pdf_page_margin_bottom'] ) ) ? $options['pdf_page_margin_bottom'] : '2cm',
+					'page-margin-outside' => ( isset( $options['pdf_page_margin_outside'] ) ) ? $options['pdf_page_margin_outside'] : '2cm',
+				]
+			);
 		}
 
 		// Should we display crop marks? True or false (default).
 		if ( 1 === absint( $options['pdf_crop_marks'] ) ) {
 			if ( $v2_compatible ) {
-				$styles->getSass()->setVariables( [
-					'page-cropmarks' => 'crop',
-				] );
+				$styles->getSass()->setVariables(
+					[
+						'page-cropmarks' => 'crop',
+					]
+				);
 			} else {
 				$scss .= "@page { marks: crop } \n";
 			}
@@ -1787,17 +1802,21 @@ class PDFOptions extends \Pressbooks\Options {
 		// Hyphens?
 		if ( 1 === absint( $options['pdf_hyphens'] ) ) {
 			if ( $v2_compatible ) {
-				$styles->getSass()->setVariables( [
-					'para-hyphens' => 'auto',
-				] );
+				$styles->getSass()->setVariables(
+					[
+						'para-hyphens' => 'auto',
+					]
+				);
 			} else {
 				$scss .= "p { hyphens: auto; } \n";
 			}
 		} else {
 			if ( $v2_compatible ) {
-				$styles->getSass()->setVariables( [
-					'para-hyphens' => 'manual',
-				] );
+				$styles->getSass()->setVariables(
+					[
+						'para-hyphens' => 'manual',
+					]
+				);
 			} else {
 				$scss .= "p { hyphens: manual; } \n";
 			}
@@ -1806,19 +1825,23 @@ class PDFOptions extends \Pressbooks\Options {
 		// Indent paragraphs?
 		if ( 'skiplines' === $options['pdf_paragraph_separation'] ) {
 			if ( $v2_compatible ) {
-				$styles->getSass()->setVariables( [
-					'para-margin-top' => '1em',
-					'para-indent' => '0',
-				] );
+				$styles->getSass()->setVariables(
+					[
+						'para-margin-top' => '1em',
+						'para-indent' => '0',
+					]
+				);
 			} else {
 				$scss .= "p + p { text-indent: 0em; margin-top: 1em; } \n";
 			}
 		} else {
 			if ( $v2_compatible ) {
-				$styles->getSass()->setVariables( [
-					'para-margin-top' => '0',
-					'para-indent' => '1em',
-				] );
+				$styles->getSass()->setVariables(
+					[
+						'para-margin-top' => '0',
+						'para-indent' => '1em',
+					]
+				);
 			} else {
 				$scss .= "p + p { text-indent: 1em; margin-top: 0em; } \n";
 			}
@@ -1828,23 +1851,27 @@ class PDFOptions extends \Pressbooks\Options {
 		if ( isset( $options['pdf_sectionopenings'] ) ) {
 			if ( 'openright' === $options['pdf_sectionopenings'] ) {
 				if ( $v2_compatible ) {
-					$styles->getSass()->setVariables( [
-						'recto-verso-standard-opening' => 'right',
-						'recto-verso-first-section-opening' => 'right',
-						'recto-verso-section-opening' => 'right',
-					] );
+					$styles->getSass()->setVariables(
+						[
+							'recto-verso-standard-opening' => 'right',
+							'recto-verso-first-section-opening' => 'right',
+							'recto-verso-section-opening' => 'right',
+						]
+					);
 				} else {
 					$scss .= "#title-page, #toc, div.part, div.front-matter, div.front-matter.introduction, div.front-matter + div.front-matter, div.chapter, div.chapter + div.chapter, div.back-matter, div.back-matter + div.back-matter, #half-title-page h1.title:first-of-type  { page-break-before: right; } \n";
 					$scss .= "#copyright-page { page-break-before: left; }\n";
 				}
 			} elseif ( 'remove' === $options['pdf_sectionopenings'] ) {
 				if ( $v2_compatible ) {
-					$styles->getSass()->setVariables( [
-						'recto-verso-standard-opening' => 'auto',
-						'recto-verso-first-section-opening' => 'auto',
-						'recto-verso-section-opening' => 'auto',
-						'recto-verso-copyright-page-opening' => 'auto',
-					] );
+					$styles->getSass()->setVariables(
+						[
+							'recto-verso-standard-opening' => 'auto',
+							'recto-verso-first-section-opening' => 'auto',
+							'recto-verso-section-opening' => 'auto',
+							'recto-verso-copyright-page-opening' => 'auto',
+						]
+					);
 				} else {
 					$scss .= "#title-page, #copyright-page, #toc, div.part, div.front-matter, div.back-matter, div.chapter, #half-title-page h1.title:first-of-type  { page-break-before: auto; } \n";
 				}
@@ -1854,9 +1881,11 @@ class PDFOptions extends \Pressbooks\Options {
 		// Should we display the TOC? True (default) or false.
 		if ( ! $options['pdf_toc'] ) {
 			if ( $v2_compatible ) {
-				$styles->getSass()->setVariables( [
-					'toc-display' => 'none',
-				] );
+				$styles->getSass()->setVariables(
+					[
+						'toc-display' => 'none',
+					]
+				);
 			} else {
 				$scss .= "#toc { display: none; } \n";
 			}
@@ -1865,9 +1894,11 @@ class PDFOptions extends \Pressbooks\Options {
 		// Widows
 		if ( isset( $options['widows'] ) ) {
 			if ( $v2_compatible ) {
-				$styles->getSass()->setVariables( [
-					'widows' => $options['widows'],
-				] );
+				$styles->getSass()->setVariables(
+					[
+						'widows' => $options['widows'],
+					]
+				);
 			} else {
 				$scss .= "p { widows: {$options['widows']}; }\n";
 			}
@@ -1880,9 +1911,11 @@ class PDFOptions extends \Pressbooks\Options {
 		// Orphans
 		if ( isset( $options['orphans'] ) ) {
 			if ( $v2_compatible ) {
-				$styles->getSass()->setVariables( [
-					'orphans' => $options['orphans'],
-				] );
+				$styles->getSass()->setVariables(
+					[
+						'orphans' => $options['orphans'],
+					]
+				);
 			} else {
 				$scss .= "p { orphans: {$options['orphans']}; }\n";
 			}
@@ -1904,18 +1937,20 @@ class PDFOptions extends \Pressbooks\Options {
 			$chapter_running_content_right = ( isset( $options['running_content_chapter_right'] ) ) ? self::replaceRunningContentTags( $options['running_content_chapter_right'] ) : 'string(section-title)';
 			$back_matter_running_content_left = ( isset( $options['running_content_back_matter_left'] ) ) ? self::replaceRunningContentTags( $options['running_content_back_matter_left'] ) : 'string(book-title)';
 			$back_matter_running_content_right = ( isset( $options['running_content_back_matter_right'] ) ) ? self::replaceRunningContentTags( $options['running_content_back_matter_right'] ) : 'string(section-title)';
-			$styles->getSass()->setVariables( [
-				'front-matter-running-content-left' => $front_matter_running_content_left,
-				'front-matter-running-content-right' => $front_matter_running_content_right,
-				'introduction-running-content-left' => $introduction_running_content_left,
-				'introduction-running-content-right' => $introduction_running_content_right,
-				'part-running-content-left' => $part_running_content_left,
-				'part-running-content-right' => $part_running_content_right,
-				'chapter-running-content-left' => $chapter_running_content_left,
-				'chapter-running-content-right' => $chapter_running_content_right,
-				'back-matter-running-content-left' => $back_matter_running_content_left,
-				'back-matter-running-content-right' => $back_matter_running_content_right,
-			] );
+			$styles->getSass()->setVariables(
+				[
+					'front-matter-running-content-left' => $front_matter_running_content_left,
+					'front-matter-running-content-right' => $front_matter_running_content_right,
+					'introduction-running-content-left' => $introduction_running_content_left,
+					'introduction-running-content-right' => $introduction_running_content_right,
+					'part-running-content-left' => $part_running_content_left,
+					'part-running-content-right' => $part_running_content_right,
+					'chapter-running-content-left' => $chapter_running_content_left,
+					'chapter-running-content-right' => $chapter_running_content_right,
+					'back-matter-running-content-left' => $back_matter_running_content_left,
+					'back-matter-running-content-right' => $back_matter_running_content_right,
+				]
+			);
 		}
 
 		// a11y Font Size

--- a/inc/modules/themeoptions/class-pdfoptions.php
+++ b/inc/modules/themeoptions/class-pdfoptions.php
@@ -58,7 +58,8 @@ class PDFOptions extends \Pressbooks\Options {
 	 * Configure the PDF options tab using the settings API.
 	 */
 	function init() {
-		$_page = $_option = 'pressbooks_theme_options_' . $this->getSlug();
+		$_option = 'pressbooks_theme_options_' . $this->getSlug();
+		$_page = $_option;
 		$_section = $this->getSlug() . '_options_section';
 
 		if ( false === get_option( $_option ) ) {
@@ -1438,7 +1439,7 @@ class PDFOptions extends \Pressbooks\Options {
 			];
 			foreach ( $files as $file ) {
 				if ( file_exists( $file ) ) {
-					$parsed_sass_variables[] = $sass->parseVariables( file_get_contents( $file ) );
+					$parsed_sass_variables[] = $sass->parseVariables( \Pressbooks\Utility\get_contents( $file ) );
 				}
 			}
 			set_transient( $transient_name, $parsed_sass_variables );

--- a/inc/modules/themeoptions/class-themeoptions.php
+++ b/inc/modules/themeoptions/class-themeoptions.php
@@ -140,19 +140,28 @@ class ThemeOptions {
 			<?php $active_tab = isset( $_GET['tab'] ) ? $_GET['tab'] : 'global'; ?>
 			<h2 class="nav-tab-wrapper">
 				<?php foreach ( $this->getTabs() as $slug => $subclass ) { ?>
-					<a href="<?php echo admin_url( '/themes.php' );
-					?>?page=pressbooks_theme_options&tab=<?php echo $slug;
-					?>" class="nav-tab <?php echo $active_tab === $slug ? 'nav-tab-active' : ''; ?>"><?php echo $subclass::getTitle() ?></a>
+					<a href="
+					<?php
+					echo admin_url( '/themes.php' );
+					?>
+					?page=pressbooks_theme_options&tab=
+					<?php
+					echo $slug;
+					?>
+					" class="nav-tab <?php echo $active_tab === $slug ? 'nav-tab-active' : ''; ?>"><?php echo $subclass::getTitle(); ?></a>
 				<?php } ?>
 			</h2>
 			<form method="post" action="options.php">
-				<?php do_action( 'pb_before_themeoptions_settings_fields' );
+				<?php
+				do_action( 'pb_before_themeoptions_settings_fields' );
 				settings_fields( 'pressbooks_theme_options_' . $active_tab );
 				do_settings_sections( 'pressbooks_theme_options_' . $active_tab );
-				submit_button(); ?>
+				submit_button();
+				?>
 			</form>
 		</div>
-	<?php }
+	<?php
+	}
 
 	/**
 	 * Override saved options with filtered defaults when switching theme

--- a/inc/modules/themeoptions/class-themeoptions.php
+++ b/inc/modules/themeoptions/class-themeoptions.php
@@ -6,6 +6,8 @@
 
 namespace Pressbooks\Modules\ThemeOptions;
 
+use function \Pressbooks\Utility\debug_error_log;
+
 /**
  * Not a subclass of \Pressbooks\Options!
  * Handles initialization of Theme Options admin menu
@@ -108,8 +110,8 @@ class ThemeOptions {
 			if ( $tab::VERSION !== null && $version < $tab::VERSION ) {
 				$tab->upgrade( $version );
 				update_option( "pressbooks_theme_options_{$slug}_version", $tab::VERSION, false );
-				if ( WP_DEBUG && ! defined( 'WP_TESTS_MULTISITE' ) ) {
-					error_log( 'Upgraded ' . $slug . ' options from version ' . $version . ' --> ' . $tab::VERSION );
+				if ( ! defined( 'WP_TESTS_MULTISITE' ) ) {
+					debug_error_log( 'Upgraded ' . $slug . ' options from version ' . $version . ' --> ' . $tab::VERSION );
 				}
 			}
 		}

--- a/inc/modules/themeoptions/class-weboptions.php
+++ b/inc/modules/themeoptions/class-weboptions.php
@@ -246,9 +246,9 @@ class WebOptions extends \Pressbooks\Options {
 		 */
 		return apply_filters(
 			'pb_theme_options_web_defaults', [
-			'social_media' => 1,
-			'paragraph_separation' => 'skiplines',
-			'part_title' => 0,
+				'social_media' => 1,
+				'paragraph_separation' => 'skiplines',
+				'part_title' => 0,
 			]
 		);
 	}
@@ -279,8 +279,8 @@ class WebOptions extends \Pressbooks\Options {
 		 */
 		return apply_filters(
 			'pb_theme_options_web_booleans', [
-			'social_media',
-			'part_title',
+				'social_media',
+				'part_title',
 			]
 		);
 	}
@@ -348,7 +348,7 @@ class WebOptions extends \Pressbooks\Options {
 		 */
 		return apply_filters(
 			'pb_theme_options_web_predefined', [
-			'paragraph_separation',
+				'paragraph_separation',
 			]
 		);
 	}
@@ -372,19 +372,23 @@ class WebOptions extends \Pressbooks\Options {
 		if ( isset( $options['paragraph_separation'] ) ) {
 			if ( 'indent' === $options['paragraph_separation'] ) {
 				if ( $v2_compatible ) {
-					$styles->getSass()->setVariables( [
-						'para-margin-top' => '0',
-						'para-indent' => '1em',
-					] );
+					$styles->getSass()->setVariables(
+						[
+							'para-margin-top' => '0',
+							'para-indent' => '1em',
+						]
+					);
 				} else {
 					$scss .= "* + p { text-indent: 1em; margin-top: 0; margin-bottom: 0; } \n";
 				}
 			} elseif ( 'skiplines' === $options['paragraph_separation'] ) {
 				if ( $v2_compatible ) {
-					$styles->getSass()->setVariables( [
-						'para-margin-top' => '1em',
-						'para-indent' => '0',
-					] );
+					$styles->getSass()->setVariables(
+						[
+							'para-margin-top' => '1em',
+							'para-indent' => '0',
+						]
+					);
 				} else {
 					$scss .= "p + p { text-indent: 0em; margin-top: 1em; } \n";
 				}

--- a/inc/modules/themeoptions/class-weboptions.php
+++ b/inc/modules/themeoptions/class-weboptions.php
@@ -55,7 +55,8 @@ class WebOptions extends \Pressbooks\Options {
 	 * Configure the web options tab using the settings API.
 	 */
 	function init() {
-		$_page = $_option = 'pressbooks_theme_options_' . $this->getSlug();
+		$_option = 'pressbooks_theme_options_' . $this->getSlug();
+		$_page = $_option;
 		$_section = $this->getSlug() . '_options_section';
 
 		if ( false === get_option( $_option ) ) {

--- a/inc/posttype/namespace.php
+++ b/inc/posttype/namespace.php
@@ -22,12 +22,12 @@ function list_post_types() {
 	 */
 	return apply_filters(
 		'pb_supported_post_types', [
-		'metadata',
-		'part',
-		'chapter',
-		'front-matter',
-		'back-matter',
-		'custom-css',
+			'metadata',
+			'part',
+			'chapter',
+			'front-matter',
+			'back-matter',
+			'custom-css',
 		]
 	);
 }
@@ -62,7 +62,10 @@ function register_post_types() {
 		'show_in_menu' => true,
 		'menu_position' => 5,
 		'query_var' => true,
-		'rewrite' => [ 'slug' => 'chapter', 'with_front' => false ],
+		'rewrite' => [
+		'slug' => 'chapter',
+		'with_front' => false,
+			],
 		'capability_type' => 'post',
 		'has_archive' => true,
 		'hierarchical' => false, // do not set to true unless you want to break permalinks. Do you really want to do that? >:(
@@ -99,7 +102,10 @@ function register_post_types() {
 		'show_in_menu' => true,
 		'menu_position' => 5,
 		'query_var' => true,
-		'rewrite' => [ 'slug' => 'part', 'with_front' => false ],
+		'rewrite' => [
+			'slug' => 'part',
+			'with_front' => false,
+		],
 		'capability_type' => 'post',
 		'has_archive' => true,
 		'hierarchical' => true,
@@ -134,7 +140,10 @@ function register_post_types() {
 		'show_in_menu' => true,
 		'menu_position' => 5,
 		'query_var' => true,
-		'rewrite' => [ 'slug' => 'front-matter', 'with_front' => false ],
+		'rewrite' => [
+			'slug' => 'front-matter',
+			'with_front' => false,
+		],
 		'capability_type' => 'post',
 		'has_archive' => true,
 		'hierarchical' => true,
@@ -169,7 +178,10 @@ function register_post_types() {
 		'show_in_menu' => true,
 		'menu_position' => 5,
 		'query_var' => true,
-		'rewrite' => [ 'slug' => 'back-matter', 'with_front' => false ],
+		'rewrite' => [
+			'slug' => 'back-matter',
+			'with_front' => false,
+		],
 		'capability_type' => 'post',
 		'has_archive' => true,
 		'hierarchical' => true,
@@ -227,36 +239,67 @@ function register_meta() {
 		'type' => 'string',
 	];
 
-	\register_meta( 'post', 'pb_export', array_merge( $defaults, [
-		'description' => __( 'Include in exports', 'pressbooks' ),
-		'sanitize_callback' => function( $v ) { return ( $v ? 'on' : null ) ; },
-	] ) );
+	\register_meta(
+		'post', 'pb_export', array_merge(
+			$defaults, [
+				'description' => __( 'Include in exports', 'pressbooks' ),
+				'sanitize_callback' => function( $v ) {
+					return ( $v ? 'on' : null ) ; },
+			]
+		)
+	);
 
-	\register_meta( 'post', 'pb_show_title', array_merge( $defaults, [
-		'description' => __( 'Show title in exports', 'pressbooks' ),
-		'sanitize_callback' => function( $v ) { return ( $v ? 'on' : null ) ; },
-	] ) );
+	\register_meta(
+		'post', 'pb_show_title', array_merge(
+			$defaults, [
+				'description' => __( 'Show title in exports', 'pressbooks' ),
+				'sanitize_callback' => function( $v ) {
+					return ( $v ? 'on' : null ) ; },
+			]
+		)
+	);
 
-	\register_meta( 'post', 'pb_ebook_start', array_merge( $defaults, [
-		'description' => __( 'Set as ebook start-point', 'pressbooks' ),
-		'sanitize_callback' => function( $v ) { return ( $v ? 'on' : null ) ; },
-	] ) );
+	\register_meta(
+		'post', 'pb_ebook_start', array_merge(
+			$defaults, [
+				'description' => __( 'Set as ebook start-point', 'pressbooks' ),
+				'sanitize_callback' => function( $v ) {
+					return ( $v ? 'on' : null ) ; },
+			]
+		)
+	);
 
-	\register_meta( 'post', 'pb_short_title', array_merge( $defaults, [
-		'description' => __( 'Chapter Short Title (appears in the PDF running header)', 'pressbooks' ),
-	] ) );
+	\register_meta(
+		'post', 'pb_short_title', array_merge(
+			$defaults, [
+				'description' => __( 'Chapter Short Title (appears in the PDF running header)', 'pressbooks' ),
+			]
+		)
+	);
 
-	\register_meta( 'post', 'pb_subtitle', array_merge( $defaults, [
-		'description' => __( 'Chapter Subtitle (appears in the Web/ebook/PDF output)', 'pressbooks' ),
-	] ) );
+	\register_meta(
+		'post', 'pb_subtitle', array_merge(
+			$defaults, [
+				'description' => __( 'Chapter Subtitle (appears in the Web/ebook/PDF output)', 'pressbooks' ),
+			]
+		)
+	);
 
-	\register_meta( 'post', 'pb_section_author', array_merge( $defaults, [
-		'description' => __( 'Chapter Author (appears in Web/ebook/PDF output)', 'pressbooks' ),
-	] ) );
+	\register_meta(
+		'post', 'pb_section_author', array_merge(
+			$defaults, [
+				'description' => __( 'Chapter Author (appears in Web/ebook/PDF output)', 'pressbooks' ),
+			]
+		)
+	);
 
-	\register_meta( 'post', 'pb_section_license', array_merge( $defaults, [
-		'description' => __( 'Chapter Copyright License (overrides book license on this page)', 'pressbooks' ),
-	] ) );
+	\register_meta(
+		'post', 'pb_section_license', array_merge(
+			$defaults, [
+				'description' => __( 'Chapter Copyright License (overrides book license on this page)', 'pressbooks' ),
+			]
+		)
+	);
 }
 
 /**

--- a/inc/redirect/namespace.php
+++ b/inc/redirect/namespace.php
@@ -382,7 +382,8 @@ function do_open() {
 				}
 
 				// Force download
-				@set_time_limit( 0 ); // @codingStandardsIgnoreLine
+				// @codingStandardsIgnoreStart
+				@set_time_limit( 0 );
 				header( 'Content-Description: File Transfer' );
 				header( 'Content-Type: ' . \Pressbooks\Modules\Export\Export::mimeType( $filepath ) );
 				header( 'Content-Disposition: attachment; filename="' . $book_title_slug . '.' . $file_ext . '"' );
@@ -391,12 +392,13 @@ function do_open() {
 				header( 'Cache-Control: must-revalidate, post-check=0, pre-check=0' );
 				header( 'Pragma: public' );
 				header( 'Content-Length: ' . filesize( $filepath ) );
-				@ob_clean(); // @codingStandardsIgnoreLine
+				@ob_clean();
 				flush();
-				while ( @ob_end_flush() ) { // @codingStandardsIgnoreLine
+				while ( @ob_end_flush() ) {
 					// Fix out-of-memory problem
 				}
 				readfile( $filepath );
+				// @codingStandardsIgnoreEnd
 
 				exit;
 			}
@@ -426,7 +428,7 @@ function redirect_away_from_bad_urls() {
 		return; // Do nothing
 	}
 
-	$check_against_url = parse_url( ( is_ssl() ? 'http://' : 'https://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'], PHP_URL_PATH );
+	$check_against_url = wp_parse_url( ( is_ssl() ? 'http://' : 'https://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'], PHP_URL_PATH );
 	$redirect_url = get_site_url( get_current_blog_id(), '/wp-admin/' );
 	$trash_url = get_site_url( get_current_blog_id(), '/wp-admin/edit.php?post_type=chapter&page=trash' );
 

--- a/inc/redirect/namespace.php
+++ b/inc/redirect/namespace.php
@@ -374,7 +374,11 @@ function do_open() {
 				$book_title_slug = str_replace( [ '+' ], '', $book_title_slug ); // Remove symbols which confuse Apache (Ie. form urlencoded spaces)
 				$book_title_slug = sanitize_file_name( $book_title_slug );
 				if ( ! is_readable( $filepath ) ) {
-					wp_die( __( 'File not found', 'pressbooks' ) . ': ' . $files[ $_GET['type'] ], '', [ 'response' => 404 ] );
+					wp_die(
+						__( 'File not found', 'pressbooks' ) . ': ' . $files[ $_GET['type'] ], '', [
+							'response' => 404,
+						]
+					);
 				}
 
 				// Force download

--- a/inc/registration/namespace.php
+++ b/inc/registration/namespace.php
@@ -24,64 +24,64 @@ function custom_signup_text( $translated_text, $untranslated_text, $domain ) {
 
 	if ( 'wp-signup.php' === $pagenow ) {
 		switch ( $untranslated_text ) {
-			case 'Gimme a site!' :
+			case 'Gimme a site!':
 				$translated_text = __( 'Register my book now', 'pressbooks' );
 				break;
-			case 'Just a username, please.' :
+			case 'Just a username, please.':
 				$translated_text = __( 'Register my book later', 'pressbooks' );
 				break;
-			case 'Site Name:' :
-			case 'Site Domain:' :
+			case 'Site Name:':
+			case 'Site Domain:':
 				$translated_text = __( 'Webbook Address:', 'pressbooks' );
 				break;
-			case 'Must be at least 4 characters, letters and numbers only. It cannot be changed, so choose carefully!' :
+			case 'Must be at least 4 characters, letters and numbers only. It cannot be changed, so choose carefully!':
 				$translated_text = __( 'Your webbook address is the web address where you will access and create your book. It must be at least 4 characters, letters and numbers only. It <strong>cannot be changed</strong>, so choose carefully! We suggest using the title of your book with no spaces.', 'pressbooks' );
 				break;
-			case 'Site Title:' :
+			case 'Site Title:':
 				$translated_text = __( 'Book Title:', 'pressbooks' );
 				break;
-			case 'Site Language:' :
+			case 'Site Language:':
 				$translated_text = __( 'Book Language:', 'pressbooks' );
 				break;
-			case 'Allow search engines to index this site.' :
+			case 'Allow search engines to index this site.':
 				$translated_text = __( 'Would you like your webbook to be visible to the public?', 'pressbooks' );
 				break;
-			case 'Create Site' :
-			case 'Signup' :
+			case 'Create Site':
+			case 'Signup':
 				$translated_text = __( 'Create Book', 'pressbooks' );
 				break;
-			case 'Get your own %s account in seconds' :
+			case 'Get your own %s account in seconds':
 				$translated_text = __( 'Register a %s account', 'pressbooks' );
 				break;
-			case 'Get <em>another</em> %s site in seconds' :
+			case 'Get <em>another</em> %s site in seconds':
 				$translated_text = __( 'Create a new book', 'pressbooks' );
 				break;
-			case 'Welcome back, %s. By filling out the form below, you can <strong>add another site to your account</strong>. There is no limit to the number of sites you can have, so create to your heart&#8217;s content, but write responsibly!' :
+			case 'Welcome back, %s. By filling out the form below, you can <strong>add another site to your account</strong>. There is no limit to the number of sites you can have, so create to your heart&#8217;s content, but write responsibly!':
 				$translated_text = __( 'Welcome, %s. Fill out the form below to <strong>add a new book to your account</strong>.', 'pressbooks' );
 				break;
-			case 'domain' :
-			case 'sitename' :
+			case 'domain':
+			case 'sitename':
 				$translated_text = __( 'yourwebbookname', 'pressbooks' );
 				break;
-			case 'Sites you are already a member of:' :
+			case 'Sites you are already a member of:':
 				$translated_text = __( 'Books you are already a member of:', 'pressbooks' );
 				break;
-			case 'If you&#8217;re not going to use a great site domain, leave it for a new user. Now have at it!' :
+			case 'If you&#8217;re not going to use a great site domain, leave it for a new user. Now have at it!':
 				$translated_text = __( 'Your webbook address is the web address where you will access and create your book. It must be at least 4 characters, letters and numbers only. It <strong>cannot be changed</strong>, so choose carefully! We suggest using the title of your book with no spaces.', 'pressbooks' );
 				break;
-			case 'Congratulations! Your new site, %s, is almost ready.' :
+			case 'Congratulations! Your new site, %s, is almost ready.':
 				$translated_text = __( 'Congratulations! Your new book, %s, is almost ready', 'pressbooks' );
 				break;
-			case 'But, before you can start using your site, <strong>you must activate it</strong>.' :
+			case 'But, before you can start using your site, <strong>you must activate it</strong>.':
 				$translated_text = __( 'But, before you can start writing your book, <strong>you must activate it</strong>.', 'pressbooks' );
 				break;
-			case 'Your account has been activated. You may now <a href="%1$s">log in</a> to the site using your chosen username of &#8220;%2$s&#8221;. Please check your email inbox at %3$s for your password and login instructions. If you do not receive an email, please check your junk or spam folder. If you still do not receive an email within an hour, you can <a href="%4$s">reset your password</a>.' :
+			case 'Your account has been activated. You may now <a href="%1$s">log in</a> to the site using your chosen username of &#8220;%2$s&#8221;. Please check your email inbox at %3$s for your password and login instructions. If you do not receive an email, please check your junk or spam folder. If you still do not receive an email within an hour, you can <a href="%4$s">reset your password</a>.':
 				$translated_text = __( 'Your account has been activated. You may now <a href="%1$s">log in</a> to your book using your chosen username of &#8220;%2$s&#8221;. Please check your email inbox at %3$s for your password and login instructions. If you do not receive an email, please check your junk or spam folder. If you still do not receive an email within an hour, you can <a href="%4$s">reset your password</a>.', 'pressbooks' );
 				break;
-			case 'Your site at <a href="%1$s">%2$s</a> is active. You may now log in to your site using your chosen username of &#8220;%3$s&#8221;. Please check your email inbox at %4$s for your password and login instructions. If you do not receive an email, please check your junk or spam folder. If you still do not receive an email within an hour, you can <a href="%5$s">reset your password</a>.' :
+			case 'Your site at <a href="%1$s">%2$s</a> is active. You may now log in to your site using your chosen username of &#8220;%3$s&#8221;. Please check your email inbox at %4$s for your password and login instructions. If you do not receive an email, please check your junk or spam folder. If you still do not receive an email within an hour, you can <a href="%5$s">reset your password</a>.':
 				$translated_text = __( 'Your book at <a href="%1$s">%2$s</a> is active. You may now log in to your book using your chosen username of &#8220;%3$s&#8221;. Please check your email inbox at %4$s for your password and login instructions. If you do not receive an email, please check your junk or spam folder. If you still do not receive an email within an hour, you can <a href="%5$s">reset your password</a>.', 'pressbooks' );
 				break;
-			case 'Your account is now activated. <a href="%1$s">View your site</a> or <a href="%2$s">Log in</a>' :
+			case 'Your account is now activated. <a href="%1$s">View your site</a> or <a href="%2$s">Log in</a>':
 				$translated_text = __( 'Your account is now activated. <a href="%1$s">View your book</a> or <a href="%2$s">Log in</a>', 'pressbooks' );
 				break;
 		}
@@ -104,13 +104,17 @@ function add_password_field( $errors ) {
 	} ?>
 
 	<label for="password_1"><?php _e( 'Password', 'pressbooks' ); ?>:</label>
-	<?php if ( $error ) { ?><p class="error"><?php echo $error; ?></p><?php } ?>
+	<?php
+	if ( $error ) {
+?>
+<p class="error"><?php echo $error; ?></p><?php } ?>
 	<input name="password_1" type="password" id="password_1" value="" autocomplete="off" maxlength="20"/><br/>
 	<?php _e( 'Type in your password.', 'pressbooks' ); ?>
 
 	<label for="password_2"><?php _e( 'Confirm Password', 'pressbooks' ); ?>:</label>
 	<input name="password_2" type="password" id="password_2" value="" autocomplete="off" maxlength="20"/><br/>
-	<?php _e( 'Type in your password again.', 'pressbooks' );
+	<?php
+	_e( 'Type in your password again.', 'pressbooks' );
 }
 
 /**
@@ -161,7 +165,9 @@ function add_temporary_password( $meta ) {
 	if ( isset( $_POST['password_1'] ) ) {
 
 		// Store as base64 to avoid injections
-		$add_meta = [ 'password' => ( isset( $_POST['password_1_base64'] ) ? $_POST['password_1'] : base64_encode( $_POST['password_1'] ) ) ];
+		$add_meta = [
+			'password' => ( isset( $_POST['password_1_base64'] ) ? $_POST['password_1'] : base64_encode( $_POST['password_1'] ) ),
+		];
 		$meta = array_merge( $add_meta, $meta );
 	}
 
@@ -177,10 +183,12 @@ function add_hidden_password_field() {
 	if ( isset( $_POST['_signup_form'] ) && ! wp_verify_nonce( $_POST['_signup_form'], 'signup_form_' . $_POST['signup_form_id'] ) ) {
 		wp_die( __( 'Please try again.', 'pressbooks' ) );
 	}
-	if ( isset( $_POST['password_1'] ) ) { ?>
+	if ( isset( $_POST['password_1'] ) ) {
+	?>
 		<input type="hidden" name="password_1_base64" value="1"/>
 		<input type="hidden" name="password_1" value="<?php echo( isset( $_POST['password_1_base64'] ) ? $_POST['password_1'] : base64_encode( $_POST['password_1'] ) ); ?>"/>
-	<?php }
+	<?php
+	}
 }
 
 /**
@@ -220,7 +228,13 @@ function override_password_generation( $password ) {
 			// Remove old password from signup meta
 			unset( $meta['password'] );
 			$meta = maybe_serialize( $meta );
-			$wpdb->update( $wpdb->signups, [ 'meta' => $meta ], [ 'activation_key' => $key ], [ '%s' ], [ '%s' ] );
+			$wpdb->update(
+				$wpdb->signups, [
+					'meta' => $meta,
+				], [
+					'activation_key' => $key,
+				], [ '%s' ], [ '%s' ]
+			);
 			return $password;
 		} else {
 			return $password; // No password meta set = just activate user as normal with random password

--- a/inc/sanitize/namespace.php
+++ b/inc/sanitize/namespace.php
@@ -237,7 +237,9 @@ function strip_br( $slug ) {
 function filter_title( $title ) {
 	$allowed = [
 		'br' => [],
-		'span' => [ 'class' => [] ],
+		'span' => [
+			'class' => [],
+		],
 		'em' => [],
 		'strong' => [],
 		'del' => [],
@@ -358,7 +360,8 @@ function normalize_css_urls( $css, $url_path = '' ) {
 			return $matches[0]; // No change
 
 		},
-	$css );
+		$css
+	);
 
 	return $css;
 }

--- a/inc/sanitize/namespace.php
+++ b/inc/sanitize/namespace.php
@@ -55,7 +55,10 @@ function html5_to_xhtml11( $html, $config = [], $spec = [] ) {
 		'wbr',
 	];
 
-	$search_open = $replace_open = $search_closed = $replace_closed = [];
+	$search_open = [];
+	$search_closed = [];
+	$replace_open = [];
+	$replace_closed = [];
 
 	foreach ( $html5 as $tag ) {
 		$search_open[] = '`(<' . $tag . ')([^\w])`i';
@@ -83,7 +86,10 @@ function html5_to_epub3( $html, $config = [], $spec = [] ) {
 	// HTML5 elements we don't want to deal with just yet
 	$html5 = [ 'command', 'embed', 'track' ];
 
-	$search_open = $replace_open = $search_closed = $replace_closed = [];
+	$search_open = [];
+	$search_closed = [];
+	$replace_open = [];
+	$replace_closed = [];
 
 	foreach ( $html5 as $tag ) {
 		$search_open[] = '`(<' . $tag . ')([^\w])`i';
@@ -274,9 +280,9 @@ function canonicalize_url( $url ) {
 	}
 
 	// protocol and domain to lowercase (but NOT the rest of the URL),
-	$scheme = parse_url( $url, PHP_URL_SCHEME );
+	$scheme = wp_parse_url( $url, PHP_URL_SCHEME );
 	$url = preg_replace( '/' . preg_quote( $scheme ) . '/', mb_strtolower( $scheme ), $url, 1 );
-	$host = parse_url( $url, PHP_URL_HOST );
+	$host = wp_parse_url( $url, PHP_URL_HOST );
 	$url = preg_replace( '/' . preg_quote( $host ) . '/', mb_strtolower( $host ), $url, 1 );
 
 	// Sanitize for good measure
@@ -508,15 +514,16 @@ function strip_container_tags( $html ) {
 function cleanup_css( $css ) {
 
 	$css = stripslashes( $css );
-
-	$css = preg_replace( '/\\\\([0-9a-fA-F]{2,4})/', '\\\\\\\\$1', $prev = $css );
+	$prev = $css;
+	$css = preg_replace( '/\\\\([0-9a-fA-F]{2,4})/', '\\\\\\\\$1', $prev );
 
 	if ( $css !== $prev ) {
 		$warnings[] = 'preg_replace() double escaped unicode escape sequences';
 	}
 
 	$css = str_replace( '<=', '&lt;=', $css ); // Some people put weird stuff in their CSS, KSES tends to be greedy
-	$css = wp_kses_split( $prev = $css, [], [] );
+	$prev = $css;
+	$css = wp_kses_split( $prev, [], [] );
 	$css = str_replace( '&gt;', '>', $css ); // kses replaces lone '>' with &gt;
 	$css = strip_tags( $css );
 

--- a/inc/shortcodes/footnotes/class-footnotes.php
+++ b/inc/shortcodes/footnotes/class-footnotes.php
@@ -34,10 +34,12 @@ class Footnotes {
 		if ( ! self::$instance ) {
 			$self = new self;
 			add_shortcode( 'footnote', [ $self, 'shortcodeHandler' ] );
-			add_filter( 'no_texturize_shortcodes', function ( $excluded_shortcodes ) {
-				$excluded_shortcodes[] = 'footnote';
-				return $excluded_shortcodes;
-			} );
+			add_filter(
+				'no_texturize_shortcodes', function ( $excluded_shortcodes ) {
+					$excluded_shortcodes[] = 'footnote';
+					return $excluded_shortcodes;
+				}
+			);
 			// do_shortcode() is registered as a default filter on 'the_content' with a priority of 11.
 			// We need to run $this->footNoteContent() after this, set to 12
 			add_filter( 'the_content', [ $self, 'footnoteContent' ], 12 );
@@ -169,9 +171,9 @@ class Footnotes {
 				'admin_enqueue_scripts', function () {
 					wp_localize_script(
 						'editor', 'PB_FootnotesToken', [
-						'nonce' => wp_create_nonce( 'pb-footnote-convert' ),
-						'fn_title' => __( 'Insert Footnote', 'pressbooks' ),
-						'ftnref_title' => __( 'Convert MS Word Footnotes', 'pressbooks' ),
+							'nonce' => wp_create_nonce( 'pb-footnote-convert' ),
+							'fn_title' => __( 'Insert Footnote', 'pressbooks' ),
+							'ftnref_title' => __( 'Convert MS Word Footnotes', 'pressbooks' ),
 						]
 					);
 				}
@@ -302,10 +304,10 @@ class Footnotes {
 
 				$tmp = wp_kses(
 					$footnote[3], [
-					'b' => [],
-					'em' => [],
-					'i' => [],
-					'strong' => [],
+						'b' => [],
+						'em' => [],
+						'i' => [],
+						'strong' => [],
 					]
 				);
 				$tmp = \Pressbooks\Sanitize\remove_control_characters( $tmp );
@@ -328,7 +330,11 @@ class Footnotes {
 
 		// Send back JSON
 		header( 'Content-Type: application/json' );
-		$json = json_encode( [ 'content' => $html ] );
+		$json = json_encode(
+			[
+				'content' => $html,
+			]
+		);
 		echo $json;
 
 		wp_die();

--- a/inc/shortcodes/footnotes/class-footnotes.php
+++ b/inc/shortcodes/footnotes/class-footnotes.php
@@ -294,7 +294,9 @@ class Footnotes {
 			'~<a[\s]+[^>]*?href[\s]?=[\s"\']+(?:#sdfootnote__REPLACE_ME__sym)["\']+.*?>(?:[^<]+|.*?)?</a>~si', // Libre Office
 		];
 
-		$footnotes = $find = $replace = [];
+		$footnotes = [];
+		$find = [];
+		$replace = [];
 
 		foreach ( $patterns as $i => $pattern ) {
 
@@ -330,7 +332,7 @@ class Footnotes {
 
 		// Send back JSON
 		header( 'Content-Type: application/json' );
-		$json = json_encode(
+		$json = wp_json_encode(
 			[
 				'content' => $html,
 			]

--- a/inc/shortcodes/wikipublisher/class-glyphs.php
+++ b/inc/shortcodes/wikipublisher/class-glyphs.php
@@ -37,10 +37,12 @@ class Glyphs {
 		if ( ! self::$instance ) {
 			$self = new self;
 			add_shortcode( 'pb_language', [ $self, 'langShortcode' ] );
-			add_filter( 'no_texturize_shortcodes', function ( $excluded_shortcodes ) {
-				$excluded_shortcodes[] = 'pb_language';
-				return $excluded_shortcodes;
-			} );
+			add_filter(
+				'no_texturize_shortcodes', function ( $excluded_shortcodes ) {
+					$excluded_shortcodes[] = 'pb_language';
+					return $excluded_shortcodes;
+				}
+			);
 			self::$instance = $self;
 		}
 		return self::$instance;
@@ -74,7 +76,7 @@ class Glyphs {
 			return $_error;
 		}
 
-		// Reverse Wordpress' fancy formatting
+		// Reverse WordPress' fancy formatting
 		// We want to keep all characters such as ‘ ` " '' [...] < > should be &gt; &lt; Ie. not numeric
 		$content = str_replace( [ '&#8216;', '&#8217;', '&lsquo;', '&rsquo;' ], "'", $content ); // Change back to '
 		$content = str_replace( [ '&#8220;', '&#8221;', '&ldquo;', '&rdquo;' ], '"', $content ); // Change back to "

--- a/inc/theme/class-lock.php
+++ b/inc/theme/class-lock.php
@@ -200,9 +200,9 @@ class Lock {
 			'timestamp' => $time,
 			'features' => $theme_features,
 		];
-		$json = json_encode( $data );
+		$json = wp_json_encode( $data );
 		$lockfile = $this->getLockDir() . '/lock.json';
-		file_put_contents( $lockfile, $json );
+		\Pressbooks\Utility\put_contents( $lockfile, $json );
 		return $data;
 	}
 
@@ -236,7 +236,7 @@ class Lock {
 	 * @return array
 	 */
 	public function getLockData() {
-		$json = file_get_contents( $this->getLockDir( false ) . '/lock.json' );
+		$json = \Pressbooks\Utility\get_contents( $this->getLockDir( false ) . '/lock.json' );
 		$output = json_decode( $json, true );
 		return $output;
 	}
@@ -265,7 +265,7 @@ class Lock {
 
 			// Redirect and notify users of theme lock status.
 
-			$check_against_url = parse_url( ( is_ssl() ? 'http://' : 'https://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'], PHP_URL_PATH );
+			$check_against_url = wp_parse_url( ( is_ssl() ? 'http://' : 'https://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'], PHP_URL_PATH );
 			$redirect_url = get_site_url( get_current_blog_id(), '/wp-admin/' );
 
 			// ---------------------------------------------------------------------------------------------------------------

--- a/inc/theme/namespace.php
+++ b/inc/theme/namespace.php
@@ -30,41 +30,47 @@ function check_required_themes() {
 	$theme = wp_get_theme();
 
 	if ( ! $theme->exists() && in_array( $theme->get_stylesheet(), $migrated_book_themes, true ) ) {
-		wp_die( sprintf(
-			__( 'Your theme, %1$s, is not installed. Please visit %2$s for installation instructions.', 'pressbooks' ),
-			$theme->get_stylesheet(),
+		wp_die(
 			sprintf(
-				'<a href="%1$s">%2$s</a>',
-				'https://github.com/pressbooks/' . $theme->get_stylesheet(),
-				'GitHub'
+				__( 'Your theme, %1$s, is not installed. Please visit %2$s for installation instructions.', 'pressbooks' ),
+				$theme->get_stylesheet(),
+				sprintf(
+					'<a href="%1$s">%2$s</a>',
+					'https://github.com/pressbooks/' . $theme->get_stylesheet(),
+					'GitHub'
+				)
 			)
-		) );
+		);
 	}
 
 	if ( PB_ROOT_THEME === 'pressbooks-publisher' ) { // To bypass this check, define PB_ROOT_THEME to the name of your custom root theme in wp-config.php.
 		$theme = wp_get_theme( 'pressbooks-publisher' );
 		if ( ! $theme->exists() ) {
-			wp_die( sprintf(
-				__( 'The Pressbooks Publisher theme is not installed, but Pressbooks needs it in order to function properly. Please visit %s for installation instructions.', 'pressbooks' ),
+			wp_die(
 				sprintf(
-					'<a href="%1$s">%2$s</a>',
-					'https://github.com/pressbooks/pressbooks-publisher',
-					'GitHub'
+					__( 'The Pressbooks Publisher theme is not installed, but Pressbooks needs it in order to function properly. Please visit %s for installation instructions.', 'pressbooks' ),
+					sprintf(
+						'<a href="%1$s">%2$s</a>',
+						'https://github.com/pressbooks/pressbooks-publisher',
+						'GitHub'
+					)
 				)
-			) );
+			);
 		}
 	}
 
 	$theme = wp_get_theme( 'pressbooks-book' );
 	if ( ! $theme->exists() ) {
-		wp_die( sprintf(
-			__( 'The Pressbooks Book theme is not installed, but Pressbooks needs it in order to function properly. Please visit %s for installation instructions.', 'pressbooks' ),
+		wp_die(
 			sprintf(
-				'<a href="%1$s">%2$s</a>',
-				'https://github.com/pressbooks/pressbooks-book',
-				'GitHub'
+				__( 'The Pressbooks Book theme is not installed, but Pressbooks needs it in order to function properly. Please visit %s for installation instructions.', 'pressbooks' ),
+				sprintf(
+					'<a href="%1$s">%2$s</a>',
+					'https://github.com/pressbooks/pressbooks-book',
+					'GitHub'
+				)
 			)
-		) );
+		);
 	}
 
 	set_transient( 'pb_has_required_themes', 1 );
@@ -83,14 +89,16 @@ function check_upgraded_customcss() {
 	foreach ( [ 'pressbooks-custom-css', 'pressbooks-customcss' ] as $name ) {
 		$theme = wp_get_theme( $name );
 		if ( $theme->exists() && ! version_compare( $theme->get( 'Version' ), '1.0.0', '>=' ) ) {
-			wp_die( sprintf(
-				__( 'The Pressbooks Custom CSS theme must be upgraded. Please visit %s for installation instructions.', 'pressbooks' ),
+			wp_die(
 				sprintf(
-					'<a href="%1$s">%2$s</a>',
-					'https://github.com/pressbooks/pressbooks-custom-css',
-					'GitHub'
+					__( 'The Pressbooks Custom CSS theme must be upgraded. Please visit %s for installation instructions.', 'pressbooks' ),
+					sprintf(
+						'<a href="%1$s">%2$s</a>',
+						'https://github.com/pressbooks/pressbooks-custom-css',
+						'GitHub'
+					)
 				)
-			) );
+			);
 		}
 	}
 

--- a/inc/theme/namespace.php
+++ b/inc/theme/namespace.php
@@ -128,9 +128,9 @@ function migrate_book_themes() {
 			if ( $lock->isLocked() ) {
 				$data = $lock->getLockData();
 				$data['stylesheet'] = $comparisons[ $theme ];
-				$json = json_encode( $data );
+				$json = wp_json_encode( $data );
 				$lockfile = $lock->getLockDir( false ) . '/lock.json';
-				file_put_contents( $lockfile, $json );
+				\Pressbooks\Utility\put_contents( $lockfile, $json );
 			}
 		}
 

--- a/inc/utility/namespace.php
+++ b/inc/utility/namespace.php
@@ -1159,6 +1159,8 @@ function get_cache_path() {
 }
 
 /**
+ * @since 5.0.0
+ *
  * @see \WP_Filesystem
  * @return \WP_Filesystem_Direct
  */
@@ -1180,6 +1182,8 @@ function init_direct_filesystem() {
 }
 
 /**
+ * @since 5.0.0
+ *
  * @param string $filename
  *
  * @return bool|string
@@ -1190,6 +1194,8 @@ function get_contents( $filename ) {
 }
 
 /**
+ * @since 5.0.0
+ *
  * @param string $filename
  * @param mixed $data
  *

--- a/inc/utility/namespace.php
+++ b/inc/utility/namespace.php
@@ -195,17 +195,17 @@ function latest_exports() {
 	 */
 	$filetypes = apply_filters(
 		'pb_latest_export_filetypes', [
-		'epub3' => '._3.epub',
-		'epub' => '.epub',
-		'pdf' => '.pdf',
-		'print-pdf' => '._print.pdf',
-		'mobi' => '.mobi',
-		'icml' => '.icml',
-		'xhtml' => '.html',
-		'wxr' => '.xml',
-		'vanillawxr' => '._vanilla.xml',
-		'mpdf' => '._oss.pdf',
-		'odf' => '.odt',
+			'epub3' => '._3.epub',
+			'epub' => '.epub',
+			'pdf' => '.pdf',
+			'print-pdf' => '._print.pdf',
+			'mobi' => '.mobi',
+			'icml' => '.icml',
+			'xhtml' => '.html',
+			'wxr' => '.xml',
+			'vanillawxr' => '._vanilla.xml',
+			'mpdf' => '._oss.pdf',
+			'odf' => '.odt',
 		]
 	);
 
@@ -525,7 +525,11 @@ function disable_comments() {
 	}
 
 	$old_option = get_option( 'disable_comments_options' );
-	$new_option = get_option( 'pressbooks_sharingandprivacy_options', [ 'disable_comments' => 1 ] );
+	$new_option = get_option(
+		'pressbooks_sharingandprivacy_options', [
+			'disable_comments' => 1,
+		]
+	);
 
 	if ( false === (bool) $old_option ) {
 		$retval = (bool) $new_option['disable_comments'];
@@ -616,13 +620,21 @@ function fetch_recommended_plugins() {
 	if ( $ssl ) {
 		$url = set_url_scheme( $url, 'https' );
 	}
-	$request = wp_remote_get( $url, [ 'timeout' => 15 ] );
+	$request = wp_remote_get(
+		$url, [
+			'timeout' => 15,
+		]
+	);
 	if ( $ssl && is_wp_error( $request ) ) {
 		trigger_error(
 			__( 'An unexpected error occurred. Something may be wrong with the plugin recommendations server or your site&#8217;s server&#8217;s configuration.', 'pressbooks' ) . ' ' . __( '(Pressbooks could not establish a secure connection to the plugin recommendations server. Please contact your server administrator.)', 'pressbooks' ),
 			headers_sent() || WP_DEBUG ? E_USER_WARNING : E_USER_NOTICE
 		);
-		$request = wp_remote_get( $http_url, [ 'timeout' => 15 ] );
+		$request = wp_remote_get(
+			$http_url, [
+				'timeout' => 15,
+			]
+		);
 	}
 	if ( is_wp_error( $request ) ) {
 		$res = new \WP_Error(

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -14,16 +14,23 @@
 
     <!-- Use HM Coding Standards -->
     <rule ref="vendor/humanmade/coding-standards">
-        <!-- Disable all ESLint checks -->
+        <!-- Disable all ESLint checks: -->
         <exclude name="HM.Debug.ESLint"/>
-        <!-- Disable rules Pressbooks disagrees with -->
+        <!-- Disable rules Pressbooks disagrees with: -->
         <exclude name="WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid"/>
         <exclude name="WordPress.NamingConventions.ValidVariableName.MemberNotSnakeCase"/>
         <exclude name="WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar"/>
         <exclude name="WordPress.VIP.SessionVariableUsage"/>
         <exclude name="WordPress.VIP.SessionFunctionsUsage"/>
-        <!-- Disable LayoutOrder until humanmade/coding-standards#5 is fixed -->
+        <exclude name="WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec"/>
+        <exclude name="WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_ini_set"/>
+        <exclude name="WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_putenv"/>
+        <exclude name="WordPress.PHP.DevelopmentFunctions.error_log_trigger_error"/>
+        <!-- Disable LayoutOrder until humanmade/coding-standards#5 is fixed: -->
         <exclude name="HM.Layout.Order.WrongOrder"/>
+        <!-- Temporary, these should be enabled someday soon: -->
+        <exclude name="WordPress.CSRF.NonceVerification.NoNonceVerification"/>
+        <exclude name="WordPress.WP.I18n.MissingTranslatorsComment"/>
     </rule>
 
     <!-- Re-enable rules Pressbooks agrees with -->

--- a/pressbooks.php
+++ b/pressbooks.php
@@ -11,6 +11,8 @@ License: GPLv2
 Network: True
 */
 
+use function \Pressbooks\Utility\debug_error_log;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	return;
 }
@@ -19,7 +21,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 // Turn on $_SESSION
 // -------------------------------------------------------------------------------------------------------------------
 
-function _pb_session_start() { // @codingStandardsIgnoreLine
+// @codingStandardsIgnoreStart
+function _pb_session_start() {
 	if ( ! session_id() ) {
 		if ( ! headers_sent() ) {
 			ini_set( 'session.use_only_cookies', true );
@@ -42,15 +45,16 @@ function _pb_session_start() { // @codingStandardsIgnoreLine
 			);
 			session_start();
 		} else {
-			error_log( 'There was a problem with _pb_session_start(), headers already sent!' );
+			debug_error_log( 'There was a problem with _pb_session_start(), headers already sent!' );
 		}
 	}
 }
 
-function _pb_session_kill() { // @codingStandardsIgnoreLine
+function _pb_session_kill() {
 	$_SESSION = [];
 	session_destroy();
 }
+// @codingStandardsIgnoreEnd
 
 add_action( 'init', '_pb_session_start', 1 );
 add_action( 'wp_logout', '_pb_session_kill' );
@@ -106,6 +110,7 @@ if ( file_exists( $composer ) ) {
 	require_once( $composer );
 } else {
 	if ( ! class_exists( '\Illuminate\Container\Container' ) ) {
+		/* translators: 1: URL to Composer documentation, 2: URL to Pressbooks latest releases */
 		die( sprintf( __( 'Pressbooks dependencies are missing. Please make sure that your project&rsquo;s <a href="%1$s">Composer autoload file</a> is being required, or use the <a href="%2$s">latest release</a> instead.', 'pressbooks' ), 'https://getcomposer.org/doc/01-basic-usage.md#autoloading', 'https://github.com/pressbooks/pressbooks/releases/latest/' ) );
 	}
 }

--- a/pressbooks.php
+++ b/pressbooks.php
@@ -101,7 +101,8 @@ putenv( "LC_CTYPE={$pb_lc_ctype}" );
 // Composer autoloader (if needed)
 // -------------------------------------------------------------------------------------------------------------------
 
-if ( file_exists( $composer = PB_PLUGIN_DIR . 'vendor/autoload.php' ) ) {
+$composer = PB_PLUGIN_DIR . 'vendor/autoload.php';
+if ( file_exists( $composer ) ) {
 	require_once( $composer );
 } else {
 	if ( ! class_exists( '\Illuminate\Container\Container' ) ) {

--- a/pressbooks.php
+++ b/pressbooks.php
@@ -114,9 +114,11 @@ if ( file_exists( $composer = PB_PLUGIN_DIR . 'vendor/autoload.php' ) ) {
 // -------------------------------------------------------------------------------------------------------------------
 
 if ( ! function_exists( 'pb_meets_minimum_requirements' ) && ! @include_once( PB_PLUGIN_DIR . 'compatibility.php' ) ) { // @codingStandardsIgnoreLine
-	return add_action( 'admin_notices', function () {
-		echo '<div id="message" class="error fade"><p>' . __( 'Cannot find Pressbooks install.', 'pressbooks' ) . '</p></div>';
-	} );
+	return add_action(
+		'admin_notices', function () {
+			echo '<div id="message" class="error fade"><p>' . __( 'Cannot find Pressbooks install.', 'pressbooks' ) . '</p></div>';
+		}
+	);
 } elseif ( ! pb_meets_minimum_requirements() ) {
 	return;
 }
@@ -131,9 +133,11 @@ pb_init_autoloader();
 // Configure root site
 // -------------------------------------------------------------------------------------------------------------------
 
-register_activation_hook( __FILE__, function () {
-	( new \Pressbooks\Activation() )->registerActivationHook();
-} );
+register_activation_hook(
+	__FILE__, function () {
+		( new \Pressbooks\Activation() )->registerActivationHook();
+	}
+);
 
 // -------------------------------------------------------------------------------------------------------------------
 // Initialize

--- a/services.php
+++ b/services.php
@@ -4,22 +4,30 @@
 
 $c = new \Illuminate\Container\Container();
 
-$c->singleton( 'Sass', function () {
-	return new \Pressbooks\Sass();
-} );
+$c->singleton(
+	'Sass', function () {
+		return new \Pressbooks\Sass();
+	}
+);
 
-$c->singleton( 'GlobalTypography', function ( \Illuminate\Container\Container $c ) {
-	return new \Pressbooks\GlobalTypography( $c->make( 'Sass' ) );
-} );
+$c->singleton(
+	'GlobalTypography', function ( \Illuminate\Container\Container $c ) {
+		return new \Pressbooks\GlobalTypography( $c->make( 'Sass' ) );
+	}
+);
 
-$c->singleton( 'Styles', function ( \Illuminate\Container\Container $c ) {
-	return new \Pressbooks\Styles( $c->make( 'Sass' ) );
-} );
+$c->singleton(
+	'Styles', function ( \Illuminate\Container\Container $c ) {
+		return new \Pressbooks\Styles( $c->make( 'Sass' ) );
+	}
+);
 
-$c->singleton( 'Blade', function ( \Illuminate\Container\Container $c ) {
-	$views = __DIR__ . '/templates';
-	$cache = \Pressbooks\Utility\get_cache_path();
-	return new \Jenssegers\Blade\Blade( $views, $cache, $c );
-} );
+$c->singleton(
+	'Blade', function ( \Illuminate\Container\Container $c ) {
+		$views = __DIR__ . '/templates';
+		$cache = \Pressbooks\Utility\get_cache_path();
+		return new \Jenssegers\Blade\Blade( $views, $cache, $c );
+	}
+);
 
 return $c;

--- a/templates/admin/custom-styles.php
+++ b/templates/admin/custom-styles.php
@@ -16,7 +16,7 @@ $slugs_dropdown = $styles->renderDropdownForSlugs( $slug );
 $revisions_table = $styles->renderRevisionsTable( $slug, $style_post->ID );
 $post_id = absint( $style_post->ID );
 $theme = wp_get_theme();
-$theme_styles = $styles->customize( $slug, file_get_contents( $styles->getPathToScss( $slug ) ) );
+$theme_styles = $styles->customize( $slug, \Pressbooks\Utility\get_contents( $styles->getPathToScss( $slug ) ) );
 $your_styles = $style_post->post_content;
 
 // -------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
I had to disable two rules that should be on:

 ```        
<!-- Temporary, these should be enabled someday soon: -->
  <exclude name="WordPress.CSRF.NonceVerification.NoNonceVerification"/>
  <exclude name="WordPress.WP.I18n.MissingTranslatorsComment"/>
```

The first one is about this: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1172

A quote from the ticket:
> The error seems correct to me as you're accessing a request variable without doing a nonce check.

We have a lot of places in the code that looks like that ticket but these new (or fixed?) standards complain because they don't see `wp_verify_nonce` `check_admin_referer` or `check_ajax_referer` on the same line.

In the past I've cheated and hidden those types of interactions from the rules with a function called `utility\getset` but there are just too many being reported on stuff I don't consider dangerous. 

The second rule is translation hint comments. Lots to do.

Another 10,000 lines of code changed thanks to WordPress' glorious code standards. 🙄 