### PR TITLE
Increase max_execution_time from 5 to 10 minutes for export, import and clone

### DIFF
--- a/inc/class-cloner.php
+++ b/inc/class-cloner.php
@@ -2023,7 +2023,19 @@ class Cloner {
 				if ( is_wp_error( $bookname ) ) {
 					$_SESSION['pb_errors'][] = $bookname->get_error_message();
 				} else {
-					@set_time_limit( 300 ); // @codingStandardsIgnoreLine
+					/**
+					 * Maximum execution time, in seconds. If set to zero, no time limit
+					 * Overrides PHP's max_execution_time of a Nginx->PHP-FPM->PHP configuration
+					 * See also request_terminate_timeout (PHP-FPM) and request_terminate_timeout (Nginx)
+					 *
+					 * @since 5.6.0
+					 *
+					 * @param int $seconds
+					 * @param string $some_action
+					 *
+					 * @return int
+					 */
+					@set_time_limit( apply_filters( 'pb_set_time_limit', 600, 'clone' ) ); // @codingStandardsIgnoreLine
 					$cloner = new Cloner( esc_url( $_POST['source_book_url'] ), $bookname, $booktitle );
 					if ( $cloner->cloneBook() ) {
 						$_SESSION['pb_notices'][] = sprintf(

--- a/inc/class-cloner.php
+++ b/inc/class-cloner.php
@@ -2026,7 +2026,7 @@ class Cloner {
 					/**
 					 * Maximum execution time, in seconds. If set to zero, no time limit
 					 * Overrides PHP's max_execution_time of a Nginx->PHP-FPM->PHP configuration
-					 * See also request_terminate_timeout (PHP-FPM) and request_terminate_timeout (Nginx)
+					 * See also request_terminate_timeout (PHP-FPM) and fastcgi_read_timeout (Nginx)
 					 *
 					 * @since 5.6.0
 					 *

--- a/inc/modules/export/class-export.php
+++ b/inc/modules/export/class-export.php
@@ -720,7 +720,7 @@ abstract class Export {
 			/**
 			 * Maximum execution time, in seconds. If set to zero, no time limit
 			 * Overrides PHP's max_execution_time of a Nginx->PHP-FPM->PHP configuration
-			 * See also request_terminate_timeout (PHP-FPM) and request_terminate_timeout (Nginx)
+			 * See also request_terminate_timeout (PHP-FPM) and fastcgi_read_timeout (Nginx)
 			 *
 			 * @since 5.6.0
 			 *

--- a/inc/modules/export/class-export.php
+++ b/inc/modules/export/class-export.php
@@ -717,7 +717,19 @@ abstract class Export {
 			// --------------------------------------------------------------------------------------------------------
 			// Do Export
 
-			@set_time_limit( 300 ); // @codingStandardsIgnoreLine
+			/**
+			 * Maximum execution time, in seconds. If set to zero, no time limit
+			 * Overrides PHP's max_execution_time of a Nginx->PHP-FPM->PHP configuration
+			 * See also request_terminate_timeout (PHP-FPM) and request_terminate_timeout (Nginx)
+			 *
+			 * @since 5.6.0
+			 *
+			 * @param int $seconds
+			 * @param string $some_action
+			 *
+			 * @return int
+			 */
+			@set_time_limit( apply_filters( 'pb_set_time_limit', 600, 'export' ) ); // @codingStandardsIgnoreLine
 
 			$redirect_url = get_admin_url( get_current_blog_id(), '/admin.php?page=pb_export' );
 			$conversion_error = [];

--- a/inc/modules/import/class-import.php
+++ b/inc/modules/import/class-import.php
@@ -279,7 +279,7 @@ abstract class Import {
 		/**
 		 * Maximum execution time, in seconds. If set to zero, no time limit
 		 * Overrides PHP's max_execution_time of a Nginx->PHP-FPM->PHP configuration
-		 * See also request_terminate_timeout (PHP-FPM) and request_terminate_timeout (Nginx)
+		 * See also request_terminate_timeout (PHP-FPM) and fastcgi_read_timeout (Nginx)
 		 *
 		 * @since 5.6.0
 		 *

--- a/inc/modules/import/class-import.php
+++ b/inc/modules/import/class-import.php
@@ -276,7 +276,19 @@ abstract class Import {
 		// Set post status
 		$current_import['default_post_status'] = ( isset( $_POST['show_imports_in_web'] ) ) ? 'publish' : 'private'; // @codingStandardsIgnoreLine
 
-		@set_time_limit( 300 ); // @codingStandardsIgnoreLine
+		/**
+		 * Maximum execution time, in seconds. If set to zero, no time limit
+		 * Overrides PHP's max_execution_time of a Nginx->PHP-FPM->PHP configuration
+		 * See also request_terminate_timeout (PHP-FPM) and request_terminate_timeout (Nginx)
+		 *
+		 * @since 5.6.0
+		 *
+		 * @param int $seconds
+		 * @param string $some_action
+		 *
+		 * @return int
+		 */
+		@set_time_limit( apply_filters( 'pb_set_time_limit', 600, 'import' ) ); // @codingStandardsIgnoreLine
 
 		$ok = false;
 		switch ( $current_import['type_of'] ) {

--- a/inc/modules/searchandreplace/class-search.php
+++ b/inc/modules/searchandreplace/class-search.php
@@ -115,7 +115,19 @@ abstract class Search {
 		$limit = intval( $limit );
 		$offset = intval( $offset );
 		if ( strlen( $search ) > 0 ) {
-			@set_time_limit( 300 ); // @codingStandardsIgnoreLine
+			/**
+			 * Maximum execution time, in seconds. If set to zero, no time limit
+			 * Overrides PHP's max_execution_time of a Nginx->PHP-FPM->PHP configuration
+			 * See also request_terminate_timeout (PHP-FPM) and request_terminate_timeout (Nginx)
+			 *
+			 * @since 5.6.0
+			 *
+			 * @param int $seconds
+			 * @param string $some_action
+			 *
+			 * @return int
+			 */
+			@set_time_limit( apply_filters( 'pb_set_time_limit', 300, 'search' ) ); // @codingStandardsIgnoreLine
 			if ( $this->regex ) {
 				$error = $this->regexValidate( $search );
 				if ( null !== $error ) {

--- a/inc/modules/searchandreplace/class-search.php
+++ b/inc/modules/searchandreplace/class-search.php
@@ -118,7 +118,7 @@ abstract class Search {
 			/**
 			 * Maximum execution time, in seconds. If set to zero, no time limit
 			 * Overrides PHP's max_execution_time of a Nginx->PHP-FPM->PHP configuration
-			 * See also request_terminate_timeout (PHP-FPM) and request_terminate_timeout (Nginx)
+			 * See also request_terminate_timeout (PHP-FPM) and fastcgi_read_timeout (Nginx)
 			 *
 			 * @since 5.6.0
 			 *

--- a/inc/redirect/namespace.php
+++ b/inc/redirect/namespace.php
@@ -405,7 +405,7 @@ function force_download( $filepath, $inline = false ) {
 	/**
 	 * Maximum execution time, in seconds. If set to zero, no time limit
 	 * Overrides PHP's max_execution_time of a Nginx->PHP-FPM->PHP configuration
-	 * See also request_terminate_timeout (PHP-FPM) and request_terminate_timeout (Nginx)
+	 * See also request_terminate_timeout (PHP-FPM) and fastcgi_read_timeout (Nginx)
 	 *
 	 * @since 5.6.0
 	 *

--- a/inc/redirect/namespace.php
+++ b/inc/redirect/namespace.php
@@ -402,7 +402,19 @@ function force_download( $filepath, $inline = false ) {
 
 	// Force download
 	// @codingStandardsIgnoreStart
-	@set_time_limit( 0 );
+	/**
+	 * Maximum execution time, in seconds. If set to zero, no time limit
+	 * Overrides PHP's max_execution_time of a Nginx->PHP-FPM->PHP configuration
+	 * See also request_terminate_timeout (PHP-FPM) and request_terminate_timeout (Nginx)
+	 *
+	 * @since 5.6.0
+	 *
+	 * @param int $seconds
+	 * @param string $some_action
+	 *
+	 * @return int
+	 */
+	@set_time_limit( apply_filters( 'pb_set_time_limit', 0, 'download' ) );
 	header( 'Content-Description: File Transfer' );
 	header( 'Content-Type: ' . \Pressbooks\Media\mime_type( $filepath ) );
 	if ( $inline ) {


### PR DESCRIPTION
Local dev environment is slower than production. It sometimes takes longer than 5 minutes when cloning large books. Nginx will still 504 but I want the PHP process to keep going longer than 5 minutes. I Added a filter so this can be tweaked as needed.

Also, I think 10 minutes as the default in production is acceptable.