### PR TITLE
Add revisions support to parts

### DIFF
--- a/inc/posttype/namespace.php
+++ b/inc/posttype/namespace.php
@@ -71,7 +71,7 @@ function register_post_types() {
 			'capability_type' => 'page',
 			'has_archive' => true,
 			'hierarchical' => true,
-			'supports' => [ 'title', 'editor', 'page-attributes' ],
+			'supports' => [ 'title', 'editor', 'page-attributes', 'revisions' ],
 			'show_in_menu' => false,
 			'show_in_admin_bar' => true,
 			'show_in_rest' => true,


### PR DESCRIPTION
It's been [pointed out](https://discourse.pressbooks.org/t/revision-history-in-parts/440) that parts don't support revisions. This is an oversight; as they support editable content, they should support revisions. Props [Naomi Salmon](https://discourse.pressbooks.org/u/Naomi_Salmon) on Discourse for reporting.