### PR TITLE
JS tweaks

### DIFF
--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -776,10 +776,6 @@ function disable_customizer() {
 function init_css_js() {
 	$assets = new Assets( 'pressbooks', 'plugin' );
 
-	// This is to work around JavaScript dependency errors
-	global $concatenate_scripts;
-	$concatenate_scripts = false;
-
 	// Note: Will auto-register a dependency $handle named 'colors'
 	wp_admin_css_color(
 		'pb_colors', 'Pressbooks', $assets->getPath( 'styles/colors-pb.css' ), apply_filters(
@@ -849,7 +845,7 @@ function init_css_js() {
 	wp_register_script( 'cssanimations', $assets->getPath( 'scripts/cssanimations.js' ), false );
 	wp_register_script( 'pb-cloner', $assets->getPath( 'scripts/cloner.js' ), [ 'jquery', 'cssanimations' ] );
 	wp_register_script( 'pb-export', $assets->getPath( 'scripts/export.js' ), [ 'jquery', 'cssanimations' ] );
-	wp_register_script( 'pb-organize', $assets->getPath( 'scripts/organize.js' ), [ 'jquery', 'jquery-ui-core', 'jquery-blockui', 'wp-api', 'cssanimations' ] );
+	wp_register_script( 'pb-organize', $assets->getPath( 'scripts/organize.js' ), [ 'jquery', 'jquery-ui-core', 'jquery-blockui', 'cssanimations' ] );
 	wp_register_script( 'pb-metadata', $assets->getPath( 'scripts/book-information.js' ), [ 'jquery' ], false, true );
 	wp_register_script( 'pb-import', $assets->getPath( 'scripts/import.js' ), [ 'jquery' ] );
 	wp_register_script( 'pb-post-visibility', $assets->getPath( 'scripts/post-visibility.js' ), [ 'jquery' ], false, true );


### PR DESCRIPTION
## Tweak 1

Remove unused 'wp-api' dependeny in pb-organize script. Leftover from when we tried to do this in React?

## Tweak 2

A regular WordPress site does something like

`<script type='text/javascript' src='https://pressbooks.test/poem/wp-admin/load-scripts.php?c=1&load%5B%5D=jquery-core,jquery-migrate,utils,quicktags,moxiejs,plupload&ver=4.9.6'>`

Keywords `load-scripts.php` and a WordPress function called `script_concat_settings`

I looked at git blame for the reason we did `$concatenate_scripts = false` was ...drumroll... "Initial commit"

Maybe 5+ years ago someone didn't know how to enqueue a script with dependencies and was doing it wrong (?) but I think if we remove this, and `define('SCRIPT_DEBUG', false)`, everything will be fine and we'll get a mini boost in production.