### PR TITLE
Ensure that classnames are output properly for EPUB TOC (fix pressbooks/pressbooks-asimov#32)

### DIFF
--- a/inc/modules/export/epub/class-epub201.php
+++ b/inc/modules/export/epub/class-epub201.php
@@ -1748,8 +1748,7 @@ class Epub201 extends Export {
 					$m++;
 				}
 			} elseif ( preg_match( '/^chapter-/', $k ) ) {
-				$class = 'chapter';
-				$class .= $this->taxonomy->getChapterType( $v['ID'] );
+				$class = implode( ' ', [ 'chapter', $this->taxonomy->getChapterType( $v['ID'] ) ] );
 				$subtitle = trim( get_post_meta( $v['ID'], 'pb_subtitle', true ) );
 				$author = $this->contributors->get( $v['ID'], 'pb_authors' );
 				$license = $this->doTocLicense( $v['ID'] );


### PR DESCRIPTION
Fixes an issue introduced in https://github.com/pressbooks/pressbooks/commit/5bfc4e4d93c64d26362dd064c4daa6a7aac0170c where the `chapter` and `standard` or `numberless` classnames were concatenated with no space between them in the EPUB TOC creation function.