### PR TITLE
Fix missing login screen logo

### DIFF
--- a/inc/admin/branding/namespace.php
+++ b/inc/admin/branding/namespace.php
@@ -65,7 +65,7 @@ function custom_login_logo() {
 	} else {
 		$logo = sprintf(
 			'<style type="text/css">.login h1 a {background-image: url(%s);}</style>',
-			$assets->getPath( 'images/PB-logo.svg' )
+			PB_PLUGIN_URL . 'assets/dist/images/PB-logo.svg'
 		);
 	}
 	$style = '<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Karla:400,400i,700|Spectral:400,400i,600" />';


### PR DESCRIPTION
I was referencing the source image, not the one in the `assets/dist` folder, so it was throwing a 404 in production.