### PR TITLE
Fix web paragraph separation bug, for real (closes #1303)

### DIFF
--- a/bin/compile-scss.php
+++ b/bin/compile-scss.php
@@ -32,9 +32,9 @@ $include_paths = [
 $scss = \Pressbooks\Utility\get_contents( $input_file_name );
 
 try {
-	$sass = new \Leafo\ScssPhp\Compiler;
-	$sass->setImportPaths( $include_paths );
-	$css = $sass->compile( $scss );
+	$scssphp = new \Leafo\ScssPhp\Compiler;
+	$scssphp->setImportPaths( $include_paths );
+	$css = $scssphp->compile( $scss );
 } catch ( Exception $e ) {
 	die( $e->getMessage() );
 }

--- a/hooks-admin.php
+++ b/hooks-admin.php
@@ -231,7 +231,6 @@ if ( $is_book ) {
 	// Overrides
 	add_filter( 'pb_epub_css_override', [ '\Pressbooks\Modules\ThemeOptions\EbookOptions', 'scssOverrides' ] );
 	add_filter( 'pb_pdf_css_override', [ '\Pressbooks\Modules\ThemeOptions\PDFOptions', 'scssOverrides' ] );
-	add_filter( 'pb_web_css_override', [ '\Pressbooks\Modules\ThemeOptions\WebOptions', 'scssOverrides' ] );
 }
 
 // -------------------------------------------------------------------------------------------------------------------

--- a/hooks.php
+++ b/hooks.php
@@ -288,10 +288,15 @@ add_filter( 'wp_mail_from', '\Pressbooks\Utility\mail_from' );
 add_filter( 'wp_mail_from_name', '\Pressbooks\Utility\mail_from_name' );
 
 // -------------------------------------------------------------------------------------------------------------------
-// Custom Styles
+// (Custom) Styles
 // -------------------------------------------------------------------------------------------------------------------
 
 Container::get( 'Styles' )->init();
+
+if ( $is_book ) {
+	// Overrides (sometimes a web stylesheet update will be triggered by a visitor so this filter needs to be active outside of the admin)
+	add_filter( 'pb_web_css_override', [ '\Pressbooks\Modules\ThemeOptions\WebOptions', 'scssOverrides' ] );
+}
 
 // -------------------------------------------------------------------------------------------------------------------
 // GDPR

--- a/inc/admin/fonts/namespace.php
+++ b/inc/admin/fonts/namespace.php
@@ -6,6 +6,7 @@
 
 namespace Pressbooks\Admin\Fonts;
 
+use function Pressbooks\Editor\update_editor_style;
 use Pressbooks\Container;
 
 /**
@@ -14,7 +15,7 @@ use Pressbooks\Container;
 function update_font_stacks() {
 	Container::get( 'GlobalTypography' )->updateGlobalTypographyMixin();
 	Container::get( 'Styles' )->updateWebBookStyleSheet();
-	\Pressbooks\Editor\update_editor_style();
+	update_editor_style();
 }
 
 
@@ -34,6 +35,6 @@ function fix_missing_font_stacks() {
 	}
 
 	if ( ! is_file( $sass->pathToUserGeneratedCss() . '/editor.css' ) ) {
-		\Pressbooks\Editor\update_editor_style();
+		update_editor_style();
 	}
 }

--- a/inc/class-sass.php
+++ b/inc/class-sass.php
@@ -156,11 +156,11 @@ class Sass {
 
 		try {
 			$css = '/* Silence is golden. */'; // If no SCSS input was passed, prevent file write errors by putting a comment in the CSS output.
-			$sass = new \Leafo\ScssPhp\Compiler;
+			$scssphp = new \Leafo\ScssPhp\Compiler;
 			if ( ! empty( $scss ) || ! empty( $this->vars ) ) {
-				$sass->setVariables( $this->vars );
-				$sass->setImportPaths( $includes );
-				$css = $sass->compile( $scss );
+				$scssphp->setVariables( $this->vars );
+				$scssphp->setImportPaths( $includes );
+				$css = $scssphp->compile( $scss );
 				$this->vars = []; // Reset
 			}
 		} catch ( \Exception $e ) {

--- a/inc/class-styles.php
+++ b/inc/class-styles.php
@@ -7,6 +7,7 @@
 namespace Pressbooks;
 
 use function \Pressbooks\Editor\update_editor_style;
+use function \Pressbooks\Sanitize\normalize_css_urls;
 use function \Pressbooks\Utility\debug_error_log;
 use Pressbooks\CustomCss;
 use Pressbooks\Modules\ThemeOptions\ThemeOptions;
@@ -436,7 +437,6 @@ class Styles {
 	 * @return string
 	 */
 	public function customize( $type, $scss, $overrides = [] ) {
-
 		$scss = $this->applyOverrides( $scss, $overrides );
 
 		// Apply Theme Options
@@ -532,6 +532,9 @@ class Styles {
 	 */
 	public function updateWebBookStyleSheet( $stylesheet = null ) {
 
+		$styles = Container::get( 'Styles' );
+		$sass = Container::get( 'Sass' );
+
 		if ( CustomCss::isCustomCss() ) {
 			// Compile pressbooks-book web stylesheet when using the *DEPRECATED* Custom CSS theme
 			$theme = wp_get_theme( 'pressbooks-book' );
@@ -539,13 +542,12 @@ class Styles {
 			$theme = wp_get_theme( $stylesheet );
 		}
 
-		$overrides = apply_filters( 'pb_web_css_override', '' ) . "\n";
 		// Populate $url-base variable so that links to images and other assets remain intact
-		$scss = '$url-base: \'' . $theme->get_stylesheet_directory_uri() . "/';\n";
+		$overrides = [ '$url-base: "' . $theme->get_stylesheet_directory_uri() . '";' ];
 		if ( $this->isCurrentThemeCompatible( 1 ) ) {
-			$scss .= \Pressbooks\Utility\get_contents( realpath( $theme->get_stylesheet_directory() . '/style.scss' ) );
+			$scss = \Pressbooks\Utility\get_contents( realpath( $theme->get_stylesheet_directory() . '/style.scss' ) );
 		} elseif ( $this->isCurrentThemeCompatible( 2 ) || CustomCss::isCustomCss() ) {
-			$scss .= \Pressbooks\Utility\get_contents( realpath( $theme->get_stylesheet_directory() . '/assets/styles/web/style.scss' ) );
+			$scss = \Pressbooks\Utility\get_contents( realpath( $theme->get_stylesheet_directory() . '/assets/styles/web/style.scss' ) );
 		} else {
 			return;
 		}
@@ -557,7 +559,8 @@ class Styles {
 		}
 
 		$css = $this->customize( 'web', $scss, $overrides );
-		$css = \Pressbooks\Sanitize\normalize_css_urls( $css );
+
+		$css = normalize_css_urls( $css );
 
 		$css_file = $this->sass->pathToUserGeneratedCss() . '/style.css';
 		\Pressbooks\Utility\put_contents( $css_file, $css );
@@ -572,17 +575,18 @@ class Styles {
 		// Theme was updated?
 		$theme = wp_get_theme();
 		$current_theme_version = $theme->get( 'Version' );
-		$last_theme_version = get_option( 'pressbooks_theme_version', $current_theme_version );
+		$last_theme_version = get_option( 'pressbooks_theme_version', 0 );
 		if ( version_compare( $current_theme_version, $last_theme_version ) > 0 ) {
 			( new ThemeOptions() )->clearCache();
 			$this->updateWebBookStyleSheet();
+			update_editor_style();
 			update_option( 'pressbooks_theme_version', $current_theme_version );
 			return true;
 		}
 
 		// Buckram was updated?
 		$current_buckram_version = $this->getBuckramVersion();
-		$last_buckram_version = get_option( 'pressbooks_buckram_version', '0.1.0' );
+		$last_buckram_version = get_option( 'pressbooks_buckram_version', 0 );
 		if ( version_compare( $current_buckram_version, $last_buckram_version ) > 0 ) {
 			( new ThemeOptions() )->clearCache();
 			$this->updateWebBookStyleSheet();

--- a/inc/class-styles.php
+++ b/inc/class-styles.php
@@ -575,8 +575,9 @@ class Styles {
 		// Theme was updated?
 		$theme = wp_get_theme();
 		$current_theme_version = $theme->get( 'Version' );
-		$last_theme_version = get_option( 'pressbooks_theme_version', 0 );
+		$last_theme_version = get_option( 'pressbooks_theme_version' );
 		if ( version_compare( $current_theme_version, $last_theme_version ) > 0 ) {
+			xdebug_break();
 			( new ThemeOptions() )->clearCache();
 			$this->updateWebBookStyleSheet();
 			update_editor_style();
@@ -586,7 +587,7 @@ class Styles {
 
 		// Buckram was updated?
 		$current_buckram_version = $this->getBuckramVersion();
-		$last_buckram_version = get_option( 'pressbooks_buckram_version', 0 );
+		$last_buckram_version = get_option( 'pressbooks_buckram_version' );
 		if ( version_compare( $current_buckram_version, $last_buckram_version ) > 0 ) {
 			( new ThemeOptions() )->clearCache();
 			$this->updateWebBookStyleSheet();

--- a/inc/class-styles.php
+++ b/inc/class-styles.php
@@ -577,7 +577,6 @@ class Styles {
 		$current_theme_version = $theme->get( 'Version' );
 		$last_theme_version = get_option( 'pressbooks_theme_version' );
 		if ( version_compare( $current_theme_version, $last_theme_version ) > 0 ) {
-			xdebug_break();
 			( new ThemeOptions() )->clearCache();
 			$this->updateWebBookStyleSheet();
 			update_editor_style();

--- a/inc/editor/namespace.php
+++ b/inc/editor/namespace.php
@@ -261,22 +261,19 @@ function update_editor_style() {
 
 	if ( $styles->isCurrentThemeCompatible( 1 ) ) {
 		$scss = \Pressbooks\Utility\get_contents( $sass->pathToPartials() . '/_editor-with-custom-fonts.scss' );
-		$css = $styles->customize( 'web', $scss );
 	} elseif ( $styles->isCurrentThemeCompatible( 2 ) ) {
 		$scss = \Pressbooks\Utility\get_contents( $sass->pathToGlobals() . '/editor/_editor.scss' );
-		$css = $styles->customize( 'web', $scss );
 	} else {
 		$scss = \Pressbooks\Utility\get_contents( $sass->pathToPartials() . '/_editor.scss' );
-		$css = $sass->compile(
-			$scss,
-			[
-				$sass->pathToUserGeneratedSass(),
-				$sass->pathToPartials(),
-				$sass->pathToFonts(),
-				get_stylesheet_directory(),
-			]
-		);
 	}
+
+	$custom_styles = $styles->getWebPost();
+	if ( $custom_styles && ! empty( $custom_styles->post_content ) ) {
+		// Append the user's custom styles to the editor stylesheet prior to compilation
+		$scss .= "\n" . $custom_styles->post_content;
+	}
+
+	$css = $styles->customize( 'web', $scss );
 
 	$css = normalize_css_urls( $css );
 


### PR DESCRIPTION
This PR fixes three issues I found that were causing paragraph separation to fall back to indent for editor and web stylesheets.

- [x] Using the variable `$sass` for both an instance of `\Leafo\ScssPhp\Compiler` and an instance of `\Pressbooks\Sass` was causing conflicts between identically-named `setVariables()` methods in these classes.
- [x] Adding `\Pressbooks\Modules\ThemeOptions\WebOptions::scssOverrides` to the `pb_web_css_override` filter hook in `hooks-admin.php` meant that regeneration of the web stylesheet triggered by a visit to the webbook would not apply theme options overrides.
- [x] Looking up the webbook theme version with a default value of `$current_theme_version` meant that the `version_compare()` check would always show that nothing had changed (unless Buckram was updated).