### PR TITLE
Prevent slug collisions  (fix #1174)

### DIFF
--- a/inc/modules/export/htmlbook/class-htmlbook.php
+++ b/inc/modules/export/htmlbook/class-htmlbook.php
@@ -645,7 +645,7 @@ class HTMLBook extends Export {
 				$fm->setAttributes(
 					[
 						'class' => "front-matter {$subclass}",
-						'id' => $front_matter['post_name'],
+						'id' => "front-matter-{$front_matter['post_name']}",
 					]
 				);
 
@@ -861,7 +861,7 @@ class HTMLBook extends Export {
 				$fm->setAttributes(
 					[
 						'class' => "front-matter {$subclass}",
-						'id' => $front_matter['post_name'],
+						'id' => "front-matter-{$front_matter['post_name']}",
 					]
 				);
 
@@ -952,7 +952,7 @@ class HTMLBook extends Export {
 
 			if ( 'part' === $type ) {
 				foreach ( $struct as $part ) {
-					$slug = $part['post_name'];
+					$slug = "part-{$part['post_name']}";
 					$title = Sanitize\strip_br( $part['post_title'] );
 					$part_content = trim( $part['post_content'] );
 
@@ -1018,7 +1018,7 @@ class HTMLBook extends Export {
 						}
 
 						$subclass = $this->taxonomy->getChapterType( $chapter['ID'] );
-						$slug = $chapter['post_name'];
+						$slug = "chapter-{$chapter['post_name']}";
 						$title = Sanitize\strip_br( $chapter['post_title'] );
 						$subtitle = trim( get_post_meta( $chapter['ID'], 'pb_subtitle', true ) );
 						$author = $this->contributors->get( $chapter['ID'], 'pb_authors' );
@@ -1072,7 +1072,7 @@ class HTMLBook extends Export {
 					$subtitle = '';
 					$author = '';
 					$license = '';
-					$slug = $val['post_name'];
+					$slug = "{$type}-{$val['post_name']}";
 					$title = Sanitize\strip_br( $val['post_title'] );
 
 					if ( 'front-matter' === $type ) {
@@ -1193,7 +1193,7 @@ class HTMLBook extends Export {
 			$fm->setAttributes(
 				[
 					'class' => "front-matter {$subclass}",
-					'id' => $front_matter['post_name'],
+					'id' => "front-matter-{$front_matter['post_name']}",
 				]
 			);
 
@@ -1278,7 +1278,7 @@ class HTMLBook extends Export {
 			$my_part = new Part();
 
 			$invisibility = ( get_post_meta( $part['ID'], 'pb_part_invisible', true ) === 'on' ) ? 'invisible' : '';
-			$slug = $part['post_name'];
+			$slug = "part-{$part['post_name']}";
 			$title = $part['post_title'];
 			$part_content = trim( $part['post_content'] );
 
@@ -1361,7 +1361,7 @@ class HTMLBook extends Export {
 
 				$chapter_id = $chapter['ID'];
 				$subclass = $this->taxonomy->getChapterType( $chapter_id );
-				$slug = $chapter['post_name'];
+				$slug = "chapter-{$chapter['post_name']}";
 				$title = ( get_post_meta( $chapter_id, 'pb_show_title', true ) ? $chapter['post_title'] : '<span class="display-none">' . $chapter['post_title'] . '</span>' ); // Preserve auto-indexing in Prince using hidden span
 				$content = $chapter['post_content'];
 				$append_chapter_content = apply_filters( 'pb_append_chapter_content', '', $chapter_id );
@@ -1533,7 +1533,7 @@ class HTMLBook extends Export {
 			$bm->setAttributes(
 				[
 					'class' => "back-matter {$subclass}",
-					'id' => $back_matter['post_name'],
+					'id' => "back-matter-{$back_matter['post_name']}",
 				]
 			);
 

--- a/inc/modules/export/xhtml/class-xhtml11.php
+++ b/inc/modules/export/xhtml/class-xhtml11.php
@@ -686,7 +686,7 @@ class Xhtml11 extends Export {
 					continue; //Skip
 				}
 
-				$slug = $front_matter['post_name'];
+				$slug = "front-matter-{$front_matter['post_name']}";
 				$title = ( get_post_meta( $front_matter_id, 'pb_show_title', true ) ? $front_matter['post_title'] : '<span class="display-none">' . $front_matter['post_title'] . '</span>' ); // Preserve auto-indexing in Prince using hidden span
 				$content = $front_matter['post_content'];
 
@@ -852,7 +852,7 @@ class Xhtml11 extends Export {
 					continue; // Skip
 				}
 
-				$slug = $front_matter['post_name'];
+				$slug = "front-matter-{$front_matter['post_name']}";
 				$title = ( get_post_meta( $front_matter_id, 'pb_show_title', true ) ? $front_matter['post_title'] : '<span class="display-none">' . $front_matter['post_title'] . '</span>' ); // Preserve auto-indexing in Prince using hidden span
 				$content = $front_matter['post_content'];
 
@@ -889,7 +889,7 @@ class Xhtml11 extends Export {
 
 			if ( 'part' === $type ) {
 				foreach ( $struct as $part ) {
-					$slug = $part['post_name'];
+					$slug = "part-{$part['post_name']}";
 					$title = Sanitize\strip_br( $part['post_title'] );
 					$part_content = trim( $part['post_content'] );
 					if ( get_post_meta( $part['ID'], 'pb_part_invisible', true ) !== 'on' ) { // visible
@@ -920,7 +920,7 @@ class Xhtml11 extends Export {
 						}
 
 						$subclass = $this->taxonomy->getChapterType( $chapter['ID'] );
-						$slug = $chapter['post_name'];
+						$slug = "chapter-{$chapter['post_name']}";
 						$title = Sanitize\strip_br( $chapter['post_title'] );
 						$subtitle = trim( get_post_meta( $chapter['ID'], 'pb_subtitle', true ) );
 						$author = $this->contributors->get( $chapter['ID'], 'pb_authors' );
@@ -967,7 +967,7 @@ class Xhtml11 extends Export {
 					$subtitle = '';
 					$author = '';
 					$license = '';
-					$slug = $val['post_name'];
+					$slug = "{$type}-{$val['post_name']}";
 					$title = Sanitize\strip_br( $val['post_title'] );
 
 					if ( 'front-matter' === $type ) {
@@ -1051,7 +1051,7 @@ class Xhtml11 extends Export {
 				$this->hasIntroduction = true;
 			}
 
-			$slug = $front_matter['post_name'];
+			$slug = "front-matter-{$front_matter['post_name']}";
 			$title = ( get_post_meta( $front_matter_id, 'pb_show_title', true ) ? $front_matter['post_title'] : '<span class="display-none">' . $front_matter['post_title'] . '</span>' ); // Preserve auto-indexing in Prince using hidden span
 			$after_title = '';
 			$content = $front_matter['post_content'];
@@ -1146,7 +1146,7 @@ class Xhtml11 extends Export {
 			$invisibility = ( get_post_meta( $part['ID'], 'pb_part_invisible', true ) === 'on' ) ? 'invisible' : '';
 
 			$part_printf_changed = '';
-			$slug = $part['post_name'];
+			$slug = "part-{$part['post_name']}";
 			$title = $part['post_title'];
 			$part_content = trim( $part['post_content'] );
 
@@ -1195,10 +1195,9 @@ class Xhtml11 extends Export {
 					continue; // Skip
 				}
 
-				$chapter_printf_changed = '';
 				$chapter_id = $chapter['ID'];
 				$subclass = $this->taxonomy->getChapterType( $chapter_id );
-				$slug = $chapter['post_name'];
+				$slug = "chapter-{$chapter['post_name']}";
 				$title = ( get_post_meta( $chapter_id, 'pb_show_title', true ) ? $chapter['post_title'] : '<span class="display-none">' . $chapter['post_title'] . '</span>' ); // Preserve auto-indexing in Prince using hidden span
 				$after_title = '';
 				$content = $chapter['post_content'];
@@ -1317,7 +1316,7 @@ class Xhtml11 extends Export {
 
 			$back_matter_id = $back_matter['ID'];
 			$subclass = $this->taxonomy->getBackMatterType( $back_matter_id );
-			$slug = $back_matter['post_name'];
+			$slug = "back-matter-{$back_matter['post_name']}";
 			$title = ( get_post_meta( $back_matter_id, 'pb_show_title', true ) ? $back_matter['post_title'] : '<span class="display-none">' . $back_matter['post_title'] . '</span>' ); // Preserve auto-indexing in Prince using hidden span
 			$after_title = '';
 			$content = $back_matter['post_content'];


### PR DESCRIPTION
Escape clause:

HTMLawed tries its best [1] but this won't stop a user from generating their own bad content like:

```
<div class="ugc front-matter-ugc">
  <div id="chapter-identical-post-name">Just because</div>
</div>
```

[1] http://www.bioinformatics.org/phplabware/internal_utilities/htmLawed/htmLawed_README.htm#s3.4.2