### PR TITLE
Fix: Wrong parameters for Exception

### DIFF
--- a/inc/covergenerator/class-docraptorjpg.php
+++ b/inc/covergenerator/class-docraptorjpg.php
@@ -178,8 +178,7 @@ class DocraptorJpg extends Generator {
 			);
 			if ( is_wp_error( $pid ) ) {
 				throw new \Exception(
-					$pid->get_error_message(),
-					$pid->get_error_code()
+					$pid->get_error_message()
 				);
 			}
 

--- a/inc/covergenerator/class-isbn.php
+++ b/inc/covergenerator/class-isbn.php
@@ -85,14 +85,13 @@ class Isbn {
 
 		$pid = media_handle_sideload(
 			[
-				'name' => "{$isbn_number}.png",
+				'name' => "{$this->isbnNumber}.png",
 				'tmp_name' => $png,
 			], 0
 		);
 		if ( is_wp_error( $pid ) ) {
 			throw new \Exception(
-				$pid->get_error_message(),
-				$pid->get_error_code()
+				$pid->get_error_message()
 			);
 		}
 

--- a/inc/covergenerator/class-sku.php
+++ b/inc/covergenerator/class-sku.php
@@ -65,14 +65,13 @@ class Sku extends Isbn {
 
 		$pid = media_handle_sideload(
 			[
-				'name' => "{$sku}.png",
+				'name' => "{$this->sku}.png",
 				'tmp_name' => $png,
 			], 0
 		);
 		if ( is_wp_error( $pid ) ) {
 			throw new \Exception(
-				$pid->get_error_message(),
-				$pid->get_error_code()
+				$pid->get_error_message()
 			);
 		}
 


### PR DESCRIPTION
$wp_error->get_error_code() doesn't always return an int/float. New versions of PHP are stricter about at Exception parameters. App was crashing.

Use sanitized variable for filename.