### PR TITLE
Match PrinceXML HTTP timeout to PHP's max_execution_time

### DIFF
--- a/inc/modules/export/prince/class-docraptor.php
+++ b/inc/modules/export/prince/class-docraptor.php
@@ -71,7 +71,7 @@ class Docraptor extends Pdf {
 		$docraptor = new \DocRaptor\DocApi();
 		$prince_options = new \DocRaptor\PrinceOptions();
 		$prince_options->setNoCompress( false );
-		$prince_options->setHttpTimeout( ini_get( 'max_execution_time' ) );
+		$prince_options->setHttpTimeout( max( ini_get( 'max_execution_time' ), 30 ) );
 		$prince_options->setProfile( $this->pdfProfile );
 		$retval = false;
 

--- a/inc/modules/export/prince/class-docraptor.php
+++ b/inc/modules/export/prince/class-docraptor.php
@@ -71,6 +71,7 @@ class Docraptor extends Pdf {
 		$docraptor = new \DocRaptor\DocApi();
 		$prince_options = new \DocRaptor\PrinceOptions();
 		$prince_options->setNoCompress( false );
+		$prince_options->setHttpTimeout( ini_get( 'max_execution_time' ) );
 		$prince_options->setProfile( $this->pdfProfile );
 		$retval = false;
 

--- a/inc/modules/export/prince/class-pdf.php
+++ b/inc/modules/export/prince/class-pdf.php
@@ -127,6 +127,7 @@ class Pdf extends Export {
 		$prince = new \PrinceXMLPhp\PrinceWrapper( PB_PRINCE_COMMAND );
 		$prince->setHTML( true );
 		$prince->setCompress( true );
+		$prince->setHttpTimeout( ini_get( 'max_execution_time' ) );
 		if ( defined( 'WP_ENV' ) && ( WP_ENV === 'development' || WP_ENV === 'staging' ) ) {
 			$prince->setInsecure( true );
 		}

--- a/inc/modules/export/prince/class-pdf.php
+++ b/inc/modules/export/prince/class-pdf.php
@@ -127,7 +127,7 @@ class Pdf extends Export {
 		$prince = new \PrinceXMLPhp\PrinceWrapper( PB_PRINCE_COMMAND );
 		$prince->setHTML( true );
 		$prince->setCompress( true );
-		$prince->setHttpTimeout( ini_get( 'max_execution_time' ) );
+		$prince->setHttpTimeout( max( ini_get( 'max_execution_time' ), 30 ) );
 		if ( defined( 'WP_ENV' ) && ( WP_ENV === 'development' || WP_ENV === 'staging' ) ) {
 			$prince->setInsecure( true );
 		}


### PR DESCRIPTION
With extremely large books, Prince may time out while the export XHTML source is being assembled by the PHP process (see forum thread [here](https://discourse.pressbooks.org/t/prince-pdf-errors-exporting-a-book-imported-from-lumen-openstax/524/3)). This PR attempts to avoid such situations by setting Prince's [`--http-timeout`](https://www.princexml.com/doc/command-line/#cmd-network) parameter to the value of PHP's `max_execution_time`.

Props to @rootl for reporting this issue.