### PR TITLE
Delete hidden _GoBack bookmarks (fix #1493, #1473)

### DIFF
--- a/inc/modules/import/ooxml/class-docx.php
+++ b/inc/modules/import/ooxml/class-docx.php
@@ -522,18 +522,25 @@ class Docx extends Import {
 	protected function addHyperlinks( \DOMDocument $chapter ) {
 		$ln = $chapter->getElementsByTagName( 'a' );
 
-		if ( $ln->length > 0 ) {
-			foreach ( $ln as $link ) {
-				/** @var \DOMElement $link */
-				if ( $link->hasAttribute( 'class' ) ) {
-					$ln_id = $link->getAttribute( 'class' );
-
-					if ( array_key_exists( $ln_id, $this->ln ) ) {
-						$link->setAttribute( 'href', $this->ln[ $ln_id ] );
-					}
+		for ( $i = $ln->length; --$i >= 0; ) {  // If you're deleting elements from within a loop, you need to loop backwards
+			$link = $ln->item( $i );
+			if (
+				$link->hasAttribute( 'name' ) &&
+				in_array( $link->getAttribute( 'name' ), [ '_GoBack' ], true )
+			) {
+				// Delete hidden Shift+F5 editing bookmark
+				$link->parentNode->removeChild( $link );
+				continue;
+			}
+			if ( $link->hasAttribute( 'class' ) ) {
+				$ln_id = $link->getAttribute( 'class' );
+				if ( array_key_exists( $ln_id, $this->ln ) ) {
+					// Add external hyperlink
+					$link->setAttribute( 'href', $this->ln[ $ln_id ] );
 				}
 			}
 		}
+
 		return $chapter;
 	}
 


### PR DESCRIPTION
> The _Goback bookmark enables the go to previous edit functionality (Shift+F5) across sessions. It is a hidden bookmark (and should be displayed if you check the box) and you should expect it to be present in documents produced by Word. In the case where you are manipulating documents outside Word it is very questionable whether it has any validity after you have finished so it isn't likely to matter if you delete it.

[Source](https://social.msdn.microsoft.com/Forums/en-US/0e0c5c33-dc4b-4e0f-b795-7868e6a63836/goback-hidden-bookmark-in-open-xml-while-processing-office-2010-word-document?forum=oxmlsdk) 