### PR TITLE
lower version numbers for rhel compatible cover generator dependencies

### DIFF
--- a/inc/covergenerator/class-covergenerator.php
+++ b/inc/covergenerator/class-covergenerator.php
@@ -75,10 +75,10 @@ class Covergenerator {
 	 */
 	function hasDependencies() {
 		$commands = [
-			PB_CONVERT_COMMAND . ' --version' => '6.8.9',
-			PB_GS_COMMAND . ' --version' => '9.18',
-			PB_PDFINFO_COMMAND . ' -v' => '0.41.0',
-			PB_PDFTOPPM_COMMAND . ' -v' => '0.41.0',
+			PB_CONVERT_COMMAND . ' --version' => '6.7',
+			PB_GS_COMMAND . ' --version' => '8.7',
+			PB_PDFINFO_COMMAND . ' -v' => '0.12.4',
+			PB_PDFTOPPM_COMMAND . ' -v' => '0.12.4',
 		];
 
 		$not_found = [];


### PR DESCRIPTION
As discussed in https://discourse.pressbooks.org/t/cover-generator-commands-versions/787 this brings server dependency versions to a level consistent with what is available to RHEL. 

Testing confirms no loss of functionality on 16.04.5 LTS (Xenial Xerus) and enables functionality on RHEL 6.10 (Santiago)