### PR TITLE
Use SVG images instead of spans (depends on pressbooks/buckram#98) (fix #1170)

### DIFF
--- a/inc/class-licensing.php
+++ b/inc/class-licensing.php
@@ -448,9 +448,9 @@ class Licensing {
 	}
 
 	/**
-	 * Returns URL for saved license value.
+	 * Returns long description for saved license value.
 	 *
-	 * @since 4.1.0
+	 * @since 5.3.0
 	 *
 	 * @param string
 	 *

--- a/inc/class-licensing.php
+++ b/inc/class-licensing.php
@@ -378,7 +378,7 @@ class Licensing {
 			if ( \Pressbooks\Utility\str_starts_with( $license, 'cc' ) ) {
 				return sprintf(
 					'<div class="license-attribution"><p>%1$s</p><p>%2$s</p></div>',
-					sprintf( '<span class="icon icon--%1$s">%2$s</span>', $license, $name ),
+					sprintf( '<img src="%1$s" alt="%2$s" />', get_template_directory_uri() . '/assets/book/images/' . $license . '.svg', sprintf( __( 'Icon for the %s', 'pressbooks' ), $name ) ),
 					sprintf(
 						__( '%1$s by %2$s is licensed under a %3$s, except where otherwise noted.', 'pressbooks' ),
 						$title,
@@ -399,7 +399,7 @@ class Licensing {
 			} elseif ( $license === 'public-domain' ) {
 				return sprintf(
 					'<div class="license-attribution"><p>%1$s</p><p>%2$s</p></div>',
-					sprintf( '<span class="icon icon--%1$s">%2$s</span>', $license, $name ),
+					sprintf( '<img src="%1$s" alt="%2$s" />', get_template_directory_uri() . '/assets/book/images/' . $license . '.svg', sprintf( __( 'Icon for the %s license', 'pressbooks' ), $name ) ),
 					sprintf(
 						__( 'To the extent possible under law, %1$s has waived all copyright and related or neighboring rights to %2$s, except where otherwise noted.', 'pressbooks' ),
 						sprintf( '<a href="%1$s">%2$s</a>', $link, $copyright_holder ),

--- a/inc/class-licensing.php
+++ b/inc/class-licensing.php
@@ -61,6 +61,7 @@ class Licensing {
 				],
 				'url' => 'https://creativecommons.org/licenses/by/4.0/',
 				'desc' => __( 'CC BY (Attribution)', 'pressbooks' ),
+				'longdesc' => __( 'Creative Commons Attribution 4.0 International License', 'pressbooks' ),
 			],
 			'cc-by-sa' => [
 				'api' => [
@@ -70,6 +71,7 @@ class Licensing {
 				],
 				'url' => 'https://creativecommons.org/licenses/by-sa/4.0/',
 				'desc' => __( 'CC BY-SA (Attribution ShareAlike)', 'pressbooks' ),
+				'longdesc' => __( 'Creative Commons Attribution-ShareAlike 4.0 International License', 'pressbooks' ),
 			],
 			'cc-by-nd' => [
 				'api' => [
@@ -79,6 +81,7 @@ class Licensing {
 				],
 				'url' => 'https://creativecommons.org/licenses/by-nd/4.0/',
 				'desc' => __( 'CC BY-ND (Attribution NoDerivatives)', 'pressbooks' ),
+				'longdesc' => __( 'Creative Commons Attribution-NoDerivatives 4.0 International License', 'pressbooks' ),
 			],
 			'cc-by-nc' => [
 				'api' => [
@@ -88,6 +91,7 @@ class Licensing {
 				],
 				'url' => 'https://creativecommons.org/licenses/by-nc/4.0/',
 				'desc' => __( 'CC BY-NC (Attribution NonCommercial)', 'pressbooks' ),
+				'longdesc' => __( 'Creative Commons Attribution-NonCommercial 4.0 International License', 'pressbooks' ),
 			],
 			'cc-by-nc-sa' => [
 				'api' => [
@@ -97,6 +101,7 @@ class Licensing {
 				],
 				'url' => 'https://creativecommons.org/licenses/by-nc-sa/4.0/',
 				'desc' => __( 'CC BY-NC-SA (Attribution NonCommercial ShareAlike)', 'pressbooks' ),
+				'longdesc' => __( 'Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License', 'pressbooks' ),
 			],
 			'cc-by-nc-nd' => [
 				'api' => [
@@ -106,6 +111,7 @@ class Licensing {
 				],
 				'url' => 'https://creativecommons.org/licenses/by-nc-nd/4.0/',
 				'desc' => __( 'CC BY-NC-ND (Attribution NonCommercial NoDerivatives)', 'pressbooks' ),
+				'longdesc' => __( 'Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License', 'pressbooks' ),
 			],
 			'all-rights-reserved' => [
 				'api' => [], // Not supported
@@ -367,15 +373,17 @@ class Licensing {
 				)
 			);
 		} elseif ( $this->isSupportedType( $license ) ) {
+			$name = $this->getNameForLicense( $license );
+			$url = $this->getUrlForLicense( $license );
 			if ( \Pressbooks\Utility\str_starts_with( $license, 'cc' ) ) {
 				return sprintf(
 					'<div class="license-attribution"><p>%1$s</p><p>%2$s</p></div>',
-					'Images go here.', // TODO
+					sprintf( '<span class="icon icon--%1$s">%2$s</span>', $license, $name ),
 					sprintf(
 						__( '%1$s by %2$s is licensed under a %3$s, except where otherwise noted.', 'pressbooks' ),
 						$title,
 						sprintf( '<a href="%1$s">%2$s</a>', $link, $copyright_holder ),
-						$license // TODO
+						sprintf( '<a href="%1$s">%2$s</a>', $url, $name )
 					)
 				);
 			} elseif ( $license === 'all-rights-reserved' ) {
@@ -385,15 +393,15 @@ class Licensing {
 						__( '%1$s Copyright &copy;%2$s by %3$s. All Rights Reserved.', 'pressbooks' ),
 						$title,
 						( $copyright_year ) ? ' ' . $copyright_year : '',
-						$copyright_holder
+						sprintf( '<a href="%1$s">%2$s</a>', $link, $copyright_holder )
 					)
 				);
 			} elseif ( $license === 'public-domain' ) {
 				return sprintf(
 					'<div class="license-attribution"><p>%1$s</p><p>%2$s</p></div>',
-					'Images go here.', // TODO
+					sprintf( '<span class="icon icon--%1$s">%2$s</span>', $license, $name ),
 					sprintf(
-						__( 'To the extent possible under law, %1$s  has waived all copyright and related or neighboring rights to %2$s, except where otherwise noted.', 'pressbooks' ),
+						__( 'To the extent possible under law, %1$s has waived all copyright and related or neighboring rights to %2$s, except where otherwise noted.', 'pressbooks' ),
 						sprintf( '<a href="%1$s">%2$s</a>', $link, $copyright_holder ),
 						$title
 					)
@@ -437,5 +445,28 @@ class Licensing {
 		}
 
 		return 'all-rights-reserved';
+	}
+
+	/**
+	 * Returns URL for saved license value.
+	 *
+	 * @since 4.1.0
+	 *
+	 * @param string
+	 *
+	 * @return string
+	 */
+	public function getNameForLicense( $license ) {
+		$types = $this->getSupportedTypes();
+
+		if ( $this->isSupportedType( $license ) ) {
+			if ( isset( $types[ $license ]['longdesc'] ) ) {
+				return $types[ $license ]['longdesc'];
+			} else {
+				return $types[ $license ]['desc'];
+			}
+		} else {
+			return $types['all-rights-reserved']['desc'];
+		}
 	}
 }

