### PR TITLE
Fix: Keep multiselect order when using select2

### DIFF
--- a/symbionts/custom-metadata/js/custom-metadata-manager.js
+++ b/symbionts/custom-metadata/js/custom-metadata-manager.js
@@ -202,6 +202,14 @@
 		// init the color picker fields
 		$( '.colorpicker' ).find( 'input' ).wpColorPicker();
 
+		// Fix: In multi-select, selections do not appear in the order in which they were selected
+		// @see https://github.com/select2/select2/issues/3106
+		$("select").on('select2:select', function(e){
+			var id = e.params.data.id;
+			var option = $(e.target).children('[value='+id+']');
+			option.detach();
+			$(e.target).append(option).change();
+		});
 
 	});
 })(jQuery);


### PR DESCRIPTION
More info:
> In multi-select, selections do not appear in the order in which they were selected:
https://github.com/select2/select2/issues/3106