### PR TITLE
Always use the filtered stylesheet directory in `\Pressbooks\Styles->customize()` (fix #1361)

### DIFF
--- a/inc/class-styles.php
+++ b/inc/class-styles.php
@@ -453,7 +453,7 @@ class Styles {
 					$this->sass->pathToUserGeneratedSass(),
 					$this->sass->pathToPartials(),
 					$this->sass->pathToFonts(),
-					get_stylesheet_directory(),
+					$this->getDir(),
 				]
 			);
 		} elseif ( $this->isCurrentThemeCompatible( 2 ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -38,6 +38,7 @@ TK.
 * Handle Dillard (Plain) 1.x to 2.0 upgrade: [#1361](https://github.com/pressbooks/pressbooks/pull/1361)
 * Hide "Welcome to WordPress" everywhere ([#1364](https://github.com/pressbooks/pressbooks/issues/#1364)): [#1365](https://github.com/pressbooks/pressbooks/pull/1365)
 * Use a file that is guaranteed to remain available for HTMLBook validation: [#1366](https://github.com/pressbooks/pressbooks/issues/1366)
+* Always use the filtered stylesheet directory in `\Pressbooks\Styles->customize()`: [#1372](https://github.com/pressbooks/pressbooks/pull/1372)
 
 = 5.5.1 =
 


### PR DESCRIPTION
In testing #1361 we discovered an edge case where a locked v1 (pre-Buckram) theme's default stylesheet directory (as opposed to the filtered one) would be used as the include path in `\Pressbooks\Styles->customize()`. This PR ensures that the correct directory, default or filtered (locked) is always used for v1 themes.