### PR TITLE
Improve sanitization of glossary term content

### DIFF
--- a/inc/shortcodes/glossary/class-glossary.php
+++ b/inc/shortcodes/glossary/class-glossary.php
@@ -200,7 +200,7 @@ class Glossary {
 		$old_global_post = $post;
 		$post = $terms;
 
-		$html = '<a href="javascript:void(0);" class="tooltip" title="' . $terms->post_content . '">' . $content . '</a>';
+		$html = '<a href="javascript:void(0);" class="tooltip" title="' . wp_strip_all_tags( $terms->post_content ) . '">' . $content . '</a>';
 
 		// reset post data
 		wp_reset_postdata();

--- a/pressbooks.php
+++ b/pressbooks.php
@@ -3,7 +3,7 @@
 Plugin Name: Pressbooks
 Plugin URI: https://pressbooks.org
 Description: Simple Book Production
-Version: 5.6.0
+Version: 5.6.1
 Author: Pressbooks (Book Oven Inc.)
 Author URI: https://pressbooks.org
 Text Domain: pressbooks

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: ebooks, publishing, webbooks
 Requires at least: 4.9.8
 Tested up to: 4.9.8
 Requires PHP: 7.1
-Stable tag: 5.6.0
+Stable tag: 5.6.1
 License: GPL v3.0 or later
 License URI: https://github.com/pressbooks/pressbooks/blob/master/LICENSE.md
 
@@ -21,6 +21,16 @@ For installation instructions, visit [docs.pressbooks.org/installation](https://
 TK.
 
 == Changelog ==
+= 5.6.1 =
+
+* Pressbooks 5.6.1 requires PHP >= 7.1.
+* Pressbooks 5.6.1 requires [WordPress 4.9.8](https://wordpress.org/news/2018/08/wordpress-4-9-8-maintenance-release/).
+* Pressbooks 5.6.1 requires [McLuhan >= 2.6.0](https://github.com/pressbooks/pressbooks-book/).
+
+**Patches**
+
+* Improve sanitization of glossary term content: [#1480](https://github.com/pressbooks/pressbooks/pull/1480)
+
 = 5.6.0 =
 
 * Pressbooks 5.6.0 requires PHP >= 7.1.
@@ -77,8 +87,8 @@ TK.
 * Hide the "View" link when editing taxonomies (props [@colomet](https://github.com/colomet) for the suggestion): [#1351](https://github.com/pressbooks/pressbooks/issues/1351), [#1356](https://github.com/pressbooks/pressbooks/issues/1356), [#1360](https://github.com/pressbooks/pressbooks/issues/1360)
 
 == Upgrade Notice ==
-= 5.6.0 =
+= 5.6.1 =
 
-* Pressbooks 5.6.0 requires PHP >= 7.1.
-* Pressbooks 5.6.0 requires [WordPress 4.9.8](https://wordpress.org/news/2018/08/wordpress-4-9-8-maintenance-release/).
-* Pressbooks 5.6.0 requires [McLuhan >= 2.6.0](https://github.com/pressbooks/pressbooks-book/).
+* Pressbooks 5.6.1 requires PHP >= 7.1.
+* Pressbooks 5.6.1 requires [WordPress 4.9.8](https://wordpress.org/news/2018/08/wordpress-4-9-8-maintenance-release/).
+* Pressbooks 5.6.1 requires [McLuhan >= 2.6.0](https://github.com/pressbooks/pressbooks-book/).

--- a/tests/test-integrations.php
+++ b/tests/test-integrations.php
@@ -34,7 +34,7 @@ class IntegrationsTest extends \WP_UnitTestCase {
 		$meta = $cloner->getSourceBookMetadata();
 		$this->assertInternalType( 'array', $meta );
 		$this->assertNotEmpty( $meta );
-		$this->assertEquals( 'Public Domain (No Rights Reserved)', $meta['license']['name'] );
+		$this->assertEquals( 'Public Domain', $meta['license']['name'] );
 
 		$cloned_items = $cloner->getClonedItems();
 

--- a/tests/test-shortcodes-glossary.php
+++ b/tests/test-shortcodes-glossary.php
@@ -57,7 +57,7 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 		$args = [
 			'post_type'    => 'glossary',
 			'post_title'   => 'PHP',
-			'post_content' => 'A popular general-purpose <script>scripting</script> language that is especially suited to web development.',
+			'post_content' => 'A popular general-purpose <script>scripting</script> language that is <em>especially</em> suited to web development.',
 			'post_status'  => 'publish',
 		];
 		$pid  = $this->factory()->post->create_object( $args );


### PR DESCRIPTION
This PR is for backwards compatibility with CM Tooltip Glossary; it ensures that glosses with rich text will not cause problems with tooltips by applying `wp_strip_all_tags()` during tooltip output.