### PR TITLE
Contributor UI [WIP]

### DIFF
--- a/hooks-admin.php
+++ b/hooks-admin.php
@@ -164,6 +164,11 @@ if ( $is_book ) {
 	add_action( 'save_post_metadata', '\Pressbooks\Admin\Metaboxes\upload_cover_image', 10, 2 );
 	add_action( 'save_post_metadata', '\Pressbooks\Admin\Metaboxes\add_required_data', 20, 2 );
 	add_action( 'save_post_metadata', '\Pressbooks\Admin\Metaboxes\save_subject_metadata', 10, 2 );
+	add_action( 'contributor_add_form_fields', '\Pressbooks\Admin\Metaboxes\contributor_add_form' );
+	add_action( 'contributor_edit_form_fields', '\Pressbooks\Admin\Metaboxes\contributor_edit_form' );
+	add_action( 'init', '\Pressbooks\Metadata\register_contributor_meta' );
+	add_action( 'create_term', '\Pressbooks\Admin\Metaboxes\save_contributor_meta', 10, 3 );
+	add_action( 'edit_term', '\Pressbooks\Admin\Metaboxes\save_contributor_meta', 10, 3 );
 	add_action( 'added_post_meta', '\Pressbooks\Admin\Metaboxes\title_update', 10, 4 );
 	add_action( 'updated_post_meta', '\Pressbooks\Admin\Metaboxes\title_update', 10, 4 );
 	add_action( 'updated_post_meta', '\Pressbooks\L10n\install_book_locale', 10, 4 );

--- a/inc/admin/metaboxes/namespace.php
+++ b/inc/admin/metaboxes/namespace.php
@@ -904,7 +904,8 @@ function save_subject_metadata( $post_id ) {
  * @since 5.0.0
  */
 function contributor_add_form() {
-	wp_nonce_field( 'contributor-meta', 'contributor_meta_nonce' ); ?>
+	wp_nonce_field( 'contributor-meta', 'contributor_meta_nonce' );
+?>
 	<div class="form-field contributor-first-name-wrap">
 		<label for="contributor_first_name"><?php _e( 'First Name', 'pressbooks' ); ?></label>
 		<input type="text" name="contributor_first_name" id="contributor-first-name" value="" class="contributor-first-name-field" />

--- a/inc/admin/metaboxes/namespace.php
+++ b/inc/admin/metaboxes/namespace.php
@@ -903,8 +903,8 @@ function save_subject_metadata( $post_id ) {
 /**
  * @since 5.0.0
  */
-function contributor_add_form() { ?>
-	<?php wp_nonce_field( 'contributor-meta', 'contributor_meta_nonce' ); ?>
+function contributor_add_form() {
+	wp_nonce_field( 'contributor-meta', 'contributor_meta_nonce' ); ?>
 	<div class="form-field contributor-first-name-wrap">
 		<label for="contributor_first_name"><?php _e( 'First Name', 'pressbooks' ); ?></label>
 		<input type="text" name="contributor_first_name" id="contributor-first-name" value="" class="contributor-first-name-field" />

--- a/inc/admin/metaboxes/namespace.php
+++ b/inc/admin/metaboxes/namespace.php
@@ -192,47 +192,117 @@ function add_meta_boxes() {
 		]
 	);
 
+	// x_add_metadata_field( @codingStandardsIgnoreStart
+	// 	'pb_author', 'metadata', [
+	// 		'group' => 'general-book-information',
+	// 		'label' => __( 'Author', 'pressbooks' ),
+	// 	]
+	// ); @codingStandardsIgnoreEnd
+
 	x_add_metadata_field(
-		'pb_author', 'metadata', [
+		'pb_authors', 'metadata', [
 			'group' => 'general-book-information',
-			'label' => __( 'Author', 'pressbooks' ),
+			'label' => __( 'Author(s)', 'pressbooks' ),
+			'field_type' => 'taxonomy_multi_select',
+			'taxonomy' => 'contributor',
+			'select2' => true,
+		]
+	);
+
+	x_add_metadata_field(
+		'pb_editors', 'metadata', [
+			'group' => 'general-book-information',
+			'label' => __( 'Editor(s)', 'pressbooks' ),
+			'field_type' => 'taxonomy_multi_select',
+			'taxonomy' => 'contributor',
+			'select2' => true,
+		]
+	);
+
+	x_add_metadata_field(
+		'pb_translators', 'metadata', [
+			'group' => 'general-book-information',
+			'label' => __( 'Translator(s)', 'pressbooks' ),
+			'field_type' => 'taxonomy_multi_select',
+			'taxonomy' => 'contributor',
+			'select2' => true,
+		]
+	);
+
+	x_add_metadata_field(
+		'pb_proofreaders', 'metadata', [
+			'group' => 'general-book-information',
+			'label' => __( 'Proofreader(s)', 'pressbooks' ),
+			'field_type' => 'taxonomy_multi_select',
+			'taxonomy' => 'contributor',
+			'select2' => true,
+		]
+	);
+
+	x_add_metadata_field(
+		'pb_reviewers', 'metadata', [
+			'group' => 'general-book-information',
+			'label' => __( 'Reviewer(s)', 'pressbooks' ),
+			'field_type' => 'taxonomy_multi_select',
+			'taxonomy' => 'contributor',
+			'select2' => true,
+		]
+	);
+
+	x_add_metadata_field(
+		'pb_illustrators', 'metadata', [
+			'group' => 'general-book-information',
+			'label' => __( 'Illustrator(s)', 'pressbooks' ),
+			'field_type' => 'taxonomy_multi_select',
+			'taxonomy' => 'contributor',
+			'select2' => true,
+		]
+	);
+
+	x_add_metadata_field(
+		'pb_contributors', 'metadata', [
+			'group' => 'general-book-information',
+			'label' => __( 'Contributor(s)', 'pressbooks' ),
+			'field_type' => 'taxonomy_multi_select',
+			'taxonomy' => 'contributor',
+			'select2' => true,
 		]
 	);
 
 	if ( $show_expanded_metadata ) {
-		x_add_metadata_field(
-			'pb_author_file_as', 'metadata', [
-				'group' => 'general-book-information',
-				'label' => __( 'Author, file as', 'pressbooks' ),
-				'description' => __( 'This ensures that your ebook will sort properly in ebook stores, by the author\'s last name.', 'pressbooks' ),
-			]
-		);
+		// x_add_metadata_field( @codingStandardsIgnoreStart
+		// 	'pb_author_file_as', 'metadata', [
+		// 		'group' => 'general-book-information',
+		// 		'label' => __( 'Author, file as', 'pressbooks' ),
+		// 		'description' => __( 'This ensures that your ebook will sort properly in ebook stores, by the author\'s last name.', 'pressbooks' ),
+		// 	]
+		// ); @codingStandardsIgnoreEnd
 	}
 
-	x_add_metadata_field(
-		'pb_contributing_authors', 'metadata', [
-			'group' => 'general-book-information',
-			'label' => __( 'Contributing Author(s)', 'pressbooks' ),
-			'multiple' => true,
-			'description' => __( 'This may be used when more than one person shares the responsibility for the intellectual content of a book.', 'pressbooks' ),
-		]
-	);
+	// x_add_metadata_field( @codingStandardsIgnoreStart
+	// 	'pb_contributing_authors', 'metadata', [
+	// 		'group' => 'general-book-information',
+	// 		'label' => __( 'Contributing Author(s)', 'pressbooks' ),
+	// 		'multiple' => true,
+	// 		'description' => __( 'This may be used when more than one person shares the responsibility for the intellectual content of a book.', 'pressbooks' ),
+	// 	]
+	// );
 
-	x_add_metadata_field(
-		'pb_editor', 'metadata', [
-			'group' => 'general-book-information',
-			'label' => __( 'Editor(s)', 'pressbooks' ),
-			'multiple' => true,
-		]
-	);
+	// x_add_metadata_field(
+	// 	'pb_editor', 'metadata', [
+	// 		'group' => 'general-book-information',
+	// 		'label' => __( 'Editor(s)', 'pressbooks' ),
+	// 		'multiple' => true,
+	// 	]
+	// );
 
-	x_add_metadata_field(
-		'pb_translator', 'metadata', [
-			'group' => 'general-book-information',
-			'label' => __( 'Translator(s)', 'pressbooks' ),
-			'multiple' => true,
-		]
-	);
+	// x_add_metadata_field(
+	// 	'pb_translator', 'metadata', [
+	// 		'group' => 'general-book-information',
+	// 		'label' => __( 'Translator(s)', 'pressbooks' ),
+	// 		'multiple' => true,
+	// 	]
+	// ); @codingStandardsIgnoreEnd
 
 	x_add_metadata_field(
 		'pb_publisher', 'metadata', [

--- a/inc/admin/metaboxes/namespace.php
+++ b/inc/admin/metaboxes/namespace.php
@@ -192,13 +192,6 @@ function add_meta_boxes() {
 		]
 	);
 
-	// x_add_metadata_field( @codingStandardsIgnoreStart
-	// 	'pb_author', 'metadata', [
-	// 		'group' => 'general-book-information',
-	// 		'label' => __( 'Author', 'pressbooks' ),
-	// 	]
-	// ); @codingStandardsIgnoreEnd
-
 	x_add_metadata_field(
 		'pb_authors', 'metadata', [
 			'group' => 'general-book-information',
@@ -268,41 +261,6 @@ function add_meta_boxes() {
 			'select2' => true,
 		]
 	);
-
-	if ( $show_expanded_metadata ) {
-		// x_add_metadata_field( @codingStandardsIgnoreStart
-		// 	'pb_author_file_as', 'metadata', [
-		// 		'group' => 'general-book-information',
-		// 		'label' => __( 'Author, file as', 'pressbooks' ),
-		// 		'description' => __( 'This ensures that your ebook will sort properly in ebook stores, by the author\'s last name.', 'pressbooks' ),
-		// 	]
-		// ); @codingStandardsIgnoreEnd
-	}
-
-	// x_add_metadata_field( @codingStandardsIgnoreStart
-	// 	'pb_contributing_authors', 'metadata', [
-	// 		'group' => 'general-book-information',
-	// 		'label' => __( 'Contributing Author(s)', 'pressbooks' ),
-	// 		'multiple' => true,
-	// 		'description' => __( 'This may be used when more than one person shares the responsibility for the intellectual content of a book.', 'pressbooks' ),
-	// 	]
-	// );
-
-	// x_add_metadata_field(
-	// 	'pb_editor', 'metadata', [
-	// 		'group' => 'general-book-information',
-	// 		'label' => __( 'Editor(s)', 'pressbooks' ),
-	// 		'multiple' => true,
-	// 	]
-	// );
-
-	// x_add_metadata_field(
-	// 	'pb_translator', 'metadata', [
-	// 		'group' => 'general-book-information',
-	// 		'label' => __( 'Translator(s)', 'pressbooks' ),
-	// 		'multiple' => true,
-	// 	]
-	// ); @codingStandardsIgnoreEnd
 
 	x_add_metadata_field(
 		'pb_publisher', 'metadata', [
@@ -591,9 +549,12 @@ function add_meta_boxes() {
 	);
 
 	x_add_metadata_field(
-		'pb_section_author', 'chapter', [
+		'pb_authors', 'chapter', [
 			'group' => 'chapter-metadata',
-			'label' => __( 'Chapter Author (appears in Web/ebook/PDF output)', 'pressbooks' ),
+			'label' => __( 'Author(s)', 'pressbooks' ),
+			'field_type' => 'taxonomy_multi_select',
+			'taxonomy' => 'contributor',
+			'select2' => true,
 		]
 	);
 
@@ -675,9 +636,12 @@ function add_meta_boxes() {
 	);
 
 	x_add_metadata_field(
-		'pb_section_author', 'front-matter', [
-			'group' => 'front-matter-metadata',
-			'label' => __( 'Front Matter Author (appears in Web/ebook/PDF output)', 'pressbooks' ),
+		'pb_authors', 'front-matter', [
+			'group' => 'front-matter-metadata-metadata',
+			'label' => __( 'Author(s)', 'pressbooks' ),
+			'field_type' => 'taxonomy_multi_select',
+			'taxonomy' => 'contributor',
+			'select2' => true,
 		]
 	);
 
@@ -715,9 +679,12 @@ function add_meta_boxes() {
 	);
 
 	x_add_metadata_field(
-		'pb_section_author', 'back-matter', [
-			'group' => 'back-matter-metadata',
-			'label' => __( 'Back Matter Author (appears in Web/ebook/PDF output)', 'pressbooks' ),
+		'pb_authors', 'back-matter', [
+			'group' => 'back-matter-metadata-metadata',
+			'label' => __( 'Author(s)', 'pressbooks' ),
+			'field_type' => 'taxonomy_multi_select',
+			'taxonomy' => 'contributor',
+			'select2' => true,
 		]
 	);
 

--- a/inc/admin/metaboxes/namespace.php
+++ b/inc/admin/metaboxes/namespace.php
@@ -899,3 +899,72 @@ function save_subject_metadata( $post_id ) {
 		delete_post_meta( $post_id, 'pb_additional_subjects' );
 	}
 }
+
+/**
+ * @since 5.0.0
+ */
+function contributor_add_form() { ?>
+	<?php wp_nonce_field( 'contributor-meta', 'contributor_meta_nonce' ); ?>
+	<div class="form-field contributor-first-name-wrap">
+		<label for="contributor_first_name"><?php _e( 'First Name', 'pressbooks' ); ?></label>
+		<input type="text" name="contributor_first_name" id="contributor-first-name" value="" class="contributor-first-name-field" />
+		<p>
+	</div>
+	<div class="form-field contributor-last-name-wrap">
+		<label for="contributor_last_name"><?php _e( 'Last Name', 'pressbooks' ); ?></label>
+		<input type="text" name="contributor_last_name" id="contributor-last-name" value="" class="contributor-last-name-field" />
+	</div>
+	<?php
+}
+
+function contributor_edit_form( $term ) {
+	$firstname = get_term_meta( $term->term_id, 'contributor_first_name', true );
+	$lastname = get_term_meta( $term->term_id, 'contributor_last_name', true );
+	if ( ! $firstname ) {
+		$firstname = '';
+	}
+	if ( ! $lastname ) {
+		$lastname = '';
+	}
+?>
+	<tr class="form-field contributor-first-name-wrap">
+		<th scope="row"><label for="contributor_first_name"><?php _e( 'First Name', 'pressbooks' ); ?></label></th>
+		<td>
+			<?php wp_nonce_field( 'contributor-meta', 'contributor_meta_nonce' ); ?>
+			<input type="text" name="contributor_first_name" id="contributor-first-name" value="<?php echo esc_attr( $firstname ); ?>" class="contributor-first-name-field"  />
+		</td>
+	</tr>
+	<tr class="form-field contributor-last-name-wrap">
+		<th scope="row"><label for="contributor_last_name"><?php _e( 'First Name', 'pressbooks' ); ?></label></th>
+		<td>
+			<input type="text" name="contributor_last_name" id="contributor-last-name" value="<?php echo esc_attr( $lastname ); ?>" class="contributor-last-name-field"  />
+		</td>
+	</tr>
+<?php
+}
+
+/**
+ * @since 5.0.0
+ */
+function save_contributor_meta( $term_id, $tt_id, $taxonomy ) {
+	if ( $taxonomy !== 'contributor' ) {
+		return;
+	}
+	if ( ! isset( $_POST['contributor_meta_nonce'] ) || ! wp_verify_nonce( $_POST['contributor_meta_nonce'], 'contributor-meta' ) ) {
+		return;
+	}
+	$old_first_name  = get_term_meta( $term_id, 'contributor_first_name', true );
+	$old_last_name  = get_term_meta( $term_id, 'contributor_last_name', true );
+	$new_first_name = isset( $_POST['contributor_first_name'] ) ? sanitize_text_field( $_POST['contributor_first_name'] ) : '';
+	$new_last_name = isset( $_POST['contributor_last_name'] ) ? sanitize_text_field( $_POST['contributor_last_name'] ) : '';
+	if ( $new_first_name === '' ) {
+		delete_term_meta( $term_id, 'contributor_first_name' );
+	} elseif ( $old_first_name !== $new_first_name ) {
+		update_term_meta( $term_id, 'contributor_first_name', $new_first_name );
+	}
+	if ( $new_last_name === '' ) {
+		delete_term_meta( $term_id, 'contributor_last_name' );
+	} elseif ( $old_last_name !== $new_last_name ) {
+		update_term_meta( $term_id, 'contributor_last_name', $new_last_name );
+	}
+}

--- a/inc/metadata/namespace.php
+++ b/inc/metadata/namespace.php
@@ -717,3 +717,11 @@ function is_bisac( $code ) {
 
 	return false;
 }
+
+/**
+ * @since 5.0.0
+ */
+function register_contributor_meta() {
+	register_meta( 'term', 'contributor_first_name', 'sanitize_text_field' );
+	register_meta( 'term', 'contributor_last_name', 'sanitize_text_field' );
+}


### PR DESCRIPTION
This PR implements a basic UI for saving contributors terms from the taxonomy as authors, editors, translators, proofreaders, reviewers, illustrators, or contributors (in Book Info) or authors (in Chapters, Front Matter and Back Matter).

## Notes

- This PR removes the UI for editing the (now deprecated) `pb_author`, `pb_section_author`, `pb_contributing_authors`, `pb_editor`, and `pb_translator` metadata.
- Terms selected will be saved into the appropriate post meta field via their slug _and_ be assigned to the related post object (so assigning Ned Zimmerman as an author in Book Info will assign the Ned Zimmerman `contributor` term to the Book Info post and also save `ned-zimmerman` into the `pb_authors` post meta field.

## To Do

- [ ] Add [automatic tagging](https://select2.org/tagging#tagging-with-multi-value-select-boxes) so that new terms can be added via input to any of these fields.
- [ ] Replace usage of deprecated post meta in other places.