### PR TITLE
Fix default color bug, add section headings, remove text colors

### DIFF
--- a/inc/class-options.php
+++ b/inc/class-options.php
@@ -211,6 +211,51 @@ abstract class Options {
 	}
 
 	/**
+	 * Render a WordPress color picker.
+	 *
+	 * @param array $args {
+	 *     Arguments to render the color picker.
+	 *
+	 * @type string $id The id which will be assigned to the rendered field.
+	 * @type string $name The name of the field.
+	 * @type string $option The name of the option that the field is within.
+	 * @type string $value The stored value of the field as retrieved from the database.
+	 * @type string $default The default value of the field.
+	 * @type string $description A description which will be displayed below the field.
+	 * @type bool $disabled Is the field disabled?
+	 * }
+	 */
+	static function renderColorField( $args ) {
+		$defaults = [
+			'id' => null,
+			'name' => null,
+			'option' => null,
+			'value' => '',
+			'default' => '#000',
+			'description' => null,
+			'disabled' => false,
+		];
+
+		$args = wp_parse_args( $args, $defaults );
+
+		printf(
+			'<input id="%1$s" class="color-picker" name="%2$s[%3$s]" type="text" data-default-color="%4$s" value="%5$s" %6$s/>',
+			$args['id'],
+			$args['name'],
+			$args['option'],
+			$args['default'],
+			$args['value'],
+			( ! empty( $args['disabled'] ) ) ? ' disabled' : ''
+		);
+		if ( isset( $args['description'] ) ) {
+			printf(
+				'<p class="description">%s</p>',
+				$args['description']
+			);
+		}
+	}
+
+	/**
 	 * Render a checkbox.
 	 *
 	 * @param array $args

--- a/inc/modules/themeoptions/class-ebookoptions.php
+++ b/inc/modules/themeoptions/class-ebookoptions.php
@@ -445,19 +445,15 @@ class EbookOptions extends \Pressbooks\Options {
 			foreach ( [
 				'edu_textbox_examples_header_color' => 'examples-header-color',
 				'edu_textbox_examples_header_background' => 'examples-header-background',
-				'edu_textbox_examples_color' => 'examples-color',
 				'edu_textbox_examples_background' => 'examples-background',
 				'edu_textbox_exercises_header_color' => 'exercises-header-color',
 				'edu_textbox_exercises_header_background' => 'exercises-header-background',
-				'edu_textbox_exercises_color' => 'exercises-color',
 				'edu_textbox_exercises_background' => 'exercises-background',
 				'edu_textbox_objectives_header_color' => 'learning-objectives-header-color',
 				'edu_textbox_objectives_header_background' => 'learning-objectives-header-background',
-				'edu_textbox_objectives_color' => 'learning-objectives-color',
 				'edu_textbox_objectives_background' => 'learning-objectives-background',
 				'edu_textbox_takeaways_header_color' => 'key-takeaways-header-color',
 				'edu_textbox_takeaways_header_background' => 'key-takeaways-header-background',
-				'edu_textbox_takeaways_color' => 'key-takeaways-color',
 				'edu_textbox_takeaways_background' => 'key-takeaways-background',
 			] as $option => $variable ) {
 				if ( isset( $options[ $option ] ) ) {

--- a/inc/modules/themeoptions/class-globaloptions.php
+++ b/inc/modules/themeoptions/class-globaloptions.php
@@ -140,9 +140,20 @@ class GlobalOptions extends \Pressbooks\Options {
 				'objectives' => __( 'Learning Objectives', 'pressbooks' ),
 			] as $key => $label ) {
 				add_settings_field(
+					"edu_textbox_{$key}_section",
+					sprintf( '<h3>%s</h3>', $label ),
+					[ $this, 'renderTextboxHeader' ],
+					$_page,
+					$_section,
+					[
+						sprintf( __( 'Customize colors for %s textboxes using the fields below.', 'pressbooks' ), $label ),
+					]
+				);
+
+				add_settings_field(
 					"edu_textbox_{$key}_header_color",
-					sprintf( __( '%s Header Color', 'pressbooks' ), $label ),
-					[ $this, 'renderColorField' ],
+					__( 'Header Color', 'pressbooks' ),
+					[ $this, 'renderTextboxColorField' ],
 					$_page,
 					$_section,
 					[
@@ -152,8 +163,8 @@ class GlobalOptions extends \Pressbooks\Options {
 				);
 				add_settings_field(
 					"edu_textbox_{$key}_header_background",
-					sprintf( __( '%s Header Background', 'pressbooks' ), $label ),
-					[ $this, 'renderColorField' ],
+					__( 'Header Background', 'pressbooks' ),
+					[ $this, 'renderTextboxColorField' ],
 					$_page,
 					$_section,
 					[
@@ -162,20 +173,9 @@ class GlobalOptions extends \Pressbooks\Options {
 					]
 				);
 				add_settings_field(
-					"edu_textbox_{$key}_color",
-					sprintf( __( '%s Color', 'pressbooks' ), $label ),
-					[ $this, 'renderColorField' ],
-					$_page,
-					$_section,
-					[
-						'key' => "edu_textbox_{$key}_color",
-						'description' => sprintf( __( 'The text color for a %s textbox.', 'pressbooks' ), $label ),
-					]
-				);
-				add_settings_field(
 					"edu_textbox_{$key}_background",
-					sprintf( __( '%s Background', 'pressbooks' ), $label ),
-					[ $this, 'renderColorField' ],
+					__( 'Background', 'pressbooks' ),
+					[ $this, 'renderTextboxColorField' ],
 					$_page,
 					$_section,
 					[
@@ -369,20 +369,28 @@ class GlobalOptions extends \Pressbooks\Options {
 	}
 
 	/**
+	 * Render a textbox header.
+	 *
+	 * @param array $args
+	 */
+	function renderTextboxHeader( $args ) {
+		printf( $args[0] );
+	}
+
+	/**
 	 * Render the header color inputs.
 	 *
 	 * @param array $args
 	 */
