### PR TITLE
Rename Austen theme (pressbooks-austentwo → pressbooks-austen) (fix #1601)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ php:
 - 7.2
 - nightly
 env:
-- WP_VERSION=latest WP_MULTISITE=1 TRAVIS_NODE_VERSION="8"
+- WP_VERSION=5.0.3 WP_MULTISITE=1 TRAVIS_NODE_VERSION="8"
 matrix:
   fast_finish: true
   allow_failures:

--- a/inc/theme/namespace.php
+++ b/inc/theme/namespace.php
@@ -194,6 +194,26 @@ function migrate_book_themes() {
 		$pressbooks_theme_migration = 4;
 		update_option( 'pressbooks_theme_migration', $pressbooks_theme_migration );
 	}
+
+	// Rename Austen Two to Austen
+	if ( $pressbooks_theme_migration === 4 ) {
+		$theme = wp_get_theme()->get_stylesheet();
+		if ( $theme === 'pressbooks-austentwo' ) {
+			// Switch theme to Austen 3.0
+			switch_theme( 'pressbooks-austen' );
+			$lock = Lock::init();
+			if ( $lock->isLocked() ) {
+				$data = $lock->getLockData();
+				$data['stylesheet'] = 'pressbooks-austen';
+				$json = wp_json_encode( $data );
+				$lockfile = $lock->getLockDir() . '/lock.json';
+				\Pressbooks\Utility\put_contents( $lockfile, $json );
+			}
+		}
+
+		$pressbooks_theme_migration = 5;
+		update_option( 'pressbooks_theme_migration', $pressbooks_theme_migration );
+	}
 }
 
 /**

--- a/inc/theme/namespace.php
+++ b/inc/theme/namespace.php
@@ -206,7 +206,7 @@ function update_template_root() {
  *
  * @since 5.7.0
  *
- * @param array $data An array of lock file data.
+ * @param array $new_data An array of lock file data.
  *
  * @return bool True on success, false on failure.
  */

--- a/inc/theme/namespace.php
+++ b/inc/theme/namespace.php
@@ -8,6 +8,7 @@
 
 namespace Pressbooks\Theme;
 
+use function \Pressbooks\Utility\put_contents;
 use Pressbooks\Container;
 use Pressbooks\CustomCss;
 
