### PR TITLE
Fix bad config in sanitize_webbook_content

### DIFF
--- a/inc/sanitize/namespace.php
+++ b/inc/sanitize/namespace.php
@@ -698,7 +698,7 @@ function sanitize_webbook_content( $content ) {
 	$spec = '';
 	$spec .= 'table=-border;';
 
-	return \Pressbooks\HtmLawed::filter( $content, null, $spec );
+	return \Pressbooks\HtmLawed::filter( $content, [], $spec );
 }
 
 /**

--- a/tests/test-sanitize.php
+++ b/tests/test-sanitize.php
@@ -403,10 +403,11 @@ RAW;
 		</tr>
 	</tbody>
 </table>
+<p style="text-align: center">This should be centered.</p>
 RAW;
 		$result = \Pressbooks\Sanitize\sanitize_webbook_content( $content );
 		$this->assertContains( '<table>', $result );
-
+		$this->assertContains( '<p style="text-align: center">This should be centered.</p>', $result );
 	}
 
 	public function test_filter_export_content() {


### PR DESCRIPTION
#1422 introduced a regression which applied (bad) HTMLawed defaults to webbook HTML by passing a `null` config. This passes an empty array config instead.