### PR TITLE
Fix footnotes and media conflict (fix #1472)

### DIFF
--- a/inc/shortcodes/complex/class-complex.php
+++ b/inc/shortcodes/complex/class-complex.php
@@ -224,7 +224,7 @@ class Complex {
 		if ( ! filter_var( $src, FILTER_VALIDATE_URL ) ) {
 			return '';
 		}
-		// Can't use `do_shortcode_by_tags because` because the default callback for 'embed' is `__return_false` - @see \WP_Embed::__construct
+		// Can't use `do_shortcode_by_tags` because the default callback for 'embed' is `__return_false` - @see \WP_Embed::__construct
 		$e = $wp_embed->run_shortcode( sprintf( '[embed src="%s"]', $src ) );
 		if ( $atts['caption'] ) {
 			return sprintf(

--- a/inc/shortcodes/complex/class-complex.php
+++ b/inc/shortcodes/complex/class-complex.php
@@ -6,6 +6,8 @@
 
 namespace Pressbooks\Shortcodes\Complex;
 
+use function \Pressbooks\Utility\do_shortcode_by_tags;
+
 class Complex {
 
 	/**
@@ -49,10 +51,12 @@ class Complex {
 	 * @param array $atts Shortcode attributes.
 	 * @param string $content Shortcode content.
 	 * @param string $shortcode Shortcode name.
+	 *
+	 * @return string
 	 */
-	public function anchorShortCodeHandler( $atts, $content = '', $shortcode ) {
+	public function anchorShortCodeHandler( $atts, $content, $shortcode ) {
 		if ( ! isset( $atts['id'] ) ) {
-			return;
+			return '';
 		}
 
 		$atts = shortcode_atts(
@@ -78,10 +82,12 @@ class Complex {
 	 * @param array $atts Shortcode attributes.
 	 * @param string $content Shortcode content.
 	 * @param string $shortcode Shortcode name.
+	 *
+	 * @return string
 	 */
-	public function columnsShortCodeHandler( $atts, $content = '', $shortcode ) {
+	public function columnsShortCodeHandler( $atts, $content, $shortcode ) {
 		if ( ! $content ) {
-			return;
+			return '';
 		}
 
 		$atts = shortcode_atts(
@@ -119,8 +125,10 @@ class Complex {
 	 * @param array $atts Shortcode attributes.
 	 * @param string $content Shortcode content.
 	 * @param string $shortcode Shortcode name.
+	 *
+	 * @return string
 	 */
-	public function emailShortCodeHandler( $atts, $content = '', $shortcode ) {
+	public function emailShortCodeHandler( $atts, $content, $shortcode ) {
 		$atts = shortcode_atts(
 			[
 				'class' => null,
@@ -133,7 +141,7 @@ class Complex {
 		$address = $atts['address'] ?? $content;
 
 		if ( ! is_email( $address ) ) {
-			return;
+			return '';
 		}
 
 		if ( $address === $content ) {
@@ -158,10 +166,12 @@ class Complex {
 	 * @param array $atts Shortcode attributes.
 	 * @param string $content Shortcode content.
 	 * @param string $shortcode Shortcode name.
+	 *
+	 * @return string
 	 */
-	public function equationShortCodeHandler( $atts, $content = '', $shortcode ) {
+	public function equationShortCodeHandler( $atts, $content, $shortcode ) {
 		if ( ! $content ) {
-			return;
+			return '';
 		}
 		$atts = shortcode_atts(
 			[
@@ -170,10 +180,10 @@ class Complex {
 				'background' => false,
 			], $atts
 		);
-		return apply_filters(
-			'the_export_content',
+
+		return do_shortcode_by_tags(
 			sprintf(
-				'[latex%1$s]%2$s[/latex]',
+				'<p>[latex%1$s]%2$s[/latex]' . "</p>\n",
 				( $atts['size'] !== 0 )
 				? sprintf(
 					' size="%1$s" color="%2$s" background="%3$s"',
@@ -187,7 +197,8 @@ class Complex {
 					$atts['background']
 				),
 				$content
-			)
+			),
+			[ 'latex' ]
 		);
 	}
 
@@ -197,8 +208,11 @@ class Complex {
 	 * @param array $atts Shortcode attributes.
 	 * @param string $content Shortcode content.
 	 * @param string $shortcode Shortcode name.
+	 *
+	 * @return string
 	 */
-	public function mediaShortCodeHandler( $atts, $content = '', $shortcode ) {
+	public function mediaShortCodeHandler( $atts, $content, $shortcode ) {
+		global $wp_embed;
 		$atts = shortcode_atts(
 			[
 				'caption' => null,
@@ -208,15 +222,18 @@ class Complex {
 		$src = $atts['src'] ?? $content;
 		$src = esc_url_raw( $src );
 		if ( ! filter_var( $src, FILTER_VALIDATE_URL ) ) {
-			return;
+			return '';
 		}
+		// Can't use `do_shortcode_by_tags because` because the default callback for 'embed' is `__return_false` - @see \WP_Embed::__construct
+		$e = $wp_embed->run_shortcode( sprintf( '[embed src="%s"]', $src ) );
 		if ( $atts['caption'] ) {
 			return sprintf(
 				'<figure class="embed">%1$s<figcaption>%2$s</figcaption></figure>',
-				str_replace( [ '<p>', '</p>' ], '', apply_filters( 'the_export_content', sprintf( '[embed src="%s"]', $src ) ) ),
+				str_replace( [ '<p>', '</p>' ], '', $e ),
 				$atts['caption']
 			);
+		} else {
+			return $e;
 		}
-		return apply_filters( 'the_export_content', sprintf( '[embed src="%s"]', $src ) );
 	}
 }

--- a/inc/utility/namespace.php
+++ b/inc/utility/namespace.php
@@ -1506,3 +1506,25 @@ function shortcode_att_replace( $content, $tag, $att, $from, $to ) {
 	return $fixed_content;
 }
 
+/**
+ * This works by filtering the global $shortcode_tags, running do_shortcode(), then putting everything back as it was before.
+ *
+ * @since 5.6.3
+ *
+ * @param string $content
+ * @param array $tags
+ *
+ * @return string
+ */
+function do_shortcode_by_tags( $content, array $tags ) {
+	global $shortcode_tags;
+	$_tags = $shortcode_tags;
+	foreach ( $_tags as $tag => $callback ) {
+		if ( ! in_array( $tag, $tags, true ) ) {
+			unset( $shortcode_tags[ $tag ] );
+		}
+	}
+	$shortcoded = do_shortcode( $content );
+	$shortcode_tags = $_tags;
+	return $shortcoded;
+}

--- a/tests/test-utility.php
+++ b/tests/test-utility.php
@@ -585,4 +585,17 @@ class UtilityTest extends \WP_UnitTestCase {
 		$this->assertEquals( '[pb_glossary hello=world id=&quot;999&quot; foo="111"]Skatboards[/pb_glossary][pb_glossary broken=\'pebkac\']Yes[/pb_glossary]', $x );
 	}
 
+	public function test_do_shortcode_by_tags() {
+		$content = '[latex]e^{\i \pi} + 1 = 0[/latex][embed]https://image.png[/embed]';
+
+		$expected = "<img src='http://s0.wp.com/latex.php?latex=e%5E%7B%5Ci+%5Cpi%7D+%2B+1+%3D+0&#038;bg=ffffff&#038;fg=000000&#038;s=0&#038;zoom=1' alt='e^{\i \pi} + 1 = 0' title='e^{\i \pi} + 1 = 0' class='latex' />[embed]https://image.png[/embed]";
+		$this->assertEquals( $expected, \Pressbooks\Utility\do_shortcode_by_tags( $content, [ 'latex' ] ) );
+
+		$expected = "[latex]e^{\i \pi} + 1 = 0[/latex]";
+		$this->assertEquals( $expected, \Pressbooks\Utility\do_shortcode_by_tags( $content, [ 'embed' ] ) );
+
+		$expected = "<img src='http://s0.wp.com/latex.php?latex=e%5E%7B%5Ci+%5Cpi%7D+%2B+1+%3D+0&#038;bg=ffffff&#038;fg=000000&#038;s=0&#038;zoom=1' alt='e^{\i \pi} + 1 = 0' title='e^{\i \pi} + 1 = 0' class='latex' />";
+		$this->assertEquals( $expected, \Pressbooks\Utility\do_shortcode_by_tags( $content, [ 'latex', 'embed' ] ) );
+	}
+
 }


### PR DESCRIPTION
It’s tricky but have to remember not to use use `the_export_content` more than once per post (or `the_content`, for that matter)

The bug was: When running `the_export_content` on a shortcode snippet, the footnote process was running more than once.