### PR TITLE
Fix suppression of TOC part and chapter numbers for Buckram 1.0 themes

### DIFF
--- a/inc/modules/themeoptions/class-pdfoptions.php
+++ b/inc/modules/themeoptions/class-pdfoptions.php
@@ -1727,8 +1727,13 @@ class PDFOptions extends \Pressbooks\Options {
 					[
 						'chapter-number-display' => 'none',
 						'part-number-display' => 'none',
+						'toc-left-left-gutter' => '0',
 						'toc-chapter-number-display' => 'none',
+						'toc-left-chapter-number-display' => 'none',
+						'toc-center-chapter-number-display' => 'none',
 						'toc-part-number-display' => 'none',
+						'toc-left-part-number-display' => 'none',
+						'toc-center-part-number-display' => 'none',
 					]
 				);
 			} else {

--- a/tests/test-pdfoptions.php
+++ b/tests/test-pdfoptions.php
@@ -1,6 +1,19 @@
 <?php
 
 class PDFOptionsTest extends \WP_UnitTestCase {
+	use utilsTrait;
+
+	public function test_scssOverrides() {
+		$this->_book( 'pressbooks-donham' );
+
+		update_option( 'pressbooks_theme_options_global', [
+			'chapter_numbers' => 0,
+		] );
+
+		$result = \Pressbooks\Modules\ThemeOptions\PDFOptions::scssOverrides( '' );
+		$this->assertContains( 'div.part-title-wrap > .part-number, div.chapter-title-wrap > .chapter-number, #toc .part a::before, #toc .chapter a::before { display: none !important; }', $result );
+
+	}
 
 	public function test_replaceRunningContentTags() {
 		$result = \Pressbooks\Modules\ThemeOptions\PDFOptions::replaceRunningContentTags( '%section_title%' );


### PR DESCRIPTION
The new variables for left and center part and chapter number display weren't being overridden by the `scssOverrides` method; this adds overrides for them to ensure that part and chapter numbers are hidden in PDF exports for Buckram >= 1.0 themes.