### PR TITLE
Update TOC chapter license display to support human-readable license

### DIFF
--- a/inc/modules/export/class-export.php
+++ b/inc/modules/export/class-export.php
@@ -424,7 +424,17 @@ abstract class Export {
 		$option = get_option( 'pressbooks_theme_options_global' );
 		if ( ! empty( $option['copyright_license'] ) ) {
 			if ( 1 === absint( $option['copyright_license'] ) ) {
-				return (string) get_post_meta( $post_id, 'pb_section_license', true );
+				$section_license = get_post_meta( $post_id, 'pb_section_license', true );
+				if ( ! empty( $section_license ) ) {
+
+					$licensing = new \Pressbooks\Licensing();
+					$supported_types = $licensing->getSupportedTypes();
+					if ( array_key_exists( $section_license, $supported_types ) ) {
+						return $supported_types[ $section_license ]['desc'];
+					} else {
+						return '';
+					}
+				}
 			} elseif ( 2 === absint( $option['copyright_license'] ) ) {
 				return '';
 			}

--- a/tests/test-styles.php
+++ b/tests/test-styles.php
@@ -89,12 +89,12 @@ class StylesTest extends \WP_UnitTestCase {
 
 	public function test_customize() {
 		// V1
-		$this->_book();
+		$this->_book( 'pressbooks-donham' );
 		$this->assertContains( 'font-size:', $this->cs->customizeWeb() );
 		$this->assertContains( 'font-size:', $this->cs->customizeEpub() );
 		$this->assertContains( 'font-size:', $this->cs->customizePrince() );
 		// V2
-		switch_theme( 'pressbooks-clarke' );
+		switch_theme( 'pressbooks-book' );
 		$this->assertContains( 'font-size:', $this->cs->customizeWeb() );
 		$this->assertContains( 'font-size:', $this->cs->customizeEpub() );
 		$this->assertContains( 'font-size:', $this->cs->customizePrince() );


### PR DESCRIPTION
The TOC license display was outputting `cc-by` etc. This updates it to display the human readable license name.