### PR TITLE
Add DOI support at book and section level, exposed via metadata API

### DIFF
--- a/inc/admin/metaboxes/namespace.php
+++ b/inc/admin/metaboxes/namespace.php
@@ -442,6 +442,13 @@ function add_meta_boxes() {
 		);
 
 		x_add_metadata_field(
+			'pb_book_doi', 'metadata', [
+				'group' => 'additional-catalog-information',
+				'label' => __( 'Digital Object Identifier (DOI)', 'pressbooks' ),
+			]
+		);
+
+		x_add_metadata_field(
 			'pb_series_title', 'metadata', [
 				'group' => 'additional-catalog-information',
 				'label' => __( 'Series Title', 'pressbooks' ),
@@ -553,48 +560,61 @@ function add_meta_boxes() {
 		);
 	}
 
-	// Chapter Metadata
+	// Front Matter, Back Matter, and Chapter Metadata
 
-	x_add_metadata_group(
-		'chapter-metadata', 'chapter', [
-			'label' => __( 'Chapter Metadata', 'pressbooks' ),
-		]
-	);
+	foreach ( [
+		'front-matter' => __( 'Front Matter', 'pressbooks' ),
+		'chapter' => __( 'Chapter', 'pressbooks' ),
+		'back-matter' => __( 'Back Matter', 'pressbooks' ),
+	] as $slug => $label ) {
+		x_add_metadata_group(
+			'section-metadata', $slug, [
+				'label' => sprintf( __( '%s Metadata', 'pressbooks' ), $label ),
+			]
+		);
 
-	x_add_metadata_field(
-		'pb_short_title', 'chapter', [
-			'group' => 'chapter-metadata',
-			'label' => __( 'Chapter Short Title (appears in the PDF running header)', 'pressbooks' ),
-		]
-	);
+		x_add_metadata_field(
+			'pb_short_title', $slug, [
+				'group' => 'section-metadata',
+				'label' => sprintf( __( '%s Short Title (appears in the PDF running header)', 'pressbooks' ), $label ),
+			]
+		);
 
-	x_add_metadata_field(
-		'pb_subtitle', 'chapter', [
-			'group' => 'chapter-metadata',
-			'label' => __( 'Chapter Subtitle (appears in the Web/ebook/PDF output)', 'pressbooks' ),
-		]
-	);
+		x_add_metadata_field(
+			'pb_subtitle', $slug, [
+				'group' => 'section-metadata',
+				'label' => sprintf( __( '%s Subtitle (appears in the Web/ebook/PDF output)', 'pressbooks' ), $label ),
+			]
+		);
 
-	x_add_metadata_field(
-		'pb_authors', 'chapter', [
-			'group' => 'chapter-metadata',
-			'label' => __( 'Author(s)', 'pressbooks' ),
-			'field_type' => 'taxonomy_multi_select',
-			'taxonomy' => Contributors::TAXONOMY,
-			'select2' => true,
-			'description' => '<a class="button" href="edit-tags.php?taxonomy=contributor">' . __( 'Create New Contributor', 'pressbooks' ) . '</a>',
-			'placeholder' => __( 'Choose author(s)...', 'pressbooks' ),
-		]
-	);
+		x_add_metadata_field(
+			'pb_authors', $slug, [
+				'group' => 'section-metadata',
+				'label' => sprintf( __( '%s Author(s)', 'pressbooks' ), $label ),
+				'field_type' => 'taxonomy_multi_select',
+				'taxonomy' => Contributors::TAXONOMY,
+				'select2' => true,
+				'description' => '<a class="button" href="edit-tags.php?taxonomy=contributor">' . __( 'Create New Contributor', 'pressbooks' ) . '</a>',
+				'placeholder' => __( 'Choose author(s)...', 'pressbooks' ),
+			]
+		);
 
-	x_add_metadata_field(
-		'pb_section_license', 'chapter', [
-			'group' => 'chapter-metadata',
-			'field_type' => 'taxonomy_select',
-			'taxonomy' => Licensing::TAXONOMY,
-			'label' => __( 'Chapter Copyright License (overrides book license on this page)', 'pressbooks' ),
-		]
-	);
+		x_add_metadata_field(
+			'pb_section_license', $slug, [
+				'group' => 'section-metadata',
+				'field_type' => 'taxonomy_select',
+				'taxonomy' => Licensing::TAXONOMY,
+				'label' => sprintf( __( '%s Copyright License (overrides book license on this page)', 'pressbooks' ), $label ),
+			]
+		);
+
+		x_add_metadata_field(
+			'pb_section_doi', $slug, [
+				'group' => 'section-metadata',
+				'label' => sprintf( __( '%s Digital Object Identifier (DOI)', 'pressbooks' ), $label ),
+			]
+		);
+	}
 
 	// Chapter Parent
 
@@ -603,92 +623,6 @@ function add_meta_boxes() {
 			'label' => __( 'Part', 'pressbooks' ),
 			'context' => 'side',
 			'priority' => 'high',
-		]
-	);
-
-	// Front Matter Metadata
-
-	x_add_metadata_group(
-		'front-matter-metadata', 'front-matter', [
-			'label' => __( 'Front Matter Metadata', 'pressbooks' ),
-		]
-	);
-
-	x_add_metadata_field(
-		'pb_short_title', 'front-matter', [
-			'group' => 'front-matter-metadata',
-			'label' => __( 'Front Matter Short Title (appears in the PDF running header)', 'pressbooks' ),
-		]
-	);
-
-	x_add_metadata_field(
-		'pb_subtitle', 'front-matter', [
-			'group' => 'front-matter-metadata',
-			'label' => __( 'Front Matter Subtitle (appears in the Web/ebook/PDF output)', 'pressbooks' ),
-		]
-	);
-
-	x_add_metadata_field(
-		'pb_authors', 'front-matter', [
-			'group' => 'front-matter-metadata',
-			'label' => __( 'Author(s)', 'pressbooks' ),
-			'field_type' => 'taxonomy_multi_select',
-			'taxonomy' => Contributors::TAXONOMY,
-			'select2' => true,
-			'description' => '<a class="button" href="edit-tags.php?taxonomy=contributor">' . __( 'Create New Contributor', 'pressbooks' ) . '</a>',
-			'placeholder' => __( 'Choose author(s)...', 'pressbooks' ),
-		]
-	);
-
-	x_add_metadata_field(
-		'pb_section_license', 'front-matter', [
-			'group' => 'front-matter-metadata',
-			'field_type' => 'taxonomy_select',
-			'taxonomy' => Licensing::TAXONOMY,
-			'label' => __( 'Front Matter Copyright License (overrides book license on this page)', 'pressbooks' ),
-		]
-	);
-
-	// Back Matter Metadata
-
-	x_add_metadata_group(
-		'back-matter-metadata', 'back-matter', [
-			'label' => __( 'Back Matter Metadata', 'pressbooks' ),
-		]
-	);
-
-	x_add_metadata_field(
-		'pb_short_title', 'back-matter', [
-			'group' => 'back-matter-metadata',
-			'label' => __( 'Back Matter Short Title (appears in the PDF running header)', 'pressbooks' ),
-		]
-	);
-
-	x_add_metadata_field(
-		'pb_subtitle', 'back-matter', [
-			'group' => 'back-matter-metadata',
-			'label' => __( 'Back Matter Subtitle (appears in the Web/ebook/PDF output)', 'pressbooks' ),
-		]
-	);
-
-	x_add_metadata_field(
-		'pb_authors', 'back-matter', [
-			'group' => 'back-matter-metadata',
-			'label' => __( 'Author(s)', 'pressbooks' ),
-			'field_type' => 'taxonomy_multi_select',
-			'taxonomy' => Contributors::TAXONOMY,
-			'select2' => true,
-			'description' => '<a class="button" href="edit-tags.php?taxonomy=contributor">' . __( 'Create New Contributor', 'pressbooks' ) . '</a>',
-			'placeholder' => __( 'Choose author(s)...', 'pressbooks' ),
-		]
-	);
-
-	x_add_metadata_field(
-		'pb_section_license', 'back-matter', [
-			'group' => 'back-matter-metadata',
-			'field_type' => 'taxonomy_select',
-			'taxonomy' => Licensing::TAXONOMY,
-			'label' => __( 'Back Matter Copyright License (overrides book license on this page)', 'pressbooks' ),
 		]
 	);
 