-	function renderColorField( $args ) {
-		$this->renderField(
+	function renderTextboxColorField( $args ) {
+		$this->renderColorField(
 			[
 				'id' => $args['key'],
 				'name' => 'pressbooks_theme_options_' . $this->getSlug(),
 				'option' => $args['key'],
 				'value' => ( isset( $this->options[ $args['key'] ] ) ) ? $this->options[ $args['key'] ] : $this->defaults[ $args['key'] ],
+				'default' => $this->defaults[ $args['key'] ],
 				'description' => $args['description'],
-				'type' => 'color',
-				'class' => 'color-picker',
 			]
 		);
 	}
@@ -423,19 +431,15 @@ class GlobalOptions extends \Pressbooks\Options {
 				'copyright_license' => 0,
 				'edu_textbox_examples_header_color' => '#fff',
 				'edu_textbox_examples_header_background' => '#7a333a',
-				'edu_textbox_examples_color' => '#000',
 				'edu_textbox_examples_background' => '#f3e1e3',
 				'edu_textbox_exercises_header_color' => '#fff',
 				'edu_textbox_exercises_header_background' => '#0b6396',
-				'edu_textbox_exercises_color' => '#000',
 				'edu_textbox_exercises_background' => '#e3eff6',
 				'edu_textbox_objectives_header_color' => '#fff',
 				'edu_textbox_objectives_header_background' => '#111',
-				'edu_textbox_objectives_color' => '#000',
 				'edu_textbox_objectives_background' => '#f7f7f9',
 				'edu_textbox_takeaways_header_color' => '#fff',
 				'edu_textbox_takeaways_header_background' => '#3a7a33',
-				'edu_textbox_takeaways_color' => '#000',
 				'edu_textbox_takeaways_background' => '#eaf5ea',
 			]
 		);
@@ -454,19 +458,15 @@ class GlobalOptions extends \Pressbooks\Options {
 		$overrides = [
 			'examples-header-color' => 'edu_textbox_examples_header_color',
 			'examples-header-background' => 'edu_textbox_examples_header_background',
-			'examples-color' => 'edu_textbox_examples_color',
 			'examples-background' => 'edu_textbox_examples_background',
 			'exercises-header-color' => 'edu_textbox_exercises_header_color',
 			'exercises-header-background' => 'edu_textbox_exercises_header_background',
-			'exercises-color' => 'edu_textbox_exercises_color',
 			'exercises-background' => 'edu_textbox_exercises_background',
 			'learning-objectives-header-color' => 'edu_textbox_objectives_header_color',
 			'learning-objectives-header-background' => 'edu_textbox_objectives_header_background',
-			'learning-objectives-color' => 'edu_textbox_objectives_color',
 			'learning-objectives-background' => 'edu_textbox_objectives_background',
 			'key-takeaways-header-color' => 'edu_textbox_takeaways_header_color',
 			'key-takeaways-header-background' => 'edu_textbox_takeaways_header_background',
-			'key-takeaways-color' => 'edu_textbox_takeaways_color',
 			'key-takeaways-background' => 'edu_textbox_takeaways_background',
 		];
 
@@ -540,19 +540,15 @@ class GlobalOptions extends \Pressbooks\Options {
 		return apply_filters( 'pb_theme_options_global_strings', [
 			'edu_textbox_examples_header_color',
 			'edu_textbox_examples_header_background',
-			'edu_textbox_examples_color',
 			'edu_textbox_examples_background',
 			'edu_textbox_exercises_header_color',
 			'edu_textbox_exercises_header_background',
-			'edu_textbox_exercises_color',
 			'edu_textbox_exercises_background',
 			'edu_textbox_objectives_header_color',
 			'edu_textbox_objectives_header_background',
-			'edu_textbox_objectives_color',
 			'edu_textbox_objectives_background',
 			'edu_textbox_takeaways_header_color',
 			'edu_textbox_takeaways_header_background',
-			'edu_textbox_takeaways_color',
 			'edu_textbox_takeaways_background',
 		] );
 	}

--- a/inc/modules/themeoptions/class-globaloptions.php
+++ b/inc/modules/themeoptions/class-globaloptions.php
@@ -152,7 +152,7 @@ class GlobalOptions extends \Pressbooks\Options {
 
 				add_settings_field(
 					"edu_textbox_{$key}_header_color",
-					__( 'Header Color', 'pressbooks' ),
+					sprintf( '<span class="screen-reader-text">%1$s </span>%2$s', $label, __( 'Header Color', 'pressbooks' ) ),
 					[ $this, 'renderTextboxColorField' ],
 					$_page,
 					$_section,
@@ -163,7 +163,7 @@ class GlobalOptions extends \Pressbooks\Options {
 				);
 				add_settings_field(
 					"edu_textbox_{$key}_header_background",
-					__( 'Header Background', 'pressbooks' ),
+					sprintf( '<span class="screen-reader-text">%1$s </span>%2$s', $label, __( 'Header Background', 'pressbooks' ) ),
 					[ $this, 'renderTextboxColorField' ],
 					$_page,
 					$_section,
@@ -174,7 +174,7 @@ class GlobalOptions extends \Pressbooks\Options {
 				);
 				add_settings_field(
 					"edu_textbox_{$key}_background",
-					__( 'Background', 'pressbooks' ),
+					sprintf( '<span class="screen-reader-text">%1$s </span>%2$s', $label, __( 'Background', 'pressbooks' ) ),
 					[ $this, 'renderTextboxColorField' ],
 					$_page,
 					$_section,

--- a/inc/modules/themeoptions/class-pdfoptions.php
+++ b/inc/modules/themeoptions/class-pdfoptions.php
@@ -1742,19 +1742,15 @@ class PDFOptions extends \Pressbooks\Options {
 			foreach ( [
 				'edu_textbox_examples_header_color' => 'examples-header-color',
 				'edu_textbox_examples_header_background' => 'examples-header-background',
-				'edu_textbox_examples_color' => 'examples-color',
 				'edu_textbox_examples_background' => 'examples-background',
 				'edu_textbox_exercises_header_color' => 'exercises-header-color',
 				'edu_textbox_exercises_header_background' => 'exercises-header-background',
-				'edu_textbox_exercises_color' => 'exercises-color',
 				'edu_textbox_exercises_background' => 'exercises-background',
 				'edu_textbox_objectives_header_color' => 'learning-objectives-header-color',
 				'edu_textbox_objectives_header_background' => 'learning-objectives-header-background',
-				'edu_textbox_objectives_color' => 'learning-objectives-color',
 				'edu_textbox_objectives_background' => 'learning-objectives-background',
 				'edu_textbox_takeaways_header_color' => 'key-takeaways-header-color',
 				'edu_textbox_takeaways_header_background' => 'key-takeaways-header-background',
-				'edu_textbox_takeaways_color' => 'key-takeaways-color',
 				'edu_textbox_takeaways_background' => 'key-takeaways-background',
 			] as $option => $variable ) {
 				if ( isset( $options[ $option ] ) ) {

--- a/inc/modules/themeoptions/class-weboptions.php
+++ b/inc/modules/themeoptions/class-weboptions.php
@@ -443,19 +443,15 @@ class WebOptions extends \Pressbooks\Options {
 			foreach ( [
 				'edu_textbox_examples_header_color' => 'examples-header-color',
 				'edu_textbox_examples_header_background' => 'examples-header-background',
-				'edu_textbox_examples_color' => 'examples-color',
 				'edu_textbox_examples_background' => 'examples-background',
 				'edu_textbox_exercises_header_color' => 'exercises-header-color',
 				'edu_textbox_exercises_header_background' => 'exercises-header-background',
-				'edu_textbox_exercises_color' => 'exercises-color',
 				'edu_textbox_exercises_background' => 'exercises-background',
 				'edu_textbox_objectives_header_color' => 'learning-objectives-header-color',
 				'edu_textbox_objectives_header_background' => 'learning-objectives-header-background',
-				'edu_textbox_objectives_color' => 'learning-objectives-color',
 				'edu_textbox_objectives_background' => 'learning-objectives-background',
 				'edu_textbox_takeaways_header_color' => 'key-takeaways-header-color',
 				'edu_textbox_takeaways_header_background' => 'key-takeaways-header-background',
-				'edu_textbox_takeaways_color' => 'key-takeaways-color',
 				'edu_textbox_takeaways_background' => 'key-takeaways-background',
 			] as $option => $variable ) {
 				if ( isset( $options[ $option ] ) ) {

--- a/tests/test-options.php
+++ b/tests/test-options.php
@@ -302,6 +302,20 @@ class OptionsTest extends \WP_UnitTestCase {
 		$this->assertEquals( '"blah  blah"', $v );
 	}
 
+	public function test_renderColorField() {
+		ob_start();
+		$output = \Pressbooks\Options::renderColorField([
+			'id' => 'test_color',
+			'name' => 'pressbooks_options_test',
+			'option' => 'test_color',
+			'value' => '',
+			'default' => '#c00'
+		]);
+		$buffer = ob_get_clean();
+
+		$this->assertEquals( '<input id="test_color" class="color-picker" name="pressbooks_options_test[test_color]" type="text" data-default-color="#c00" value="" />', $buffer );
+	}
+
 	public function test_deleteCacheAfterUpdate() {
 		$now = time() - 60;
 		set_transient( 'pb_cache_deleted', $now, DAY_IN_SECONDS );


### PR DESCRIPTION
- Add textbox type headings for clarity
- Fix a bug where the color `#fff` would not be recognized (we can't use `<input type="color" />` with abbreviated hex codes—[see here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/color#Providing_a_default_color))
- Remove textbox body color options