### PR TITLE
Add get_section_information() and add_json_ld_metadata() functions

### DIFF
--- a/inc/api/endpoints/controller/class-sectionmetadata.php
+++ b/inc/api/endpoints/controller/class-sectionmetadata.php
@@ -2,6 +2,7 @@
 
 namespace Pressbooks\Api\Endpoints\Controller;
 
+use function \Pressbooks\Metadata\get_section_information;
 use Pressbooks\Book;
 
 class SectionMetadata extends \WP_REST_Controller {
@@ -471,7 +472,7 @@ class SectionMetadata extends \WP_REST_Controller {
 		}
 
 		$section_meta = $this->buildMetadata(
-			$this->getSectionInformation( $request['parent'] ),
+			get_section_information( $request['parent'] ),
 			Book::getBookInformation()
 		);
 
@@ -485,31 +486,6 @@ class SectionMetadata extends \WP_REST_Controller {
 		$response->add_links( $this->linkCollector );
 
 		return $response;
-	}
-
-	/**
-	 * @param int $post_id
-	 *
-	 * @return array
-	 */
-	protected function getSectionInformation( $post_id ) {
-		$section_meta = get_post_meta( $post_id, '', true );
-		$section_meta['pb_title'] = get_the_title( $post_id );
-		if ( $this->post_type === 'chapter' ) {
-			$section_meta['pb_chapter_number'] = pb_get_chapter_number( $post_id );
-		}
-		foreach ( $section_meta as $key => $value ) {
-			if ( is_array( $value ) ) {
-				$section_meta[ $key ] = array_pop( $value );
-			}
-		}
-		// Override Contributors
-		$contributors = new \Pressbooks\Contributors();
-		foreach ( $contributors->getAll( $post_id ) as $key => $val ) {
-			$section_meta[ $key ] = $val;
-		};
-
-		return $section_meta;
 	}
 
 	/**

--- a/inc/metadata/namespace.php
+++ b/inc/metadata/namespace.php
@@ -909,3 +909,32 @@ function init_book_data_models() {
 		\Pressbooks\Taxonomy::init()->registerTaxonomies();
 	}
 }
+
+/**
+ * Get the section metadata for a given ID.
+ *
+ * @since 5.7.0
+ *
+ * @param int $post_id
+ *
+ * @return array
+ */
+function get_section_information( $post_id ) {
+	$section_meta = get_post_meta( $post_id, '', true );
+	$section_meta['pb_title'] = get_the_title( $post_id );
+	if ( get_post_type( $post_id ) === 'chapter' ) {
+		$section_meta['pb_chapter_number'] = pb_get_chapter_number( $post_id );
+	}
+	foreach ( $section_meta as $key => $value ) {
+		if ( is_array( $value ) ) {
+			$section_meta[ $key ] = array_pop( $value );
+		}
+	}
+	// Override Contributors
+	$contributors = new \Pressbooks\Contributors();
+	foreach ( $contributors->getAll( $post_id ) as $key => $val ) {
+		$section_meta[ $key ] = $val;
+	};
+
+	return $section_meta;
+}

--- a/inc/metadata/namespace.php
+++ b/inc/metadata/namespace.php
@@ -11,6 +11,7 @@ use function \Pressbooks\Utility\oxford_comma;
 use function \Pressbooks\Utility\oxford_comma_explode;
 use Pressbooks\Book;
 use Pressbooks\Licensing;
+use Pressbooks\Metadata;
 
 /**
  * Returns an html blob of meta elements based on what is set in 'Book Information'
@@ -573,9 +574,9 @@ function section_information_to_schema( $section_information, $book_information 
 
 	// Use section, if missing use book
 	$authors = [];
-	if ( isset( $section_information['pb_authors'] ) ) {
+	if ( ! empty( $section_information['pb_authors'] ) ) {
 		$authors = oxford_comma_explode( $section_information['pb_authors'] );
-	} elseif ( isset( $book_information['pb_authors'] ) ) {
+	} elseif ( ! empty( $book_information['pb_authors'] ) ) {
 		$authors = oxford_comma_explode( $book_information['pb_authors'] );
 	}
 	foreach ( $authors as $author ) {
@@ -938,3 +939,25 @@ function get_section_information( $post_id ) {
 
 	return $section_meta;
 }
+
+
+/**
+ * Echo the JSON-LD metadata tag for a book or section.
+ *
+ * @since 5.7.0
+ *
+ * @return null
+ */
+function add_json_ld_metadata() {
+	$context = is_singular( [ 'front-matter', 'part', 'chapter', 'back-matter' ] ) ? 'section' : 'book';
+	if ( $context === 'section' ) {
+		global $post_id;
+		$section_information = get_section_information( $post_id );
+		$book_information = Book::getBookInformation();
+		$metadata = section_information_to_schema( $section_information, $book_information );
+	} else {
+		$metadata = new Metadata();
+	}
+	printf( '<script type="application/ld+json">%s</script>', wp_json_encode( $metadata ) );
+}
+

--- a/tests/test-metadata.php
+++ b/tests/test-metadata.php
@@ -324,4 +324,12 @@ class MetadataTest extends \WP_UnitTestCase {
 		$this->assertStringStartsWith( 'Test Chapter: ', $section_information['pb_title'] );
 		$this->assertEquals( 'Or, A Chapter to Test', $section_information['pb_subtitle'] );
 	}
+
+	public function test_add_json_ld_metadata() {
+		$this->_book();
+		ob_start();
+		\Pressbooks\Metadata\add_json_ld_metadata();
+		$buffer = ob_get_clean();
+		$this->assertStringStartsWith( '<script type="application/ld+json">{"@context":"http:\/\/schema.org","@type":"Book"', $buffer );
+	}
 }

--- a/tests/test-metadata.php
+++ b/tests/test-metadata.php
@@ -315,4 +315,13 @@ class MetadataTest extends \WP_UnitTestCase {
 		$content = get_post_field( 'post_content', $pid );
 		$this->assertContains( '<iframe width="560" height="315" src="https://www.youtube.com/embed/JgIhGTpKTwM" frameborder="0"></iframe>', $content );
 	}
+
+	public function test_get_section_information() {
+		$this->_book();
+		$chapters = get_posts( ['post_type' => 'chapter', 'posts_per_page' => 1 ] );
+		$section_information = \Pressbooks\Metadata\get_section_information( $chapters[0]->ID );
+		$this->assertInternalType( 'array', $section_information );
+		$this->assertStringStartsWith( 'Test Chapter: ', $section_information['pb_title'] );
+		$this->assertEquals( 'Or, A Chapter to Test', $section_information['pb_subtitle'] );
+	}
 }


### PR DESCRIPTION
`\Pressbooks\Book::getBookInformation()` returns an array of metadata for a book. The comparable method for retrieving an array of metadata for a section currently exists as a [protected method](https://github.com/pressbooks/pressbooks/compare/get-section-information?expand=1#diff-04432fb41c011fa09444fca0e999a5acL495) in the section metadata API class. This PR:

- creates a function in the `\Pressbooks\Metadata` namespace to retrieve an array of section metadata
- creates a function in the same namespace to generate a JSON-LD metadata blob for https://github.com/pressbooks/pressbooks-book/issues/434
- fixes an issue where a section with author metadata set to an empty string would not inherit the book author metadata