@@ -720,7 +654,6 @@ function add_meta_boxes() {
 		]
 	);
 }
-
 
 /**
  * Render "Part" meta box

--- a/inc/api/endpoints/controller/class-metadata.php
+++ b/inc/api/endpoints/controller/class-metadata.php
@@ -402,6 +402,38 @@ class Metadata extends \WP_REST_Controller {
 					'context' => [ 'view' ],
 					'readonly' => true,
 				],
+				'identifier' => [
+					'type' => 'object',
+					'description' => __( 'The identifier property represents any kind of identifier for any kind of Thing, such as ISBNs, GTIN codes, UUIDs etc.' ),
+					'properties' => [
+						'@type' => [
+							'type' => 'string',
+							'enum' => [
+								'PropertyValue',
+							],
+							'description' => __( 'The type of the thing.' ),
+							'context' => [ 'view' ],
+							'readonly' => true,
+						],
+						'propertyID' => [
+							'type' => 'string',
+							'enum' => [
+								'DOI',
+							],
+							'description' => __( 'A commonly used identifier for the characteristic represented by the property.' ),
+							'context' => [ 'view' ],
+							'readonly' => true,
+						],
+						'value' => [
+							'type' => 'string',
+							'description' => __( 'The value of the property value node.' ),
+							'context' => [ 'view' ],
+							'readonly' => true,
+						],
+					],
+					'context' => [ 'view' ],
+					'readonly' => true,
+				],
 				'sameAs' => [
 					'type' => 'string',
 					'format' => 'uri',

--- a/inc/api/endpoints/controller/class-metadata.php
+++ b/inc/api/endpoints/controller/class-metadata.php
@@ -402,6 +402,13 @@ class Metadata extends \WP_REST_Controller {
 					'context' => [ 'view' ],
 					'readonly' => true,
 				],
+				'sameAs' => [
+					'type' => 'string',
+					'format' => 'uri',
+					'description' => __( 'URL of a reference Web page that unambiguously indicates the item\'s identity.', 'pressbooks' ),
+					'context' => [ 'view' ],
+					'readonly' => true,
+				],
 			],
 		];
 

--- a/inc/api/endpoints/controller/class-sectionmetadata.php
+++ b/inc/api/endpoints/controller/class-sectionmetadata.php
@@ -384,6 +384,13 @@ class SectionMetadata extends \WP_REST_Controller {
 					'context' => [ 'view' ],
 					'readonly' => true,
 				],
+				'sameAs' => [
+					'type' => 'string',
+					'format' => 'uri',
+					'description' => __( 'URL of a reference Web page that unambiguously indicates the item\'s identity.', 'pressbooks' ),
+					'context' => [ 'view' ],
+					'readonly' => true,
+				],
 			],
 		];
 

--- a/inc/api/endpoints/controller/class-sectionmetadata.php
+++ b/inc/api/endpoints/controller/class-sectionmetadata.php
@@ -384,6 +384,38 @@ class SectionMetadata extends \WP_REST_Controller {
 					'context' => [ 'view' ],
 					'readonly' => true,
 				],
+				'identifier' => [
+					'type' => 'object',
+					'description' => __( 'The identifier property represents any kind of identifier for any kind of Thing, such as ISBNs, GTIN codes, UUIDs etc.' ),
+					'properties' => [
+						'@type' => [
+							'type' => 'string',
+							'enum' => [
+								'PropertyValue',
+							],
+							'description' => __( 'The type of the thing.' ),
+							'context' => [ 'view' ],
+							'readonly' => true,
+						],
+						'propertyID' => [
+							'type' => 'string',
+							'enum' => [
+								'DOI',
+							],
+							'description' => __( 'A commonly used identifier for the characteristic represented by the property.' ),
+							'context' => [ 'view' ],
+							'readonly' => true,
+						],
+						'value' => [
+							'type' => 'string',
+							'description' => __( 'The value of the property value node.' ),
+							'context' => [ 'view' ],
+							'readonly' => true,
+						],
+					],
+					'context' => [ 'view' ],
+					'readonly' => true,
+				],
 				'sameAs' => [
 					'type' => 'string',
 					'format' => 'uri',

--- a/inc/metadata/namespace.php
+++ b/inc/metadata/namespace.php
@@ -351,6 +351,16 @@ function book_information_to_schema( $book_information ) {
 		$book_schema['license']['description'] = $book_information['pb_custom_copyright'];
 	}
 
+	if ( isset( $book_information['pb_book_doi'] ) ) {
+		/**
+		 * Filter the DOI resolver service URL (default: https://dx.doi.org).
+		 *
+		 * @since 5.6.0
+		 */
+		$doi_resolver = apply_filters( 'pb_doi_resolver', 'https://dx.doi.org' );
+		$book_schema['sameAs'] = trailingslashit( $doi_resolver ) . $book_information['pb_book_doi'];
+	}
+
 	// TODO: educationalAlignment, educationalUse, timeRequired, typicalAgeRange, interactivityType, learningResourceType, isBasedOnUrl
 
 	return $book_schema;
