### PR TITLE
Add unique class to <hr> before footnotes (fix pressbooks/buckram#219)

### DIFF
--- a/inc/shortcodes/footnotes/class-footnotes.php
+++ b/inc/shortcodes/footnotes/class-footnotes.php
@@ -140,9 +140,9 @@ class Footnotes {
 		}
 
 		if ( $this->numbered[ $id ] ) {
-			$content .= '<hr /><div class="footnotes"><ol>';
+			$content .= '<hr class="before-footnotes" /><div class="footnotes"><ol>';
 		} else {
-			$content .= '<hr /><div class="footnotes"><ul>';
+			$content .= '<hr class="before-footnotes" /><div class="footnotes"><ul>';
 		}
 
 		foreach ( $footnotes as $num => $footnote ) {


### PR DESCRIPTION
This PR will allow the horizontal rule (`<hr>`) that appears above footnotes to be targeted for styling.