@@ -113,15 +114,7 @@ function migrate_book_themes() {
 
 		if ( isset( $comparisons[ $theme ] ) ) {
 			switch_theme( $comparisons[ $theme ] );
-
-			$lock = Lock::init();
-			if ( $lock->isLocked() ) {
-				$data = $lock->getLockData();
-				$data['stylesheet'] = $comparisons[ $theme ];
-				$json = wp_json_encode( $data );
-				$lockfile = $lock->getLockDir( false ) . '/lock.json';
-				\Pressbooks\Utility\put_contents( $lockfile, $json );
-			}
+			update_lock_file( [ 'stylesheet' => $comparisons[ $theme ] ] );
 		}
 
 		$pressbooks_theme_migration = 1;
@@ -134,14 +127,7 @@ function migrate_book_themes() {
 		if ( $theme === 'pressbooks-book' ) {
 			if ( wp_get_theme( 'pressbooks-luther' )->exists() ) {
 				switch_theme( 'pressbooks-luther' );
-				$lock = Lock::init();
-				if ( $lock->isLocked() ) {
-					$data = $lock->getLockData();
-					$data['stylesheet'] = 'pressbooks-luther';
-					$json = wp_json_encode( $data );
-					$lockfile = $lock->getLockDir() . '/lock.json';
-					\Pressbooks\Utility\put_contents( $lockfile, $json );
-				}
+				update_lock_file( [ 'stylesheet' => 'pressbooks-luther' ] );
 			} else {
 				add_action(
 					'admin_notices', function () {
@@ -181,14 +167,8 @@ function migrate_book_themes() {
 		if ( $theme === 'pressbooks-dillardplain' ) {
 			// Switch theme to Dillard 2.0 with title decoration disabled
 			switch_theme( 'pressbooks-dillard' );
-			$lock = Lock::init();
-			if ( $lock->isLocked() ) {
-				$data = $lock->getLockData();
-				$data['stylesheet'] = 'pressbooks-dillard';
-				$json = wp_json_encode( $data );
-				$lockfile = $lock->getLockDir() . '/lock.json';
-				\Pressbooks\Utility\put_contents( $lockfile, $json );
-			}
+			update_lock_file( [ 'stylesheet' => 'pressbooks-dillard' ] );
+
 		}
 
 		$pressbooks_theme_migration = 4;
@@ -201,14 +181,7 @@ function migrate_book_themes() {
 		if ( $theme === 'pressbooks-austentwo' ) {
 			// Switch theme to Austen 3.0
 			switch_theme( 'pressbooks-austen' );
-			$lock = Lock::init();
-			if ( $lock->isLocked() ) {
-				$data = $lock->getLockData();
-				$data['stylesheet'] = 'pressbooks-austen';
-				$json = wp_json_encode( $data );
-				$lockfile = $lock->getLockDir() . '/lock.json';
-				\Pressbooks\Utility\put_contents( $lockfile, $json );
-			}
+			update_lock_file( [ 'stylesheet' => 'pressbooks-austen' ] );
 		}
 
 		$pressbooks_theme_migration = 5;
@@ -226,4 +199,32 @@ function update_template_root() {
 	if ( strpos( $template_root, '/plugins/pressbooks/themes-book' ) !== false ) {
 		update_option( 'template_root', str_replace( '/plugins/pressbooks/themes-book', '/themes', $template_root ) );
 	}
+}
+
+/**
+ * Update lock file for a locked theme.
+ *
+ * @since 5.7.0
+ *
+ * @param array $data An array of lock file data.
+ *
+ * @return bool True on success, false on failure.
+ */
+function update_lock_file( $new_data ) {
+	$result = false;
+	if ( is_array( $new_data ) ) {
+		$lock = Lock::init();
+		if ( $lock->isLocked() ) {
+			$data = $lock->getLockData();
+			foreach ( [ 'stylesheet', 'name', 'version', 'timestamp', 'features' ] as $key ) {
+				if ( isset( $new_data[ $key ] ) && ! empty( $new_data[ $key ] ) ) {
+					$data[ $key ] = $new_data[ $key ];
+				}
+			}
+			$json = wp_json_encode( $data );
+			$lockfile = $lock->getLockDir() . '/lock.json';
+			$result = put_contents( $lockfile, $json );
+		}
+	}
+	return $result;
 }

--- a/tests/test-theme.php
+++ b/tests/test-theme.php
@@ -6,7 +6,7 @@ class ThemeTest extends \WP_UnitTestCase {
 	use utilsTrait;
 
 	/**
-	 * @var Lock
+	 * @var \Pressbooks\Theme\Lock
 	 */
 	protected $lock;
 

--- a/tests/test-theme.php
+++ b/tests/test-theme.php
@@ -1,23 +1,49 @@
 <?php
 
-class ThemeTest extends \WP_UnitTestCase
-{
-    use utilsTrait;
+use function Pressbooks\Theme\update_lock_file;
 
-    public function test_migrate_book_themes() {
-        $this->_book();
-        delete_option( 'pressbooks_theme_migration' );
-        \Pressbooks\Theme\migrate_book_themes();
-        $this->assertEquals( 5, get_option( 'pressbooks_theme_migration' ) );
-    }
+class ThemeTest extends \WP_UnitTestCase {
+	use utilsTrait;
 
-    public function test_update_template_root() {
-        $old = get_option( 'template_root' );
+	/**
+	 * @var Lock
+	 */
+	protected $lock;
 
-        update_option( 'template_root', '/plugins/pressbooks/themes-book' );
-        \Pressbooks\Theme\update_template_root();
-        $this->assertEquals( '/themes', get_option( 'template_root' ) );
+	public function setUp() {
+		$this->lock = new \Pressbooks\Theme\Lock();
+	}
 
-        update_option( 'template_root', $old ); // Put back to normal
-    }
+	public function test_migrate_book_themes() {
+		$this->_book();
+		delete_option( 'pressbooks_theme_migration' );
+		\Pressbooks\Theme\migrate_book_themes();
+		$this->assertEquals( 5, get_option( 'pressbooks_theme_migration' ) );
+	}
+
+	public function test_update_template_root() {
+		$old = get_option( 'template_root' );
+
+		update_option( 'template_root', '/plugins/pressbooks/themes-book' );
+		\Pressbooks\Theme\update_template_root();
+		$this->assertEquals( '/themes', get_option( 'template_root' ) );
+
+		update_option( 'template_root', $old ); // Put back to normal
+	}
+
+	public function test_update_lock_file() {
+		$this->_book();
+		$lock = $this->lock::init();
+		$old_lock = $lock->lockTheme();
+		$this->assertArrayHasKey( 'stylesheet', $old_lock );
+		$this->assertEquals( $old_lock['stylesheet'], get_stylesheet() );
+		$new_data = [ 'stylesheet' => '' ];
+		\Pressbooks\Theme\update_lock_file( $new_data );
+		$new_lock = $lock->getLockData();
+		$this->assertEquals( $old_lock, $new_lock );
+		$new_data = [ 'stylesheet' => 'pressbooks-what' ];
+		\Pressbooks\Theme\update_lock_file( $new_data );
+		$new_lock = $lock->getLockData();
+		$this->assertEquals( 'pressbooks-what', $new_lock['stylesheet'] );
+	}
 }

--- a/tests/test-theme.php
+++ b/tests/test-theme.php
@@ -36,7 +36,8 @@ class ThemeTest extends \WP_UnitTestCase {
 	 */
 	public function test_update_lock_file() {
 		$this->_book();
-		$old_lock = $this->lock->generateLock( time() );
+		update_option( 'pressbooks_export_options', [ 'theme_lock' => 1 ] );
+		$old_lock = $this->lock->getLockData();
 		$this->assertArrayHasKey( 'stylesheet', $old_lock );
 		$this->assertEquals( $old_lock['stylesheet'], get_stylesheet() );
 		$new_data = [ 'stylesheet' => '' ];

--- a/tests/test-theme.php
+++ b/tests/test-theme.php
@@ -8,7 +8,7 @@ class ThemeTest extends \WP_UnitTestCase
         $this->_book();
         delete_option( 'pressbooks_theme_migration' );
         \Pressbooks\Theme\migrate_book_themes();
-        $this->assertEquals( 4, get_option( 'pressbooks_theme_migration' ) );
+        $this->assertEquals( 5, get_option( 'pressbooks_theme_migration' ) );
     }
 
     public function test_update_template_root() {

--- a/tests/test-theme.php
+++ b/tests/test-theme.php
@@ -37,6 +37,7 @@ class ThemeTest extends \WP_UnitTestCase {
 	public function test_update_lock_file() {
 		$this->_book();
 		update_option( 'pressbooks_export_options', [ 'theme_lock' => 1 ] );
+		$this->lock->generateLock( time() );
 		$old_lock = $this->lock->getLockData();
 		$this->assertArrayHasKey( 'stylesheet', $old_lock );
 		$this->assertEquals( $old_lock['stylesheet'], get_stylesheet() );

--- a/tests/test-theme.php
+++ b/tests/test-theme.php
@@ -31,19 +31,22 @@ class ThemeTest extends \WP_UnitTestCase {
 		update_option( 'template_root', $old ); // Put back to normal
 	}
 
+	/**
+	 * @group themes
+	 */
 	public function test_update_lock_file() {
 		$this->_book();
-		$lock = $this->lock::init();
-		$old_lock = $lock->lockTheme();
+		$old_lock = $this->lock->generateLock( time() );
 		$this->assertArrayHasKey( 'stylesheet', $old_lock );
 		$this->assertEquals( $old_lock['stylesheet'], get_stylesheet() );
 		$new_data = [ 'stylesheet' => '' ];
 		\Pressbooks\Theme\update_lock_file( $new_data );
-		$new_lock = $lock->getLockData();
+		$new_lock = $this->lock->getLockData();
 		$this->assertEquals( $old_lock, $new_lock );
-		$new_data = [ 'stylesheet' => 'pressbooks-what' ];
-		\Pressbooks\Theme\update_lock_file( $new_data );
-		$new_lock = $lock->getLockData();
-		$this->assertEquals( 'pressbooks-what', $new_lock['stylesheet'] );
+		$new_data = [ 'stylesheet' => 'pressbooks-newtheme' ];
+		$result = \Pressbooks\Theme\update_lock_file( $new_data );
+		$this->assertTrue( $result );
+		$new_lock = $this->lock->getLockData();
+		$this->assertEquals( 'pressbooks-newtheme', $new_lock['stylesheet'] );
 	}
 }


### PR DESCRIPTION
We will be renaming Austen with the v3.0 upgrade (`"pressbooks/pressbooks-austentwo":"^3.0.0"` gives me a headache). This handles the upgrade, which will only take place on Pressbooks/PressbooksEDU infrastructure.