### PR TITLE
Add support for decoupled language pack updates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
 		"vanilla/htmlawed": "^2.2",
 		"yahnis-elsts/plugin-update-checker": "^4.4",
 		"docraptor/docraptor": "1.3",
-		"fale/isbn": "^3.0"
+		"fale/isbn": "^3.0",
+		"afragen/translations-updater": "dev-master"
 	},
 	"require-dev": {
 		"mybuilder/phpunit-accelerator": "^2.0",

--- a/inc/class-updates.php
+++ b/inc/class-updates.php
@@ -44,6 +44,7 @@ class Updates {
 			add_action( 'core_upgrade_preamble', [ $obj, 'coreUpgradePreamble' ] );
 		}
 		add_filter( 'extra_plugin_headers', [ $obj, 'extraPluginHeaders' ] );
+		add_action( 'admin_init', [ $obj, 'translationsUpdater' ] );
 	}
 
 	/**
@@ -210,4 +211,22 @@ class Updates {
 		return $matches;
 	}
 
+	/**
+	 * Get Pressbooks translations from separate repository.
+	 * Hooked into action `admin_init`.
+	 *
+	 * @see https://github.com/afragen/translations-updater
+	 *
+	 * @return void
+	 */
+	public function translationsUpdater() {
+		$config = [
+			'git'       => 'github',
+			'type'      => 'plugin',
+			'slug'      => 'pressbooks',
+			'version'   => PB_PLUGIN_VERSION,
+			'languages' => 'https://my-path-to/language-packs',
+		];
+		( new \Fragen\Translations_Updater\Init() )->run( $config );
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/pressbooks/pressbooks/issues/590

Still need to create a public repository to contain translations. Also need to update the $config array to use that URL.

What I do for the translations repository is use it for people to make PRs only to MO/PO files. After committing the PRs I pull the updates locally where I run the Language Pack Maker. This creates updated language pack zip files and the `language-pack.json` that is read by the `translations-updater` library.

It may take a little hand holding from me the first time, but after that it's pretty simple. Then you can remove the MO/PO files from the main plugin.