### PR TITLE
License

### DIFF
--- a/inc/class-licensing.php
+++ b/inc/class-licensing.php
@@ -353,11 +353,11 @@ class Licensing {
 	 *
 	 * @since 5.3.0
 	 *
-	 * @param string $type license type
+	 * @param string $license license type
 	 * @param string $copyright_holder of the page
-	 * @param string $src_url of the page
+	 * @param string $link of the page
 	 * @param string $title of the page
-	 * @param int $year (optional)
+	 * @param int $copyright_year (optional)
 	 *
 	 * @return string $html License blob.
 	 */
@@ -374,16 +374,16 @@ class Licensing {
 			);
 		} elseif ( $this->isSupportedType( $license ) ) {
 			$name = $this->getNameForLicense( $license );
-			$url = $this->getUrlForLicense( $license );
+			$url  = $this->getUrlForLicense( $license );
 			if ( \Pressbooks\Utility\str_starts_with( $license, 'cc' ) ) {
 				return sprintf(
 					'<div class="license-attribution"><p>%1$s</p><p>%2$s</p></div>',
 					sprintf( '<img src="%1$s" alt="%2$s" />', get_template_directory_uri() . '/assets/book/images/' . $license . '.svg', sprintf( __( 'Icon for the %s', 'pressbooks' ), $name ) ),
 					sprintf(
 						__( '%1$s by %2$s is licensed under a %3$s, except where otherwise noted.', 'pressbooks' ),
-						$title,
-						sprintf( '<a href="%1$s">%2$s</a>', $link, $copyright_holder ),
-						sprintf( '<a href="%1$s">%2$s</a>', $url, $name )
+						sprintf( '<a rel="cc:attributionURL" href="%1$s" property="dc:title">%2$s</a>', $link, $title ),
+						sprintf( '<span property="cc:attributionName">%1$s</span>', $copyright_holder ),
+						sprintf( '<a rel="license" href="%1$s">%2$s</a>', $url, $name )
 					)
 				);
 			} elseif ( $license === 'all-rights-reserved' ) {
@@ -391,9 +391,9 @@ class Licensing {
 					'<div class="license-attribution"><p>%s</p></div>',
 					sprintf(
 						__( '%1$s Copyright &copy;%2$s by %3$s. All Rights Reserved.', 'pressbooks' ),
-						$title,
+						sprintf( '<a href="%1$s" property="dc:title">%2$s</a>', $link, $title ),
 						( $copyright_year ) ? ' ' . $copyright_year : '',
-						sprintf( '<a href="%1$s">%2$s</a>', $link, $copyright_holder )
+						$copyright_holder
 					)
 				);
 			} elseif ( $license === 'public-domain' ) {
@@ -402,8 +402,8 @@ class Licensing {
 					sprintf( '<img src="%1$s" alt="%2$s" />', get_template_directory_uri() . '/assets/book/images/' . $license . '.svg', sprintf( __( 'Icon for the %s license', 'pressbooks' ), $name ) ),
 					sprintf(
 						__( 'To the extent possible under law, %1$s has waived all copyright and related or neighboring rights to %2$s, except where otherwise noted.', 'pressbooks' ),
-						sprintf( '<a href="%1$s">%2$s</a>', $link, $copyright_holder ),
-						$title
+						$copyright_holder,
+						sprintf( '<a href="%1$s">%2$s</a>', $link, $title )
 					)
 				);
 			}

--- a/tests/test-licensing.php
+++ b/tests/test-licensing.php
@@ -79,11 +79,11 @@ class LicensingTest extends \WP_UnitTestCase {
 
 	public function test_getLicense() {
 		$result = $this->licensing->getLicense( 'public-domain', 'Herman Melville', 'https://mobydick.whale', 'Moby Dick', 1851 );
-		$this->assertEquals( $result, '<div class="license-attribution"><p><img src="' . get_template_directory_uri() . '/assets/book/images/public-domain.svg" alt="Icon for the Public Domain (No Rights Reserved) license" /></p><p>To the extent possible under law, <a href="https://mobydick.whale">Herman Melville</a> has waived all copyright and related or neighboring rights to Moby Dick, except where otherwise noted.</p></div>' );
+		$this->assertEquals( $result, '<div class="license-attribution"><p><img src="' . get_template_directory_uri() . '/assets/book/images/public-domain.svg" alt="Icon for the Public Domain (No Rights Reserved) license" /></p><p>To the extent possible under law, Herman Melville has waived all copyright and related or neighboring rights to <a href="https://mobydick.whale">Moby Dick</a>, except where otherwise noted.</p></div>' );
 		$result = $this->licensing->getLicense( 'all-rights-reserved', 'Herman Melville', 'https://mobydick.whale', 'Moby Dick', 1851 );
-		$this->assertEquals( $result, '<div class="license-attribution"><p>Moby Dick Copyright &copy; 1851 by <a href="https://mobydick.whale">Herman Melville</a>. All Rights Reserved.</p></div>' );
+		$this->assertEquals( $result, '<div class="license-attribution"><p><a href="https://mobydick.whale" property="dc:title">Moby Dick</a> Copyright &copy; 1851 by Herman Melville. All Rights Reserved.</p></div>' );
 		$result = $this->licensing->getLicense( 'cc-by', 'Herman Melville', 'https://mobydick.whale', 'Moby Dick', 1851 );
-		$this->assertEquals( $result, '<div class="license-attribution"><p><img src="' . get_template_directory_uri() . '/assets/book/images/cc-by.svg" alt="Icon for the Creative Commons Attribution 4.0 International License" /></p><p>Moby Dick by <a href="https://mobydick.whale">Herman Melville</a> is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>, except where otherwise noted.</p></div>' );
+		$this->assertEquals( $result, '<div class="license-attribution"><p><img src="' . get_template_directory_uri() . '/assets/book/images/cc-by.svg" alt="Icon for the Creative Commons Attribution 4.0 International License" /></p><p><a rel="cc:attributionURL" href="https://mobydick.whale" property="dc:title">Moby Dick</a> by <span property="cc:attributionName">Herman Melville</span> is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>, except where otherwise noted.</p></div>' );
 	}
 
 	public function test_getUrlForLicense() {


### PR DESCRIPTION
This is an effort to adhere to best practices for attribution as outlined [here](https://wiki.creativecommons.org/wiki/Marking_Works_Technical#Attribution).

Currently the link of the resource hyperlinks the author name. My understanding is that a hyperlink for the author should lead to an author page, not to the resource source.

This PR does two things: 
- it hyperlinks the title of the work instead of the author
- it adds some semantics for clarity