### PR TITLE
Fix theme migration for Pressbooks 5.0

### DIFF
--- a/inc/class-activation.php
+++ b/inc/class-activation.php
@@ -25,7 +25,7 @@ class Activation {
 	 * @var array The set of default WP options to set up on activation
 	 */
 	private $opts = [
-		'pressbooks_theme_migration' => 2, // @see \Pressbooks\Theme\migrate_book_themes()
+		'pressbooks_theme_migration' => 2,
 		'show_on_front' => 'page',
 		'rewrite_rules' => '',
 	];

--- a/inc/class-activation.php
+++ b/inc/class-activation.php
@@ -25,6 +25,7 @@ class Activation {
 	 * @var array The set of default WP options to set up on activation
 	 */
 	private $opts = [
+		'pressbooks_theme_migration' => 2, // @see \Pressbooks\Theme\migrate_book_themes()
 		'show_on_front' => 'page',
 		'rewrite_rules' => '',
 	];
@@ -124,6 +125,7 @@ class Activation {
 
 		switch_to_blog( $this->blog_id );
 		if ( ! $this->isBookSetup() ) {
+
 			$this->wpmuActivate();
 			array_walk(
 				$this->opts, function ( $v, $k ) {


### PR DESCRIPTION
Make sure that new books don't try to switch from `pressbooks-book` to `pressbooks-luther`.