### PR TITLE
Add site icon to logged in (dashboard) pages

### DIFF
--- a/hooks-admin.php
+++ b/hooks-admin.php
@@ -40,6 +40,7 @@ add_action( 'admin_bar_menu', '\Pressbooks\Admin\Laf\replace_menu_bar_branding',
 add_action( 'admin_bar_menu', '\Pressbooks\Admin\Laf\replace_menu_bar_my_sites', 21 );
 add_action( 'admin_bar_menu', '\Pressbooks\Admin\Laf\remove_menu_bar_update', 41 );
 add_action( 'admin_bar_menu', '\Pressbooks\Admin\Laf\remove_menu_bar_new_content', 71 );
+add_action( 'admin_head', '\Pressbooks\Admin\Branding\favicon' );
 
 // Add contact Info
 add_filter( 'admin_footer_text', '\Pressbooks\Admin\Laf\add_footer_link' );

--- a/hooks.php
+++ b/hooks.php
@@ -69,6 +69,7 @@ if ( $is_book ) {
 // -------------------------------------------------------------------------------------------------------------------
 
 add_filter( 'login_body_class', '\Pressbooks\Admin\Branding\login_body_class' );
+add_action( 'login_head', '\Pressbooks\Admin\Branding\favicon' );
 add_action( 'login_head', '\Pressbooks\Admin\Branding\custom_color_scheme' );
 add_action( 'login_head', '\Pressbooks\Admin\Branding\custom_login_logo' );
 add_filter( 'login_headerurl', '\Pressbooks\Admin\Branding\login_url' );

--- a/inc/admin/branding/namespace.php
+++ b/inc/admin/branding/namespace.php
@@ -184,3 +184,16 @@ function login_scripts() {
 		]
 	);
 }
+
+/**
+ * Favicon
+ */
+function favicon() {
+	// Specify 'pressbooks-book' because when in network or main site, WordPress uses Aldine.
+	$href = get_theme_root_uri( 'pressbooks-book' ) . '/pressbooks-book';
+	?>
+	<link rel="icon" type="image/png" sizes="32x32" href="<?php echo $href; ?>/dist/images/favicon-32x32.png">
+	<link rel="icon" type="image/png" sizes="16x16" href="<?php echo $href; ?>/dist/images/favicon-16x16.png">
+	<link rel="shortcut icon" href="<?php echo $href; ?>/dist/images/favicon.ico">
+	<?php
+}

--- a/templates/pb-catalog.php
+++ b/templates/pb-catalog.php
@@ -155,7 +155,7 @@ $_current_user_id = $catalog->getUserId();
 <!--[if (gt IE 9)|!(IE)]><!--><html <?php language_attributes(); ?> class="no-js"> <!--<![endif]-->
 <head>
 	<meta http-equiv="Content-Type" content="<?php bloginfo( 'html_type' ); ?>; charset=<?php bloginfo( 'charset' ); ?>" />
-	<link rel="shortcut icon" href="<?php bloginfo( 'stylesheet_directory' ); ?>/favicon.ico" />
+	<?php \Pressbooks\Admin\Branding\favicon(); ?>
 	<title><?php echo ucfirst( get_userdata( $pb_user_id )->user_login );
 	_e( '\'s Catalog Page', 'pressbooks' ); ?> | Pressbooks</title>
  	<?php // @codingStandardsIgnoreStart ?>

--- a/tests/test-admin-branding.php
+++ b/tests/test-admin-branding.php
@@ -41,4 +41,11 @@ class Admin_BrandingTest extends \WP_UnitTestCase {
 		$result = \Pressbooks\Admin\Branding\get_customizer_colors();
 		$this->assertEquals( $result, '<style type="text/css">:root{--primary:#663399;}</style>' );
 	}
+
+	public function test_favicon() {
+		ob_start();
+		\Pressbooks\Admin\Branding\favicon();
+		$buffer = ob_get_clean();
+		$this->assertContains( '<link rel="shortcut icon"', $buffer );
+	}
 }


### PR DESCRIPTION
Specify 'pressbooks-book' because when in network or main site, WordPress uses Aldine.