### PR TITLE
Ignore SASS vars prefixed with _ in parseVariables method

### DIFF
--- a/inc/class-sass.php
+++ b/inc/class-sass.php
@@ -6,6 +6,8 @@
 
 namespace Pressbooks;
 
+use function Pressbooks\Utility\str_starts_with;
+
 /**
  * SCSS Compiler and Build Tools
  */
@@ -216,7 +218,7 @@ class Sass {
 		$parser = new \Leafo\ScssPhp\Parser( null );
 		$tree = $parser->parse( $scss );
 		foreach ( $tree->children as $item ) {
-			if ( $item[0] === \Leafo\ScssPhp\Type::T_ASSIGN && $item[1][0] === \Leafo\ScssPhp\Type::T_VARIABLE ) {
+			if ( $item[0] === \Leafo\ScssPhp\Type::T_ASSIGN && $item[1][0] === \Leafo\ScssPhp\Type::T_VARIABLE && ! str_starts_with( $item[1][1], '_' ) ) {
 				$key = $item[1][1];
 				switch ( $item[2][0] ) {
 					case \Leafo\ScssPhp\Type::T_VARIABLE:

--- a/tests/test-sass.php
+++ b/tests/test-sass.php
@@ -61,16 +61,17 @@ class SassTest extends \WP_UnitTestCase {
 
 	public function test_parseVariables() {
 		$scss = '$red: #d4002d !default;
-		$font-size: 
+		$font-size:
 		    14pt;
 		$body-font-size: (
-			web:   14cm,  
+			web:   14cm,
 		    epub:  medium,
             prince:10.5pt,
         )   !default;
         $var1: $var2 !default;
         $f: xxx(one, two,  three,    four,     five);
-        ignored: becauseKeyHasNoDollarSign;
+		ignored: becauseKeyHasNoDollarSign;
+		$_secret: becauseStartsWithUnderscore
         ';
 
 		$vars = $this->sass->parseVariables( $scss );
@@ -81,6 +82,7 @@ class SassTest extends \WP_UnitTestCase {
 		$this->assertEquals( $vars['var1'], '$var2' );
 		$this->assertEquals( $vars['f'], 'xxx(one, two, three, four, five)' );
 		$this->assertArrayNotHasKey( 'ignored', $vars );
+		$this->assertArrayNotHasKey( '_secret', $vars );
 	}
 
 


### PR DESCRIPTION
In Buckram, there's a use case for one-off utility variables that do not need to be parsed within `\Pressbooks\Sass::parseVariables()`. Case in point:

```
$_heading-line-height: (
  h1: $h1-line-height,
  h2: $h2-line-height,
  h3: $h3-line-height,
  h4: $h4-line-height,
  h5: $h5-line-height,
  h6: $h6-line-height,
);
```

This PR updates the `\Pressbooks\Sass::parseVariables()` method to ignore SASS variables prefixed with `_` ([see here for rationale](https://sass-lang.com/guide)).