### PR TITLE
Compatibility with WordPress 5.1 (Fix #1552)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ php:
 - 7.2
 - nightly
 env:
-- WP_VERSION=5.0.3 WP_MULTISITE=1 TRAVIS_NODE_VERSION="8"
+- WP_VERSION=latest WP_MULTISITE=1 TRAVIS_NODE_VERSION="8"
 matrix:
   fast_finish: true
   allow_failures:

--- a/compatibility.php
+++ b/compatibility.php
@@ -33,7 +33,7 @@ function pb_meets_minimum_requirements() {
 
 	// WordPress Version
 	global $pb_minimum_wp;
-	$pb_minimum_wp = '5.0.2';
+	$pb_minimum_wp = '5.1.0';
 
 	include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 	$is_compatible = true;

--- a/inc/class-taxonomy.php
+++ b/inc/class-taxonomy.php
@@ -87,6 +87,7 @@ class Taxonomy {
 			'front-matter',
 			[
 				'meta_box' => 'dropdown',
+				'meta_box_sanitize_cb' => 'taxonomy_meta_box_sanitize_cb_input',
 				'capabilities' => [
 					'manage_terms' => 'manage_sites',
 					'edit_terms' => 'manage_sites',
@@ -102,6 +103,7 @@ class Taxonomy {
 			'back-matter',
 			[
 				'meta_box' => 'dropdown',
+				'meta_box_sanitize_cb' => 'taxonomy_meta_box_sanitize_cb_input',
 				'capabilities' => [
 					'manage_terms' => 'manage_sites',
 					'edit_terms' => 'manage_sites',
@@ -117,6 +119,7 @@ class Taxonomy {
 			'chapter',
 			[
 				'meta_box' => 'dropdown',
+				'meta_box_sanitize_cb' => 'taxonomy_meta_box_sanitize_cb_input',
 				'capabilities' => [
 					'manage_terms' => 'manage_sites',
 					'edit_terms' => 'manage_sites',
@@ -164,6 +167,7 @@ class Taxonomy {
 			'glossary',
 			[
 				'meta_box' => 'dropdown',
+				'meta_box_sanitize_cb' => 'taxonomy_meta_box_sanitize_cb_input',
 				'capabilities' => [
 					'manage_terms' => 'manage_sites',
 					'edit_terms' => 'manage_sites',

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: Pressbooks <code@pressbooks.com>
 Donate link: https://opencollective.com/pressbooks
 Tags: ebooks, publishing, webbooks
-Requires at least: 5.0.3
-Tested up to: 5.0.3
+Requires at least: 5.1.0
+Tested up to: 5.1.0
 Requires PHP: 7.1
 Stable tag: 5.6.5
 License: GPL v3.0 or later

--- a/tests/test-activation.php
+++ b/tests/test-activation.php
@@ -40,7 +40,7 @@ class ActivationTest extends \WP_UnitTestCase {
 
 	public function test_hooks() {
 		$this->activation->hooks( $this->activation );
-		$this->assertEquals( 9, has_filter( 'wpmu_new_blog', [ $this->activation, 'wpmuNewBlog' ] ) );
+		$this->assertEquals( 11, has_filter( 'wp_initialize_site', [ $this->activation, 'wpmuNewBlog' ] ) );
 		$this->assertEquals( 10, has_filter( 'user_register', [ $this->activation, 'forcePbColors' ] ) );
 	}
 


### PR DESCRIPTION
New `@since 5.1.0` filter is here:

+ https://github.com/WordPress/wordpress-develop/blob/30862799862b64258e9525fdb5699f09502ae36e/src/wp-includes/ms-site.php#L91

Merging this code will make things work with 5.1, but break with 5.0.3. (Replacing `wpmu_new_blog` with `wp_initialize_site` means that the code won't run in 5.0.3 because there is no such action)