### PR TITLE
Don't import deleted posts (WXR import)

### DIFF
--- a/inc/modules/import/wordpress/class-wxr.php
+++ b/inc/modules/import/wordpress/class-wxr.php
@@ -140,6 +140,11 @@ class Wxr extends Import {
 				continue;
 			}
 
+			// Skip deleted post types.
+			if ( $p['status'] === 'trash' ) {
+				continue;
+			}
+
 			// Skip webbook required pages.
 			if ( '<!-- Here be dragons.-->' === $p['post_content'] || '<!-- Here be dragons. -->' === $p['post_content'] ) {
 				continue;

--- a/tests/test-integrations.php
+++ b/tests/test-integrations.php
@@ -125,7 +125,7 @@ class IntegrationsTest extends \WP_UnitTestCase {
 		$this->assertTrue( $importer->import( $options ) );
 
 		$this->asserttrue( count( $_SESSION['pb_notices'] ) === 1 );
-		$this->assertContains( 'Imported 2 front matter, 2 parts, 6 chapters, 2 back matter, 2 media attachments, and 0 glossary terms.', $_SESSION['pb_notices'][0] );
+		$this->assertContains( 'Imported 1 front matter, 2 parts, 5 chapters, 1 back matter, 2 media attachments, and 0 glossary terms.', $_SESSION['pb_notices'][0] );
 		unset( $_SESSION['pb_notices'] );
 
 		$info = \Pressbooks\Book::getBookInformation();


### PR DESCRIPTION
Currently, a Pressbooks or WordPress WXR file with deleted posts in it will list them alongside published posts on the import selection screen. This can lead to the importing of unexpected content (e.g. an older version of a post which has been trashed), or, at best, the inability to distinguish between a deleted post and a published post with the same name. This PR ignores posts with status = `trash` when listing posts for import. An alternative approach could be to label these as `Post Name (Deleted)` but that seems like it could be a source of confusion.