### PR TITLE
Process [heading] shortcode in getSubsections (fix #1403)

### DIFF
--- a/inc/class-book.php
+++ b/inc/class-book.php
@@ -517,12 +517,14 @@ class Book {
 		if ( empty( $parent ) ) {
 			return false;
 		}
-		if ( stripos( $parent->post_content, '<h1' ) === false ) {
+		$has_shortcode = has_shortcode( $parent->post_content, 'heading' );
+		if ( stripos( $parent->post_content, '<h1' ) === false && $has_shortcode === false ) { // No <h1> or [heading] shortcode
 			return false;
 		}
 
 		$type = $parent->post_type;
-		$content = strip_tags( $parent->post_content, '<h1>' );  // Strip everything except h1 to speed up load time
+		$content = ( $has_shortcode ) ? apply_filters( 'the_content', $parent->post_content ) : $parent->post_content; // Only render shortcodes if we have to
+		$content = strip_tags( $content, '<h1>' );  // Strip everything except h1 to speed up load time
 		$output = [];
 		$s = 1;
 

--- a/tests/test-book.php
+++ b/tests/test-book.php
@@ -145,6 +145,7 @@ class BookTest extends \WP_UnitTestCase {
 
 	public function test_getSubsections() {
 		$this->_book();
+		$this->_shortcodes();
 		$book = \Pressbooks\Book::getInstance();
 
 		$result = $book::getSubsections( 0 );
@@ -158,11 +159,16 @@ class BookTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'Hi there!', $result["front-matter-{$id}-section-1"] );
 
 		$test = "<H1 style='font-size:small;'>Hi there! Hope you're doing good.<B></B></H1><P>How are you?</P>"; // ALL CAPS, texturized
-		$id = $book::getBookStructure()['front-matter'][0]['ID'];
 		$this->factory()->post->update_object( $id, [ 'post_content' => $test ] );
 		$result = $book::getSubsections( $id );
 		$this->assertArrayHasKey( "front-matter-{$id}-section-1", $result );
 		$this->assertEquals( 'Hi there! Hope you&#8217;re doing good.', $result["front-matter-{$id}-section-1"] );
+
+		$test = '[heading]Whoa, a shortcode![/heading]<p>Some other stuff.</p>'; // A [heading] shortcode
+		$this->factory()->post->update_object( $id, [ 'post_content' => $test ] );
+		$result = $book::getSubsections( $id );
+		$this->assertArrayHasKey( "front-matter-{$id}-section-1", $result );
+		$this->assertEquals( 'Whoa, a shortcode!', $result["front-matter-{$id}-section-1"] );
 
 		$test = "<h2>Hi there! Hope you're doing good.<b></b></h2><p>How are you?</p>"; // H2
 		$this->factory()->post->update_object( $id, [ 'post_content' => $test ] );

--- a/tests/utils-trait.php
+++ b/tests/utils-trait.php
@@ -124,7 +124,7 @@ There are many maths like it but these ones are mine.
 			$content .= "
 [video]{$video_url}[/video]
 
-{$thumbnail_html}		
+{$thumbnail_html}
 ";
 		}
 
@@ -254,6 +254,23 @@ There are many maths like it but these ones are mine.
 		];
 
 		return $allowed;
+	}
+
+	/**
+	 * Set up shortcodes.
+	 * @see hooks.php
+	 */
+	public function _shortcodes() {
+		remove_filter( 'the_content', 'wpautop' );
+		add_filter( 'the_content', 'wpautop', 12 ); // execute wpautop after shortcode processing
+
+		\Pressbooks\Shortcodes\Footnotes\Footnotes::init();
+		\Pressbooks\Shortcodes\Attributions\Attachments::init();
+		\Pressbooks\Shortcodes\Glossary\Glossary::init();
+		\Pressbooks\Shortcodes\Complex\Complex::init();
+		\Pressbooks\Shortcodes\Generics\Generics::init();
+		\Pressbooks\Shortcodes\WikiPublisher\Glyphs::init();
+		\Pressbooks\Shortcodes\TablePress::init();
 	}
 
 }


### PR DESCRIPTION
Resolves #1403. To maintain optimal performance, `the_content` filter is only applied if `[heading]` shortcodes are present.