### PR TITLE
When Buckram is updated, rebuild the editor stylesheet (fix #1278)

### DIFF
--- a/inc/class-styles.php
+++ b/inc/class-styles.php
@@ -6,6 +6,7 @@
 
 namespace Pressbooks;
 
+use function \Pressbooks\Editor\update_editor_style;
 use function \Pressbooks\Utility\debug_error_log;
 use Pressbooks\CustomCss;
 use Pressbooks\Modules\ThemeOptions\ThemeOptions;
@@ -585,6 +586,7 @@ class Styles {
 		if ( version_compare( $current_buckram_version, $last_buckram_version ) > 0 ) {
 			( new ThemeOptions() )->clearCache();
 			$this->updateWebBookStyleSheet();
+			update_editor_style();
 			update_option( 'pressbooks_buckram_version', $current_buckram_version );
 			return true;
 		}


### PR DESCRIPTION
We use the `\Pressbooks\Styles::maybeUpdateStylesheets()` method to update the webbook stylesheet when the theme version or Buckram version is incremented. This PR also updates the editor stylesheet, resolving #1278.