### PR TITLE
Remove Glossary Terms Header (fix #1434)

### DIFF
--- a/inc/shortcodes/glossary/class-glossary.php
+++ b/inc/shortcodes/glossary/class-glossary.php
@@ -165,7 +165,7 @@ class Glossary {
 			}
 		}
 		if ( ! empty( $glossary ) ) {
-			$output = sprintf( '<section data-type="glossary"><header><h2>%1$s</h2></header><dl data-type="glossary">%2$s</dl></section>', __( 'Glossary Terms', 'pressbooks' ), $glossary );
+			$output = sprintf( '<dl data-type="glossary">%1$s</dl>', $glossary );
 		}
 
 		return $output;

--- a/tests/test-shortcodes-glossary.php
+++ b/tests/test-shortcodes-glossary.php
@@ -80,10 +80,10 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 	public function test_glossaryTerms() {
 		// assures alphabetical listing and format
 		$dl = $this->gl->glossaryTerms();
-		$this->assertEquals( '<section data-type="glossary"><header><h2>Glossary Terms</h2></header><dl data-type="glossary"><dt data-type="glossterm"><dfn id="dfn-neural-network">Neural Network</dfn></dt><dd data-type="glossdef">A computer system modeled on the human brain and nervous system.</dd><dt data-type="glossterm"><dfn id="dfn-support-vector-machine">Support Vector Machine</dfn></dt><dd data-type="glossdef">An algorithm that uses a nonlinear mapping to transform the original training data into a higher dimension</dd></dl></section>', $dl );
+		$this->assertEquals( '<dl data-type="glossary"><dt data-type="glossterm"><dfn id="dfn-neural-network">Neural Network</dfn></dt><dd data-type="glossdef">A computer system modeled on the human brain and nervous system.</dd><dt data-type="glossterm"><dfn id="dfn-support-vector-machine">Support Vector Machine</dfn></dt><dd data-type="glossdef">An algorithm that uses a nonlinear mapping to transform the original training data into a higher dimension</dd></dl>', $dl );
 		// assures found by type
 		$dl = $this->gl->glossaryTerms( 'definitions' );
-		$this->assertEquals( '<section data-type="glossary"><header><h2>Glossary Terms</h2></header><dl data-type="glossary"><dt data-type="glossterm"><dfn id="dfn-support-vector-machine">Support Vector Machine</dfn></dt><dd data-type="glossdef">An algorithm that uses a nonlinear mapping to transform the original training data into a higher dimension</dd></dl></section>', $dl );
+		$this->assertEquals( '<dl data-type="glossary"><dt data-type="glossterm"><dfn id="dfn-support-vector-machine">Support Vector Machine</dfn></dt><dd data-type="glossdef">An algorithm that uses a nonlinear mapping to transform the original training data into a higher dimension</dd></dl>', $dl );
 		// assures empty (because this type is not found)
 		$dl = $this->gl->glossaryTerms( 'nothing-to-find' );
 		$this->assertEmpty( $dl );
@@ -152,7 +152,7 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 		// Yes, changed
 		$pid = $this->factory()->post->update_object( $pid, [ 'post_content' => ' &nbsp;    ' ] );
 		$post = get_post( $pid );
-		$this->assertContains( '<section data-type="glossary">', $this->gl->backMatterAutoDisplay( $post->post_content ) );
+		$this->assertContains( '<dl data-type="glossary">', $this->gl->backMatterAutoDisplay( $post->post_content ) );
 	}
 
 }


### PR DESCRIPTION
When used in a glossary back-matter, it doesn't make a whole lot of sense.