### PR TITLE
Add debug parameter to XHTML and HTMLBook URLs

### DIFF
--- a/inc/modules/export/htmlbook/class-htmlbook.php
+++ b/inc/modules/export/htmlbook/class-htmlbook.php
@@ -22,7 +22,9 @@ use Pressbooks\HTMLBook\Validator;
 use Masterminds\HTML5;
 use Pressbooks\Modules\Export\Export;
 use Pressbooks\Sanitize;
+use function Pressbooks\Sanitize\clean_filename;
 use function Pressbooks\Utility\oxford_comma_explode;
+use function Pressbooks\Utility\get_generated_content_url;
 
 class HTMLBook extends Export {
 
@@ -230,6 +232,14 @@ class HTMLBook extends Export {
 
 		echo "<head>\n";
 		echo '<title>' . get_bloginfo( 'name' ) . "</title>\n";
+
+		if ( WP_DEBUG ) {
+			if ( ! empty( $_GET['debug'] ) ) {
+				$url = get_generated_content_url( '/scss-debug' ) . '/' . clean_filename( $_GET['debug'] ) . '.css';
+				echo "<link rel='stylesheet' href='$url' type='text/css' />\n";
+			}
+		}
+
 		echo "</head>\n";
 
 		$book = new Book();

--- a/inc/modules/export/xhtml/class-xhtml11.php
+++ b/inc/modules/export/xhtml/class-xhtml11.php
@@ -11,6 +11,7 @@ use Pressbooks\Container;
 use Pressbooks\Modules\Export\Export;
 use Pressbooks\Sanitize;
 use function Pressbooks\Sanitize\clean_filename;
+use function Pressbooks\Utility\get_generated_content_url;
 
 class Xhtml11 extends Export {
 
@@ -250,6 +251,13 @@ class Xhtml11 extends Export {
 		$this->echoMetaData( $book_contents, $metadata );
 
 		echo '<title>' . get_bloginfo( 'name' ) . "</title>\n";
+
+		if ( WP_DEBUG ) {
+			if ( ! empty( $_GET['debug'] ) ) {
+				$url = get_generated_content_url( '/scss-debug' ) . '/' . clean_filename( $_GET['debug'] ) . '.css';
+				echo "<link rel='stylesheet' href='$url' type='text/css' />\n";
+			}
+		}
 
 		if ( ! empty( $_GET['style'] ) ) {
 			$url = Container::get( 'Sass' )->urlToUserGeneratedCss() . '/' . clean_filename( $_GET['style'] ) . '.css';

--- a/tests/test-modules-export.php
+++ b/tests/test-modules-export.php
@@ -225,4 +225,24 @@ class Modules_ExportTest extends \WP_UnitTestCase {
 
 		unlink( $exporter->getOutputPath() );
 	}
+
+	public function test_sanityCheckXhtmlDebug() {
+		$this->_book();
+		$meta_post = ( new \Pressbooks\Metadata() )->getMetaPost();
+		( new \Pressbooks\Contributors() )->insert( 'Ned Zimmerman', $meta_post->ID );
+		$user_id = $this->factory()->user->create( [ 'role' => 'contributor' ] );
+		wp_set_current_user( $user_id );
+		$_GET['debug'] = 'prince';
+		if ( ! defined( 'WP_DEBUG' ) ) {
+			define( 'WP_DEBUG', true );
+		}
+
+		$exporter = new \Pressbooks\Modules\Export\Xhtml\Xhtml11( [] );
+		$this->assertTrue( $exporter->convert() );
+		$this->assertTrue( $exporter->validate() );
+		$xhtml_content = file_get_contents( $exporter->getOutputPath() );
+		$url = network_home_url( sprintf( '/wp-content/uploads/sites/%d/pressbooks/scss-debug/prince.css', get_current_blog_id() ) );
+		$this->assertContains( "<link rel='stylesheet' href='$url' type='text/css' />", $xhtml_content );
+		unlink( $exporter->getOutputPath() );
+	}
 }


### PR DESCRIPTION
Visiting https://pressbooks.test/somebook/format/xhtml?debug=prince while in debug mode will load the XHTML/HTMLBook with a compiled Prince stylesheet, if it exists. Better than nothing. 🤷🏼‍♂️