### PR TITLE
Copy hm-autoloader.php to mu-plugins if absent

### DIFF
--- a/compatibility.php
+++ b/compatibility.php
@@ -131,9 +131,32 @@ function pb_register_activation_hook() {
 function pb_init_autoloader() {
 	static $registered = false;
 	if ( ! $registered ) {
+		_pb_copy_autoloader();
 		require_once( __DIR__ . '/requires.php' );
 		\HM\Autoloader\register_class_path( 'Pressbooks', __DIR__ . '/inc' );
 		$registered = true;
+	}
+}
+
+/**
+ * Copy Pressbooks’ autoloader file
+ */
+function _pb_copy_autoloader() {
+	$mu_plugin_dir = defined( 'WPMU_PLUGIN_DIR' ) ? WPMU_PLUGIN_DIR : trailingslashit( WP_CONTENT_DIR ) . 'mu-plugins';
+	if ( ! file_exists( $mu_plugin_dir ) ) {
+		if ( ! wp_mkdir_p( $mu_plugin_dir ) ) {
+			die( sprintf( __( 'Pressbooks could not create the mu-plugins folder. Please create the following directory: %s', 'pressbooks' ), $mu_plugin_dir ) );
+		}
+	}
+	$dest = $mu_plugin_dir . '/hm-autoloader.php';
+	if ( ! file_exists( $dest ) ) {
+		$source = __DIR__ . '/hm-autoloader.php';
+		if ( ! @copy( $source, $dest ) ) { // @codingStandardsIgnoreLine
+			die( sprintf( __( 'Pressbooks could not copy the autoloader from %1$s to %2$s. Please copy the file manually.', 'pressbooks' ), $source, $dest ) );
+		}
+		if ( ! function_exists( '\HM\Autoloader\register_class_path' ) ) {
+			require_once( $dest );
+		}
 	}
 }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,14 +5,9 @@ if ( ! $_tests_dir ) {
 	$_tests_dir = '/tmp/wordpress-tests-lib';
 }
 
-if ( ! function_exists( '\HM\Autoloader\register_class_path' ) ) {
-	require_once( __DIR__ . '/../hm-autoloader.php' );
-}
-
 require_once $_tests_dir . '/includes/functions.php';
 
 function _manually_load_plugin() {
-	require_once( __DIR__ . '/../hm-autoloader.php' );
 	require_once( __DIR__ . '/../pressbooks.php' );
 }
 


### PR DESCRIPTION
This change will break other Pressbooks plugins that load hm-autoloader.php in a phpunit bootstrap.php file

> Fatal error: Cannot declare class HM\Autoloader\Autoloader, because the name is already in use in /tmp/wordpress/wp-content/mu-plugins/hm-autoloader.php on line 5
> PHP Fatal error:  Cannot declare class HM\Autoloader\Autoloader, because the name is already in use in /tmp/wordpress/wp-content/mu-plugins/hm-autoloader.php on line 5


The reason is 1) the bootstrap file loads `/pressbooks/hm-autoloader.php` before 2) mu-plugins are loaded. Because the same code is loaded twice, from two different files, the second time it loads PHP dies.

The fix is to remove `hm-autoloader.php` from the bootstrap.php file

![culprits](https://user-images.githubusercontent.com/812192/49894479-061e7980-fe1c-11e8-945b-d4457de1ab5c.png)
