### PR TITLE
regex and case insensitive for epubcheck version

### DIFF
--- a/inc/utility/namespace.php
+++ b/inc/utility/namespace.php
@@ -298,9 +298,9 @@ function check_epubcheck_install() {
 	exec( PB_EPUBCHECK_COMMAND . ' -h 2>&1', $output, $return_val );
 
 	$output = $output[0];
-	if ( false !== strpos( $output, 'EpubCheck' ) ) { // Command found.
-		$output = explode( 'EpubCheck v', $output );
-		$version = $output[1];
+	if ( false !== stripos( $output, 'EPUBCheck' ) ) { // Command found.
+		preg_match( '/(?:EPUBCheck\sv)*(([0-9]+.?)+)/i', $output, $matches );
+		$version = $matches[1];
 		if ( version_compare( $version, '4.0.0' ) >= 0 ) {
 			return true;
 		}


### PR DESCRIPTION
EpubCheck has changed their brand name from `EpubCheck` to `EPUBCheck`. 
ref: https://github.com/w3c/epubcheck/commit/dfd7fd272068cbca4c0c3929742e514c7de8affb

Case sensitive checking for dependencies fails with an update to EPUB v4.1.0. This PR moves to case insensitive `stripos` and `preg_match` for forward and backward compatibility.

https://github.com/w3c/epubcheck/releases/tag/v4.1.0


