### PR TITLE
Add title attribute to section divs (fix PB-14549)

### DIFF
--- a/inc/modules/export/htmlbook/class-htmlbook.php
+++ b/inc/modules/export/htmlbook/class-htmlbook.php
@@ -1236,9 +1236,6 @@ class HTMLBook extends Export {
 			if ( $subtitle ) {
 				$content = '<h2 class="chapter-subtitle">' . Sanitize\decode( $subtitle ) . '</h2>' . $content;
 			}
-			if ( $short_title ) {
-				$content = '<h6 class="short-title">' . Sanitize\decode( $short_title ) . '</h6>' . $content;
-			}
 
 			$append_front_matter_content .= $this->removeAttributionLink( $this->doSectionLevelLicense( $metadata, $front_matter_id ) );
 
@@ -1251,6 +1248,7 @@ class HTMLBook extends Export {
 				[
 					'class' => "front-matter {$subclass}",
 					'id' => "front-matter-{$front_matter['post_name']}",
+					'title' => $short_title ? $short_title : $front_matter['post_title'],
 				]
 			);
 
@@ -1438,9 +1436,6 @@ class HTMLBook extends Export {
 				if ( $subtitle ) {
 					$content = '<h2 class="chapter-subtitle">' . Sanitize\decode( $subtitle ) . '</h2>' . $content;
 				}
-				if ( $short_title ) {
-					$content = '<h6 class="short-title">' . Sanitize\decode( $short_title ) . '</h6>' . $content;
-				}
 
 				// Inject introduction class?
 				if ( ! $this->hasIntroduction ) {
@@ -1467,6 +1462,7 @@ class HTMLBook extends Export {
 				$my_chapter->appendAttributes(
 					[
 						'id' => $slug,
+						'title' => $short_title ? $short_title : $chapter['post_title'],
 					]
 				);
 
@@ -1574,9 +1570,6 @@ class HTMLBook extends Export {
 			if ( $subtitle ) {
 				$content = '<h2 class="chapter-subtitle">' . Sanitize\decode( $subtitle ) . '</h2>' . $content;
 			}
-			if ( $short_title ) {
-				$content = '<h6 class="short-title">' . Sanitize\decode( $short_title ) . '</h6>' . $content;
-			}
 
 			$append_back_matter_content .= $this->removeAttributionLink( $this->doSectionLevelLicense( $metadata, $back_matter_id ) );
 
@@ -1589,6 +1582,7 @@ class HTMLBook extends Export {
 				[
 					'class' => "back-matter {$subclass}",
 					'id' => "back-matter-{$back_matter['post_name']}",
+					'title' => $short_title ? $short_title : $back_matter['post_title'],
 				]
 			);
 

--- a/inc/modules/export/xhtml/class-xhtml11.php
+++ b/inc/modules/export/xhtml/class-xhtml11.php
@@ -69,6 +69,15 @@ class Xhtml11 extends Export {
 	protected $wrapHeaderElements = false;
 
 	/**
+	 * Should the short title be output in a hidden element? Requires a theme based on Buckram 1.2.0 or greater.
+	 *
+	 * @see https://github.com/pressbooks/buckram/
+	 *
+	 * @var bool
+	 */
+	protected $outputShortTitle = true;
+
+	/**
 	 * Main language of document, two letter code
 	 *
 	 * @var string
@@ -104,6 +113,10 @@ class Xhtml11 extends Export {
 
 		if ( Container::get( 'Styles' )->hasBuckram( '0.3.0' ) ) {
 			$this->wrapHeaderElements = true;
+		}
+
+		if ( Container::get( 'Styles' )->hasBuckram( '1.2.0' ) ) {
+			$this->outputShortTitle = false;
 		}
 
 		if ( ! defined( 'PB_XMLLINT_COMMAND' ) ) {
@@ -696,6 +709,7 @@ class Xhtml11 extends Export {
 
 		$spec = '';
 		$spec .= 'table=-border;';
+		$spec .= 'div=title;';
 
 		return \Pressbooks\HtmLawed::filter( $html, $config, $spec );
 	}
@@ -1120,9 +1134,9 @@ class Xhtml11 extends Export {
 	 * @param array $metadata
 	 */
 	protected function echoFrontMatter( $book_contents, $metadata ) {
-		$front_matter_printf = '<div class="front-matter %1$s" id="%2$s">';
-		$front_matter_printf .= '<div class="front-matter-title-wrap"><h3 class="front-matter-number">%3$s</h3><h1 class="front-matter-title">%4$s</h1>%5$s</div>';
-		$front_matter_printf .= '<div class="ugc front-matter-ugc">%6$s</div>%7$s%8$s';
+		$front_matter_printf = '<div class="front-matter %1$s" id="%2$s" title="%3$s">';
+		$front_matter_printf .= '<div class="front-matter-title-wrap"><h3 class="front-matter-number">%4$s</h3><h1 class="front-matter-title">%5$s</h1>%6$s</div>';
+		$front_matter_printf .= '<div class="ugc front-matter-ugc">%7$s</div>%8$s%9$s';
 		$front_matter_printf .= '</div>';
 
 		$i = $this->frontMatterPos;
@@ -1179,7 +1193,7 @@ class Xhtml11 extends Export {
 				}
 			}
 
-			if ( $short_title ) {
+			if ( $short_title && $this->outputShortTitle ) {
 				if ( $this->wrapHeaderElements ) {
 					$after_title = '<h6 class="short-title">' . Sanitize\decode( $short_title ) . '</h6>' . $after_title;
 				} else {
@@ -1193,6 +1207,7 @@ class Xhtml11 extends Export {
 				$front_matter_printf,
 				$subclass,
 				$slug,
+				( $short_title ) ? $short_title : $front_matter['post_title'],
 				$i,
 				Sanitize\decode( $title ),
 				$after_title,
@@ -1230,9 +1245,9 @@ class Xhtml11 extends Export {
 		$part_printf .= '<div class="part-title-wrap"><h3 class="part-number">%3$s</h3><h1 class="part-title">%4$s</h1></div>%5$s';
 		$part_printf .= '</div>';
 
-		$chapter_printf = '<div class="chapter %1$s" id="%2$s">';
-		$chapter_printf .= '<div class="chapter-title-wrap"><h3 class="chapter-number">%3$s</h3><h2 class="chapter-title">%4$s</h2>%5$s</div>';
-		$chapter_printf .= '<div class="ugc chapter-ugc">%6$s</div>%7$s%8$s';
+		$chapter_printf = '<div class="chapter %1$s" id="%2$s" title="%3$s">';
+		$chapter_printf .= '<div class="chapter-title-wrap"><h3 class="chapter-number">%4$s</h3><h2 class="chapter-title">%5$s</h2>%6$s</div>';
+		$chapter_printf .= '<div class="ugc chapter-ugc">%7$s</div>%8$s%9$s';
 		$chapter_printf .= '</div>';
 
 		$i = 1;
@@ -1324,7 +1339,7 @@ class Xhtml11 extends Export {
 					}
 				}
 
-				if ( $short_title ) {
+				if ( $short_title && $this->outputShortTitle ) {
 					if ( $this->wrapHeaderElements ) {
 						$after_title = '<h6 class="short-title">' . Sanitize\decode( $short_title ) . '</h6>' . $after_title;
 					} else {
@@ -1345,6 +1360,7 @@ class Xhtml11 extends Export {
 					$chapter_printf,
 					$subclass,
 					$slug,
+					( $short_title ) ? $short_title : $chapter['post_title'],
 					$n,
 					Sanitize\decode( $title ),
 					$after_title,
@@ -1397,9 +1413,9 @@ class Xhtml11 extends Export {
 	 * @param array $metadata
 	 */
 	protected function echoBackMatter( $book_contents, $metadata ) {
-		$back_matter_printf = '<div class="back-matter %1$s" id="%2$s">';
-		$back_matter_printf .= '<div class="back-matter-title-wrap"><h3 class="back-matter-number">%3$s</h3><h1 class="back-matter-title">%4$s</h1>%5$s</div>';
-		$back_matter_printf .= '<div class="ugc back-matter-ugc">%6$s</div>%7$s%8$s';
+		$back_matter_printf = '<div class="back-matter %1$s" id="%2$s" title="%3$s">';
+		$back_matter_printf .= '<div class="back-matter-title-wrap"><h3 class="back-matter-number">%4$s</h3><h1 class="back-matter-title">%5$s</h1>%6$s</div>';
+		$back_matter_printf .= '<div class="ugc back-matter-ugc">%7$s</div>%8$s%9$s';
 		$back_matter_printf .= '</div>';
 
 		$i = 1;
@@ -1443,7 +1459,7 @@ class Xhtml11 extends Export {
 				}
 			}
 
-			if ( $short_title ) {
+			if ( $short_title && $this->outputShortTitle ) {
 				if ( $this->wrapHeaderElements ) {
 					$after_title = '<h6 class="short-title">' . Sanitize\decode( $short_title ) . '</h6>' . $after_title;
 				} else {
@@ -1457,6 +1473,7 @@ class Xhtml11 extends Export {
 				$back_matter_printf,
 				$subclass,
 				$slug,
+				( $short_title ) ? $short_title : $back_matter['post_title'],
 				$i,
 				Sanitize\decode( $title ),
 				$after_title,

--- a/tests/test-modules-export.php
+++ b/tests/test-modules-export.php
@@ -329,17 +329,16 @@ class Modules_ExportTest extends \WP_UnitTestCase {
 			}
 
 			$this->assertTrue( $exporter->convert(), "Could not convert with {$module}" );
+			$paths[] = $exporter->getOutputPath();
+			if ( strpos( $format, '\Xhtml\Xhtml11' ) !== false ) {
+				$xhtml_path = $exporter->getOutputPath();
+			}
 			if ( strpos( $format, '\HTMLBook\HTMLBook' ) !== false ) {
 				// TODO: HTMLBook is too strict we don't pass the validation
 			} elseif ( $runtime->isPHPDBG() && strpos( $format, '\Epub\Epub' ) !== false ) {
 				// TODO: exec(): Unable to fork [/usr/bin/epubcheck -q /path/to.epub 2>&1]
 			} else {
 				$this->assertTrue( $exporter->validate(), "Could not validate with {$format}" );
-			}
-			$paths[] = $exporter->getOutputPath();
-
-			if ( strpos( $format, '\Xhtml\Xhtml11' ) !== false ) {
-				$xhtml_path = $exporter->getOutputPath();
 			}
 
 			unset( $exporter );
@@ -369,9 +368,10 @@ class Modules_ExportTest extends \WP_UnitTestCase {
 		$user_id = $this->factory()->user->create( [ 'role' => 'contributor' ] );
 		wp_set_current_user( $user_id );
 
-		$exporter = new \Pressbooks\Modules\Export\Xhtml\Xhtml11( [] );
-		$this->assertTrue( $exporter->convert() );
-		$this->assertTrue( $exporter->validate() );
+		$module = '\Pressbooks\Modules\Export\Xhtml\Xhtml11';
+		$exporter = new $module( [] );
+		$this->assertTrue( $exporter->convert(), "Could not convert with {$module}" );
+		$this->assertTrue( $exporter->validate(), "Could not validate with {$module}" );
 		$xhtml_content = file_get_contents( $exporter->getOutputPath() );
 
 		$this->assertContains( '<span class="footnote">', $xhtml_content );
@@ -400,9 +400,10 @@ class Modules_ExportTest extends \WP_UnitTestCase {
 		$css_file = Container::get( 'Sass' )->pathToUserGeneratedCss() . "/prince-$timestamp.css";
 		\Pressbooks\Utility\put_contents( $css_file, $css );
 
-		$exporter = new \Pressbooks\Modules\Export\Xhtml\Xhtml11( [] );
-		$this->assertTrue( $exporter->convert() );
-		$this->assertTrue( $exporter->validate() );
+		$module = '\Pressbooks\Modules\Export\Xhtml\Xhtml11';
+		$exporter = new $module( [] );
+		$this->assertTrue( $exporter->convert(), "Could not convert with {$module}" );
+		$this->assertTrue( $exporter->validate(), "Could not validate with {$module}" );
 		$xhtml_content = file_get_contents( $exporter->getOutputPath() );
 		$url = network_home_url( sprintf( '/wp-content/uploads/sites/%d/pressbooks/css/prince-', get_current_blog_id() ) );
 		$this->assertContains( "<link rel='stylesheet' href='$url", $xhtml_content );

--- a/tests/utils-trait.php
+++ b/tests/utils-trait.php
@@ -136,7 +136,7 @@ There are many maths like it but these ones are mine.
 			'post_parent' => $post_parent,
 		];
 		$pid = $this->factory()->post->create_object( $new_post );
-		update_post_meta( $val['ID'], 'pb_export', 'on' );
+		update_post_meta( $pid, 'pb_export', 'on' );
 		update_post_meta( $pid, 'pb_subtitle', 'Or, A Chapter to Test' );
 
 		return $pid;

--- a/tests/utils-trait.php
+++ b/tests/utils-trait.php
@@ -24,7 +24,6 @@ trait utilsTrait {
 		foreach ( $book::getBookStructure() as $key => $section ) {
 			if ( $key === 'front-matter' || $key === 'back-matter' ) {
 				foreach ( $section as $val ) {
-					update_post_meta( $val['ID'], 'pb_export', 'on' );
 					wp_update_post( [ 'ID' => $val['ID'], 'post_status' => 'publish' ] );
 				}
 			}
@@ -40,7 +39,6 @@ trait utilsTrait {
 						$pid = false;
 					}
 					foreach ( $part['chapters'] as $val ) {
-						update_post_meta( $val['ID'], 'pb_export', 'on' );
 						wp_update_post( [ 'ID' => $val['ID'], 'post_status' => 'publish' ] );
 					}
 				}
@@ -136,7 +134,6 @@ There are many maths like it but these ones are mine.
 			'post_parent' => $post_parent,
 		];
 		$pid = $this->factory()->post->create_object( $new_post );
-		update_post_meta( $pid, 'pb_export', 'on' );
 		update_post_meta( $pid, 'pb_subtitle', 'Or, A Chapter to Test' );
 
 		return $pid;

--- a/tests/utils-trait.php
+++ b/tests/utils-trait.php
@@ -24,6 +24,7 @@ trait utilsTrait {
 		foreach ( $book::getBookStructure() as $key => $section ) {
 			if ( $key === 'front-matter' || $key === 'back-matter' ) {
 				foreach ( $section as $val ) {
+					update_post_meta( $val['ID'], 'pb_export', 'on' );
 					wp_update_post( [ 'ID' => $val['ID'], 'post_status' => 'publish' ] );
 				}
 			}
@@ -39,6 +40,7 @@ trait utilsTrait {
 						$pid = false;
 					}
 					foreach ( $part['chapters'] as $val ) {
+						update_post_meta( $val['ID'], 'pb_export', 'on' );
 						wp_update_post( [ 'ID' => $val['ID'], 'post_status' => 'publish' ] );
 					}
 				}
@@ -134,6 +136,7 @@ There are many maths like it but these ones are mine.
 			'post_parent' => $post_parent,
 		];
 		$pid = $this->factory()->post->create_object( $new_post );
+		update_post_meta( $val['ID'], 'pb_export', 'on' );
 		update_post_meta( $pid, 'pb_subtitle', 'Or, A Chapter to Test' );
 
 		return $pid;


### PR DESCRIPTION
This PR adds a `title` attribute to front matter, chapter and back matter `<div>` elements in XHTML exports. The `title` attribute is set to the front matter, chapter, or back matter's short title (if present) or the title, if the short title is not set. This allows the [CSS generated content](https://www.w3.org/TR/css-gcpm-3/#named-strings) `section-title` property to be consistently set from this attribute instead of trying to set it from one of two sources (the title element or a hidden short title element). When Buckram >= 1.2.0 (see corresponding PR), the hidden short title element will not be included as it will no longer be needed.