### PR TITLE
Cache getGlossaryTerms method, remove setter

### DIFF
--- a/inc/shortcodes/attributions/class-attachments.php
+++ b/inc/shortcodes/attributions/class-attachments.php
@@ -17,11 +17,6 @@ class Attachments {
 	static $instance = null;
 
 	/**
-	 * @var array
-	 */
-	private $book_media = [];
-
-	/**
 	 * Function to init our class, set filters & hooks, set a singleton instance
 	 *
 	 * @since 5.5.0
@@ -107,10 +102,8 @@ class Attachments {
 			foreach ( $attached_media as $media ) {
 				$book_media[ $media->ID ] = $media->guid;
 			}
-			$this->book_media = $book_media;
 		}
-
-		return $this->book_media;
+		return $book_media;
 	}
 
 	/**

--- a/tests/test-shortcodes-glossary.php
+++ b/tests/test-shortcodes-glossary.php
@@ -106,10 +106,22 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 	}
 
 	public function test_getGlossaryTerms() {
-		$this->gl->setGlossaryTerms();
 		$terms = $this->gl->getGlossaryTerms();
 		$this->assertEquals( 2, count( $terms ) );
 		$this->assertEquals( 'A computer system modeled on the <b>human brain</b> and <a href="https://en.wikipedia.org/wiki/Nervous_system" target="_blank">nervous system</a>.', $terms['Neural Network']['content'] );
+
+		// Test cache (and cache reset)
+		$args = [
+			'post_type' => 'glossary',
+			'post_title' => 'Cache Test',
+			'post_content' => 'Cache Test',
+			'post_status' => 'publish',
+		];
+		$this->factory()->post->create_object( $args );
+		$terms = $this->gl->getGlossaryTerms();
+		$this->assertArrayNotHasKey( 'Cache Test', $terms );
+		$terms = $this->gl->getGlossaryTerms( true );
+		$this->assertArrayHasKey( 'Cache Test', $terms );
 	}
 
 }


### PR DESCRIPTION
Also: Removed class property because of weird behaviour. The function remembers the value of the given variable between multiple calls. No point in duplicating it.