### PR TITLE
Bump minimum WordPress to 4.9.5 (fix #1176)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ you need to install Pressbooks for development, please see the
 
 ## Requirements
 
-Pressbooks works with PHP 7.0 and WordPress 4.9.4. Lower versions are not
+Pressbooks works with PHP 7.0 and WordPress 4.9.5. Lower versions are not
 supported.
 
 ## Disclaimers

--- a/compatibility.php
+++ b/compatibility.php
@@ -33,7 +33,7 @@ function pb_meets_minimum_requirements() {
 
 	// WordPress Version
 	global $pb_minimum_wp;
-	$pb_minimum_wp = '4.9.4';
+	$pb_minimum_wp = '4.9.5';
 
 	include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 	$is_compatible = true;

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"select2": "^4.0.3",
 		"sidr": "^2.2.1",
 		"tinymce": "^4.7.10",
-		"wp-admin-colors": "^4.9.4",
+		"wp-admin-colors": "^4.9.5",
 		"wpapi": "^1.1.2"
 	},
 	"devDependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: Pressbooks <code@pressbooks.com>
 Donate link: https://opencollective.com/pressbooks
 Tags: ebooks, publishing, webbooks
-Requires at least: 4.9.4
-Tested up to: 4.9.4
+Requires at least: 4.9.5
+Tested up to: 4.9.5
 Requires PHP: 7.0
 Stable tag: 5.2.1
 License: GPL v3.0 or later
@@ -21,10 +21,16 @@ For installation instructions, visit [docs.pressbooks.org/installation](https://
 TK.
 
 == Changelog ==
-= 5.2.1 =
-**NOTICE:** Pressbooks 5.2.1 requires [WordPress 4.9.4](https://wordpress.org/news/2018/02/wordpress-4-9-4-maintenance-release/).
-**NOTICE:** Pressbooks 5.2.1 requires [McLuhan >= 2.2.0](https://github.com/pressbooks/pressbooks-book/).
+= 5.3.0 =
+**Minor Changes**
+- Disallow certain taxonomies based on a blacklist instead of a whitelist (#1095): #1172
+- Update Isotope to 3.0.6: #1177
+- Update TinyMCE Table plugin to 4.7.10: #1173
 
+**Patches**
+- Prevent slug collisions in XHTML and HTMLBook outputs (#1174): #1175
+
+= 5.2.1 =
 **Patches**
 
 - Patch [select2](https://github.com/select2/select2) and [Custom Metadata Manager](https://github.com/Automattic/custom-metadata) to save multiselect data in the specified order: [#1167](https://github.com/pressbooks/pressbooks/pull/1167)
@@ -34,7 +40,7 @@ TK.
 - Remove unit test that was failing due to inaccessible Creative Commons API: [#1171](https://github.com/pressbooks/pressbooks/pull/1171)
 
 == Upgrade Notice ==
-= 5.2.1 =
+= 5.3.0 =
 
-Pressbooks 5.2.1 requires [WordPress 4.9.4](https://wordpress.org/news/2018/02/wordpress-4-9-4-maintenance-release/).
-Pressbooks 5.2.1 requires [McLuhan >= 2.2.0](https://github.com/pressbooks/pressbooks-book/).
+Pressbooks 5.3.0 requires [WordPress 4.9.4](https://wordpress.org/news/2018/04/wordpress-4-9-5-security-and-maintenance-release/).
+Pressbooks 5.3.0 requires [McLuhan >= 2.3.0](https://github.com/pressbooks/pressbooks-book/).

--- a/yarn.lock
+++ b/yarn.lock
@@ -9266,9 +9266,9 @@ worker-farm@^1.5.2:
     errno "^0.1.4"
     xtend "^4.0.1"
 
-wp-admin-colors@^4.9.4:
-  version "4.9.4"
-  resolved "https://registry.yarnpkg.com/wp-admin-colors/-/wp-admin-colors-4.9.4.tgz#54091c5cfd5646484c49fac6086445361768f138"
+wp-admin-colors@^4.9.5:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/wp-admin-colors/-/wp-admin-colors-4.9.5.tgz#8a861a68f06e9eb7205fd9c14fe8ed5d4bd3335a"
 
 wp-pot-cli@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
FYI @pressbooks/core.