### PR TITLE
Add filters for contact and help links

### DIFF
--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -23,15 +23,46 @@ use Pressbooks\Metadata;
  * Add a custom message in admin footer
  */
 function add_footer_link() {
-
 	printf(
-		'<p id="footer-left" class="alignleft"><span id="footer-thankyou">%s <a href="http://pressbooks.com">Pressbooks</a></span> &bull; <a href="http://pressbooks.com/about">%s</a> &bull; <a href="http://pressbooks.com/help">%s</a> &bull; <a href="%s">%s</a> &bull; <a href="http://pressbooks.com/contact">%s</a></p>',
-		__( 'Powered by', 'pressbooks' ),
-		__( 'About', 'pressbooks' ),
-		__( 'Help', 'pressbooks' ),
-		admin_url( 'options.php?page=pressbooks_diagnostics' ),
-		__( 'Diagnostics', 'pressbooks' ),
-		__( 'Contact', 'pressbooks' )
+		'<p id="footer-left" class="alignleft"><span id="footer-thankyou">%1$s</span> &bull; %2$s &bull; %3$s &bull; %4$s &bull; %5$s</p>',
+		sprintf(
+			__( 'Powered by %s', 'pressbooks' ),
+			sprintf(
+				'<a href="%1$s">%2$s</a>',
+				'https://pressbooks.com/',
+				'Pressbooks'
+			)
+		),
+		sprintf(
+			'<a href="%1$s">%2$s</a>',
+			'https://pressbooks.com/about/',
+			__( 'About', 'pressbooks' )
+		),
+		sprintf(
+			'<a href="%1$s">%2$s</a>',
+			/**
+			 * Filter the "Help" link.
+			 *
+			 * @since 5.7.0
+			 */
+			apply_filters( 'pb_help_link', 'https://pressbooks.com/help/' ),
+			__( 'Help', 'pressbooks' )
+		),
+		sprintf(
+			'<a href="%1$s">%2$s</a>',
+			admin_url( 'options.php?page=pressbooks_diagnostics' ),
+			__( 'Diagnostics', 'pressbooks' )
+		),
+		sprintf(
+			'<a href="%1$s">%2$s</a>',
+			/**
+			 * Filter the "Contact" link.
+			 *
+			 * @since 5.7.0
+			 */
+			apply_filters( 'pb_contact_link', 'https://pressbooks.com/contact/' ),
+			__( 'Contact', 'pressbooks' )
+		)
 	);
 }
 
@@ -508,7 +539,7 @@ function replace_menu_bar_branding( $wp_admin_bar ) {
 		[
 			'id' => 'wp-logo',
 			'title' => '<span class="ab-icon"></span>',
-			'href' => ( 'https://pressbooks.com/about' ),
+			'href' => ( 'https://pressbooks.com/about/' ),
 			'meta' => [
 				'title' => __( 'About Pressbooks', 'pressbooks' ),
 			],
@@ -522,7 +553,7 @@ function replace_menu_bar_branding( $wp_admin_bar ) {
 				'parent' => 'wp-logo',
 				'id' => 'about',
 				'title' => __( 'About Pressbooks', 'pressbooks' ),
-				'href' => 'https://pressbooks.com/about',
+				'href' => 'https://pressbooks.com/about/',
 			]
 		);
 	}
@@ -533,7 +564,7 @@ function replace_menu_bar_branding( $wp_admin_bar ) {
 			'parent' => 'wp-logo-external',
 			'id' => 'wporg',
 			'title' => __( 'Pressbooks.com', 'pressbooks' ),
-			'href' => 'https://pressbooks.com',
+			'href' => 'https://pressbooks.com/',
 		]
 	);
 
@@ -543,7 +574,12 @@ function replace_menu_bar_branding( $wp_admin_bar ) {
 			'parent' => 'wp-logo-external',
 			'id' => 'support-forums',
 			'title' => __( 'Help', 'pressbooks' ),
-			'href' => 'https://pressbooks.com/help',
+			/**
+			 * Filter the "Help" link.
+			 *
+			 * @since 5.7.0
+			 */
+			'href' => apply_filters( 'pb_help_link', 'https://pressbooks.com/help/' ),
 		]
 	);
 
