### PR TITLE
Fix theme filters

### DIFF
--- a/inc/class-pressbooks.php
+++ b/inc/class-pressbooks.php
@@ -66,9 +66,8 @@ class Pressbooks {
 	 * @return array
 	 */
 	function allowedBookThemes( $themes ) {
-
 		$compare = search_theme_directories();
-
+		$themes = array_intersect_key( $themes, $compare );
 		foreach ( $compare as $key => $val ) {
 			$stylesheet = str_replace( 'style.css', '', $val['theme_file'] );
 			$theme = wp_get_theme( $stylesheet, $val['theme_root'] );
@@ -91,7 +90,7 @@ class Pressbooks {
 	 */
 	function allowedRootThemes( $themes ) {
 		$compare = search_theme_directories();
-
+		$themes = array_intersect_key( $themes, $compare );
 		foreach ( $compare as $key => $val ) {
 			$stylesheet = str_replace( 'style.css', '', $val['theme_file'] );
 			$theme = wp_get_theme( $stylesheet, $val['theme_root'] );

--- a/tests/test-pressbooks.php
+++ b/tests/test-pressbooks.php
@@ -18,12 +18,19 @@ class PressbooksTest extends \WP_UnitTestCase {
 	}
 
 	public function test_allowedBookThemes() {
-		$result = $this->pb->allowedBookThemes( [ 'pressbooks-mcluhan' ] );
+		$result = $this->pb->allowedBookThemes( [ 'pressbooks-book' => true, 'pressbooks-clarke' => true, 'pressbooks-fake' => true, 'twentyseventeen' => true ] );
 		$this->assertTrue( is_array( $result ) );
+		$this->assertCount( 2, $result );
+		$this->assertArrayHasKey( 'pressbooks-book', $result );
+		$this->assertArrayHasKey( 'pressbooks-clarke', $result );
 	}
 
 	public function test_allowedRootThemes() {
-		$result = $this->pb->allowedRootThemes( [ 'pressbooks-librarian' ] );
+		$result = $this->pb->allowedRootThemes( [ 'pressbooks-book' => true, 'pressbooks-clarke' => true, 'pressbooks-fake' => true, 'twentyseventeen' => true ] );
 		$this->assertTrue( is_array( $result ) );
+		$this->assertCount( 1, $result );
+		$this->assertArrayHasKey( 'twentyseventeen', $result );
+		// TODO: Travis CI doesn't download (git clone) the root theme so we can't test it yet
+		// @see: https://github.com/pressbooks/pressbooks/blob/dev/bin/install-wp-tests.sh
 	}
 }


### PR DESCRIPTION
`get_site_option( 'allowedthemes' )` can contain themes that have been removed. Our filters were letting these pass through when they should not.