### PR TITLE
Ensure empty custom part/chapter labels saved still work (fix #1440)

### DIFF
--- a/inc/posttype/namespace.php
+++ b/inc/posttype/namespace.php
@@ -556,9 +556,10 @@ function get_post_type_label( $posttype ) {
 
 function filter_post_type_label( $label, $args ) {
 	if ( isset( $args['post_type'] ) && in_array( $args['post_type'], [ 'part', 'chapter' ], true ) ) {
-		$options = get_option( 'pressbooks_theme_options_global', GlobalOptions::getDefaults() );
+		$defaults = GlobalOptions::getDefaults();
+		$options = get_option( 'pressbooks_theme_options_global', $defaults );
 		$post_type = str_replace( '-', '_', $args['post_type'] );
-		return $options[ "{$post_type}_label" ];
+		return $options[ "{$post_type}_label" ] ?? $defaults[ "{$post_type}_label" ];
 	}
 	return $label;
 }

--- a/tests/test-posttype.php
+++ b/tests/test-posttype.php
@@ -194,5 +194,7 @@ class PostTypeTest extends \WP_UnitTestCase {
 		$this->assertEquals( filter_post_type_label( 'Chapter', [ 'post_type' => 'chapter' ] ), 'Chapter' );
 		update_option( 'pressbooks_theme_options_global', [ 'chapter_label' => 'Section' ] );
 		$this->assertEquals( filter_post_type_label( 'Chapter', [ 'post_type' => 'chapter' ] ), 'Section' );
+		update_option( 'pressbooks_theme_options_global', [ 'part_label' => 'Unit' ] );
+		$this->assertEquals( filter_post_type_label( 'Chapter', [ 'post_type' => 'chapter' ] ), 'Chapter' );
 	}
 }


### PR DESCRIPTION
This ensures that if saved theme options do not include custom part/chapter labels, the filter will still work as expected (falling back to defaults).