--- a/inc/modules/export/epub/class-epub201.php
+++ b/inc/modules/export/epub/class-epub201.php
@@ -20,6 +20,7 @@ use function Pressbooks\Sanitize\sanitize_xml_attribute;
 use function Pressbooks\Utility\oxford_comma_explode;
 use function Pressbooks\Utility\str_ends_with;
 use function Pressbooks\Utility\debug_error_log;
+use function Pressbooks\Utility\str_starts_with;
 
 class Epub201 extends Export {
 
@@ -1920,6 +1921,10 @@ class Epub201 extends Export {
 			/** @var \DOMElement $image */
 			// Fetch image, change src
 			$url = $image->getAttribute( 'src' );
+			// Replace Buckram SVGs with PNGs
+			if ( str_starts_with( $url, get_template_directory_uri() . '/assets/book/images' ) && str_ends_with( $url, '.svg' ) ) {
+				$url = str_replace( '.svg', '.png', $url );
+			}
 			$filename = $this->fetchAndSaveUniqueImage( $url, $fullpath );
 			if ( $filename ) {
 				// Replace with new image
@@ -1944,7 +1949,6 @@ class Epub201 extends Export {
 	 * @return string filename
 	 */
 	protected function fetchAndSaveUniqueImage( $url, $fullpath ) {
-
 		if ( isset( $this->fetchedImageCache[ $url ] ) ) {
 			return $this->fetchedImageCache[ $url ];
 		}

--- a/tests/test-licensing.php
+++ b/tests/test-licensing.php
@@ -79,11 +79,11 @@ class LicensingTest extends \WP_UnitTestCase {
 
 	public function test_getLicense() {
 		$result = $this->licensing->getLicense( 'public-domain', 'Herman Melville', 'https://mobydick.whale', 'Moby Dick', 1851 );
-		$this->assertEquals( $result, '<div class="license-attribution"><p><span class="icon icon--public-domain">Public Domain (No Rights Reserved)</span></p><p>To the extent possible under law, <a href="https://mobydick.whale">Herman Melville</a> has waived all copyright and related or neighboring rights to Moby Dick, except where otherwise noted.</p></div>' );
+		$this->assertEquals( $result, '<div class="license-attribution"><p><img src="' . get_template_directory_uri() . '/assets/book/images/public-domain.svg" alt="Icon for the Public Domain (No Rights Reserved) license" /></p><p>To the extent possible under law, <a href="https://mobydick.whale">Herman Melville</a> has waived all copyright and related or neighboring rights to Moby Dick, except where otherwise noted.</p></div>' );
 		$result = $this->licensing->getLicense( 'all-rights-reserved', 'Herman Melville', 'https://mobydick.whale', 'Moby Dick', 1851 );
 		$this->assertEquals( $result, '<div class="license-attribution"><p>Moby Dick Copyright &copy; 1851 by <a href="https://mobydick.whale">Herman Melville</a>. All Rights Reserved.</p></div>' );
 		$result = $this->licensing->getLicense( 'cc-by', 'Herman Melville', 'https://mobydick.whale', 'Moby Dick', 1851 );
-		$this->assertEquals( $result, '<div class="license-attribution"><p><span class="icon icon--cc-by">Creative Commons Attribution 4.0 International License</span></p><p>Moby Dick by <a href="https://mobydick.whale">Herman Melville</a> is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>, except where otherwise noted.</p></div>' );
+		$this->assertEquals( $result, '<div class="license-attribution"><p><img src="' . get_template_directory_uri() . '/assets/book/images/cc-by.svg" alt="Icon for the Creative Commons Attribution 4.0 International License" /></p><p>Moby Dick by <a href="https://mobydick.whale">Herman Melville</a> is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>, except where otherwise noted.</p></div>' );
 	}
 
 	public function test_getUrlForLicense() {

--- a/tests/test-licensing.php
+++ b/tests/test-licensing.php
@@ -77,6 +77,15 @@ class LicensingTest extends \WP_UnitTestCase {
 		$this->assertContains( '</div>', $result );
 	}
 
+	public function test_getLicense() {
+		$result = $this->licensing->getLicense( 'public-domain', 'Herman Melville', 'https://mobydick.whale', 'Moby Dick', 1851 );
+		$this->assertEquals( $result, '<div class="license-attribution"><p><span class="icon icon--public-domain">Public Domain (No Rights Reserved)</span></p><p>To the extent possible under law, <a href="https://mobydick.whale">Herman Melville</a> has waived all copyright and related or neighboring rights to Moby Dick, except where otherwise noted.</p></div>' );
+		$result = $this->licensing->getLicense( 'all-rights-reserved', 'Herman Melville', 'https://mobydick.whale', 'Moby Dick', 1851 );
+		$this->assertEquals( $result, '<div class="license-attribution"><p>Moby Dick Copyright &copy; 1851 by <a href="https://mobydick.whale">Herman Melville</a>. All Rights Reserved.</p></div>' );
+		$result = $this->licensing->getLicense( 'cc-by', 'Herman Melville', 'https://mobydick.whale', 'Moby Dick', 1851 );
+		$this->assertEquals( $result, '<div class="license-attribution"><p><span class="icon icon--cc-by">Creative Commons Attribution 4.0 International License</span></p><p>Moby Dick by <a href="https://mobydick.whale">Herman Melville</a> is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>, except where otherwise noted.</p></div>' );
+	}
+
 	public function test_getUrlForLicense() {
 		$result = $this->licensing->getUrlForLicense( 'public-domain' );
 		$this->assertEquals( $result, 'https://creativecommons.org/publicdomain/zero/1.0/' );
@@ -87,4 +96,12 @@ class LicensingTest extends \WP_UnitTestCase {
 		$this->assertEquals( $result, 'public-domain' );
 	}
 
+	public function test_getNameForLicense() {
+		$result = $this->licensing->getNameForLicense( 'public-domain' );
+		$this->assertEquals( $result, 'Public Domain (No Rights Reserved)' );
+		$result = $this->licensing->getNameForLicense( 'cc-by-nc-sa' );
+		$this->assertEquals( $result, 'Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License' );
+		$result = $this->licensing->getNameForLicense( 'made-up-license' );
+		$this->assertEquals( $result, 'All Rights Reserved' );
+	}
 }


### PR DESCRIPTION
Also needs: swap with PNG for old EPUBs.