### PR TITLE
Allow customization of part and chapter labels in exports (resolves PB-14997)

### DIFF
--- a/hooks.php
+++ b/hooks.php
@@ -146,6 +146,7 @@ if ( $is_book ) {
 	add_action( 'init', '\Pressbooks\PostType\register_post_statii' );
 	add_filter( 'request', '\Pressbooks\PostType\add_post_types_rss' );
 	add_filter( 'hypothesis_supported_posttypes', '\Pressbooks\PostType\add_posttypes_to_hypothesis' );
+	add_filter( 'pb_post_type_label', '\Pressbooks\PostType\filter_post_type_label', 10, 2 );
 }
 
 // -------------------------------------------------------------------------------------------------------------------

--- a/inc/admin/metaboxes/namespace.php
+++ b/inc/admin/metaboxes/namespace.php
@@ -576,7 +576,7 @@ function add_meta_boxes() {
 		x_add_metadata_field(
 			'pb_short_title', $slug, [
 				'group' => 'section-metadata',
-				'label' => sprintf( __( '%s Short Title (appears in the PDF running header)', 'pressbooks' ), $label ),
+				'label' => sprintf( __( '%s Short Title (appears in the PDF running header and webbook navigation)', 'pressbooks' ), $label ),
 			]
 		);
 

--- a/inc/class-sass.php
+++ b/inc/class-sass.php
@@ -62,8 +62,28 @@ class Sass {
 	public function getStringsToLocalize() {
 
 		return [
-			'chapter' => __( 'Chapter', 'pressbooks' ),
-			'part' => __( 'Part', 'pressbooks' ),
+			/**
+			 * Filter the label used for post types (front matter/parts/chapters/back matter) in the TOC and section headings.
+			 *
+			 * @since 5.6.0
+			 *
+			 * @param string $label
+			 * @param array $args
+			 *
+			 * @return string Filtered label
+			 */
+			'chapter' => apply_filters( 'pb_post_type_label', __( 'Chapter', 'pressbooks' ), [ 'post_type' => 'chapter' ] ),
+			/**
+			 * Filter the label used for post types (front matter/parts/chapters/back matter) in the TOC and section headings.
+			 *
+			 * @since 5.6.0
+			 *
+			 * @param string $label
+			 * @param array $args
+			 *
+			 * @return string Filtered label
+			 */
+			'part' => apply_filters( 'pb_post_type_label', __( 'Part', 'pressbooks' ), [ 'post_type' => 'part' ] ),
 		];
 
 	}

--- a/inc/modules/export/epub/class-epub201.php
+++ b/inc/modules/export/epub/class-epub201.php
@@ -1745,7 +1745,17 @@ class Epub201 extends Export {
 				if ( get_post_meta( $v['ID'], 'pb_part_invisible', true ) === 'on' ) {
 					$class .= ' display-none';
 				} else {
-					$title = ( $this->numbered ? __( 'Part', 'pressbooks' ) . ' ' . \Pressbooks\L10n\romanize( $m ) . '. ' : '' ) . $title;
+					/**
+					 * Filter the label used for post types (front matter/parts/chapters/back matter) in the TOC and section headings.
+					 *
+					 * @since 5.6.0
+					 *
+					 * @param string $label
+					 * @param array $args
+					 *
+					 * @return string Filtered label
+					 */
+					$title = ( $this->numbered ? apply_filters( 'pb_post_type_label', __( 'Part', 'pressbooks' ), [ 'post_type' => 'part' ] ) . ' ' . \Pressbooks\L10n\romanize( $m ) . '. ' : '' ) . $title;
 					$m++;
 				}
 			} elseif ( preg_match( '/^chapter-/', $k ) ) {

--- a/inc/modules/themeoptions/class-globaloptions.php
+++ b/inc/modules/themeoptions/class-globaloptions.php
@@ -94,7 +94,7 @@ class GlobalOptions extends \Pressbooks\Options {
 			$_page,
 			$_section,
 			[
-				__( 'Customize the label for parts used in exports and webbook navigation cues.', 'pressbooks' ),
+				__( 'Customize the label for parts used in exports.', 'pressbooks' ),
 			]
 		);
 
@@ -105,7 +105,7 @@ class GlobalOptions extends \Pressbooks\Options {
 			$_page,
 			$_section,
 			[
-				__( 'Customize the label for chapters used in exports and webbook navigation cues.', 'pressbooks' ),
+				__( 'Customize the label for chapters used in exports.', 'pressbooks' ),
 			]
 		);
 

--- a/inc/modules/themeoptions/class-globaloptions.php
+++ b/inc/modules/themeoptions/class-globaloptions.php
@@ -94,7 +94,7 @@ class GlobalOptions extends \Pressbooks\Options {
 			$_page,
 			$_section,
 			[
-				__( 'Customize the label for parts used in exports.', 'pressbooks' ),
+				__( 'Customize the label for parts used in exports and the webbook.', 'pressbooks' ),
 			]
 		);
 
@@ -105,7 +105,7 @@ class GlobalOptions extends \Pressbooks\Options {
 			$_page,
 			$_section,
 			[
-				__( 'Customize the label for chapters used in exports.', 'pressbooks' ),
+				__( 'Customize the label for chapters used in exports and the webbook.', 'pressbooks' ),
 			]
 		);
 

--- a/inc/modules/themeoptions/class-globaloptions.php
+++ b/inc/modules/themeoptions/class-globaloptions.php
@@ -88,6 +88,50 @@ class GlobalOptions extends \Pressbooks\Options {
 		);
 
 		add_settings_field(
+			'front_matter_label',
+			__( 'Front Matter Label', 'pressbooks' ),
+			[ $this, 'renderFrontMatterLabelField' ],
+			$_page,
+			$_section,
+			[
+				__( 'Customize the label for front matter used in exports and webbook navigation cues.', 'pressbooks' ),
+			]
+		);
+
+		add_settings_field(
+			'part_label',
+			__( 'Part Label', 'pressbooks' ),
+			[ $this, 'renderPartLabelField' ],
+			$_page,
+			$_section,
+			[
+				__( 'Customize the label for parts used in exports and webbook navigation cues.', 'pressbooks' ),
+			]
+		);
+
+		add_settings_field(
+			'chapter_label',
+			__( 'Chapter Label', 'pressbooks' ),
+			[ $this, 'renderChapterLabelField' ],
+			$_page,
+			$_section,
+			[
+				__( 'Customize the label for chapters used in exports and webbook navigation cues.', 'pressbooks' ),
+			]
+		);
+
+		add_settings_field(
+			'back_matter_label',
+			__( 'Back Matter Label', 'pressbooks' ),
+			[ $this, 'renderBackMatterLabelField' ],
+			$_page,
+			$_section,
+			[
+				__( 'Customize the label for back matter used in exports and webbook navigation cues.', 'pressbooks' ),
+			]
+		);
+
+		add_settings_field(
 			'parse_subsections',
 			__( 'Two-Level TOC', 'pressbooks' ),
 			[ $this, 'renderTwoLevelTOCField' ],
@@ -426,6 +470,82 @@ class GlobalOptions extends \Pressbooks\Options {
 	}
 
 	/**
+	 * Render the front_matter_label input.
+	 *
+	 * @param array $args
+	 */
+	function renderFrontMatterLabelField( $args ) {
+		$this->renderField(
+			[
+				'id' => 'front_matter_label',
+				'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+				'option' => 'front_matter_label',
+				'value' => getset( $this->options, 'front_matter_label' ),
+				'description' => $args[0],
+				'type' => 'text',
+				'class' => 'regular-text',
+			]
+		);
+	}
+
+	/**
+	 * Render the part_label input.
+	 *
+	 * @param array $args
+	 */
+	function renderPartLabelField( $args ) {
+		$this->renderField(
+			[
+				'id' => 'part_label',
+				'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+				'option' => 'part_label',
+				'value' => getset( $this->options, 'part_label' ),
+				'description' => $args[0],
+				'type' => 'text',
+				'class' => 'regular-text',
+			]
+		);
+	}
+
+	/**
+	 * Render the chapter_label input.
+	 *
+	 * @param array $args
+	 */
+	function renderChapterLabelField( $args ) {
+		$this->renderField(
+			[
+				'id' => 'chapter_label',
+				'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+				'option' => 'chapter_label',
+				'value' => getset( $this->options, 'chapter_label' ),
+				'description' => $args[0],
+				'type' => 'text',
+				'class' => 'regular-text',
+			]
+		);
+	}
+
+	/**
+	 * Render the back_matter_label input.
+	 *
+	 * @param array $args
+	 */
+	function renderBackMatterLabelField( $args ) {
+		$this->renderField(
+			[
+				'id' => 'back_matter_label',
+				'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+				'option' => 'back_matter_label',
+				'value' => getset( $this->options, 'back_matter_label' ),
+				'description' => $args[0],
+				'type' => 'text',
+				'class' => 'regular-text',
+			]
+		);
+	}
+
+	/**
 	 * Get the slug for the global options tab.
 	 *
 	 * @return string $slug
@@ -458,6 +578,10 @@ class GlobalOptions extends \Pressbooks\Options {
 			'pb_theme_options_global_defaults', [
 				'chapter_numbers' => 1,
 				'parse_subsections' => 0,
+				'front_matter_label' => __( 'Front Matter', 'pressbooks' ),
+				'part_label' => __( 'Part', 'pressbooks' ),
+				'chapter_label' => __( 'Chapter', 'pressbooks' ),
+				'back_matter_label' => __( 'Back Matter', 'pressbooks' ),
 				'attachment_attributions' => 0,
 				'copyright_license' => 0,
 				'edu_textbox_examples_header_color' => '#fff',
@@ -583,6 +707,10 @@ class GlobalOptions extends \Pressbooks\Options {
 				'edu_textbox_takeaways_header_color',
 				'edu_textbox_takeaways_header_background',
 				'edu_textbox_takeaways_background',
+				'front_matter_label',
+				'part_label',
+				'chapter_label',
+				'back_matter_label',
 			]
 		);
 	}

--- a/inc/modules/themeoptions/class-globaloptions.php
+++ b/inc/modules/themeoptions/class-globaloptions.php
@@ -88,17 +88,6 @@ class GlobalOptions extends \Pressbooks\Options {
 		);
 
 		add_settings_field(
-			'front_matter_label',
-			__( 'Front Matter Label', 'pressbooks' ),
-			[ $this, 'renderFrontMatterLabelField' ],
-			$_page,
-			$_section,
-			[
-				__( 'Customize the label for front matter used in exports and webbook navigation cues.', 'pressbooks' ),
-			]
-		);
-
-		add_settings_field(
 			'part_label',
 			__( 'Part Label', 'pressbooks' ),
 			[ $this, 'renderPartLabelField' ],
@@ -117,17 +106,6 @@ class GlobalOptions extends \Pressbooks\Options {
 			$_section,
 			[
 				__( 'Customize the label for chapters used in exports and webbook navigation cues.', 'pressbooks' ),
-			]
-		);
-
-		add_settings_field(
-			'back_matter_label',
-			__( 'Back Matter Label', 'pressbooks' ),
-			[ $this, 'renderBackMatterLabelField' ],
-			$_page,
-			$_section,
-			[
-				__( 'Customize the label for back matter used in exports and webbook navigation cues.', 'pressbooks' ),
 			]
 		);
 
@@ -470,25 +448,6 @@ class GlobalOptions extends \Pressbooks\Options {
 	}
 
 	/**
-	 * Render the front_matter_label input.
-	 *
-	 * @param array $args
-	 */
-	function renderFrontMatterLabelField( $args ) {
-		$this->renderField(
-			[
-				'id' => 'front_matter_label',
-				'name' => 'pressbooks_theme_options_' . $this->getSlug(),
-				'option' => 'front_matter_label',
-				'value' => getset( $this->options, 'front_matter_label' ),
-				'description' => $args[0],
-				'type' => 'text',
-				'class' => 'regular-text',
-			]
-		);
-	}
-
-	/**
 	 * Render the part_label input.
 	 *
 	 * @param array $args
@@ -519,25 +478,6 @@ class GlobalOptions extends \Pressbooks\Options {
 				'name' => 'pressbooks_theme_options_' . $this->getSlug(),
 				'option' => 'chapter_label',
 				'value' => getset( $this->options, 'chapter_label' ),
-				'description' => $args[0],
-				'type' => 'text',
-				'class' => 'regular-text',
-			]
-		);
-	}
-
-	/**
-	 * Render the back_matter_label input.
-	 *
-	 * @param array $args
-	 */
-	function renderBackMatterLabelField( $args ) {
-		$this->renderField(
-			[
-				'id' => 'back_matter_label',
-				'name' => 'pressbooks_theme_options_' . $this->getSlug(),
-				'option' => 'back_matter_label',
-				'value' => getset( $this->options, 'back_matter_label' ),
 				'description' => $args[0],
 				'type' => 'text',
 				'class' => 'regular-text',
@@ -578,10 +518,8 @@ class GlobalOptions extends \Pressbooks\Options {
 			'pb_theme_options_global_defaults', [
 				'chapter_numbers' => 1,
 				'parse_subsections' => 0,
-				'front_matter_label' => __( 'Front Matter', 'pressbooks' ),
 				'part_label' => __( 'Part', 'pressbooks' ),
 				'chapter_label' => __( 'Chapter', 'pressbooks' ),
-				'back_matter_label' => __( 'Back Matter', 'pressbooks' ),
 				'attachment_attributions' => 0,
 				'copyright_license' => 0,
 				'edu_textbox_examples_header_color' => '#fff',
@@ -707,10 +645,8 @@ class GlobalOptions extends \Pressbooks\Options {
 				'edu_textbox_takeaways_header_color',
 				'edu_textbox_takeaways_header_background',
 				'edu_textbox_takeaways_background',
-				'front_matter_label',
 				'part_label',
 				'chapter_label',
-				'back_matter_label',
 			]
 		);
 	}

--- a/inc/posttype/namespace.php
+++ b/inc/posttype/namespace.php
@@ -6,6 +6,8 @@
 
 namespace Pressbooks\PostType;
 
+use Pressbooks\Modules\ThemeOptions\GlobalOptions;
+
 /**
  * List our post_types
  *
@@ -530,5 +532,23 @@ function get_post_type_label( $posttype ) {
 		default:
 			$label = false;
 	endswitch;
+	return $label;
+}
+
+/**
+ * @since 5.6.0
+ *
+ * @param string $label The post type label
+ * @param array $args
+ *
+ * @return string
+ */
+
+function filter_post_type_label( $label, $args ) {
+	if ( isset( $args['post_type'] ) && in_array( $args['post_type'], [ 'front-matter', 'part', 'chapter', 'back-matter' ], true ) ) {
+		$options = get_option( 'pressbooks_theme_options_global', GlobalOptions::getDefaults() );
+		$post_type = str_replace( '-', '_', $args['post_type'] );
+		return $options[ "{$post_type}_label" ];
+	}
 	return $label;
 }

--- a/inc/posttype/namespace.php
+++ b/inc/posttype/namespace.php
@@ -545,7 +545,7 @@ function get_post_type_label( $posttype ) {
  */
 
 function filter_post_type_label( $label, $args ) {
-	if ( isset( $args['post_type'] ) && in_array( $args['post_type'], [ 'front-matter', 'part', 'chapter', 'back-matter' ], true ) ) {
+	if ( isset( $args['post_type'] ) && in_array( $args['post_type'], [ 'part', 'chapter' ], true ) ) {
 		$options = get_option( 'pressbooks_theme_options_global', GlobalOptions::getDefaults() );
 		$post_type = str_replace( '-', '_', $args['post_type'] );
 		return $options[ "{$post_type}_label" ];

--- a/tests/test-posttype.php
+++ b/tests/test-posttype.php
@@ -13,7 +13,8 @@ use function \Pressbooks\PostType\{
 	add_post_types_rss,
 	add_posttypes_to_hypothesis,
 	can_export,
-	get_post_type_label
+	get_post_type_label,
+	filter_post_type_label
 };
 
 class PostTypeTest extends \WP_UnitTestCase {
@@ -180,5 +181,11 @@ class PostTypeTest extends \WP_UnitTestCase {
 		$this->assertEquals( get_post_type_label( 'back-matter' ), 'Back Matter' );
 		$this->assertEquals( get_post_type_label( 'chapter' ), 'Chapter' );
 		$this->assertEquals( get_post_type_label( 'glossary' ), 'Glossary' );
+	}
+
+	function test_filter_post_type_label() {
+		$this->assertEquals( filter_post_type_label( 'Chapter', [ 'post_type' => 'chapter' ] ), 'Chapter' );
+		update_option( 'pressbooks_theme_options_global', [ 'chapter_label' => 'Section' ] );
+		$this->assertEquals( filter_post_type_label( 'Chapter', [ 'post_type' => 'chapter' ] ), 'Section' );
 	}
 }


### PR DESCRIPTION
Allows Part and Chapter labels to be customized for readers via Global Theme Options.

For example, users could re-label "Part" as "Unit" or "Chapter" as "Section". The possibilities are endless!

NB: This does not change the back-end of Pressbooks, just the outputs.