### PR TITLE
Handle locked themes in Styles::updateWebBookStylesheet() (fix #1487)

### DIFF
--- a/inc/class-styles.php
+++ b/inc/class-styles.php
@@ -548,9 +548,9 @@ class Styles {
 		// Populate $url-base variable so that links to images and other assets remain intact
 		$overrides = [ '$url-base: "' . $theme->get_stylesheet_directory_uri() . '";' ];
 		if ( $this->isCurrentThemeCompatible( 1 ) ) {
-			$scss = \Pressbooks\Utility\get_contents( realpath( $theme->get_stylesheet_directory() . '/style.scss' ) );
+			$scss = \Pressbooks\Utility\get_contents( realpath( $this->getDir( $theme ) . '/style.scss' ) );
 		} elseif ( $this->isCurrentThemeCompatible( 2 ) || CustomCss::isCustomCss() ) {
-			$scss = \Pressbooks\Utility\get_contents( realpath( $theme->get_stylesheet_directory() . '/assets/styles/web/style.scss' ) );
+			$scss = \Pressbooks\Utility\get_contents( realpath( $this->getDir( $theme ) . '/assets/styles/web/style.scss' ) );
 		} else {
 			return;
 		}


### PR DESCRIPTION
Resolves #1487 by using `Styles::getDir()` in `Styles::updateWebBookStylesheet()` so that the locked assets directory will be returned when the theme is locked.