@@ -497,6 +507,16 @@ function schema_to_book_information( $book_schema ) {
 		}
 	} else {
 		$book_information['pb_book_license'] = $licensing->getLicenseFromUrl( $book_schema['license'] );
+	}
+
+	if ( isset( $book_schema['sameAs'] ) ) {
+		/**
+		 * Filter the DOI resolver service URL (default: https://dx.doi.org).
+		 *
+		 * @since 5.6.0
+		 */
+		$doi_resolver = apply_filters( 'pb_doi_resolver', 'https://dx.doi.org' );
+		$book_information['pb_book_doi'] = str_replace( trailingslashit( $doi_resolver ), '', $book_schema['sameAs'] );
 	}
 
 	return $book_information;
@@ -669,6 +689,16 @@ function section_information_to_schema( $section_information, $book_information 
 		$section_schema['isBasedOn'] = $book_information['pb_is_based_on'];
 	}
 
+	if ( isset( $section_information['pb_section_doi'] ) ) {
+		/**
+		 * Filter the DOI resolver service URL (default: https://dx.doi.org).
+		 *
+		 * @since 5.6.0
+		 */
+		$doi_resolver = apply_filters( 'pb_doi_resolver', 'https://dx.doi.org' );
+		$section_schema['sameAs'] = trailingslashit( $doi_resolver ) . $section_information['pb_section_doi'];
+	}
+
 	// TODO: educationalAlignment, educationalUse, timeRequired, typicalAgeRange, interactivityType, learningResourceType, isBasedOnUrl
 
 	return $section_schema;
