### PR TITLE
Fancy quoted URL (Fix #1493)

### DIFF
--- a/inc/shortcodes/complex/class-complex.php
+++ b/inc/shortcodes/complex/class-complex.php
@@ -7,6 +7,7 @@
 namespace Pressbooks\Shortcodes\Complex;
 
 use function \Pressbooks\Utility\do_shortcode_by_tags;
+use function \Pressbooks\Utility\str_starts_with;
 
 class Complex {
 
@@ -220,6 +221,9 @@ class Complex {
 			], $atts
 		);
 		$src = $atts['src'] ?? $content;
+		if ( str_starts_with( $src, '“' ) || str_starts_with( $src, '”' ) || str_starts_with( $src, '‘' ) || str_starts_with( $src, '’' ) ) {
+			$src = trim( $src, '“”‘’' ); // Trim fancy quotes, for MS-Word compatibility
+		}
 		$src = esc_url_raw( $src );
 		if ( ! filter_var( $src, FILTER_VALIDATE_URL ) ) {
 			return '';


### PR DESCRIPTION
The media shortcode in the test document is:

`[media src=”https://www.youtube.com/watch?v=Lqqsp8soXTo” /]`

The first thing that catches my eye is that the quote being used `”` (aka fancy quote) is not the same as `"` 

Same thing with `’` vs `'`

When editing this test file in LibreOffice, fancy quotes seem to be on lock down. It is difficult for me to get the correct quotes in there. I can sympathize with this pain point.

## Workaround:

However, If I remove the quotes it works:

`[media src=https://www.youtube.com/watch?v=Lqqsp8soXTo /]`

## Fix:

In PHP The URL is comming in as: `”https://www.youtube.com/watch?v=Lqqsp8soXTo”`

If I trim fancy quotes before validating the URL, the shortcode works.
