### PR TITLE
Add diagnostics link to XHTML source preview

### DIFF
--- a/inc/admin/diagnostics/namespace.php
+++ b/inc/admin/diagnostics/namespace.php
@@ -166,6 +166,14 @@ function render_page() {
 	?>
 		<textarea style="width: 800px; max-width: 100%; height: 600px; background: #fff; font-family: monospace;" readonly="readonly" onclick="this.focus(); this.select()"
 				title="<?php _e( 'To copy the system info, click below then press Ctrl + C (PC) or Cmd + C (Mac).', 'pressbooks' ); ?>"><?php echo $output; ?></textarea>
+		<h2><?php _e( 'View Source', 'pressbooks' ); ?></h2>
+		<p>
+		<?php
+		$home_url = home_url();
+		$source_url = ( is_super_admin() ) ? $home_url . '/format/xhtml?debug=prince' : $home_url . '/format/xhtml';
+		printf( __( '<a href="%s">View the XHTML source</a> for PDF exports to diagnose any output issues you are encountering.', 'pressbooks' ), $source_url );
+		?>
+		</p>
 	</div>
 	<?php
 }


### PR DESCRIPTION
Following up on productive [forum conversations](https://discourse.pressbooks.org/t/different-selectors-in-web-and-pdf-export-mcluhan/707/2), this PR adds a link to the XHTML source for PDF exports to the diagnostics page (appending the Prince preview parameter if the current user is a super admin).