### PR TITLE
Show the wp_code button in Tinymce (fix pressbooks/ideas#127)

### DIFF
--- a/inc/editor/namespace.php
+++ b/inc/editor/namespace.php
@@ -69,7 +69,7 @@ function mce_buttons_3( $buttons ) {
 	// Prepend element to the beginning of array
 	array_unshift( $buttons, 'table' );
 	// Push elements onto the end of array
-	array_push( $buttons, 'apply_class', 'anchor', 'superscript', 'subscript' );
+	array_push( $buttons, 'apply_class', 'anchor', 'superscript', 'subscript', 'wp_code' );
 	// Footnotes
 	array_push( $buttons, 'footnote', 'ftnref_convert' );
 	// Glossary

--- a/tests/test-editor.php
+++ b/tests/test-editor.php
@@ -59,6 +59,7 @@ class EditorTest extends \WP_UnitTestCase {
 		$this->assertContains( 'ftnref_convert', $buttons );
 		$this->assertContains( 'glossary', $buttons );
 		$this->assertContains( 'glossary_all', $buttons );
+		$this->assertContains( 'wp_code', $buttons );
 	}
 
 	public function test_admin_enqueue_scripts() {


### PR DESCRIPTION
https://github.com/pressbooks/ideas/issues/127

![image](https://user-images.githubusercontent.com/812192/48734059-58e88500-ec12-11e8-9bbb-197620a625c2.png)
