### PR TITLE
Clone media metadata (Fixes #1280)

### DIFF
--- a/inc/class-cloner.php
+++ b/inc/class-cloner.php
@@ -1228,9 +1228,11 @@ class Cloner {
 		$attached_file = image_strip_baseurl( $url );
 
 		if ( isset( $this->knownMedia[ $attached_file ] ) ) {
+			$remote_img_metadata = $this->knownMedia[ $attached_file ]->meta;
 			$remote_img_location = $this->knownMedia[ $attached_file ]->sourceUrl;
 			$filename = basename( $remote_img_location );
 		} else {
+			$remote_img_metadata = [];
 			$remote_img_location = $url;
 		}
 
@@ -1280,6 +1282,9 @@ class Cloner {
 		if ( ! $src ) {
 			$pid = 0;
 		} else {
+			foreach ( $remote_img_metadata as $meta_key => $meta_value ) {
+				update_post_meta( $pid, $meta_key, $meta_value );
+			}
 			$this->clonedItems['media'][] = $pid;
 			$already_done[ $remote_img_location ] = $pid;
 		}
@@ -1404,9 +1409,11 @@ class Cloner {
 		$attached_file = media_strip_baseurl( $url );
 
 		if ( isset( $this->knownMedia[ $attached_file ] ) ) {
+			$remote_media_metadata = $this->knownMedia[ $attached_file ]->meta;
 			$remote_media_location = $this->knownMedia[ $attached_file ]->sourceUrl;
 			$filename = basename( $remote_media_location );
 		} else {
+			$remote_media_metadata = [];
 			$remote_media_location = $url;
 		}
 
@@ -1435,6 +1442,9 @@ class Cloner {
 		if ( ! $src ) {
 			$pid = 0;
 		} else {
+			foreach ( $remote_media_metadata as $meta_key => $meta_value ) {
+				update_post_meta( $pid, $meta_key, $meta_value );
+			}
 			$this->clonedItems['media'][] = $pid;
 			$already_done[ $remote_media_location ] = $pid;
 		}

--- a/inc/entities/cloner/class-media.php
+++ b/inc/entities/cloner/class-media.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @author  Pressbooks <code@pressbooks.com>
+ * @license GPLv3 (or any later version)
+ */
+
+namespace Pressbooks\Entities\Cloner;
+
+class Media {
+
+	/**
+	 * @var string
+	 */
+	public $sourceUrl;
+
+	/**
+	 * @var array
+	 */
+	public $meta;
+}

--- a/inc/entities/cloner/class-media.php
+++ b/inc/entities/cloner/class-media.php
@@ -11,10 +11,10 @@ class Media {
 	/**
 	 * @var string
 	 */
-	public $sourceUrl;
+	public $sourceUrl = '';
 
 	/**
 	 * @var array
 	 */
-	public $meta;
+	public $meta = [];
 }

--- a/inc/modules/import/wordpress/class-wxr.php
+++ b/inc/modules/import/wordpress/class-wxr.php
@@ -622,7 +622,7 @@ class Wxr extends Import {
 					}
 				}
 			}
-			if ( preg_match( '/\.(jpe?g|gif|png)$/i', $m->sourceUrl ) ) {
+			if ( preg_match( $this->pregSupportedImageExtensions, $m->sourceUrl ) ) {
 				$prefix = str_replace( $this->basename( $m->sourceUrl ), '', $x['file'] ); // 2017/08
 				foreach ( $x['sizes'] as $size => $info ) {
 					$attached_file = $prefix . $info['file']; // 2017/08/foo-bar-300x225.png


### PR DESCRIPTION
Fix is different than what #1280 recommends. Reasons:

 + If a book is public then `wp/v2/media` exposes all media in the library. No concept of public/private per image.  
 + A user could upload 100 images but their book only uses 1 image. 
 + `_wp_attachment_metadata` can be fake or incompatible. It's more accurate to side load the file and have WordPress recreate this kind of info.

Fix keeps the current approach of looking for media actually being used in book, then copies PB metadata when found.