### PR TITLE
Use Luther for legacy theme testing

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -85,19 +85,19 @@ install_pressbooks_clarke() {
 	git clone --depth=1 https://github.com/pressbooks/pressbooks-clarke.git $WP_CORE_DIR/wp-content/themes/pressbooks-clarke
 }
 
-install_pressbooks_donham() {
-	if [ -d $WP_CORE_DIR/wp-content/themes/pressbooks-donham ]; then
-		cd $WP_CORE_DIR/wp-content/themes/pressbooks-donham && git pull
+install_pressbooks_luther() {
+	if [ -d $WP_CORE_DIR/wp-content/themes/pressbooks-luther ]; then
+		cd $WP_CORE_DIR/wp-content/themes/pressbooks-luther && git pull
 		return;
 	fi
 
-	git clone --depth=1 https://github.com/pressbooks/pressbooks-donham.git $WP_CORE_DIR/wp-content/themes/pressbooks-donham
+	git clone --depth=1 https://github.com/pressbooks/pressbooks-luther.git $WP_CORE_DIR/wp-content/themes/pressbooks-luther
 }
 
 install_book_themes() {
 	install_pressbooks_book
 	install_pressbooks_clarke
-	install_pressbooks_donham
+	install_pressbooks_luther
 }
 
 install_test_suite() {

--- a/tests/test-admin-fonts.php
+++ b/tests/test-admin-fonts.php
@@ -64,7 +64,7 @@ class Admin_FontsTest extends \WP_UnitTestCase {
 
 	public function test_fix_missing_font_stacks() {
 
-		$this->_book( 'pressbooks-donham' );
+		$this->_book( 'pressbooks-luther' );
 		\Pressbooks\Admin\Fonts\maybe_update_font_stacks();
 		$this->assertTrue( true ); // Did not crash
 		$this->assertFalse( get_transient( 'pressbooks_updating_font_stacks' ) );

--- a/tests/test-covergenerator-generator.php
+++ b/tests/test-covergenerator-generator.php
@@ -51,7 +51,7 @@ class CoverGenerator_GeneratorTest extends \WP_UnitTestCase {
 		$this->assertContains( 'jpeg', \Pressbooks\Media\mime_type( $output_path ) );
 
 		// V1
-		$this->_book( 'pressbooks-donham' );
+		$this->_book( 'pressbooks-luther' );
 
 		$g = new \Pressbooks\Covergenerator\DocraptorPdf( $this->input() );
 		$output_path = $g->generate();

--- a/tests/test-modules-export-export.php
+++ b/tests/test-modules-export-export.php
@@ -65,7 +65,7 @@ class Modules_Export_ExportTest extends \WP_UnitTestCase {
 
 	public function test_getExportStylePath() {
 
-		$this->_book( 'pressbooks-donham' );
+		$this->_book( 'pressbooks-luther' );
 
 		$path = $this->export->getExportStylePath( 'epub' );
 		$this->assertStringEndsWith( '/export/epub/style.scss', $path );
@@ -74,7 +74,7 @@ class Modules_Export_ExportTest extends \WP_UnitTestCase {
 		$this->assertStringEndsWith( '/export/prince/style.scss', $path );
 
 		$path = $this->export->getExportStylePath( 'web' );
-		$this->assertStringEndsWith( '/pressbooks-donham/style.scss', $path );
+		$this->assertStringEndsWith( '/pressbooks-luther/style.scss', $path );
 
 		$path = $this->export->getExportStylePath( 'foobar' );
 		$this->assertFalse( $path );
@@ -87,7 +87,7 @@ class Modules_Export_ExportTest extends \WP_UnitTestCase {
 
 	public function test_getExportScriptPath() {
 
-		$this->_book( 'pressbooks-donham' );
+		$this->_book( 'pressbooks-luther' );
 
 		$path = $this->export->getExportScriptPath( 'epub' );
 		$this->assertFalse( $path );
@@ -373,7 +373,7 @@ class Modules_Export_ExportTest extends \WP_UnitTestCase {
 
 	public function test_sanityCheckXhtmlWithoutBuckram() {
 
-		$this->_book( 'pressbooks-donham' ); // Use an old book.
+		$this->_book( 'pressbooks-luther' ); // Use an old book.
 		$meta_post = ( new \Pressbooks\Metadata() )->getMetaPost();
 		( new \Pressbooks\Contributors() )->insert( 'Ned Zimmerman', $meta_post->ID );
 		$user_id = $this->factory()->user->create( [ 'role' => 'contributor' ] );

--- a/tests/test-pdfoptions.php
+++ b/tests/test-pdfoptions.php
@@ -4,7 +4,7 @@ class PDFOptionsTest extends \WP_UnitTestCase {
 	use utilsTrait;
 
 	public function test_scssOverrides() {
-		$this->_book( 'pressbooks-donham' );
+		$this->_book( 'pressbooks-luther' );
 
 		update_option( 'pressbooks_theme_options_global', [
 			'chapter_numbers' => 0,

--- a/tests/test-styles.php
+++ b/tests/test-styles.php
@@ -42,7 +42,7 @@ class StylesTest extends \WP_UnitTestCase {
 
 	public function test_pathToScss() {
 		// V1
-		$v1 = wp_get_theme( 'pressbooks-donham' );
+		$v1 = wp_get_theme( 'pressbooks-luther' );
 		$this->assertContains( 'style.scss', $this->cs->getPathToWebScss( $v1 ) );
 		$this->assertContains( '/export/', $this->cs->getPathToEpubScss( $v1 ) );
 		$this->assertContains( '/export/', $this->cs->getPathToPrinceScss( $v1 ) );
@@ -55,7 +55,7 @@ class StylesTest extends \WP_UnitTestCase {
 
 	public function test_isCurrentThemeCompatible() {
 		// V1
-		$v1 = wp_get_theme( 'pressbooks-donham' );
+		$v1 = wp_get_theme( 'pressbooks-luther' );
 		$this->assertTrue( $this->cs->isCurrentThemeCompatible( 1, $v1 ) );
 		$this->assertFalse( $this->cs->isCurrentThemeCompatible( 2, $v1 ) );
 		$this->assertFalse( $this->cs->isCurrentThemeCompatible( 999, $v1 ) );
@@ -71,7 +71,7 @@ class StylesTest extends \WP_UnitTestCase {
 	}
 
 	public function test_hasBuckram() {
-		$this->_book( 'pressbooks-donham' );
+		$this->_book( 'pressbooks-luther' );
 		$this->assertFalse( $this->cs->hasBuckram() );
 		$this->_book( 'pressbooks-book' );
 		$this->assertTrue( $this->cs->hasBuckram() );
@@ -81,7 +81,7 @@ class StylesTest extends \WP_UnitTestCase {
 
 	public function test_applyOverrides() {
 		// V1
-		$this->_book( 'pressbooks-donham' );
+		$this->_book( 'pressbooks-luther' );
 		$result = $this->cs->applyOverrides( '// SCSS.', '// Override.' );
 		$this->assertTrue( strpos( $result, '// SCSS.' ) === 0 );
 		$result = $this->cs->applyOverrides( '// SCSS.', [ '// Override 1.', '// Override 2.' ] );
@@ -98,7 +98,7 @@ class StylesTest extends \WP_UnitTestCase {
 
 	public function test_customize() {
 		// V1
-		$this->_book( 'pressbooks-donham' );
+		$this->_book( 'pressbooks-luther' );
 		$this->assertContains( 'font-size:', $this->cs->customizeWeb() );
 		$this->assertContains( 'font-size:', $this->cs->customizeEpub() );
 		$this->assertContains( 'font-size:', $this->cs->customizePrince() );


### PR DESCRIPTION
We are about to upgrade Donham to use Buckram, which will break all the v1 theme tests that currently rely on Donham. This PR switches those tests to Luther, which is not going to be upgraded to use Buckram.