### PR TITLE
Fix filter plugins

### DIFF
--- a/inc/admin/plugins/namespace.php
+++ b/inc/admin/plugins/namespace.php
@@ -33,7 +33,8 @@ function filter_plugins( $plugins ) {
 				$approved[ $slug ] = $value;
 			}
 		}
+		return $approved;
 	}
 
-	return $approved;
+	return $plugins;
 }

--- a/inc/admin/plugins/namespace.php
+++ b/inc/admin/plugins/namespace.php
@@ -28,15 +28,12 @@ function filter_plugins( $plugins ) {
 			'wp-quicklatex',
 		];
 		$approved = [];
-		foreach ( $slugs as $slug ) {
-			$approved[] = $slug . '/' . $slug . '.php';
-		}
 		foreach ( $plugins as $slug => $value ) {
-			if ( false === strpos( $slug, 'pressbooks-' ) && ! in_array( $slug, $approved, true ) ) {
-				unset( $plugins[ $slug ] );
+			if ( strpos( $slug, 'pressbooks-' ) !== false || in_array( explode( '/', $slug )[0], $slugs, true ) ) {
+				$approved[ $slug ] = $value;
 			}
 		}
 	}
 
-	return $plugins;
+	return $approved;
 }

--- a/tests/test-admin-plugins.php
+++ b/tests/test-admin-plugins.php
@@ -6,30 +6,17 @@ class Admin_PluginsTest extends \WP_UnitTestCase {
 
 	public function test_filter_plugins() {
 		$plugins = [
-			'hello-dolly/hello.php' => [
-				'Name' => 'Hello Dolly',
-				'PluginURI' => 'http://wordpress.org/extend/plugins/hello-dolly/',
-				'Version' => '1.6',
-				'Description' => 'This is not just a plugin, it symbolizes the hope and enthusiasm of an entire generation summed up in two words sung most famously by Louis Armstrong: Hello, Dolly. When activated you will randomly see a lyric from <cite>Hello, Dolly</cite> in the upper right of your admin screen on every page.',
-				'Author' => 'Matt Mullenweg',
-				'AuthorURI' => 'http://ma.tt/',
-				'Title' => 'Hello Dolly',
-				'AuthorName' => 'Matt Mullenweg',
-			],
-			'pressbooks-textbook/pressbooks-textbook.php' => [
-				'Name' => 'Pressbooks Textbook',
-				'Version' => '2.1.2',
-				'Description' => 'A plugin that extends Pressbooks for textbook authoring',
-				'Author' => 'Brad Payne',
-				'AuthorURI' => 'http://bradpayne.ca',
-				'TextDomain' => 'pressbooks-textbook',
-				'DomainPath' => '/languages',
-				'Title' => 'Pressbooks Textbook',
-				'AuthorName' => 'Brad Payne',
-			],
+			'hello-dolly/hello.php' => [],
+			'parsedown-party/parsedownparty.php' => [],
+			'pressbooks-textbook/pressbooks-textbook.php' => [],
+			'wordpress-seo/wordpress-seo.php' => [],
 		];
 		$filtered_plugins = \Pressbooks\Admin\Plugins\filter_plugins( $plugins );
 		$this->assertArrayHasKey( 'pressbooks-textbook/pressbooks-textbook.php', $filtered_plugins );
+		$this->assertArrayHasKey( 'parsedown-party/parsedownparty.php', $filtered_plugins );
+		$this->assertArrayNotHasKey( 'hello-dolly/hello.php', $filtered_plugins );
+		$this->assertArrayNotHasKey( 'wordpress-seo/wordpress-seo.php', $filtered_plugins );
+
 	}
 
 }


### PR DESCRIPTION
This changes the `\Pressbooks\Admin\Plugins\filter_plugins()` function to compare plugin directories to the whitelist rather than the full `plugin/plugin.php` string. This will address issues where the plugin directory and main file are not equal.