@@ -750,6 +780,16 @@ function schema_to_section_information( $section_schema, $book_schema ) {
 		if ( empty( $book_schema['isBasedOn'] ) || $section_schema['isBasedOn'] !== $book_schema['isBasedOn'] ) {
 			$section_information['pb_is_based_on'] = $section_schema['isBasedOn'];
 		}
+	}
+
+	if ( isset( $section_schema['sameAs'] ) ) {
+		/**
+		 * Filter the DOI resolver service URL (default: https://dx.doi.org).
+		 *
+		 * @since 5.6.0
+		 */
+		$doi_resolver = apply_filters( 'pb_doi_resolver', 'https://dx.doi.org' );
+		$section_information['pb_section_doi'] = str_replace( trailingslashit( $doi_resolver ), '', $section_schema['sameAs'] );
 	}
 
 	return $section_information;

--- a/inc/metadata/namespace.php
+++ b/inc/metadata/namespace.php
@@ -352,6 +352,11 @@ function book_information_to_schema( $book_information ) {
 	}
 
 	if ( isset( $book_information['pb_book_doi'] ) ) {
+		$book_schema['identifier'] = [
+			'@type' => 'PropertyValue',
+			'propertyID' => 'DOI',
+			'value' => $book_information['pb_book_doi'],
+		];
 		/**
 		 * Filter the DOI resolver service URL (default: https://dx.doi.org).
 		 *
@@ -690,6 +695,11 @@ function section_information_to_schema( $section_information, $book_information 
 	}
 
 	if ( isset( $section_information['pb_section_doi'] ) ) {
+		$section_schema['identifier'] = [
+			'@type' => 'PropertyValue',
+			'propertyID' => 'DOI',
+			'value' => $section_information['pb_book_doi'],
+		];
 		/**
 		 * Filter the DOI resolver service URL (default: https://dx.doi.org).
 		 *

--- a/inc/metadata/namespace.php
+++ b/inc/metadata/namespace.php
@@ -698,7 +698,7 @@ function section_information_to_schema( $section_information, $book_information 
 		$section_schema['identifier'] = [
 			'@type' => 'PropertyValue',
 			'propertyID' => 'DOI',
-			'value' => $section_information['pb_book_doi'],
+			'value' => $section_information['pb_section_doi'],
 		];
 		/**
 		 * Filter the DOI resolver service URL (default: https://dx.doi.org).

--- a/tests/test-metadata.php
+++ b/tests/test-metadata.php
@@ -68,11 +68,14 @@ class MetadataTest extends \WP_UnitTestCase {
 		$book_information = [
 			'pb_authors' => 'Herman Melville',
 			'pb_title' => 'Moby Dick',
+			'pb_book_doi' => 'my_doi'
 		];
 
 		$result = \Pressbooks\Metadata\book_information_to_schema( $book_information );
 		$this->assertEquals( $result['name'], 'Moby Dick' );
 		$this->assertEquals( $result['author'][0]['name'], 'Herman Melville' );
+		$this->assertEquals( $result['sameAs'], 'https://dx.doi.org/my_doi' );
+		$this->assertEquals( $result['identifier']['value'], 'my_doi' );
 	}
 
 	public function test_schema_to_book_information() {
@@ -85,12 +88,14 @@ class MetadataTest extends \WP_UnitTestCase {
 				'@type' => 'Person',
 				'name' => 'Herman Melville',
 			],
+			'sameAs' => 'https://dx.doi.org/my_doi',
 		];
 
 		$result = \Pressbooks\Metadata\schema_to_book_information( $schema );
 		$this->assertEquals( $result['pb_title'], 'Moby Dick' );
 		$this->assertEquals( $result['pb_authors'], 'Herman Melville' );
 		$this->assertEquals( $result['pb_book_license'], 'public-domain' );
+		$this->assertEquals( $result['pb_book_doi'], 'my_doi' );
 
 		$schema = [
 			'@context' => 'http://schema.org',
@@ -166,6 +171,7 @@ class MetadataTest extends \WP_UnitTestCase {
 		$section_information = [
 			'pb_title' => 'Loomings',
 			'pb_chapter_number' => 1,
+			'pb_section_doi' => 'my_doi',
 		];
 
 		$book_information = [
@@ -177,6 +183,7 @@ class MetadataTest extends \WP_UnitTestCase {
 		$this->assertEquals( $result['name'], 'Loomings' );
 		$this->assertEquals( $result['author'][0]['name'], 'Herman Melville' );
 		$this->assertEquals( $result['position'], 1 );
+		$this->assertEquals( $result['identifier']['value'], 'my_doi' );
 	}
 
 	public function test_schema_to_section_information() {
@@ -206,11 +213,13 @@ class MetadataTest extends \WP_UnitTestCase {
 				'url' => 'https://creativecommons.org/publicdomain/zero/1.0/',
 				'name' => 'Public Domain (No Rights Reserved)',
 			],
+			'sameAs' => 'https://dx.doi.org/my_doi',
 		];
 
 		$result = \Pressbooks\Metadata\schema_to_section_information( $section_schema, $book_schema );
 		$this->assertArrayNotHasKey( 'pb_authors', $result );
 		$this->assertArrayNotHasKey( 'pb_section_license', $result );
+		$this->assertEquals( $result['pb_section_doi'], 'my_doi' );
 
 		$book_schema = [
 			'@context' => 'http://schema.org',


### PR DESCRIPTION
See implementation notes [here](https://discourse.pressbooks.org/t/support-for-digital-object-identifier-doi-in-book-info-metadata/684/4). Also includes a new filter hook, `pb_doi_resolver`, which allows the default DOI resolver service URL (https://dx.doi.org) to be changed.