@@ -553,7 +589,12 @@ function replace_menu_bar_branding( $wp_admin_bar ) {
 			'parent' => 'wp-logo-external',
 			'id' => 'contact',
 			'title' => __( 'Contact', 'pressbooks' ),
-			'href' => 'https://pressbooks.com/contact',
+			/**
+			 * Filter the "Contact" link.
+			 *
+			 * @since 5.7.0
+			 */
+			'href' => apply_filters( 'pb_contact_link', 'https://pressbooks.com/contact/' ),
 		]
 	);
 

--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -43,7 +43,7 @@ function add_footer_link() {
 			/**
 			 * Filter the "Help" link.
 			 *
-			 * @since 5.7.0
+			 * @since 5.6.0
 			 */
 			apply_filters( 'pb_help_link', 'https://pressbooks.com/help/' ),
 			__( 'Help', 'pressbooks' )
@@ -58,7 +58,7 @@ function add_footer_link() {
 			/**
 			 * Filter the "Contact" link.
 			 *
-			 * @since 5.7.0
+			 * @since 5.6.0
 			 */
 			apply_filters( 'pb_contact_link', 'https://pressbooks.com/contact/' ),
 			__( 'Contact', 'pressbooks' )
@@ -577,7 +577,7 @@ function replace_menu_bar_branding( $wp_admin_bar ) {
 			/**
 			 * Filter the "Help" link.
 			 *
-			 * @since 5.7.0
+			 * @since 5.6.0
 			 */
 			'href' => apply_filters( 'pb_help_link', 'https://pressbooks.com/help/' ),
 		]
@@ -592,7 +592,7 @@ function replace_menu_bar_branding( $wp_admin_bar ) {
 			/**
 			 * Filter the "Contact" link.
 			 *
-			 * @since 5.7.0
+			 * @since 5.6.0
 			 */
 			'href' => apply_filters( 'pb_contact_link', 'https://pressbooks.com/contact/' ),
 		]

--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -45,7 +45,7 @@ function add_footer_link() {
 			 *
 			 * @since 5.6.0
 			 */
-			apply_filters( 'pb_help_link', 'https://pressbooks.com/help/' ),
+			apply_filters( 'pb_help_link', 'https://pressbooks.community/' ),
 			__( 'Help', 'pressbooks' )
 		),
 		sprintf(
@@ -60,7 +60,7 @@ function add_footer_link() {
 			 *
 			 * @since 5.6.0
 			 */
-			apply_filters( 'pb_contact_link', 'https://pressbooks.com/contact/' ),
+			apply_filters( 'pb_contact_link', 'https://pressbooks.org/get-involved/' ),
 			__( 'Contact', 'pressbooks' )
 		)
 	);
@@ -579,7 +579,7 @@ function replace_menu_bar_branding( $wp_admin_bar ) {
 			 *
 			 * @since 5.6.0
 			 */
-			'href' => apply_filters( 'pb_help_link', 'https://pressbooks.com/help/' ),
+			'href' => apply_filters( 'pb_help_link', 'https://pressbooks.community/' ),
 		]
 	);
 
@@ -594,7 +594,7 @@ function replace_menu_bar_branding( $wp_admin_bar ) {
 			 *
 			 * @since 5.6.0
 			 */
-			'href' => apply_filters( 'pb_contact_link', 'https://pressbooks.com/contact/' ),
+			'href' => apply_filters( 'pb_contact_link', 'https://pressbooks.org/get-involved/' ),
 		]
 	);
 

--- a/tests/test-admin-laf.php
+++ b/tests/test-admin-laf.php
@@ -15,6 +15,21 @@ class Admin_LafTest extends \WP_UnitTestCase {
 
 		$this->assertContains( 'Powered by', $buffer );
 		$this->assertContains( 'Pressbooks', $buffer );
+
+		add_filter( 'pb_help_link', function() {
+			return 'https://pressbooks.community/';
+		} );
+
+		add_filter( 'pb_contact_link', function() {
+			return 'https://pressbooks.org/contact';
+		} );
+
+		ob_start();
+		\Pressbooks\Admin\Laf\add_footer_link();
+		$buffer = ob_get_clean();
+
+		$this->assertContains( 'https://pressbooks.community/', $buffer );
+		$this->assertContains( 'https://pressbooks.org/contact', $buffer );
 	}
 
 	function test_replace_book_admin_menu() {


### PR DESCRIPTION
Right now we hardcode https://pressbooks.com/contact and https://pressbooks.com/help into the admin bar and footer. This PR adds the `pb_contact_link` and `pb_help_link` filters to allow these links to be changed.