### PR TITLE
Chapter license tweaks (fix #1508)

### DIFF
--- a/inc/class-licensing.php
+++ b/inc/class-licensing.php
@@ -186,7 +186,7 @@ class Licensing {
 	 *
 	 * @param array $metadata \Pressbooks\Book::getBookInformation
 	 * @param int $post_id (optional)
-	 * @param string $title (@deprectaed)
+	 * @param string $title (@deprecated)
 	 *
 	 * @return string
 	 */
@@ -200,7 +200,6 @@ class Licensing {
 			// if no post $id given, set empty strings
 			$section_license = '';
 			$section_author = '';
-			$link = get_bloginfo( 'url' );
 		} else {
 			$section_license = get_post_meta( $post_id, 'pb_section_license', true );
 			$section_author = ( new Contributors() )->get( $post_id, 'pb_authors' );
@@ -223,12 +222,15 @@ class Licensing {
 		}
 
 		// Unless section is licensed differently, it should display the book license statement
-		if ( $section_license === $book_license ) {
+		if ( $section_license === $book_license || empty( $section_license ) ) {
 			$title = get_bloginfo( 'name' );
+			$link = get_bloginfo( 'url' );
 		} else {
 			$post = get_post( $post_id );
 			$title = $post ? $post->post_title : get_bloginfo( 'name' );
+			$link = get_permalink( $post_id );
 		}
+
 
 		// Copyright holder, set in order of precedence
 		if ( ! empty( $section_author ) ) {

--- a/inc/class-licensing.php
+++ b/inc/class-licensing.php
@@ -230,7 +230,6 @@ class Licensing {
 			$link = get_permalink( $post_id );
 		}
 
-
 		// Copyright holder, set in order of precedence
 		if ( ! empty( $section_author ) ) {
 			// section author higher priority than book author, copyrightholder

--- a/inc/class-licensing.php
+++ b/inc/class-licensing.php
@@ -203,7 +203,6 @@ class Licensing {
 		} else {
 			$section_license = get_post_meta( $post_id, 'pb_section_license', true );
 			$section_author = ( new Contributors() )->get( $post_id, 'pb_authors' );
-			$link = get_permalink( $post_id );
 		}
 
 		// Copyright license, set in order of precedence

--- a/tests/test-licensing.php
+++ b/tests/test-licensing.php
@@ -73,6 +73,12 @@ class LicensingTest extends \WP_UnitTestCase {
 		$this->assertContains( 'Test Blog', $result ); // Chapter and book license are the same, expected book name
 		$this->assertNotContains( 'Test Chapter', $result );
 
+		// Empty chapter license
+		$result = $this->licensing->doLicense( [ 'pb_book_license' => 'cc-by' ], $post_id );
+		$this->assertContains( 'https://creativecommons.org/licenses/by/', $result );
+		$this->assertContains( 'Test Blog', $result ); // Chapter license is empty, expected book name
+		$this->assertNotContains( 'Test Chapter', $result );
+
 		// Same licenses
 		update_post_meta( $post_id, 'pb_section_license', 'cc-by' );
 		$result = $this->licensing->doLicense( [ 'pb_book_license' => 'cc-by' ], $post_id );


### PR DESCRIPTION
The previous PR missed a case where if a chapter had an empty (unset) license, it would still show the chapter's title and link to the chapter in the license statement. As per #1508, the expected behaviour here would be to show the book's title and link to the book in the license statement.