### PR TITLE
Handle weird usernames in Network Managers table

### DIFF
--- a/inc/admin/class-network-managers-list-table.php
+++ b/inc/admin/class-network-managers-list-table.php
@@ -172,7 +172,7 @@ class Network_Managers_List_Table extends \WP_List_Table {
 		$network_managers = get_network_option( null, 'pressbooks_network_managers', [] );
 		$tmp = [];
 		foreach ( $network_admins as $id => $username ) {
-			$user = get_user_by( 'slug', $username );
+			$user = get_user_by( 'login', $username );
 			$user = $user->data;
 			$is_restricted = ( in_array( absint( $user->ID ), $network_managers, true ) ) ? true : false; // Determine admin's restricted status
 			$tmp[ $id ] = [

--- a/tests/test-admin-networkmanagers-list-table.php
+++ b/tests/test-admin-networkmanagers-list-table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Pressbooks\Admin\Network_Managers_List_Table;
+
+class Admin_Network_Managers_List_Table extends \WP_UnitTestCase {
+
+	use utilsTrait;
+
+	/**
+	 * @var Network_Managers_List_Table;
+	 */
+	protected $table;
+
+	public function setUp() {
+		$this->table = new Network_Managers_List_Table();
+	}
+
+	public function test_prepare_items() {
+		$user_id = $this->factory->user->create( [ 'user_login' => 'me@here.com' ] );
+		grant_super_admin( $user_id );
+		update_site_option( 'pressbooks_network_managers', [ $user_id ] );
+		$this->table->prepare_items();
+		// Two super-admins
+		$this->assertEquals( count( $this->table->items ), 2 );
+		// Normal username
+		$this->assertEquals( $this->table->items[0]['user_login'], 'admin' );
+		// Weird username
+		$this->assertEquals( $this->table->items[1]['user_login'], 'me@here.com' );
+		// Unrestricted user
+		$this->assertFalse( $this->table->items[0]['restricted'] );
+		// Restricted user
+		$this->assertTrue( $this->table->items[1]['restricted'] );
+	}
+}


### PR DESCRIPTION
Using `get_user_by( 'login', $username )` works with users with unexpected characters in their usernames (e.g. `@`, `.`) that may have been added by third-party plugins. I don't actually know why I used `get_user_by( 'slug', $username )` in the first place? (FYI @SteelWagstaff.)