### PR TITLE
Wrap chapter, front & back matter heading elements in EPUB and XHTML (fixes #1035)

### DIFF
--- a/inc/modules/export/epub/class-epub201.php
+++ b/inc/modules/export/epub/class-epub201.php
@@ -93,6 +93,15 @@ class Epub201 extends Export {
 	protected $hasIntroduction = false;
 
 	/**
+	 * Should all header elements be wrapped in a container? Requires a theme based on Buckram.
+	 *
+	 * @see https://github.com/pressbooks/buckram/
+	 *
+	 * @var bool
+	 */
+	protected $wrapHeaderElements = false;
+
+	/**
 	 * Used to set cover-image in OPF for kindlegen compatibility.
 	 *
 	 * @var string
@@ -210,6 +219,10 @@ class Epub201 extends Export {
 
 		$this->tmpDir = $this->createTmpDir();
 		$this->exportStylePath = $this->getExportStylePath( 'epub' );
+
+		if ( Container::get( 'Styles' )->isCurrentThemeCompatible( 2 ) ) {
+			$this->wrapHeaderElements = true;
+		}
 
 		$this->themeOptionsOverrides();
 
@@ -837,9 +850,9 @@ class Epub201 extends Export {
 	 */
 	protected function createBeforeTitle( $book_contents, $metadata ) {
 
-		$front_matter_printf = '<div class="front-matter %s" id="%s">';
-		$front_matter_printf .= '<div class="front-matter-title-wrap"><h3 class="front-matter-number">%s</h3><h1 class="front-matter-title">%s</h1></div>';
-		$front_matter_printf .= '<div class="ugc front-matter-ugc">%s</div>%s';
+		$front_matter_printf = '<div class="front-matter %1$s" id="%2$s">';
+		$front_matter_printf .= '<div class="front-matter-title-wrap"><h3 class="front-matter-number">%3$s</h3><h1 class="front-matter-title">%4$s</h1></div>';
+		$front_matter_printf .= '<div class="ugc front-matter-ugc">%5$s</div>%6$s';
 		$front_matter_printf .= '</div>';
 
 		$vars = [
@@ -1070,9 +1083,9 @@ class Epub201 extends Export {
 	 */
 	protected function createDedicationAndEpigraph( $book_contents, $metadata ) {
 
-		$front_matter_printf = '<div class="front-matter %s" id="%s">';
-		$front_matter_printf .= '<div class="front-matter-title-wrap"><h3 class="front-matter-number">%s</h3><h1 class="front-matter-title">%s</h1></div>';
-		$front_matter_printf .= '<div class="ugc front-matter-ugc">%s</div>%s';
+		$front_matter_printf = '<div class="front-matter %1$s" id="%2$s">';
+		$front_matter_printf .= '<div class="front-matter-title-wrap"><h3 class="front-matter-number">%3$s</h3><h1 class="front-matter-title">%4$s</h1></div>';
+		$front_matter_printf .= '<div class="ugc front-matter-ugc">%5$s</div>%6$s';
 		$front_matter_printf .= '</div>';
 
 		$vars = [
@@ -1144,10 +1157,9 @@ class Epub201 extends Export {
 	 * @param array $metadata
 	 */
 	protected function createFrontMatter( $book_contents, $metadata ) {
-
-		$front_matter_printf = '<div class="front-matter %s" id="%s">';
-		$front_matter_printf .= '<div class="front-matter-title-wrap"><h3 class="front-matter-number">%s</h3><h1 class="front-matter-title">%s</h1></div>';
-		$front_matter_printf .= '<div class="ugc front-matter-ugc">%s</div>%s';
+		$front_matter_printf = '<div class="front-matter %1$s" id="%2$s">';
+		$front_matter_printf .= '<div class="front-matter-title-wrap"><h3 class="front-matter-number">%3$s</h3><h1 class="front-matter-title">%4$s</h1>%5$s</div>';
+		$front_matter_printf .= '<div class="ugc front-matter-ugc">%6$s</div>%7$s';
 		$front_matter_printf .= '</div>';
 
 		$vars = [
@@ -1179,6 +1191,7 @@ class Epub201 extends Export {
 
 			$slug = $front_matter['post_name'];
 			$title = ( get_post_meta( $front_matter_id, 'pb_show_title', true ) ? $front_matter['post_title'] : '' );
+			$after_title = '';
 			$content = $this->kneadHtml( $front_matter['post_content'], 'front-matter', $i );
 			$append_front_matter_content = $this->kneadHtml( apply_filters( 'pb_append_front_matter_content', '', $front_matter_id ), 'front-matter', $i );
 			$short_title = trim( get_post_meta( $front_matter_id, 'pb_short_title', true ) );
@@ -1194,15 +1207,27 @@ class Epub201 extends Export {
 			}
 
 			if ( $author ) {
-				$content = '<h2 class="chapter-author">' . Sanitize\decode( $author ) . '</h2>' . $content;
+				if ( $this->wrapHeaderElements ) {
+					$after_title .= '<h2 class="chapter-author">' . Sanitize\decode( $author ) . '</h2>';
+				} else {
+					$content = '<h2 class="chapter-author">' . Sanitize\decode( $author ) . '</h2>' . $content;
+				}
 			}
 
 			if ( $subtitle ) {
-				$content = '<h2 class="chapter-subtitle">' . Sanitize\decode( $subtitle ) . '</h2>' . $content;
+				if ( $this->wrapHeaderElements ) {
+					$after_title .= '<h2 class="chapter-subtitle">' . Sanitize\decode( $subtitle ) . '</h2>';
+				} else {
+					$content = '<h2 class="chapter-subtitle">' . Sanitize\decode( $subtitle ) . '</h2>' . $content;
+				}
 			}
 
 			if ( $short_title ) {
-				$content = '<h6 class="short-title">' . Sanitize\decode( $short_title ) . '</h6>' . $content;
+				if ( $this->wrapHeaderElements ) {
+					$after_title .= '<h6 class="short-title">' . Sanitize\decode( $short_title ) . '</h6>';
+				} else {
+					$content = '<h6 class="short-title">' . Sanitize\decode( $short_title ) . '</h6>' . $content;
+				}
 			}
 
 			$section_license = $this->doSectionLevelLicense( $metadata, $front_matter_id );
@@ -1217,6 +1242,7 @@ class Epub201 extends Export {
 				$slug,
 				$i,
 				Sanitize\decode( $title ),
+				$after_title,
 				$content,
 				$var['append_front_matter_content'] = $append_front_matter_content,
 				''
@@ -1282,14 +1308,13 @@ class Epub201 extends Export {
 	 * @param array $metadata
 	 */
 	protected function createPartsAndChapters( $book_contents, $metadata ) {
-
-		$part_printf = '<div class="part %s" id="%s">';
-		$part_printf .= '<div class="part-title-wrap"><h3 class="part-number">%s</h3><h1 class="part-title">%s</h1></div>%s';
+		$part_printf = '<div class="part %1$s" id="%2$s">';
+		$part_printf .= '<div class="part-title-wrap"><h3 class="part-number">%3$s</h3><h1 class="part-title">%4$s</h1></div>%5$s';
 		$part_printf .= '</div>';
 
-		$chapter_printf = '<div class="chapter %s" id="%s">';
-		$chapter_printf .= '<div class="chapter-title-wrap"><h3 class="chapter-number">%s</h3><h2 class="chapter-title">%s</h2></div>';
-		$chapter_printf .= '<div class="ugc chapter-ugc">%s</div>%s';
+		$chapter_printf = '<div class="chapter %1$s" id="%2$s">';
+		$chapter_printf .= '<div class="chapter-title-wrap"><h3 class="chapter-number">%3$s</h3><h2 class="chapter-title">%4$s</h2>%5$s</div>';
+		$chapter_printf .= '<div class="ugc chapter-ugc">%6$s</div>%7$s';
 		$chapter_printf .= '</div>';
 
 		$vars = [
@@ -1324,7 +1349,7 @@ class Epub201 extends Export {
 			$part_content = trim( $part['post_content'] );
 			if ( $part_content ) {
 				$part_content = $this->kneadHtml( $this->preProcessPostContent( $part_content ), 'custom', $p );
-				$part_printf_changed = str_replace( '</h1></div>%s</div>', '</h1></div><div class="ugc part-ugc">%s</div></div>', $part_printf );
+				$part_printf_changed = str_replace( '</h1></div>%5$s</div>', '</h1></div><div class="ugc part-ugc">%5$s</div></div>', $part_printf );
 			}
 
 			foreach ( $part['chapters'] as $chapter ) {
@@ -1338,6 +1363,7 @@ class Epub201 extends Export {
 				$subclass = $this->taxonomy->getChapterType( $chapter_id );
 				$slug = $chapter['post_name'];
 				$title = ( get_post_meta( $chapter_id, 'pb_show_title', true ) ? $chapter['post_title'] : '' );
+				$after_title = '';
 				$content = $this->kneadHtml( $chapter['post_content'], 'chapter', $j );
 				$append_chapter_content = $this->kneadHtml( apply_filters( 'pb_append_chapter_content', '', $chapter_id ), 'chapter', $j );
 				$short_title = false; // Ie. running header title is not used in EPUB
@@ -1353,20 +1379,32 @@ class Epub201 extends Export {
 				}
 
 				if ( $author ) {
-					$content = '<h2 class="chapter-author">' . Sanitize\decode( $author ) . '</h2>' . $content;
+					if ( $this->wrapHeaderElements ) {
+						$after_title .= '<h2 class="chapter-author">' . Sanitize\decode( $author ) . '</h2>';
+					} else {
+						$content = '<h2 class="chapter-author">' . Sanitize\decode( $author ) . '</h2>' . $content;
+					}
 				}
 
 				if ( $subtitle ) {
-					$content = '<h2 class="chapter-subtitle">' . Sanitize\decode( $subtitle ) . '</h2>' . $content;
+					if ( $this->wrapHeaderElements ) {
+						$after_title .= '<h2 class="chapter-subtitle">' . Sanitize\decode( $subtitle ) . '</h2>';
+					} else {
+						$content = '<h2 class="chapter-subtitle">' . Sanitize\decode( $subtitle ) . '</h2>' . $content;
+					}
 				}
 
 				if ( $short_title ) {
-					$content = '<h6 class="short-title">' . Sanitize\decode( $short_title ) . '</h6>' . $content;
+					if ( $this->wrapHeaderElements ) {
+						$after_title .= '<h6 class="short-title">' . Sanitize\decode( $short_title ) . '</h6>';
+					} else {
+						$content = '<h6 class="short-title">' . Sanitize\decode( $short_title ) . '</h6>' . $content;
+					}
 				}
 
 				// Inject introduction class?
 				if ( ! $this->hasIntroduction ) {
-					$chapter_printf_changed = str_replace( '<div class="chapter %s" id=', '<div class="chapter introduction %s" id=', $chapter_printf );
+					$subclass .= ' introduction';
 					$this->hasIntroduction = true;
 				}
 
@@ -1375,14 +1413,15 @@ class Epub201 extends Export {
 					$append_chapter_content .= $this->kneadHtml( $this->tidy( $section_license ), 'chapter', $j );
 				}
 
-				$n = ( 'numberless' === $subclass ) ? '' : $c;
+				$n = ( strpos( $subclass, 'numberless' ) === false ) ? '' : $c;
 				$vars['post_title'] = $chapter['post_title'];
 				$vars['post_content'] = sprintf(
-					( $chapter_printf_changed ? $chapter_printf_changed : $chapter_printf ),
+					$chapter_printf,
 					$subclass,
 					$slug,
 					( $this->numbered ? $n : '' ),
 					Sanitize\decode( $title ),
+					$after_title,
 					$content,
 					$var['append_chapter_content'] = $append_chapter_content,
 					''
@@ -1532,10 +1571,9 @@ class Epub201 extends Export {
 	 * @param array $metadata
 	 */
 	protected function createBackMatter( $book_contents, $metadata ) {
-
-		$back_matter_printf = '<div class="back-matter %s" id="%s">';
-		$back_matter_printf .= '<div class="back-matter-title-wrap"><h3 class="back-matter-number">%s</h3><h1 class="back-matter-title">%s</h1></div>';
-		$back_matter_printf .= '<div class="ugc back-matter-ugc">%s</div>%s';
+		$back_matter_printf = '<div class="back-matter %1$s" id="%2$s">';
+		$back_matter_printf .= '<div class="back-matter-title-wrap"><h3 class="back-matter-number">%3$s</h3><h1 class="back-matter-title">%4$s</h1>%5$s</div>';
+		$back_matter_printf .= '<div class="ugc back-matter-ugc">%6$s</div>%7$s';
 		$back_matter_printf .= '</div>';
 
 		$vars = [
@@ -1558,6 +1596,7 @@ class Epub201 extends Export {
 			$subclass = $this->taxonomy->getBackMatterType( $back_matter_id );
 			$slug = $back_matter['post_name'];
 			$title = ( get_post_meta( $back_matter_id, 'pb_show_title', true ) ? $back_matter['post_title'] : '' );
+			$after_title = '';
 			$content = $this->kneadHtml( $back_matter['post_content'], 'back-matter', $i );
 			$append_back_matter_content = $this->kneadHtml( apply_filters( 'pb_append_back_matter_content', '', $back_matter_id ), 'back-matter', $i );
 			$short_title = trim( get_post_meta( $back_matter_id, 'pb_short_title', true ) );
@@ -1573,15 +1612,27 @@ class Epub201 extends Export {
 			}
 
 			if ( $author ) {
-				$content = '<h2 class="chapter-author">' . Sanitize\decode( $author ) . '</h2>' . $content;
+				if ( $this->wrapHeaderElements ) {
+					$after_title .= '<h2 class="chapter-author">' . Sanitize\decode( $author ) . '</h2>';
+				} else {
+					$content = '<h2 class="chapter-author">' . Sanitize\decode( $author ) . '</h2>' . $content;
+				}
 			}
 
 			if ( $subtitle ) {
-				$content = '<h2 class="chapter-subtitle">' . Sanitize\decode( $subtitle ) . '</h2>' . $content;
+				if ( $this->wrapHeaderElements ) {
+					$after_title .= '<h2 class="chapter-subtitle">' . Sanitize\decode( $subtitle ) . '</h2>';
+				} else {
+					$content = '<h2 class="chapter-subtitle">' . Sanitize\decode( $subtitle ) . '</h2>' . $content;
+				}
 			}
 
 			if ( $short_title ) {
-				$content = '<h6 class="short-title">' . Sanitize\decode( $short_title ) . '</h6>' . $content;
+				if ( $this->wrapHeaderElements ) {
+					$after_title .= '<h6 class="short-title">' . Sanitize\decode( $short_title ) . '</h6>';
+				} else {
+					$content = '<h6 class="short-title">' . Sanitize\decode( $short_title ) . '</h6>' . $content;
+				}
 			}
 
 			$section_license = $this->doSectionLevelLicense( $metadata, $back_matter_id );
@@ -1596,6 +1647,7 @@ class Epub201 extends Export {
 				$slug,
 				$i,
 				Sanitize\decode( $title ),
+				$after_title,
 				$content,
 				$var['append_back_matter_content'] = $append_back_matter_content,
 				''

--- a/inc/modules/export/epub/class-epub201.php
+++ b/inc/modules/export/epub/class-epub201.php
@@ -220,7 +220,7 @@ class Epub201 extends Export {
 		$this->tmpDir = $this->createTmpDir();
 		$this->exportStylePath = $this->getExportStylePath( 'epub' );
 
-		if ( Container::get( 'Styles' )->isCurrentThemeCompatible( 2 ) ) {
+		if ( get_theme_support( 'buckram' ) || wp_get_theme()->get_stylesheet() === 'pressbooks-book' ) {
 			$this->wrapHeaderElements = true;
 		}
 

--- a/inc/modules/export/xhtml/class-xhtml11.php
+++ b/inc/modules/export/xhtml/class-xhtml11.php
@@ -84,6 +84,10 @@ class Xhtml11 extends Export {
 		$this->taxonomy = \Pressbooks\Taxonomy::init();
 		$this->contributors = new \Pressbooks\Contributors();
 
+		if ( Container::get( 'Styles' )->isCurrentThemeCompatible( 2 ) ) {
+			$this->wrapHeaderElements = true;
+		}
+
 		if ( ! defined( 'PB_XMLLINT_COMMAND' ) ) {
 			define( 'PB_XMLLINT_COMMAND', '/usr/bin/xmllint' );
 		}
@@ -649,9 +653,9 @@ class Xhtml11 extends Export {
 	 */
 	protected function echoBeforeTitle( $book_contents, $metadata ) {
 
-		$front_matter_printf = '<div class="front-matter %s" id="%s">';
-		$front_matter_printf .= '<div class="front-matter-title-wrap"><h3 class="front-matter-number">%s</h3><h1 class="front-matter-title">%s</h1></div>';
-		$front_matter_printf .= '<div class="ugc front-matter-ugc">%s</div>%s';
+		$front_matter_printf = '<div class="front-matter %1$s" id="%2$s">';
+		$front_matter_printf .= '<div class="front-matter-title-wrap"><h3 class="front-matter-number">%3$s</h3><h1 class="front-matter-title">%4$s</h1></div>';
+		$front_matter_printf .= '<div class="ugc front-matter-ugc">%5$s</div>%6$s';
 		$front_matter_printf .= '</div>';
 
 		$i = $this->frontMatterPos;
@@ -1011,12 +1015,6 @@ class Xhtml11 extends Export {
 	 * @param array $metadata
 	 */
 	protected function echoFrontMatter( $book_contents, $metadata ) {
-		if ( Container::get( 'Styles' )->isCurrentThemeCompatible( 2 ) ) {
-			$wrap_header_elements = true;
-		} else {
-			$wrap_header_elements = false;
-		}
-
 		$front_matter_printf = '<div class="front-matter %1$s" id="%2$s">';
 		$front_matter_printf .= '<div class="front-matter-title-wrap"><h3 class="front-matter-number">%3$s</h3><h1 class="front-matter-title">%4$s</h1>%5$s</div>';
 		$front_matter_printf .= '<div class="ugc front-matter-ugc">%6$s</div>%7$s%8$s';
@@ -1057,7 +1055,7 @@ class Xhtml11 extends Export {
 			}
 
 			if ( $author ) {
-				if ( $wrap_header_elements ) {
+				if ( $this->wrapHeaderElements ) {
 					$after_title .= '<h2 class="chapter-author">' . Sanitize\decode( $author ) . '</h2>';
 				} else {
 					$content = '<h2 class="chapter-author">' . Sanitize\decode( $author ) . '</h2>' . $content;
@@ -1065,7 +1063,7 @@ class Xhtml11 extends Export {
 			}
 
 			if ( $subtitle ) {
-				if ( $wrap_header_elements ) {
+				if ( $this->wrapHeaderElements ) {
 					$after_title .= '<h2 class="chapter-subtitle">' . Sanitize\decode( $subtitle ) . '</h2>';
 				} else {
 					$content = '<h2 class="chapter-subtitle">' . Sanitize\decode( $subtitle ) . '</h2>' . $content;
@@ -1073,7 +1071,7 @@ class Xhtml11 extends Export {
 			}
 
 			if ( $short_title ) {
-				if ( $wrap_header_elements ) {
+				if ( $this->wrapHeaderElements ) {
 					$after_title .= '<h6 class="short-title">' . Sanitize\decode( $short_title ) . '</h6>';
 				} else {
 					$content = '<h6 class="short-title">' . Sanitize\decode( $short_title ) . '</h6>' . $content;
@@ -1119,12 +1117,6 @@ class Xhtml11 extends Export {
 	 * @param array $metadata
 	 */
 	protected function echoPartsAndChapters( $book_contents, $metadata ) {
-		if ( Container::get( 'Styles' )->isCurrentThemeCompatible( 2 ) ) {
-			$wrap_header_elements = true;
-		} else {
-			$wrap_header_elements = false;
-		}
-
 		$part_printf = '<div class="part %1$s" id="%2$s">';
 		$part_printf .= '<div class="part-title-wrap"><h3 class="part-number">%3$s</h3><h1 class="part-title">%4$s</h1></div>%5$s';
 		$part_printf .= '</div>';
@@ -1210,7 +1202,7 @@ class Xhtml11 extends Export {
 				}
 
 				if ( $author ) {
-					if ( $wrap_header_elements ) {
+					if ( $this->wrapHeaderElements ) {
 						$after_title .= '<h2 class="chapter-author">' . Sanitize\decode( $author ) . '</h2>';
 					} else {
 						$content = '<h2 class="chapter-author">' . Sanitize\decode( $author ) . '</h2>' . $content;
@@ -1218,7 +1210,7 @@ class Xhtml11 extends Export {
 				}
 
 				if ( $subtitle ) {
-					if ( $wrap_header_elements ) {
+					if ( $this->wrapHeaderElements ) {
 						$after_title .= '<h2 class="chapter-subtitle">' . Sanitize\decode( $subtitle ) . '</h2>';
 					} else {
 						$content = '<h2 class="chapter-subtitle">' . Sanitize\decode( $subtitle ) . '</h2>' . $content;
@@ -1226,7 +1218,7 @@ class Xhtml11 extends Export {
 				}
 
 				if ( $short_title ) {
-					if ( $wrap_header_elements ) {
+					if ( $this->wrapHeaderElements ) {
 						$after_title .= '<h6 class="short-title">' . Sanitize\decode( $short_title ) . '</h6>';
 					} else {
 						$content = '<h6 class="short-title">' . Sanitize\decode( $short_title ) . '</h6>' . $content;
@@ -1235,15 +1227,15 @@ class Xhtml11 extends Export {
 
 				// Inject introduction class?
 				if ( ! $this->hasIntroduction ) {
-					$chapter_printf_changed = str_replace( '<div class="chapter %s" id=', '<div class="chapter introduction %s" id=', $chapter_printf );
+					$subclass .= ' introduction';
 					$this->hasIntroduction = true;
 				}
 
 				$append_chapter_content .= $this->removeAttributionLink( $this->doSectionLevelLicense( $metadata, $chapter_id ) );
 
-				$n = ( 'numberless' === $subclass ) ? '' : $j;
+				$n = ( strpos( $subclass, 'numberless' ) === false ) ? '' : $j;
 				$my_chapters .= sprintf(
-					( $chapter_printf_changed ? $chapter_printf_changed : $chapter_printf ),
+					$chapter_printf,
 					$subclass,
 					$slug,
 					$n,
@@ -1298,12 +1290,6 @@ class Xhtml11 extends Export {
 	 * @param array $metadata
 	 */
 	protected function echoBackMatter( $book_contents, $metadata ) {
-		if ( Container::get( 'Styles' )->isCurrentThemeCompatible( 2 ) ) {
-			$wrap_header_elements = true;
-		} else {
-			$wrap_header_elements = false;
-		}
-
 		$back_matter_printf = '<div class="back-matter %1$s" id="%2$s">';
 		$back_matter_printf .= '<div class="back-matter-title-wrap"><h3 class="back-matter-number">%3$s</h3><h1 class="back-matter-title">%4$s</h1>%5$s</div>';
 		$back_matter_printf .= '<div class="ugc back-matter-ugc">%6$s</div>%7$s%8$s';
@@ -1335,7 +1321,7 @@ class Xhtml11 extends Export {
 			}
 
 			if ( $author ) {
-				if ( $wrap_header_elements ) {
+				if ( $this->wrapHeaderElements ) {
 					$after_title .= '<h2 class="chapter-author">' . Sanitize\decode( $author ) . '</h2>';
 				} else {
 					$content = '<h2 class="chapter-author">' . Sanitize\decode( $author ) . '</h2>' . $content;
@@ -1343,7 +1329,7 @@ class Xhtml11 extends Export {
 			}
 
 			if ( $subtitle ) {
-				if ( $wrap_header_elements ) {
+				if ( $this->wrapHeaderElements ) {
 					$after_title .= '<h2 class="chapter-subtitle">' . Sanitize\decode( $subtitle ) . '</h2>';
 				} else {
 					$content = '<h2 class="chapter-subtitle">' . Sanitize\decode( $subtitle ) . '</h2>' . $content;
@@ -1351,7 +1337,7 @@ class Xhtml11 extends Export {
 			}
 
 			if ( $short_title ) {
-				if ( $wrap_header_elements ) {
+				if ( $this->wrapHeaderElements ) {
 					$after_title .= '<h6 class="short-title">' . Sanitize\decode( $short_title ) . '</h6>';
 				} else {
 					$content = '<h6 class="short-title">' . Sanitize\decode( $short_title ) . '</h6>' . $content;

--- a/inc/modules/export/xhtml/class-xhtml11.php
+++ b/inc/modules/export/xhtml/class-xhtml11.php
@@ -56,6 +56,14 @@ class Xhtml11 extends Export {
 	 */
 	protected $hasIntroduction = false;
 
+	/**
+	 * Should all header elements be wrapped in a container? Requires a theme based on Buckram.
+	 *
+	 * @see https://github.com/pressbooks/buckram/
+	 *
+	 * @var bool
+	 */
+	protected $wrapHeaderElements = false;
 
 	/**
 	 * Main language of document, two letter code
@@ -84,7 +92,7 @@ class Xhtml11 extends Export {
 		$this->taxonomy = \Pressbooks\Taxonomy::init();
 		$this->contributors = new \Pressbooks\Contributors();
 
-		if ( Container::get( 'Styles' )->isCurrentThemeCompatible( 2 ) ) {
+		if ( get_theme_support( 'buckram' ) || wp_get_theme()->get_stylesheet() === 'pressbooks-book' ) {
 			$this->wrapHeaderElements = true;
 		}
 

--- a/inc/modules/export/xhtml/class-xhtml11.php
+++ b/inc/modules/export/xhtml/class-xhtml11.php
@@ -7,6 +7,7 @@
 namespace Pressbooks\Modules\Export\Xhtml;
 
 use Masterminds\HTML5;
+use Pressbooks\Container;
 use Pressbooks\Modules\Export\Export;
 use Pressbooks\Sanitize;
 use function Pressbooks\Sanitize\clean_filename;
@@ -240,7 +241,7 @@ class Xhtml11 extends Export {
 		echo '<title>' . get_bloginfo( 'name' ) . "</title>\n";
 
 		if ( ! empty( $_GET['style'] ) ) {
-			$url = \Pressbooks\Container::get( 'Sass' )->urlToUserGeneratedCss() . '/' . clean_filename( $_GET['style'] ) . '.css';
+			$url = Container::get( 'Sass' )->urlToUserGeneratedCss() . '/' . clean_filename( $_GET['style'] ) . '.css';
 			echo "<link rel='stylesheet' href='$url' type='text/css' />\n";
 		}
 
@@ -814,9 +815,9 @@ class Xhtml11 extends Export {
 	 */
 	protected function echoDedicationAndEpigraph( $book_contents, $metadata ) {
 
-		$front_matter_printf = '<div class="front-matter %s" id="%s">';
-		$front_matter_printf .= '<div class="front-matter-title-wrap"><h3 class="front-matter-number">%s</h3><h1 class="front-matter-title">%s</h1></div>';
-		$front_matter_printf .= '<div class="ugc front-matter-ugc">%s</div>%s';
+		$front_matter_printf = '<div class="front-matter %1$s" id="%2$s">';
+		$front_matter_printf .= '<div class="front-matter-title-wrap"><h3 class="front-matter-number">%3$s</h3><h1 class="front-matter-title">%4$s</h1></div>';
+		$front_matter_printf .= '<div class="ugc front-matter-ugc">%5$s</div>%6$s';
 		$front_matter_printf .= '</div>';
 
 		$i = $this->frontMatterPos;
@@ -1010,10 +1011,15 @@ class Xhtml11 extends Export {
 	 * @param array $metadata
 	 */
 	protected function echoFrontMatter( $book_contents, $metadata ) {
+		if ( Container::get( 'Styles' )->isCurrentThemeCompatible( 2 ) ) {
+			$wrap_header_elements = true;
+		} else {
+			$wrap_header_elements = false;
+		}
 
-		$front_matter_printf = '<div class="front-matter %s" id="%s">';
-		$front_matter_printf .= '<div class="front-matter-title-wrap"><h3 class="front-matter-number">%s</h3><h1 class="front-matter-title">%s</h1></div>';
-		$front_matter_printf .= '<div class="ugc front-matter-ugc">%s</div>%s%s';
+		$front_matter_printf = '<div class="front-matter %1$s" id="%2$s">';
+		$front_matter_printf .= '<div class="front-matter-title-wrap"><h3 class="front-matter-number">%3$s</h3><h1 class="front-matter-title">%4$s</h1>%5$s</div>';
+		$front_matter_printf .= '<div class="ugc front-matter-ugc">%6$s</div>%7$s%8$s';
 		$front_matter_printf .= '</div>';
 
 		$i = $this->frontMatterPos;
@@ -1036,6 +1042,7 @@ class Xhtml11 extends Export {
 
 			$slug = $front_matter['post_name'];
 			$title = ( get_post_meta( $front_matter_id, 'pb_show_title', true ) ? $front_matter['post_title'] : '<span class="display-none">' . $front_matter['post_title'] . '</span>' ); // Preserve auto-indexing in Prince using hidden span
+			$after_title = '';
 			$content = $front_matter['post_content'];
 			$append_front_matter_content = apply_filters( 'pb_append_front_matter_content', '', $front_matter_id );
 			$short_title = trim( get_post_meta( $front_matter_id, 'pb_short_title', true ) );
@@ -1050,15 +1057,27 @@ class Xhtml11 extends Export {
 			}
 
 			if ( $author ) {
-				$content = '<h2 class="chapter-author">' . Sanitize\decode( $author ) . '</h2>' . $content;
+				if ( $wrap_header_elements ) {
+					$after_title .= '<h2 class="chapter-author">' . Sanitize\decode( $author ) . '</h2>';
+				} else {
+					$content = '<h2 class="chapter-author">' . Sanitize\decode( $author ) . '</h2>' . $content;
+				}
 			}
 
 			if ( $subtitle ) {
-				$content = '<h2 class="chapter-subtitle">' . Sanitize\decode( $subtitle ) . '</h2>' . $content;
+				if ( $wrap_header_elements ) {
+					$after_title .= '<h2 class="chapter-subtitle">' . Sanitize\decode( $subtitle ) . '</h2>';
+				} else {
+					$content = '<h2 class="chapter-subtitle">' . Sanitize\decode( $subtitle ) . '</h2>' . $content;
+				}
 			}
 
 			if ( $short_title ) {
-				$content = '<h6 class="short-title">' . Sanitize\decode( $short_title ) . '</h6>' . $content;
+				if ( $wrap_header_elements ) {
+					$after_title .= '<h6 class="short-title">' . Sanitize\decode( $short_title ) . '</h6>';
+				} else {
+					$content = '<h6 class="short-title">' . Sanitize\decode( $short_title ) . '</h6>' . $content;
+				}
 			}
 
 			$append_front_matter_content .= $this->removeAttributionLink( $this->doSectionLevelLicense( $metadata, $front_matter_id ) );
@@ -1069,6 +1088,7 @@ class Xhtml11 extends Export {
 				$slug,
 				$i,
 				Sanitize\decode( $title ),
+				$after_title,
 				$content,
 				$append_front_matter_content,
 				$this->doEndnotes( $front_matter_id )
@@ -1099,14 +1119,19 @@ class Xhtml11 extends Export {
 	 * @param array $metadata
 	 */
 	protected function echoPartsAndChapters( $book_contents, $metadata ) {
+		if ( Container::get( 'Styles' )->isCurrentThemeCompatible( 2 ) ) {
+			$wrap_header_elements = true;
+		} else {
+			$wrap_header_elements = false;
+		}
 
-		$part_printf = '<div class="part %s" id="%s">';
-		$part_printf .= '<div class="part-title-wrap"><h3 class="part-number">%s</h3><h1 class="part-title">%s</h1></div>%s';
+		$part_printf = '<div class="part %1$s" id="%2$s">';
+		$part_printf .= '<div class="part-title-wrap"><h3 class="part-number">%3$s</h3><h1 class="part-title">%4$s</h1></div>%5$s';
 		$part_printf .= '</div>';
 
-		$chapter_printf = '<div class="chapter %s" id="%s">';
-		$chapter_printf .= '<div class="chapter-title-wrap"><h3 class="chapter-number">%s</h3><h2 class="chapter-title">%s</h2></div>';
-		$chapter_printf .= '<div class="ugc chapter-ugc">%s</div>%s%s';
+		$chapter_printf = '<div class="chapter %1$s" id="%2$s">';
+		$chapter_printf .= '<div class="chapter-title-wrap"><h3 class="chapter-number">%3$s</h3><h2 class="chapter-title">%4$s</h2>%5$s</div>';
+		$chapter_printf .= '<div class="ugc chapter-ugc">%6$s</div>%7$s%8$s';
 		$chapter_printf .= '</div>';
 
 		$i = 1;
@@ -1170,6 +1195,7 @@ class Xhtml11 extends Export {
 				$subclass = $this->taxonomy->getChapterType( $chapter_id );
 				$slug = $chapter['post_name'];
 				$title = ( get_post_meta( $chapter_id, 'pb_show_title', true ) ? $chapter['post_title'] : '<span class="display-none">' . $chapter['post_title'] . '</span>' ); // Preserve auto-indexing in Prince using hidden span
+				$after_title = '';
 				$content = $chapter['post_content'];
 				$append_chapter_content = apply_filters( 'pb_append_chapter_content', '', $chapter_id );
 				$short_title = trim( get_post_meta( $chapter_id, 'pb_short_title', true ) );
@@ -1184,15 +1210,27 @@ class Xhtml11 extends Export {
 				}
 
 				if ( $author ) {
-					$content = '<h2 class="chapter-author">' . Sanitize\decode( $author ) . '</h2>' . $content;
+					if ( $wrap_header_elements ) {
+						$after_title .= '<h2 class="chapter-author">' . Sanitize\decode( $author ) . '</h2>';
+					} else {
+						$content = '<h2 class="chapter-author">' . Sanitize\decode( $author ) . '</h2>' . $content;
+					}
 				}
 
 				if ( $subtitle ) {
-					$content = '<h2 class="chapter-subtitle">' . Sanitize\decode( $subtitle ) . '</h2>' . $content;
+					if ( $wrap_header_elements ) {
+						$after_title .= '<h2 class="chapter-subtitle">' . Sanitize\decode( $subtitle ) . '</h2>';
+					} else {
+						$content = '<h2 class="chapter-subtitle">' . Sanitize\decode( $subtitle ) . '</h2>' . $content;
+					}
 				}
 
 				if ( $short_title ) {
-					$content = '<h6 class="short-title">' . Sanitize\decode( $short_title ) . '</h6>' . $content;
+					if ( $wrap_header_elements ) {
+						$after_title .= '<h6 class="short-title">' . Sanitize\decode( $short_title ) . '</h6>';
+					} else {
+						$content = '<h6 class="short-title">' . Sanitize\decode( $short_title ) . '</h6>' . $content;
+					}
 				}
 
 				// Inject introduction class?
@@ -1210,6 +1248,7 @@ class Xhtml11 extends Export {
 					$slug,
 					$n,
 					Sanitize\decode( $title ),
+					$after_title,
 					$content,
 					$append_chapter_content,
 					$this->doEndnotes( $chapter_id )
@@ -1259,10 +1298,15 @@ class Xhtml11 extends Export {
 	 * @param array $metadata
 	 */
 	protected function echoBackMatter( $book_contents, $metadata ) {
+		if ( Container::get( 'Styles' )->isCurrentThemeCompatible( 2 ) ) {
+			$wrap_header_elements = true;
+		} else {
+			$wrap_header_elements = false;
+		}
 
-		$back_matter_printf = '<div class="back-matter %s" id="%s">';
-		$back_matter_printf .= '<div class="back-matter-title-wrap"><h3 class="back-matter-number">%s</h3><h1 class="back-matter-title">%s</h1></div>';
-		$back_matter_printf .= '<div class="ugc back-matter-ugc">%s</div>%s%s';
+		$back_matter_printf = '<div class="back-matter %1$s" id="%2$s">';
+		$back_matter_printf .= '<div class="back-matter-title-wrap"><h3 class="back-matter-number">%3$s</h3><h1 class="back-matter-title">%4$s</h1>%5$s</div>';
+		$back_matter_printf .= '<div class="ugc back-matter-ugc">%6$s</div>%7$s%8$s';
 		$back_matter_printf .= '</div>';
 
 		$i = 1;
@@ -1276,6 +1320,7 @@ class Xhtml11 extends Export {
 			$subclass = $this->taxonomy->getBackMatterType( $back_matter_id );
 			$slug = $back_matter['post_name'];
 			$title = ( get_post_meta( $back_matter_id, 'pb_show_title', true ) ? $back_matter['post_title'] : '<span class="display-none">' . $back_matter['post_title'] . '</span>' ); // Preserve auto-indexing in Prince using hidden span
+			$after_title = '';
 			$content = $back_matter['post_content'];
 			$append_back_matter_content = apply_filters( 'pb_append_back_matter_content', '', $back_matter_id );
 			$short_title = trim( get_post_meta( $back_matter_id, 'pb_short_title', true ) );
@@ -1290,15 +1335,27 @@ class Xhtml11 extends Export {
 			}
 
 			if ( $author ) {
-				$content = '<h2 class="chapter-author">' . Sanitize\decode( $author ) . '</h2>' . $content;
+				if ( $wrap_header_elements ) {
+					$after_title .= '<h2 class="chapter-author">' . Sanitize\decode( $author ) . '</h2>';
+				} else {
+					$content = '<h2 class="chapter-author">' . Sanitize\decode( $author ) . '</h2>' . $content;
+				}
 			}
 
 			if ( $subtitle ) {
-				$content = '<h2 class="chapter-subtitle">' . Sanitize\decode( $subtitle ) . '</h2>' . $content;
+				if ( $wrap_header_elements ) {
+					$after_title .= '<h2 class="chapter-subtitle">' . Sanitize\decode( $subtitle ) . '</h2>';
+				} else {
+					$content = '<h2 class="chapter-subtitle">' . Sanitize\decode( $subtitle ) . '</h2>' . $content;
+				}
 			}
 
 			if ( $short_title ) {
-				$content = '<h6 class="short-title">' . Sanitize\decode( $short_title ) . '</h6>' . $content;
+				if ( $wrap_header_elements ) {
+					$after_title .= '<h6 class="short-title">' . Sanitize\decode( $short_title ) . '</h6>';
+				} else {
+					$content = '<h6 class="short-title">' . Sanitize\decode( $short_title ) . '</h6>' . $content;
+				}
 			}
 
 			$append_back_matter_content .= $this->removeAttributionLink( $this->doSectionLevelLicense( $metadata, $back_matter_id ) );
@@ -1309,6 +1366,7 @@ class Xhtml11 extends Export {
 				$slug,
 				$i,
 				Sanitize\decode( $title ),
+				$after_title,
 				$content,
 				$append_back_matter_content,
 				$this->doEndnotes( $back_matter_id )

--- a/inc/utility/namespace.php
+++ b/inc/utility/namespace.php
@@ -201,6 +201,7 @@ function latest_exports() {
 			'print-pdf' => '._print.pdf',
 			'mobi' => '.mobi',
 			'icml' => '.icml',
+			'htmlbook' => '-htmlbook.html',
 			'xhtml' => '.html',
 			'wxr' => '.xml',
 			'vanillawxr' => '._vanilla.xml',

--- a/tests/test-modules-export.php
+++ b/tests/test-modules-export.php
@@ -195,10 +195,23 @@ class Modules_ExportTest extends \WP_UnitTestCase {
 		$this->assertContains( ' <div id="attachment_1" ', $xhtml_content );
 		$this->assertContains( '<p><em>Ka kite ano!</em></p>', $xhtml_content );
 		$this->assertContains( 'https://github.com/pressbooks/pressbooks', $xhtml_content );
+		$this->assertContains( '</h2><h2 class="chapter-subtitle">Or, A Chapter to Test</h2></div>', $xhtml_content );
 
 		foreach ( $paths as $path ) {
 			unlink( $path );
 		}
+
+		$this->_book( 'pressbooks-donham' ); // Use an old book.
+		$meta_post = ( new \Pressbooks\Metadata() )->getMetaPost();
+		( new \Pressbooks\Contributors() )->insert( 'Ned Zimmerman', $meta_post->ID );
+		$user_id = $this->factory()->user->create( [ 'role' => 'contributor' ] );
+		wp_set_current_user( $user_id );
+
+		$exporter = new \Pressbooks\Modules\Export\Xhtml\Xhtml11( [] );
+		$this->assertTrue( $exporter->convert() );
+		$xhtml_path = $exporter->getOutputPath();
+		// Heading elements should be in a "bad" place.
+		$this->assertContains( '</h2></div><div class="ugc chapter-ugc"><h2 class="chapter-subtitle">Or, A Chapter to Test</h2>', $xhtml_content );
 	}
 
 }

--- a/tests/test-utility.php
+++ b/tests/test-utility.php
@@ -69,6 +69,20 @@ class UtilityTest extends \WP_UnitTestCase {
 		);
 	}
 
+	public function test_latest_exports() {
+		$this->_book();
+		foreach ( [
+			'\Pressbooks\Modules\Export\HTMLBook\HTMLBook',
+			'\Pressbooks\Modules\Export\WordPress\Wxr',
+		] as $module ) {
+			$exporter = new $module( [] );
+			$exporter->convert();
+		}
+		$latest = \Pressbooks\Utility\latest_exports();
+		$this->assertArrayHasKey( 'htmlbook', $latest );
+		$this->assertArrayHasKey( 'wxr', $latest );
+	}
+
 	public function test_add_sitemap_to_robots_txt_0() {
 
 		update_option( 'blog_public', 0 );
@@ -157,6 +171,13 @@ class UtilityTest extends \WP_UnitTestCase {
 
 		$this->assertTrue( is_array( $filtered ) );
 		$this->assertArrayHasKey( 'a-plugin-that-does-not-exist/foobar.php', $filtered );
+	}
+
+	public function test_install_plugins_tabs() {
+		$tabs = \Pressbooks\Utility\install_plugins_tabs();
+		$this->assertArrayNotHasKey( 'featured', $tabs );
+		$this->assertArrayNotHasKey( 'popular', $tabs );
+		$this->assertArrayNotHasKey( 'favorites', $tabs );
 	}
 
 	public function test_file_upload_max_size() {

--- a/tests/utils-trait.php
+++ b/tests/utils-trait.php
@@ -55,7 +55,7 @@ trait utilsTrait {
 Footnotes are cool. [footnote]but endnotes are cooler?[/footnote]
 
 <h1>Math</h1>
-				
+
 This is my math:
 
 $latex \displaystyle P_\nu^{-\mu}(z)=\frac{\left(z^2-1\right)^{\frac{\mu}{2}}}{2^\mu \sqrt{\pi}\Gamma\left(\mu+\frac{1}{2}\right)}\int_{-1}^1\frac{\left(1-t^2\right)^{\mu -\frac{1}{2}}}{\left(z+t\sqrt{z^2-1}\right)^{\mu-\nu}}dt$$
@@ -85,6 +85,7 @@ There are many maths like it but these ones are mine.
 		];
 		$pid = $this->factory()->post->create_object( $new_post );
 		update_post_meta( $pid, 'pb_export', 'on' );
+		update_post_meta( $pid, 'pb_subtitle', 'Or, A Chapter to Test' );
 
 		return $pid;
 	}


### PR DESCRIPTION
This PR fixes https://github.com/pressbooks/pressbooks/issues/1035. Additionally, it switches to numbered parameters to all modified `sprintf` strings in the EPUB and XHTML export modules for increased readability.

## Implementation Notes / Potential Issues

+ We wrap heading elements if the current theme is SCSS v2-compatible (aka, if it uses [Buckram](https://github.com/pressbooks/buckram)).
+ If a theme is locked with an older version of Buckram… things may break.
+ Should we explicitly declare theme support for this feature instead?