### PR TITLE
'edition' field for 'general information' metabox

### DIFF
--- a/inc/admin/metaboxes/namespace.php
+++ b/inc/admin/metaboxes/namespace.php
@@ -299,7 +299,7 @@ function add_meta_boxes() {
 			'description' => __( 'This is added to the metadata in your ebook.', 'pressbooks' ),
 		]
 	);
-	
+
 	x_add_metadata_field(
 		'pb_edition', 'metadata', [
 			'group' => 'general-book-information',

--- a/inc/admin/metaboxes/namespace.php
+++ b/inc/admin/metaboxes/namespace.php
@@ -299,6 +299,13 @@ function add_meta_boxes() {
 			'description' => __( 'This is added to the metadata in your ebook.', 'pressbooks' ),
 		]
 	);
+	
+	x_add_metadata_field(
+		'pb_edition', 'metadata', [
+			'group' => 'general-book-information',
+			'label' => __( 'Edition', 'pressbooks' ),
+		]
+	);
 
 	if ( $show_expanded_metadata ) {
 		x_add_metadata_field(


### PR DESCRIPTION
Edition of books is important information for any book, especially if we're talking about web-books, which content is easely and contineously changing. This field will provide consistenty between web-books and exported materials, eg in any moment of time one can see if printed edition or exported file of book is up-to-date/outdated for several purpose, for example adapting modified open books with latest changes of original source. For sure this commit doesn't provide functionality for features described above, but at least it will give people opportunity to save this information for further use.