### PR TITLE
Bump minimum WordPress to 4.9.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ php:
 - 7.2
 - nightly
 env:
-- WP_VERSION=4.9.6 WP_MULTISITE=1 TRAVIS_NODE_VERSION="6"
+- WP_VERSION=4.9.7 WP_MULTISITE=1 TRAVIS_NODE_VERSION="6"
 matrix:
   fast_finish: true
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ you need to install Pressbooks for development, please see the
 
 ## Requirements
 
-Pressbooks works with PHP 7.0 and WordPress 4.9.5. Lower versions are not
+Pressbooks works with PHP 7.0 and WordPress 4.9.7. Lower versions are not
 supported.
 
 ## Disclaimers

--- a/compatibility.php
+++ b/compatibility.php
@@ -33,7 +33,7 @@ function pb_meets_minimum_requirements() {
 
 	// WordPress Version
 	global $pb_minimum_wp;
-	$pb_minimum_wp = '4.9.6';
+	$pb_minimum_wp = '4.9.7';
 
 	include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 	$is_compatible = true;

--- a/inc/image/namespace.php
+++ b/inc/image/namespace.php
@@ -347,12 +347,6 @@ function delete_attachment( $post_id ) {
  */
 function save_attachment( $data, $post_id ) {
 
-	// Temporary Hotfix
-	// https://blog.ripstech.com/2018/wordpress-file-delete-to-code-execution/
-	if ( isset( $data['thumb'] ) ) {
-		$data['thumb'] = basename( $data['thumb'] );
-	}
-
 	if ( empty( $data['file'] ) ) {
 		return $data; // Bail
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: Pressbooks <code@pressbooks.com>
 Donate link: https://opencollective.com/pressbooks
 Tags: ebooks, publishing, webbooks
-Requires at least: 4.9.6
-Tested up to: 4.9.6
+Requires at least: 4.9.7
+Tested up to: 4.9.7
 Requires PHP: 7.0
 Stable tag: 5.4.0
 License: GPL v3.0 or later

--- a/tests/test-privacy.php
+++ b/tests/test-privacy.php
@@ -26,6 +26,12 @@ class GdprTest extends \WP_UnitTestCase {
 	}
 
 	public function test_addPrivacyPolicyContent() {
+		// Doing it right
+		global $current_screen;
+		$current_screen = WP_Screen::get( 'front-matter' ); // is_admin
+		global $wp_current_filter;
+		$wp_current_filter = [ 'admin_init' ]; // doing_action
+
 		$this->privacy->addPrivacyPolicyContent();
 		$policies = WP_Privacy_Policy_Content::get_suggested_policy_text();
 		$result = false;


### PR DESCRIPTION
Includes security fix so we remove our patch.