### PR TITLE
Disregard equation size attribute if set to 0 (resolves #1297)

### DIFF
--- a/inc/shortcodes/complex/class-complex.php
+++ b/inc/shortcodes/complex/class-complex.php
@@ -175,9 +175,15 @@ class Complex {
 			'the_content',
 			sprintf(
 				'[latex%1$s]%2$s[/latex]',
-				sprintf(
+				( $atts['size'] !== 0 )
+				? sprintf(
 					' size="%1$s" color="%2$s" background="%3$s"',
 					$atts['size'],
+					$atts['color'],
+					$atts['background']
+				)
+				: sprintf(
+					' color="%1$s" background="%2$s"',
 					$atts['color'],
 					$atts['background']
 				),


### PR DESCRIPTION
This fixes an issue discovered during testing where the `[equation]` shortcode would default to a size parameter of 0, causing the output to be smaller than the default `[latex]` shortcode when using QuickLaTeX.