### PR TITLE
 Add fixInternalLinks() method to cloner (fixes #1279)

### DIFF
--- a/inc/class-cloner.php
+++ b/inc/class-cloner.php
@@ -1281,7 +1281,7 @@ class Cloner {
 				foreach ( [ 'front-matter', 'part', 'chapter', 'back-matter' ] as $post_type ) {
 					// Add book path (cloning from subdomain to subdirectory)
 					if ( str_starts_with( $href, "/$post_type/" ) ) {
-						$href = str_replace( "/$post_type/", "/$target_path/$post_type/" , $href );
+						$href = str_replace( "/$post_type/", "/$target_path/$post_type/", $href );
 					}
 				}
 			}

--- a/inc/interactive/class-h5p.php
+++ b/inc/interactive/class-h5p.php
@@ -143,7 +143,7 @@ class H5P {
 	public function setCloneableWarning() {
 		static $notice_already_set = false;
 		if ( ! $notice_already_set ) {
-			$_SESSION['pb_notices'][] = __( 'This book contains H5P content that cannot be cloned. Please review the cloned version of your text carefully, as missing H5P content will be indicated. You may want to remove or replace these section', 'pressbooks' );
+			$_SESSION['pb_notices'][] = __( 'This book contains H5P content that cannot be cloned. Please review the cloned version of your text carefully, as missing H5P content will be indicated. You may want to remove or replace these sections.', 'pressbooks' );
 			$notice_already_set = true;
 		}
 	}

--- a/templates/admin/cloner.php
+++ b/templates/admin/cloner.php
@@ -22,12 +22,15 @@ if ( is_subdomain_install() ) {
 			</tr>
 			<tr>
 				<th scope=row><?php _e( 'Target Book URL', 'pressbooks' ); ?></th>
-				<td><?php printf(
-					$template_string,
-					'<input class="regular-text code" name="target_book_url" />'
-				); ?></td>
+				<td>
+					<?php
+					printf(
+						$template_string,
+						'<input class="regular-text code" name="target_book_url" />'
+					);
+				?></td>
 			</tr>
 		</table>
+		<p><input id="pb-cloner-button" class="button button-primary" type="submit" value="<?php _e( 'Clone It!', 'pressbooks' ); ?>" /><span id="loader" class="loading-content"><span class="spinner"></span></span></p>
 	</form>
-	<p><input id="pb-cloner-button" class="button button-primary" type="submit" value="<?php _e( 'Clone It!', 'pressbooks' ); ?>" /><span id="loader" class="loading-content"><span class="spinner"></span></span></p>
 </div>


### PR DESCRIPTION
This PR adds a new `fixInternalLinks()` method to the Cloner class, which does exactly what you'd expect.