### PR TITLE
Add more specificity to web overrides for Custom CSS

### DIFF
--- a/inc/modules/themeoptions/class-weboptions.php
+++ b/inc/modules/themeoptions/class-weboptions.php
@@ -412,7 +412,7 @@ class WebOptions extends \Pressbooks\Options {
 						]
 					);
 				} else {
-					$scss .= "* + p { text-indent: 1em; margin-top: 0; margin-bottom: 0; } \n";
+					$scss .= "#content * + p { text-indent: 1em; margin-top: 0; margin-bottom: 0; } \n";
 				}
 			} elseif ( 'skiplines' === $options['paragraph_separation'] ) {
 				if ( $v2_compatible ) {
@@ -423,7 +423,7 @@ class WebOptions extends \Pressbooks\Options {
 						]
 					);
 				} else {
-					$scss .= "p + p { text-indent: 0em; margin-top: 1em; } \n";
+					$scss .= "#content p + p { text-indent: 0em; margin-top: 1em; } \n";
 				}
 			}
 		}


### PR DESCRIPTION
This PR ensures that web theme option overrides for Custom CSS will correctly target content paragraphs to change from indented to skiplines. The previous selector, `p + p`, was being overridden by the more specific `.chapter p + p` selector used in McLuhan (which supplies Custom CSS with web content styles).