### PR TITLE
Add groups to allow running subsets of unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ php:
 - 7.2
 - nightly
 env:
-- WP_VERSION=latest WP_MULTISITE=1 TRAVIS_NODE_VERSION="8"
+- WP_VERSION=5.0.3 WP_MULTISITE=1 TRAVIS_NODE_VERSION="8"
 matrix:
   fast_finish: true
   allow_failures:

--- a/tests/test-activation.php
+++ b/tests/test-activation.php
@@ -33,11 +33,17 @@ class ActivationTest extends \WP_UnitTestCase {
 		$this->activation = new Activation( $stub3 );
 	}
 
+	/**
+	 * @group activation
+	 */
 	public function test_init() {
 		$instance = Activation::init();
 		$this->assertTrue( $instance instanceof Activation );
 	}
 
+	/**
+	 * @group activation
+	 */
 	public function test_hooks() {
 		$this->activation->hooks( $this->activation );
 		$this->assertEquals( 9, has_filter( 'wpmu_new_blog', [ $this->activation, 'wpmuNewBlog' ] ) );

--- a/tests/test-admin-attachments.php
+++ b/tests/test-admin-attachments.php
@@ -3,6 +3,9 @@ require_once( PB_PLUGIN_DIR . 'inc/admin/attachments/namespace.php' );
 
 class Admin_AttachmentTest extends \WP_UnitTestCase {
 
+	/**
+	 * @group media
+	 */
 	function test_validate_attachment_metadata() {
 		$good_url   = 'https://metamorphosiskafka.pressbooks.com/wp-content/uploads/sites/26642/2014/04/themetamorphosis_1200x1600.jpg';
 		$bad_url    = 'ftp://upload.file';

--- a/tests/test-admin-branding.php
+++ b/tests/test-admin-branding.php
@@ -1,24 +1,35 @@
 <?php
 
 class Admin_BrandingTest extends \WP_UnitTestCase {
-
+	/**
+	 * @group branding
+	 */
 	public function test_custom_color_scheme() {
 		update_option( 'pb_network_color_primary', '#663399' );
 		$this->expectOutputRegex( '/<style type="text\/css">/' );
 		\Pressbooks\Admin\Branding\custom_color_scheme();
 	}
 
+	/**
+	 * @group branding
+	 */
 	public function test_custom_login_logo() {
 
 		$this->expectOutputRegex( '/<\/style>/' );
 		\Pressbooks\Admin\Branding\custom_login_logo();
 	}
 
+	/**
+	 * @group branding
+	 */
 	public function test_login_url() {
 
 		$this->assertRegExp( '#^https?://#i', \Pressbooks\Admin\Branding\login_url() );
 	}
 
+	/**
+	 * @group branding
+	 */
 	public function test_login_title() {
 
 		$title = \Pressbooks\Admin\Branding\login_title();
@@ -27,6 +38,9 @@ class Admin_BrandingTest extends \WP_UnitTestCase {
 		$this->assertNotEmpty( $title );
 	}
 
+	/**
+	 * @group branding
+	 */
 	function test_admin_title() {
 
 		$result = \Pressbooks\Admin\Branding\admin_title( 'Hello WordPress!' );
@@ -36,12 +50,18 @@ class Admin_BrandingTest extends \WP_UnitTestCase {
 		$this->assertEquals( $result, 'Hello World!' );
 	}
 
+	/**
+	 * @group branding
+	 */
 	function test_get_customizer_colors() {
 		update_option( 'pb_network_color_primary', '#663399' );
 		$result = \Pressbooks\Admin\Branding\get_customizer_colors();
 		$this->assertEquals( $result, '<style type="text/css">:root{--primary:#663399;}</style>' );
 	}
 
+	/**
+	 * @group branding
+	 */
 	public function test_favicon() {
 		ob_start();
 		\Pressbooks\Admin\Branding\favicon();

--- a/tests/test-admin-covergenerator.php
+++ b/tests/test-admin-covergenerator.php
@@ -6,6 +6,9 @@ class Admin_CoverGeneratorTest extends \WP_UnitTestCase {
 
 	use utilsTrait;
 
+	/**
+	 * @group covergenerator
+	 */
 	function test_display_generator() {
 		ob_start();
 		\Pressbooks\Admin\Covergenerator\display_generator();
@@ -13,6 +16,9 @@ class Admin_CoverGeneratorTest extends \WP_UnitTestCase {
 		$this->assertContains( '<h1>Cover Generator</h1>', $buffer );
 	}
 
+	/**
+	 * @group covergenerator
+	 */
 	function test_generator_css_js() {
 		global $wp_scripts, $wp_styles;
 		$_REQUEST['page'] = 'pressbooks_cg';
@@ -21,12 +27,18 @@ class Admin_CoverGeneratorTest extends \WP_UnitTestCase {
 		$this->assertContains( 'cg/css', $wp_styles->queue );
 	}
 
+	/**
+	 * @group covergenerator
+	 */
 	function test_cg_options_init() {
 		global $wp_settings_sections;
 		\Pressbooks\Admin\Covergenerator\cg_options_init();
 		$this->assertArrayHasKey( 'pressbooks_cg', $wp_settings_sections );
 	}
 
+	/**
+	 * @group covergenerator
+	 */
 	function test_pressbooks_cg_text_callback() {
 		ob_start();
 		\Pressbooks\Admin\Covergenerator\pressbooks_cg_text_callback();
@@ -34,6 +46,9 @@ class Admin_CoverGeneratorTest extends \WP_UnitTestCase {
 		$this->assertContains( 'The text below is pulled from', $buffer );
 	}
 
+	/**
+	 * @group covergenerator
+	 */
 	function test_pressbooks_cg_title_callback() {
 		ob_start();
 		\Pressbooks\Admin\Covergenerator\pressbooks_cg_title_callback( null );
@@ -41,6 +56,9 @@ class Admin_CoverGeneratorTest extends \WP_UnitTestCase {
 		$this->assertContains( '<textarea id="pb_title"', $buffer );
 	}
 
+	/**
+	 * @group covergenerator
+	 */
 	function test_pressbooks_cg_title_spine_callback() {
 		ob_start();
 		\Pressbooks\Admin\Covergenerator\pressbooks_cg_title_spine_callback( null );
@@ -48,6 +66,9 @@ class Admin_CoverGeneratorTest extends \WP_UnitTestCase {
 		$this->assertContains( '<input id="pb_title_spine"', $buffer );
 	}
 
+	/**
+	 * @group covergenerator
+	 */
 	function test_pressbooks_cg_subtitle_callback() {
 		ob_start();
 		\Pressbooks\Admin\Covergenerator\pressbooks_cg_subtitle_callback( null );
@@ -55,6 +76,9 @@ class Admin_CoverGeneratorTest extends \WP_UnitTestCase {
 		$this->assertContains( '<textarea id="pb_subtitle"', $buffer );
 	}
 
+	/**
+	 * @group covergenerator
+	 */
 	function test_pressbooks_cg_author_callback() {
 		ob_start();
 		\Pressbooks\Admin\Covergenerator\pressbooks_cg_author_callback( null );
@@ -62,6 +86,9 @@ class Admin_CoverGeneratorTest extends \WP_UnitTestCase {
 		$this->assertContains( '<textarea id="pb_author"', $buffer );
 	}
 
+	/**
+	 * @group covergenerator
+	 */
 	function test_pressbooks_cg_author_spine_callback() {
 		ob_start();
 		\Pressbooks\Admin\Covergenerator\pressbooks_cg_author_spine_callback( null );
@@ -69,6 +96,9 @@ class Admin_CoverGeneratorTest extends \WP_UnitTestCase {
 		$this->assertContains( '<input id="pb_author_spine"', $buffer );
 	}
 
+	/**
+	 * @group covergenerator
+	 */
 	function test_pressbooks_cg_about_callback() {
 		ob_start();
 		\Pressbooks\Admin\Covergenerator\pressbooks_cg_about_callback( null );
@@ -76,6 +106,9 @@ class Admin_CoverGeneratorTest extends \WP_UnitTestCase {
 		$this->assertContains( '<div id="wp-pb_about_unlimited-wrap"', $buffer );
 	}
 
+	/**
+	 * @group covergenerator
+	 */
 	function test_pressbooks_cg_isbn_callback() {
 		ob_start();
 		\Pressbooks\Admin\Covergenerator\pressbooks_cg_isbn_callback( [ 'Description ' ] );
@@ -83,6 +116,9 @@ class Admin_CoverGeneratorTest extends \WP_UnitTestCase {
 		$this->assertContains( '<input id="pb_print_isbn"', $buffer );
 	}
 
+	/**
+	 * @group covergenerator
+	 */
 	function test_pressbooks_cg_sku_callback() {
 		ob_start();
 		\Pressbooks\Admin\Covergenerator\pressbooks_cg_sku_callback( [ 'Description ' ] );
@@ -90,6 +126,9 @@ class Admin_CoverGeneratorTest extends \WP_UnitTestCase {
 		$this->assertContains( '<input id="pb_print_sku"', $buffer );
 	}
 
+	/**
+	 * @group covergenerator
+	 */
 	function test_pressbooks_cg_design_callback() {
 		ob_start();
 		\Pressbooks\Admin\Covergenerator\pressbooks_cg_design_callback();
@@ -97,6 +136,9 @@ class Admin_CoverGeneratorTest extends \WP_UnitTestCase {
 		$this->assertContains( 'You can upload a background image here', $buffer );
 	}
 
+	/**
+	 * @group covergenerator
+	 */
 	function test_pressbooks_cg_front_background_image_callback() {
 		ob_start();
 		\Pressbooks\Admin\Covergenerator\pressbooks_cg_front_background_image_callback( null );
@@ -104,6 +146,9 @@ class Admin_CoverGeneratorTest extends \WP_UnitTestCase {
 		$this->assertContains( '<input id="front_background_image"', $buffer );
 	}
 
+	/**
+	 * @group covergenerator
+	 */
 	function test_pressbooks_cg_text_transform_callback() {
 		ob_start();
 		\Pressbooks\Admin\Covergenerator\pressbooks_cg_text_transform_callback( [] );
@@ -111,6 +156,9 @@ class Admin_CoverGeneratorTest extends \WP_UnitTestCase {
 		$this->assertContains( '<select name=\'pressbooks_cg_options[text_transform]', $buffer );
 	}
 
+	/**
+	 * @group covergenerator
+	 */
 	function test_pressbooks_cg_spine_size_callback() {
 		ob_start();
 		\Pressbooks\Admin\Covergenerator\pressbooks_cg_spine_size_callback();
@@ -118,6 +166,9 @@ class Admin_CoverGeneratorTest extends \WP_UnitTestCase {
 		$this->assertContains( 'We can calculate the spine size based on CreateSpace and Ingram specifications', $buffer );
 	}
 
+	/**
+	 * @group covergenerator
+	 */
 	function test_pressbooks_cg_pdf_pagecount_callback() {
 		ob_start();
 		\Pressbooks\Admin\Covergenerator\pressbooks_cg_pdf_pagecount_callback( null );
@@ -125,6 +176,9 @@ class Admin_CoverGeneratorTest extends \WP_UnitTestCase {
 		$this->assertContains( '<input id="pdf_pagecount"', $buffer );
 	}
 
+	/**
+	 * @group covergenerator
+	 */
 	function test_pressbooks_cg_ppi_callback() {
 		ob_start();
 		\Pressbooks\Admin\Covergenerator\pressbooks_cg_ppi_callback( [] );
@@ -132,6 +186,9 @@ class Admin_CoverGeneratorTest extends \WP_UnitTestCase {
 		$this->assertContains( '<select name=\'pressbooks_cg_options[ppi]', $buffer );
 	}
 
+	/**
+	 * @group covergenerator
+	 */
 	function test_pressbooks_cg_custom_ppi_callback() {
 		ob_start();
 		\Pressbooks\Admin\Covergenerator\pressbooks_cg_custom_ppi_callback( null );
@@ -139,6 +196,9 @@ class Admin_CoverGeneratorTest extends \WP_UnitTestCase {
 		$this->assertContains( '<input id="custom_ppi"', $buffer );
 	}
 
+	/**
+	 * @group covergenerator
+	 */
 	function test_pressbooks_cg_colors_callback() {
 		ob_start();
 		\Pressbooks\Admin\Covergenerator\pressbooks_cg_colors_callback();
@@ -146,6 +206,9 @@ class Admin_CoverGeneratorTest extends \WP_UnitTestCase {
 		$this->assertContains( 'Choose text color and background colors below', $buffer );
 	}
 
+	/**
+	 * @group covergenerator
+	 */
 	function test_pressbooks_cg_color_callback() {
 		ob_start();
 		\Pressbooks\Admin\Covergenerator\pressbooks_cg_color_callback( [ 'id' ] );
@@ -153,6 +216,9 @@ class Admin_CoverGeneratorTest extends \WP_UnitTestCase {
 		$this->assertContains( '<input class="colorpicker"', $buffer );
 	}
 
+	/**
+	 * @group covergenerator
+	 */
 	function test_pressbooks_cg_options_sanitize() {
 		$input = \Pressbooks\Admin\Covergenerator\pressbooks_cg_options_sanitize( [] );
 		$this->assertArrayHasKey( 'pb_title', $input );

--- a/tests/test-admin-dashboard.php
+++ b/tests/test-admin-dashboard.php
@@ -6,6 +6,9 @@ class Admin_DashboardTest extends \WP_UnitTestCase {
 
 	use utilsTrait;
 
+	/**
+	 * @group dashboard
+	 */
 	public function test_get_rss_defaults() {
 		$result = \Pressbooks\Admin\Dashboard\get_rss_defaults();
 		$this->assertArrayHasKey( 'display_feed', $result );
@@ -13,6 +16,9 @@ class Admin_DashboardTest extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'title', $result );
 	}
 
+	/**
+	 * @group dashboard
+	 */
 	public function test_replace_network_dashboard_widgets() {
 		global $wp_meta_boxes;
 		\Pressbooks\Admin\Dashboard\replace_network_dashboard_widgets();
@@ -21,6 +27,9 @@ class Admin_DashboardTest extends \WP_UnitTestCase {
 	}
 
 
+	/**
+	 * @group dashboard
+	 */
 	public function test_replace_root_dashboard_widgets() {
 		global $wp_meta_boxes;
 		\Pressbooks\Admin\Dashboard\replace_root_dashboard_widgets();
@@ -28,6 +37,9 @@ class Admin_DashboardTest extends \WP_UnitTestCase {
 		$this->assertTrue( isset( $wp_meta_boxes['dashboard']['side']['low']['pb_dashboard_widget_blog'] ) );
 	}
 
+	/**
+	 * @group dashboard
+	 */
 	public function test_replace_dashboard_widgets() {
 		global $wp_meta_boxes;
 		\Pressbooks\Admin\Dashboard\replace_dashboard_widgets();
@@ -37,12 +49,18 @@ class Admin_DashboardTest extends \WP_UnitTestCase {
 		$this->assertTrue( isset( $wp_meta_boxes['dashboard']['side']['low']['pb_dashboard_widget_blog'] ) );
 	}
 
+	/**
+	 * @group dashboard
+	 */
 	public function test_lowly_user() {
 		global $wp_meta_boxes;
 		\Pressbooks\Admin\Dashboard\lowly_user();
 		$this->assertTrue( isset( $wp_meta_boxes['dashboard-user']['normal']['high']['pb_dashboard_widget_book_permissions'] ) );
 	}
 
+	/**
+	 * @group dashboard
+	 */
 	public function test_lowly_user_callback() {
 		ob_start();
 		\Pressbooks\Admin\Dashboard\lowly_user_callback();
@@ -50,6 +68,9 @@ class Admin_DashboardTest extends \WP_UnitTestCase {
 		$this->assertNotEmpty( $buffer );
 	}
 
+	/**
+	 * @group dashboard
+	 */
 	public function test_display_book_widget() {
 		$this->_book();
 		ob_start();
@@ -60,6 +81,9 @@ class Admin_DashboardTest extends \WP_UnitTestCase {
 		$this->assertContains( "<ul class='back-matter'>", $buffer );
 	}
 
+	/**
+	 * @group dashboard
+	 */
 	public function test_display_pressbooks_blog() {
 		// No cache
 		delete_site_transient( 'pb_rss_widget' );
@@ -79,6 +103,9 @@ class Admin_DashboardTest extends \WP_UnitTestCase {
 		$this->assertContains( "class='rsswidget'", $buffer );
 	}
 
+	/**
+	 * @group dashboard
+	 */
 	public function test_display_users_widget() {
 		$this->_book();
 		ob_start();
@@ -105,12 +132,18 @@ class Admin_DashboardTest extends \WP_UnitTestCase {
 
 	}
 
+	/**
+	 * @group dashboard
+	 */
 	public function test_dashboard_options_init() {
 		global $wp_settings_sections;
 		\Pressbooks\Admin\Dashboard\dashboard_options_init();
 		$this->assertArrayHasKey( 'pb_dashboard', $wp_settings_sections );
 	}
 
+	/**
+	 * @group dashboard
+	 */
 	public function test_init_network_integrations_menu() {
 		$parent_slug = \Pressbooks\Admin\Dashboard\init_network_integrations_menu();
 		$this->assertTrue( ! empty( $parent_slug ) && is_string( $parent_slug ) );

--- a/tests/test-admin-delete-book.php
+++ b/tests/test-admin-delete-book.php
@@ -2,11 +2,17 @@
 
 class Admin_DeleteBookTest extends \WP_UnitTestCase {
 
+	/**
+	 * @group deletebook
+	 */
 	public function test_init() {
 		$class = \Pressbooks\Admin\Delete\Book::init();
 		$this->assertInstanceOf( '\Pressbooks\Admin\Delete\Book', $class );
 	}
 
+	/**
+	 * @group deletebook
+	 */
 	public function test_deleteBookEmailContent() {
 		$delete_book = new \Pressbooks\Admin\Delete\Book();
 		$content = $delete_book->deleteBookEmailContent( 'WordPress' );
@@ -14,6 +20,9 @@ class Admin_DeleteBookTest extends \WP_UnitTestCase {
 		$this->assertContains( 'Pressbooks', $content );
 	}
 
+	/**
+	 * @group deletebook
+	 */
 	public function test_addMenu() {
 		$delete_book = new \Pressbooks\Admin\Delete\Book();
 		require_once ABSPATH . WPINC . '/class-wp-admin-bar.php';

--- a/tests/test-admin-diagnostics.php
+++ b/tests/test-admin-diagnostics.php
@@ -6,7 +6,10 @@ class Admin_DiagnosticsTest extends \WP_UnitTestCase {
 
 	use utilsTrait;
 
-	function test_render_page() {
+	/**
+	 * @group diagnostics
+	 */
+	public function test_render_page() {
 		ob_start();
 		\Pressbooks\Admin\Diagnostics\render_page();
 		$buffer = ob_get_clean();

--- a/tests/test-admin-fonts.php
+++ b/tests/test-admin-fonts.php
@@ -10,6 +10,7 @@ class Admin_FontsTest extends \WP_UnitTestCase {
 
 	/**
 	 * Override
+	 * @group typography
 	 */
 	public function setUp() {
 
@@ -48,6 +49,7 @@ class Admin_FontsTest extends \WP_UnitTestCase {
 
 	/**
 	 * Override
+	 * @group typography
 	 */
 	public function tearDown() {
 
@@ -55,6 +57,9 @@ class Admin_FontsTest extends \WP_UnitTestCase {
 		parent::tearDown();
 	}
 
+	/**
+	 * @group typography
+	 */
 	public function test_update_font_stacks() {
 
 		\Pressbooks\Admin\Fonts\update_font_stacks();
@@ -62,6 +67,9 @@ class Admin_FontsTest extends \WP_UnitTestCase {
 		$this->assertFalse( get_transient( 'pressbooks_updating_font_stacks' ) );
 	}
 
+	/**
+	 * @group typography
+	 */
 	public function test_fix_missing_font_stacks() {
 
 		$this->_book( 'pressbooks-luther' );

--- a/tests/test-admin-laf.php
+++ b/tests/test-admin-laf.php
@@ -7,6 +7,9 @@ class Admin_LafTest extends \WP_UnitTestCase {
 
 	use utilsTrait;
 
+	/**
+	 * @group branding
+	 */
 	function test_add_footer_link() {
 
 		ob_start();
@@ -32,6 +35,9 @@ class Admin_LafTest extends \WP_UnitTestCase {
 		$this->assertContains( 'https://pressbooks.org/contact', $buffer );
 	}
 
+	/**
+	 * @group branding
+	 */
 	function test_replace_book_admin_menu_AND_init_css_js() {
 
 		global $menu, $submenu;
@@ -99,6 +105,9 @@ class Admin_LafTest extends \WP_UnitTestCase {
 		$this->assertContains( 'pb-cloner', $wp_scripts->queue );
 	}
 
+	/**
+	 * @group branding
+	 */
 	function test_custom_screen_options() {
 		$x = \Pressbooks\Admin\Laf\custom_screen_options( false, 'pb_export_per_page', 9 );
 		$this->assertEquals( $x, 9 );
@@ -110,11 +119,17 @@ class Admin_LafTest extends \WP_UnitTestCase {
 		$this->assertTrue( $x === false );
 	}
 
+	/**
+	 * @group branding
+	 */
 	function test_reorder_book_admin_menu() {
 		$order = \Pressbooks\Admin\Laf\reorder_book_admin_menu();
 		$this->assertEquals( $order[4], 'post-new.php?post_type=metadata' );
 	}
 
+	/**
+	 * @group branding
+	 */
 	function test_replace_menu_bar_my_sites() {
 		$this->_book();
 		$user_id = $this->factory()->user->create( [ 'role' => 'administrator' ] );
@@ -133,6 +148,9 @@ class Admin_LafTest extends \WP_UnitTestCase {
 		$this->assertEquals( $node->id, 'clone-a-book' );
 	}
 
+	/**
+	 * @group branding
+	 */
 	function test_display_export() {
 		$GLOBALS['hook_suffix'] = 'mock';
 		ob_start();
@@ -142,6 +160,9 @@ class Admin_LafTest extends \WP_UnitTestCase {
 		$this->assertContains( '<div class="clear"></div>', $buffer );
 	}
 
+	/**
+	 * @group branding
+	 */
 	function test_admin_notices() {
 		$_SESSION['pb_errors'] = 'One';
 		set_transient( 'pb_errors' . get_current_user_id(), 'Two' );
@@ -178,11 +199,17 @@ class Admin_LafTest extends \WP_UnitTestCase {
 		$this->assertEmpty( $buffer );
 	}
 
+	/**
+	 * @group branding
+	 */
 	function test_sites_to_books() {
 		$result = \Pressbooks\Admin\Laf\sites_to_books( __( 'Sites' ), 'Sites', '' );
 		$this->assertEquals( 'Books', $result );
 	}
 
+	/**
+	 * @group branding
+	 */
 	function test_edit_screen_navigation() {
 
 		$this->_book();

--- a/tests/test-admin-networkmanagers-list-table.php
+++ b/tests/test-admin-networkmanagers-list-table.php
@@ -11,10 +11,16 @@ class Admin_Network_Managers_List_Table extends \WP_UnitTestCase {
 	 */
 	protected $table;
 
+	/**
+	 * @group networkmanagers
+	 */
 	public function setUp() {
 		$this->table = new Network_Managers_List_Table();
 	}
 
+	/**
+	 * @group networkmanagers
+	 */
 	public function test_prepare_items() {
 		$user_id = $this->factory->user->create( [ 'user_login' => 'me@here.com' ] );
 		grant_super_admin( $user_id );

--- a/tests/test-admin-networkmanagers.php
+++ b/tests/test-admin-networkmanagers.php
@@ -5,11 +5,17 @@ require_once( PB_PLUGIN_DIR . 'inc/admin/networkmanagers/namespace.php' );
 class Admin_NetworkManagers extends \WP_UnitTestCase {
 
 
+	/**
+	 * @group networkmanagers
+	 */
 	public function test_add_menu() {
 		\Pressbooks\Admin\NetworkManagers\add_menu();
 		$this->assertTrue( true ); // Did not crash
 	}
 
+	/**
+	 * @group networkmanagers
+	 */
 	public function test_admin_enqueues() {
 		global $wp_scripts, $wp_styles;
 		\Pressbooks\Admin\NetworkManagers\admin_enqueues();
@@ -17,7 +23,9 @@ class Admin_NetworkManagers extends \WP_UnitTestCase {
 		$this->assertContains( 'pb-network-managers', $wp_styles->queue );
 	}
 
-
+	/**
+	 * @group networkmanagers
+	 */
 	public function test_update_admin_status_AND_is_restricted_AND_hide_network_menus() {
 		$user_id = $this->factory()->user->create( [ 'role' => 'administrator' ] );
 		grant_super_admin( $user_id );
@@ -76,7 +84,9 @@ class Admin_NetworkManagers extends \WP_UnitTestCase {
 		$this->assertFalse( \Pressbooks\Admin\NetworkManagers\is_restricted() );
 	}
 
-
+	/**
+	 * @group networkmanagers
+	 */
 	public function test_permitted_setting_menus() {
 		$allowed = \Pressbooks\Admin\NetworkManagers\permitted_setting_menus();
 		$this->assertTrue( is_array( $allowed ) );

--- a/tests/test-admin-organize.php
+++ b/tests/test-admin-organize.php
@@ -6,6 +6,9 @@ class Admin_OrganizeTest extends \WP_UnitTestCase {
 
 	use utilsTrait;
 
+	/**
+	 * @group organize
+	 */
 	public function test_update_post_visibility() {
 
 		$this->_book();
@@ -26,6 +29,9 @@ class Admin_OrganizeTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'web-only', $struct['back-matter'][0]['post_status'] );
 	}
 
+	/**
+	 * @group organize
+	 */
 	public function test_update_post_title_visibility() {
 
 		$this->_book();
@@ -46,6 +52,9 @@ class Admin_OrganizeTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'on', get_post_meta( $struct['back-matter'][0]['ID'], 'pb_show_title', true ) );
 	}
 
+	/**
+	 * @group organize
+	 */
 	public function test_reorder() {
 
 		$this->_book();

--- a/tests/test-admin-plugins.php
+++ b/tests/test-admin-plugins.php
@@ -4,6 +4,9 @@ require_once( PB_PLUGIN_DIR . 'inc/admin/plugins/namespace.php' );
 
 class Admin_PluginsTest extends \WP_UnitTestCase {
 
+	/**
+	 * @group plugins
+	 */
 	public function test_filter_plugins() {
 		$plugins = [
 			'hello-dolly/hello.php' => [],
@@ -19,8 +22,10 @@ class Admin_PluginsTest extends \WP_UnitTestCase {
 
 	}
 
+	/**
+	 * @group plugins
+	 */
 	public function test_hide_gutenberg() {
-
 		$plugins = [
 			'hello-dolly/hello.php' => [
 				'Name' => 'Hello Dolly',

--- a/tests/test-analytics.php
+++ b/tests/test-analytics.php
@@ -6,6 +6,9 @@ class AnalyticsTest extends \WP_UnitTestCase {
 
 	use utilsTrait;
 
+	/**
+	 * @group analytics
+	 */
 	public function test_network_analytics_settings_init() {
 		global $wp_registered_settings;
 		\Pressbooks\Admin\Analytics\network_analytics_settings_init();
@@ -13,17 +16,26 @@ class AnalyticsTest extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'ga_mu_site_specific_allowed', $wp_registered_settings );
 	}
 
+	/**
+	 * @group analytics
+	 */
 	public function test_book_analytics_settings_init() {
 		global $wp_registered_settings;
 		\Pressbooks\Admin\Analytics\book_analytics_settings_init();
 		$this->assertArrayHasKey( 'ga_mu_uaid', $wp_registered_settings );
 	}
 
+	/**
+	 * @group analytics
+	 */
 	public function test_add_menu() {
 		$this->expectOutputRegex( '/<\/p>/' );
 		\Pressbooks\Admin\Analytics\analytics_settings_section_callback();
 	}
 
+	/**
+	 * @group analytics
+	 */
 	public function test_analytics_book_callback() {
 		$args[0] = 'Hello World!';
 		ob_start();
@@ -34,6 +46,9 @@ class AnalyticsTest extends \WP_UnitTestCase {
 		$this->assertContains( 'Hello World!', $buffer );
 	}
 
+	/**
+	 * @group analytics
+	 */
 	public function test_analytics_network_callback() {
 		$args[0] = 'Hello World!';
 		ob_start();
@@ -44,6 +59,9 @@ class AnalyticsTest extends \WP_UnitTestCase {
 		$this->assertContains( 'Hello World!', $buffer );
 	}
 
+	/**
+	 * @group analytics
+	 */
 	public function test_analytics_books_allowed_callback() {
 		$args[0] = 'Hello World!';
 		ob_start();
@@ -54,6 +72,9 @@ class AnalyticsTest extends \WP_UnitTestCase {
 		$this->assertContains( 'Hello World!', $buffer );
 	}
 
+	/**
+	 * @group analytics
+	 */
 	public function test_display_network_analytics_settings() {
 		ob_start();
 		\Pressbooks\Admin\Analytics\display_network_analytics_settings( );
@@ -61,6 +82,9 @@ class AnalyticsTest extends \WP_UnitTestCase {
 		$this->assertContains( '</form>', $buffer );
 	}
 
+	/**
+	 * @group analytics
+	 */
 	public function test_display_book_analytics_settings() {
 		ob_start();
 		\Pressbooks\Admin\Analytics\display_book_analytics_settings( );
@@ -68,6 +92,9 @@ class AnalyticsTest extends \WP_UnitTestCase {
 		$this->assertContains( '</form>', $buffer );
 	}
 
+	/**
+	 * @group analytics
+	 */
 	public function test_print_analytics() {
 
 		switch_to_blog( get_network()->site_id );

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -4,6 +4,9 @@ class ApiTest extends \WP_UnitTestCase {
 
 	use utilsTrait;
 
+	/**
+	 * @group api
+	 */
 	public function test_rootEndpoints() {
 
 		$server = $this->_setupRootApi();
@@ -21,6 +24,9 @@ class ApiTest extends \WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * @group api
+	 */
 	public function test_BookEndpoints() {
 
 		// Test that endpoints exist
@@ -74,6 +80,9 @@ class ApiTest extends \WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * @group api
+	 */
 	public function test_bookSearch() {
 
 		$this->_book();
@@ -126,6 +135,9 @@ class ApiTest extends \WP_UnitTestCase {
 		$this->assertEmpty( $data );
 	}
 
+	/**
+	 * @group api
+	 */
 	public function test_is_enabled() {
 		$result = \Pressbooks\Api\is_enabled();
 		$this->assertTrue( is_bool( $result ) );
@@ -133,6 +145,7 @@ class ApiTest extends \WP_UnitTestCase {
 
 	/**
 	 * @see \Pressbooks\Api\init_batch for documentation
+	 * @group api
 	 */
 	public function test_batch() {
 		$server = $this->_setupBookApi();

--- a/tests/test-book.php
+++ b/tests/test-book.php
@@ -6,6 +6,9 @@ class BookTest extends \WP_UnitTestCase {
 
 	use utilsTrait;
 
+	/**
+	 * @group book
+	 */
 	public function test_getInstance() {
 
 		$book = \Pressbooks\Book::getInstance();
@@ -13,7 +16,9 @@ class BookTest extends \WP_UnitTestCase {
 		$this->assertInstanceOf( '\Pressbooks\Book', $book );
 	}
 
-
+	/**
+	 * @group book
+	 */
 	public function test_isBook() {
 
 		$book = \Pressbooks\Book::getInstance();
@@ -25,6 +30,9 @@ class BookTest extends \WP_UnitTestCase {
 		$this->assertTrue( $book::isBook() );
 	}
 
+	/**
+	 * @group book
+	 */
 	public function test_getBookStructure() {
 
 		$book = \Pressbooks\Book::getInstance();
@@ -64,6 +72,9 @@ class BookTest extends \WP_UnitTestCase {
 		$this->assertFalse( $page['export'] );
 	}
 
+	/**
+	 * @group book
+	 */
 	public function test_getBookContents() {
 
 		$book = \Pressbooks\Book::getInstance();
@@ -101,6 +112,9 @@ class BookTest extends \WP_UnitTestCase {
 		$this->assertFalse( $page['export'] );
 	}
 
+	/**
+	 * @group book
+	 */
 	public function test_getBookInformation() {
 
 		$book = \Pressbooks\Book::getInstance();
@@ -131,6 +145,9 @@ class BookTest extends \WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'pb_about_unlimited', $info );
 	}
 
+	/**
+	 * @group book
+	 */
 	public function test_wordCount() {
 
 		$book = \Pressbooks\Book::getInstance();
@@ -143,6 +160,9 @@ class BookTest extends \WP_UnitTestCase {
 		$this->assertEquals( 166, $wc_selected_for_export );
 	}
 
+	/**
+	 * @group book
+	 */
 	public function test_getSubsections() {
 		$this->_book();
 		$book = \Pressbooks\Book::getInstance();
@@ -169,6 +189,9 @@ class BookTest extends \WP_UnitTestCase {
 		$this->assertEquals( false, $result );
 	}
 
+	/**
+	 * @group book
+	 */
 	public function test_getAllSubsections() {
 		$this->_book();
 		$book = \Pressbooks\Book::getInstance();
@@ -180,6 +203,9 @@ class BookTest extends \WP_UnitTestCase {
 		$this->assertInternalType( 'array', $result['chapters'][ $id ] );
 	}
 
+	/**
+	 * @group book
+	 */
 	public function test_tagSubsections() {
 
 		$this->_book();
@@ -208,6 +234,9 @@ class BookTest extends \WP_UnitTestCase {
 		$this->assertEquals( false, $result );
 	}
 
+	/**
+	 * @group book
+	 */
 	public function test_get_position() {
 		$this->_book();
 		$book = \Pressbooks\Book::getInstance();
@@ -267,8 +296,10 @@ class BookTest extends \WP_UnitTestCase {
 		$this->assertTrue( $post_id > 0 );
 	}
 
+	/**
+	 * @group book
+	 */
 	public function test_getChapterNumber() {
-
 		$this->_book();
 		update_option( 'pressbooks_theme_options_global', [ 'chapter_numbers' => 1 ] );
 		$book = \Pressbooks\Book::getInstance();
@@ -294,5 +325,4 @@ class BookTest extends \WP_UnitTestCase {
 		$this->assertEquals( 0, $book::getChapterNumber( $one['ID'], 'exports' ) );
 		$this->assertEquals( 0, $book::getChapterNumber( $two['ID'] ), 'exports' );
 	}
-
 }

--- a/tests/test-cloner.php
+++ b/tests/test-cloner.php
@@ -9,11 +9,17 @@ class ClonerTest extends \WP_UnitTestCase {
 	 */
 	protected $cloner;
 
+	/**
+	 * @group cloner
+	 */
 	public function setUp() {
 		parent::setUp();
 		$this->cloner = new \Pressbooks\Cloner\Cloner( home_url() );
 	}
 
+	/**
+	 * @group cloner
+	 */
 	public function test_removeDefaultBookContent() {
 		$posts = [
 			'main-body' => [
@@ -69,6 +75,9 @@ class ClonerTest extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'table-of-contents', $result );
 	}
 
+	/**
+	 * @group cloner
+	 */
 	public function test_getBookId() {
 		global $blog_id;
 
@@ -78,6 +87,9 @@ class ClonerTest extends \WP_UnitTestCase {
 		$this->assertEquals( $result, $blog_id );
 	}
 
+	/**
+	 * @group cloner
+	 */
 	public function test_getSubdomainOrSubDirectory() {
 		$result = $this->cloner->getSubdomainOrSubDirectory( 'https://sub.domain.com/path/' );
 		$this->assertEquals( $result, 'path' );
@@ -89,11 +101,17 @@ class ClonerTest extends \WP_UnitTestCase {
 		$this->assertEquals( $result, 'sub' );
 	}
 
+	/**
+	 * @group cloner
+	 */
 	public function test_isEnabled() {
 		$result = $this->cloner::isEnabled();
 		$this->assertTrue( is_bool( $result ) );
 	}
 
+	/**
+	 * @group cloner
+	 */
 	public function test_validateNewBookName() {
 		$result = $this->cloner::validateNewBookName( '12345' );
 		$this->assertTrue( is_wp_error( $result ) );
@@ -103,6 +121,9 @@ class ClonerTest extends \WP_UnitTestCase {
 		$this->assertEquals( $result, 'example.org/newbook/' );
 	}
 
+	/**
+	 * @group cloner
+	 */
 	public function test_isSourceCloneable() {
 		$this->assertFalse( $this->cloner->isSourceCloneable( 'https://creativecommons.org/licenses/by-nd/4.0/' ) );
 		$this->assertFalse( $this->cloner->isSourceCloneable( 'https://creativecommons.org/licenses/by-nc-nd/4.0/' ) );
@@ -116,6 +137,9 @@ class ClonerTest extends \WP_UnitTestCase {
 		$this->assertTrue( $this->cloner->isSourceCloneable( 'http://i-have-no-idea-what-license-this-is/' ) );
 	}
 
+	/**
+	 * @group cloner
+	 */
 	public function test_discoverWordPressApi(){
 
 		// Hook a fake HTTP request response.

--- a/tests/test-compatibility.php
+++ b/tests/test-compatibility.php
@@ -2,6 +2,9 @@
 
 class CompatibilityTest extends \WP_UnitTestCase {
 
+	/**
+	 * @group compatibility
+	 */
 	public function test_pb_meets_minimum_requirements() {
 
 		$result = \pb_meets_minimum_requirements();

--- a/tests/test-container.php
+++ b/tests/test-container.php
@@ -13,6 +13,7 @@ class ContainerTest extends \WP_UnitTestCase {
 
 
 	/**
+	 * @group container
 	 * WP Unit test framework auto initializes our Container but we don't want this, clear it  before running tests
 	 */
 	public function setUp() {
@@ -22,6 +23,7 @@ class ContainerTest extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @group container
 	 * Put back Container to the way it was
 	 */
 	public function tearDown() {
@@ -30,6 +32,9 @@ class ContainerTest extends \WP_UnitTestCase {
 		parent::tearDown();
 	}
 
+	/**
+	 * @group container
+	 */
 	public function test_initSetGet() {
 
 		Container::setInstance( new FakeContainer() );
@@ -39,6 +44,9 @@ class ContainerTest extends \WP_UnitTestCase {
 		$this->assertTrue( Container::getInstance() instanceof AnotherFakeContainer );
 	}
 
+	/**
+	 * @group container
+	 */
 	public function test_getSet() {
 
 		Container::init( new FakeContainer() );
@@ -92,6 +100,7 @@ class ContainerTest extends \WP_UnitTestCase {
 
 	/**
 	 * @expectedException \LogicException
+	 * @group container
 	 */
 	public function test_getException() {
 		$var = Container::get( 'foo' );
@@ -99,6 +108,7 @@ class ContainerTest extends \WP_UnitTestCase {
 
 	/**
 	 * @expectedException \LogicException
+	 * @group container
 	 */
 	public function test_setException() {
 		Container::set( 'foo', 'bar' );

--- a/tests/test-contributors.php
+++ b/tests/test-contributors.php
@@ -8,16 +8,18 @@ class ContributorsTest extends \WP_UnitTestCase {
 
 	/**
 	 * @var \Pressbooks\Taxonomy
+	 * @group contributors
 	 */
 	protected $taxonomy;
 
 	/**
 	 * @var \Pressbooks\Contributors
+	 * @group contributors
 	 */
 	protected $contributor;
 
 	/**
-	 *
+	 * @group contributors
 	 */
 	public function setUp() {
 		parent::setUp();
@@ -28,6 +30,9 @@ class ContributorsTest extends \WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * @group contributors
+	 */
 	public function test_insert() {
 		$this->taxonomy->registerTaxonomies();
 
@@ -40,7 +45,9 @@ class ContributorsTest extends \WP_UnitTestCase {
 		$this->assertEquals( $results, $results2 );
 	}
 
-
+	/**
+	 * @group contributors
+	 */
 	public function test_getContributors() {
 		$this->taxonomy->registerTaxonomies();
 		$post_id = $this->_createChapter();
@@ -81,7 +88,9 @@ class ContributorsTest extends \WP_UnitTestCase {
 		$this->assertEmpty( $all['pb_reviewers'] );
 	}
 
-
+	/**
+	 * @group contributors
+	 */
 	public function test_add() {
 		$this->taxonomy->registerTaxonomies();
 
@@ -113,6 +122,9 @@ class ContributorsTest extends \WP_UnitTestCase {
 		$this->assertFalse( $this->contributor->addBlogUser( $user_id ) );
 	}
 
+	/**
+	 * @group contributors
+	 */
 	public function test_update() {
 		$this->taxonomy->registerTaxonomies();
 
@@ -148,11 +160,17 @@ class ContributorsTest extends \WP_UnitTestCase {
 		$this->assertEquals( $term->name, $old_user_data->display_name );
 	}
 
+	/**
+	 * @group contributors
+	 */
 	public function test_maybeUpgradeSlug() {
 		$this->assertEquals( 'pb_authors', $this->contributor->maybeUpgradeSlug( 'pb_section_author' ) );
 		$this->assertEquals( 'garbage', $this->contributor->maybeUpgradeSlug( 'garbage' ) );
 	}
 
+	/**
+	 * @group contributors
+	 */
 	public function test_upgradeMetaToTerm() {
 		$this->taxonomy->registerTaxonomies();
 		$post_id = $this->_createChapter();

--- a/tests/test-covergenerator-generator.php
+++ b/tests/test-covergenerator-generator.php
@@ -6,6 +6,7 @@ class CoverGenerator_GeneratorTest extends \WP_UnitTestCase {
 
 	/**
 	 * @return \Pressbooks\Covergenerator\Input
+	 * @group covergenerator
 	 */
 	protected function input() {
 		$input = new \Pressbooks\Covergenerator\Input();
@@ -22,7 +23,9 @@ class CoverGenerator_GeneratorTest extends \WP_UnitTestCase {
 		return $input;
 	}
 
-
+	/**
+	 * @group covergenerator
+	 */
 	public function test_generators() {
 
 		\Pressbooks\Covergenerator\Covergenerator::commandLineDefaults();

--- a/tests/test-covergenerator-input.php
+++ b/tests/test-covergenerator-input.php
@@ -4,17 +4,21 @@ class CoverGenerator_InputTest extends \WP_UnitTestCase {
 
 	/**
 	 * @var \Pressbooks\Covergenerator\Input
+	 * @group covergenerator
 	 */
 	public $input;
 
 	/**
-	 *
+	 * @group covergenerator
 	 */
 	public function setUp() {
 		parent::setUp();
 		$this->input = new \Pressbooks\Covergenerator\Input();
 	}
 
+	/**
+	 * @group covergenerator
+	 */
 	public function test_mutatorMethods() {
 
 		$this->assertEmpty( $this->input->getTitle() );

--- a/tests/test-covergenerator-isbn.php
+++ b/tests/test-covergenerator-isbn.php
@@ -5,11 +5,12 @@ class CoverGenerator_IsbnTest extends \WP_UnitTestCase {
 
 	/**
 	 * @var \Pressbooks\Covergenerator\Isbn
+	 * @group covergenerator
 	 */
 	public $isbn;
 
 	/**
-	 *
+	 * @group covergenerator
 	 */
 	public function setUp() {
 		parent::setUp();
@@ -17,7 +18,9 @@ class CoverGenerator_IsbnTest extends \WP_UnitTestCase {
 		$this->isbn = new \Pressbooks\Covergenerator\Isbn();
 	}
 
-
+	/**
+	 * @group covergenerator
+	 */
 	public function test_createBarcode() {
 		$isbn = "978-1-873671-00-9 54499";
 		$url = $this->isbn->createBarcode( $isbn );
@@ -31,6 +34,7 @@ class CoverGenerator_IsbnTest extends \WP_UnitTestCase {
 	 *  [ $isbnNumber, $expected ]
 	 *
 	 * @return array
+	 * @group covergenerator
 	 */
 	public function validateIsbnNumberProvider() {
 
@@ -58,6 +62,7 @@ class CoverGenerator_IsbnTest extends \WP_UnitTestCase {
 	 *
 	 * @param string $isbnNumber
 	 * @param bool $expected
+	 * @group covergenerator
 	 */
 	public function test_validateIsbnNumber( $isbnNumber, $expected ) {
 
@@ -69,6 +74,7 @@ class CoverGenerator_IsbnTest extends \WP_UnitTestCase {
 	 *  [ $isbnNumber, $expected ]
 	 *
 	 * @return array
+	 * @group covergenerator
 	 */
 	public function fixIsbnNumberProvider() {
 
@@ -85,6 +91,7 @@ class CoverGenerator_IsbnTest extends \WP_UnitTestCase {
 	 *
 	 * @param string $isbnNumber
 	 * @param string $expected
+	 * @group covergenerator
 	 */
 	public function test_fixIsbnNumber( $isbnNumber, $expected ) {
 

--- a/tests/test-covergenerator-sku.php
+++ b/tests/test-covergenerator-sku.php
@@ -5,11 +5,12 @@ class CoverGenerator_SkuTest extends \WP_UnitTestCase {
 
 	/**
 	 * @var \Pressbooks\Covergenerator\Sku
+	 * @group covergenerator
 	 */
 	public $sku;
 
 	/**
-	 *
+	 * @group covergenerator
 	 */
 	public function setUp() {
 		parent::setUp();
@@ -17,7 +18,9 @@ class CoverGenerator_SkuTest extends \WP_UnitTestCase {
 		$this->sku = new \Pressbooks\Covergenerator\Sku();
 	}
 
-
+	/**
+	 * @group covergenerator
+	 */
 	public function test_createBarcode() {
 		$sku = "1234567890123";
 		$url = $this->sku->createBarcode( $sku );

--- a/tests/test-covergenerator-spine.php
+++ b/tests/test-covergenerator-spine.php
@@ -4,11 +4,12 @@ class CoverGenerator_SpineTest extends \WP_UnitTestCase {
 
 	/**
 	 * @var \Pressbooks\Covergenerator\Spine
+	 * @group covergenerator
 	 */
 	public $spine;
 
 	/**
-	 *
+	 * @group covergenerator
 	 */
 	public function setUp() {
 		parent::setUp();
@@ -20,6 +21,7 @@ class CoverGenerator_SpineTest extends \WP_UnitTestCase {
 	 *  [ $pages, $ppi, $expected ]
 	 *
 	 * @return array
+	 * @group covergenerator
 	 */
 	public function spineWidthCalculatorProvider() {
 
@@ -38,6 +40,7 @@ class CoverGenerator_SpineTest extends \WP_UnitTestCase {
 	 * @param int $pages
 	 * @param int $ppi
 	 * @param float $expected Inches
+	 * @group covergenerator
 	 */
 	public function test_spineWidthCalculator( $pages, $ppi, $expected ) {
 
@@ -50,6 +53,7 @@ class CoverGenerator_SpineTest extends \WP_UnitTestCase {
 	 *  [ $pages, $caliper, $expected ]
 	 *
 	 * @return array
+	 * @group covergenerator
 	 */
 	public function spineWidthCalculatorCaliperProvider() {
 		return [
@@ -67,6 +71,7 @@ class CoverGenerator_SpineTest extends \WP_UnitTestCase {
 	 * @param int $pages
 	 * @param float $caliper
 	 * @param float $expected Inches
+	 * @group covergenerator
 	 */
 	public function test_spineWidthCalculatorCaliper( $pages, $caliper, $expected ) {
 
@@ -79,6 +84,7 @@ class CoverGenerator_SpineTest extends \WP_UnitTestCase {
 	 *  [ $caliper, $expected ]
 	 *
 	 * @return array
+	 * @group covergenerator
 	 */
 	public function caliperToPpiProvider() {
 
@@ -113,6 +119,7 @@ class CoverGenerator_SpineTest extends \WP_UnitTestCase {
 	 *
 	 * @param float $caliper
 	 * @param float $expected Inches
+	 * @group covergenerator
 	 */
 	public function test_caliperToPpi( $caliper, $expected ) {
 
@@ -120,6 +127,9 @@ class CoverGenerator_SpineTest extends \WP_UnitTestCase {
 		$this->assertNotEquals( $expected + 1, $this->spine->caliperToPpi( $caliper ) );
 	}
 
+	/**
+	 * @group covergenerator
+	 */
 	function test_countPagesInMostRecentPdf() {
 		$dest = \Pressbooks\Modules\Export\Export::getExportFolder() . 'test.pdf';
 		copy( __DIR__ . '/data/test.pdf', $dest );
@@ -130,7 +140,7 @@ class CoverGenerator_SpineTest extends \WP_UnitTestCase {
 
 
 	/**
-	 *
+	 * @group covergenerator
 	 */
 	public function test_countPagesInPdf() {
 

--- a/tests/test-covergenerator.php
+++ b/tests/test-covergenerator.php
@@ -5,17 +5,21 @@ class CoverGeneratorTest extends \WP_UnitTestCase {
 
 	/**
 	 * @var \Pressbooks\Covergenerator\Covergenerator
+	 * @group covergenerator
 	 */
 	public $cg;
 
 	/**
-	 *
+	 * @group covergenerator
 	 */
 	public function setUp() {
 		parent::setUp();
 		$this->cg = new \Pressbooks\Covergenerator\Covergenerator();
 	}
 
+	/**
+	 * @group covergenerator
+	 */
 	public function test_commandLineDefaults() {
 		\Pressbooks\Covergenerator\Covergenerator::commandLineDefaults();
 		$this->assertTrue( defined( 'PB_CONVERT_COMMAND' ) );
@@ -25,6 +29,9 @@ class CoverGeneratorTest extends \WP_UnitTestCase {
 		$this->assertTrue( defined( 'PB_PRINCE_COMMAND' ) );
 	}
 
+	/**
+	 * @group covergenerator
+	 */
 	public function test_hasDependencies() {
 		$this->assertInternalType( 'bool', $this->cg->hasDependencies() );
 	}

--- a/tests/test-customcss.php
+++ b/tests/test-customcss.php
@@ -4,20 +4,32 @@ use Pressbooks\CustomCss;
 
 class CustomCssTest extends \WP_UnitTestCase {
 
+	/**
+	 * @group customcss
+	 */
 	public function test_getCustomCssFolder() {
 		$path = CustomCss::getCustomCssFolder();
 		$this->assertStringEndsWith( '/custom-css/', $path );
 
 	}
 
+	/**
+	 * @group customcss
+	 */
 	public function test_isCustomCss() {
 		$this->assertTrue( is_bool( CustomCss::isCustomCss() ) );
 	}
 
+	/**
+	 * @group customcss
+	 */
 	public function test_isRomanized() {
 		$this->assertTrue( is_bool( CustomCss::isRomanized() ) );
 	}
 
+	/**
+	 * @group customcss
+	 */
 	public function test_getBaseTheme() {
 
 		$input = file_get_contents( WP_CONTENT_DIR . '/themes/pressbooks-book/style.css' );

--- a/tests/test-editor.php
+++ b/tests/test-editor.php
@@ -4,6 +4,9 @@ class EditorTest extends \WP_UnitTestCase {
 
 	use utilsTrait;
 
+	/**
+	 * @group editor
+	 */
 	public function test_mce_valid_word_elements() {
 
 		$array = Pressbooks\Editor\mce_valid_word_elements( [] );
@@ -11,6 +14,9 @@ class EditorTest extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'paste_word_valid_elements', $array );
 	}
 
+	/**
+	 * @group editor
+	 */
 	public function test_update_editor_style() {
 		$this->_book( 'pressbooks-clarke' );
 		Pressbooks\Editor\update_editor_style();
@@ -20,6 +26,9 @@ class EditorTest extends \WP_UnitTestCase {
 		$this->assertFileExists( WP_CONTENT_DIR . '/uploads/sites/' . $blog_id . '/pressbooks/css/editor.css' );
 	}
 
+	/**
+	 * @group editor
+	 */
 	public function test_add_editor_style() {
 		$this->_book( 'pressbooks-clarke' );
 
@@ -35,6 +44,9 @@ class EditorTest extends \WP_UnitTestCase {
 		$this->assertTrue( $result );
 	}
 
+	/**
+	 * @group editor
+	 */
 	public function test_add_languages() {
 
 		$array = Pressbooks\Editor\add_languages( [] );
@@ -42,6 +54,9 @@ class EditorTest extends \WP_UnitTestCase {
 		$this->assertContains( PB_PLUGIN_DIR . 'languages/tinymce.php', $array );
 	}
 
+	/**
+	 * @group editor
+	 */
 	public function test_mce_buttons_2() {
 
 		$buttons = Pressbooks\Editor\mce_buttons_2( [ 'formatselect' ] );
@@ -49,7 +64,9 @@ class EditorTest extends \WP_UnitTestCase {
 		$this->assertContains( 'styleselect', $buttons );
 	}
 
-
+	/**
+	 * @group editor
+	 */
 	public function test_mce_buttons_3() {
 
 		$buttons = Pressbooks\Editor\mce_buttons_3( [] );
@@ -62,12 +79,18 @@ class EditorTest extends \WP_UnitTestCase {
 		$this->assertContains( 'wp_code', $buttons );
 	}
 
+	/**
+	 * @group editor
+	 */
 	public function test_admin_enqueue_scripts() {
 		\Pressbooks\Editor\admin_enqueue_scripts( 'post.php' );
 		$this->assertTrue( wp_script_is( 'my_custom_quicktags', 'queue' ) );
 		$this->assertTrue( wp_script_is( 'wp-api', 'queue' ) );
 	}
 
+	/**
+	 * @group editor
+	 */
 	public function test_mce_button_scripts() {
 
 		$x = Pressbooks\Editor\mce_button_scripts( [] );
@@ -78,6 +101,9 @@ class EditorTest extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'glossary', $x );
 	}
 
+	/**
+	 * @group editor
+	 */
 	public function test_mce_before_init_insert_formats() {
 
 		$x = Pressbooks\Editor\mce_before_init_insert_formats( [] );
@@ -85,6 +111,9 @@ class EditorTest extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'style_formats', $x );
 	}
 
+	/**
+	 * @group editor
+	 */
 	public function test_metadata_manager_default_editor_args() {
 
 		$x = Pressbooks\Editor\metadata_manager_default_editor_args( [] );
@@ -92,6 +121,9 @@ class EditorTest extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'tinymce', $x );
 	}
 
+	/**
+	 * @group editor
+	 */
 	public function test_mce_table_editor_options() {
 
 		$x = Pressbooks\Editor\mce_table_editor_options( [] );
@@ -106,6 +138,9 @@ class EditorTest extends \WP_UnitTestCase {
 		$this->assertTrue( $x['table_appearance_options'] );
 	}
 
+	/**
+	 * @group editor
+	 */
 	public function test_customize_wp_link_query_args() {
 
 		$x = \Pressbooks\Editor\customize_wp_link_query_args( [ 'post_type' => [ 'post' ] ] );
@@ -114,6 +149,9 @@ class EditorTest extends \WP_UnitTestCase {
 		$this->assertTrue( in_array( 'chapter', $x['post_type'] ) );
 	}
 
+	/**
+	 * @group editor
+	 */
 	public function test_add_anchors_to_wp_link_query() {
 
 		$post_title = 'Chapter With Anchor: ' . rand();
@@ -171,11 +209,17 @@ class EditorTest extends \WP_UnitTestCase {
 		$this->assertEmpty( $new_results );
 	}
 
+	/**
+	 * @group editor
+	 */
 	public function test_show_kitchen_sink() {
 		$result = \Pressbooks\Editor\show_kitchen_sink( [] );
 		$this->assertFalse( $result['wordpress_adv_hidden'] );
 	}
 
+	/**
+	 * @group editor
+	 */
 	public function test_force_classic_editor_mode() {
 		update_option( 'classic-editor-replace', 'no-replace' );
 		$this->assertEquals( 'no-replace', get_option( 'classic-editor-replace' ) );

--- a/tests/test-eventstreams.php
+++ b/tests/test-eventstreams.php
@@ -4,11 +4,12 @@ class EventStreamsTest extends \WP_UnitTestCase {
 
 	/**
 	 * @var \Pressbooks\EventStreams
+	 * @group eventstreams
 	 */
 	protected $eventStreams;
 
 	/**
-	 *
+	 * @group eventstreams
 	 */
 	public function setUp() {
 		parent::setUp();
@@ -18,6 +19,7 @@ class EventStreamsTest extends \WP_UnitTestCase {
 
 	/**
 	 * @return Generator
+	 * @group eventstreams
 	 */
 	protected function generator() {
 		yield 1 => 'a';
@@ -33,6 +35,7 @@ class EventStreamsTest extends \WP_UnitTestCase {
 	/**
 	 * @return Generator
 	 * @throws Exception
+	 * @group eventstreams
 	 */
 	protected function generatorWithError() {
 		yield 1 => 'a';
@@ -40,7 +43,7 @@ class EventStreamsTest extends \WP_UnitTestCase {
 	}
 
 	/**
-	 *
+	 * @group eventstreams
 	 */
 	public function test_emit() {
 		ob_start();
@@ -66,6 +69,9 @@ class EventStreamsTest extends \WP_UnitTestCase {
 		$this->assertContains( 'data: {"action":"complete","error":"Nooooooooooooooo!"}', $buffer );
 	}
 
+	/**
+	 * @group eventstreams
+	 */
 	public function test_emitOneTimeError() {
 		ob_start();
 		$this->eventStreams->emitOneTimeError( 'Nooooooooooooooo, again!' );
@@ -77,6 +83,9 @@ class EventStreamsTest extends \WP_UnitTestCase {
 		$this->assertContains( 'data: {"action":"complete","error":"Nooooooooooooooo, again!"}', $buffer );
 	}
 
+	/**
+	 * @group eventstreams
+	 */
 	public function test_emitComplete() {
 		ob_start();
 		$this->eventStreams->emitComplete();

--- a/tests/test-globaltypography.php
+++ b/tests/test-globaltypography.php
@@ -9,18 +9,21 @@ class GlobalTypographyTest extends \WP_UnitTestCase {
 
 	/**
 	 * @var \Pressbooks\GlobalTypography()
+	 * @group typography
 	 */
 	protected $gt;
 
-
 	/**
-	 *
+	 * @group typography
 	 */
 	public function setUp() {
 		parent::setUp();
 		$this->gt = new GlobalTypography( Container::get( 'Sass' ) );
 	}
 
+	/**
+	 * @group typography
+	 */
 	public function test_getSupportedLanguages() {
 
 		$result = $this->gt->getSupportedLanguages();
@@ -32,6 +35,9 @@ class GlobalTypographyTest extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'he', $result );
 	}
 
+	/**
+	 * @group typography
+	 */
 	public function test_getRequiredLanguages() {
 
 		$result = $this->gt->_getRequiredLanguages();
@@ -39,6 +45,9 @@ class GlobalTypographyTest extends \WP_UnitTestCase {
 		$this->assertTrue( is_array( $result ) );
 	}
 
+	/**
+	 * @group typography
+	 */
 	public function test_getThemeFontStacks() {
 
 		$this->_book( 'pressbooks-clarke' ); // Pick a theme with some built-in $supported_languages
@@ -49,7 +58,9 @@ class GlobalTypographyTest extends \WP_UnitTestCase {
 		$this->assertEmpty( $this->gt->getThemeFontStacks( 'garbage' ) );
 	}
 
-
+	/**
+	 * @group typography
+	 */
 	public function test_getThemeSupportedLanguages() {
 
 		$this->_book();
@@ -61,7 +72,9 @@ class GlobalTypographyTest extends \WP_UnitTestCase {
 		$this->assertContains( 'grc', $supported_languages );
 	}
 
-
+	/**
+	 * @group typography
+	 */
 	public function test_getFonts() {
 		$result = $this->gt->getFonts( [ 'ko' ] );
 		if ( $result === false && ! empty( $_SESSION['pb_errors'] ) ) {

--- a/tests/test-htmlawed.php
+++ b/tests/test-htmlawed.php
@@ -2,6 +2,9 @@
 
 class HtmLawedTest extends \WP_UnitTestCase {
 
+	/**
+	 * @group sanitize
+	 */
 	public function test_filter() {
 		$output = \Pressbooks\HtmLawed::filter( '<h1>Hello world!' );
 		$this->assertEquals( '<h1>Hello world!</h1>', $output );

--- a/tests/test-htmlbook-element.php
+++ b/tests/test-htmlbook-element.php
@@ -2,6 +2,9 @@
 
 class HTMLBook_ElementTest extends \WP_UnitTestCase {
 
+	/**
+	 * @group htmlbook
+	 */
 	public function test_isInline() {
 		$e = new \Pressbooks\HTMLBook\Element();
 		$f = new \Pressbooks\HTMLBook\Element();
@@ -18,6 +21,9 @@ class HTMLBook_ElementTest extends \WP_UnitTestCase {
 		$this->assertFalse( $e->isInline( $p ) );
 	}
 
+	/**
+	 * @group htmlbook
+	 */
 	public function test_isBlock() {
 		$e = new \Pressbooks\HTMLBook\Element();
 		$f = new \Pressbooks\HTMLBook\Element();
@@ -35,6 +41,9 @@ class HTMLBook_ElementTest extends \WP_UnitTestCase {
 		$this->assertFalse( $e->isBlock( $fn ) );
 	}
 
+	/**
+	 * @group htmlbook
+	 */
 	public function test_isHeading() {
 		$e = new \Pressbooks\HTMLBook\Element();
 		$f = new \Pressbooks\HTMLBook\Element();
@@ -71,6 +80,9 @@ class HTMLBook_ElementTest extends \WP_UnitTestCase {
 		$this->assertFalse( $e->isHeading( $header ) );
 	}
 
+	/**
+	 * @group htmlbook
+	 */
 	public function test_Block() {
 		$e = new \Pressbooks\HTMLBook\Block\Admonitions();
 		$e->setDataType( 'important' );
@@ -143,6 +155,9 @@ class HTMLBook_ElementTest extends \WP_UnitTestCase {
 		$this->assertEquals( '<table>Hi!</table>', $e->render() );
 	}
 
+	/**
+	 * @group htmlbook
+	 */
 	public function test_Component() {
 		$e = new \Pressbooks\HTMLBook\Component\Appendix();
 		$e->appendContent( 'Hi!' );
@@ -209,6 +224,9 @@ class HTMLBook_ElementTest extends \WP_UnitTestCase {
 		$this->assertEquals( '<nav data-type="toc">Hi!</nav>', $e->render() );
 	}
 
+	/**
+	 * @group htmlbook
+	 */
 	public function test_Heading() {
 		$e = new \Pressbooks\HTMLBook\Heading\H1();
 		$e->appendContent( 'Hi!' );
@@ -246,6 +264,9 @@ class HTMLBook_ElementTest extends \WP_UnitTestCase {
 		$this->assertEquals( '<header>Hi!</header>', $e->render() );
 	}
 
+	/**
+	 * @group htmlbook
+	 */
 	public function test_Inline() {
 		$e = new \Pressbooks\HTMLBook\Inline\CrossReferences();
 		$e->appendContent( 'Hi!' );
@@ -293,6 +314,9 @@ class HTMLBook_ElementTest extends \WP_UnitTestCase {
 		$this->assertEquals( '<sup>Hi!</sup>', $e->render() );
 	}
 
+	/**
+	 * @group htmlbook
+	 */
 	public function test_Interactive() {
 		$e = new \Pressbooks\HTMLBook\Interactive\Audio();
 		$e->appendContent( 'Hi!' );

--- a/tests/test-htmlbook-validator.php
+++ b/tests/test-htmlbook-validator.php
@@ -3,6 +3,9 @@
 class HTMLBook_ValidatorTest extends \WP_UnitTestCase {
 
 
+	/**
+	 * @group htmlbook
+	 */
 	public function test_validate() {
 		$v = new \Pressbooks\HTMLBook\Validator();
 		$this->assertFalse( $v->validate( __DIR__ . '/data/template.php' ) );

--- a/tests/test-htmlparser.php
+++ b/tests/test-htmlparser.php
@@ -6,6 +6,9 @@ use Pressbooks\HtmlParser;
 class HtmlParserTest extends \WP_UnitTestCase {
 
 
+	/**
+	 * @group htmlparser
+	 */
 	public function test_externalParser() {
 		$html5 = new HtmlParser( false );
 
@@ -27,7 +30,9 @@ class HtmlParserTest extends \WP_UnitTestCase {
 
 	}
 
-
+	/**
+	 * @group htmlparser
+	 */
 	public function test_internalParser() {
 		$html5 = new HtmlParser( true );
 

--- a/tests/test-image.php
+++ b/tests/test-image.php
@@ -3,6 +3,10 @@
 use function \Pressbooks\Utility\str_ends_with;
 
 class ImageTest extends \WP_UnitTestCase {
+
+	/**
+	 * @group media
+	 */
 	public function test_default_cover_url() {
 		$this->assertTrue( str_ends_with( \Pressbooks\Image\default_cover_url( 'thumbnail' ), 'default-book-cover-100x100.jpg' ) );
 		$this->assertTrue( str_ends_with( \Pressbooks\Image\default_cover_url( 'small' ), 'default-book-cover-65x0.jpg' ) );
@@ -12,6 +16,9 @@ class ImageTest extends \WP_UnitTestCase {
 		$this->assertTrue( str_ends_with( \Pressbooks\Image\default_cover_url( 'full' ), 'default-book-cover.jpg' ) );
 	}
 
+	/**
+	 * @group media
+	 */
 	public function test_default_cover_path() {
 		$this->assertTrue( str_ends_with( \Pressbooks\Image\default_cover_path( 'thumbnail' ), 'default-book-cover-100x100.jpg' ) );
 		$this->assertTrue( str_ends_with( \Pressbooks\Image\default_cover_path( 'small' ), 'default-book-cover-65x0.jpg' ) );
@@ -21,6 +28,9 @@ class ImageTest extends \WP_UnitTestCase {
 		$this->assertTrue( str_ends_with( \Pressbooks\Image\default_cover_path( 'full' ), 'default-book-cover.jpg' ) );
 	}
 
+	/**
+	 * @group media
+	 */
 	public function test_is_default_cover() {
 		$url = \Pressbooks\Image\default_cover_url();
 		$path = \Pressbooks\Image\default_cover_path();
@@ -29,6 +39,9 @@ class ImageTest extends \WP_UnitTestCase {
 		$this->assertFalse( \Pressbooks\Image\is_default_cover( 'https://pressbooks.com/wp-content/uploads/2015/04/hero-image-4.png' ) );
 	}
 
+	/**
+	 * @group media
+	 */
 	public function test_is_valid_image() {
 		$this->assertTrue( \Pressbooks\Image\is_valid_image( __DIR__ . '/data/pb.png', 'pb.png' ) );
 		$this->assertFalse( \Pressbooks\Image\is_valid_image( 'binary', 'pb.png', true ) );
@@ -36,6 +49,9 @@ class ImageTest extends \WP_UnitTestCase {
 		$this->assertFalse( \Pressbooks\Image\is_valid_image( __DIR__ . '/data/template.php', 'pb.png' ) );
 	}
 
+	/**
+	 * @group media
+	 */
 	public function test_thumbify() {
 		$thumb = '_zigzag';
 		$path = '/2017/08/foo-bar.jpeg';
@@ -48,6 +64,9 @@ class ImageTest extends \WP_UnitTestCase {
 		$this->assertEquals( '/2017/08/foo-bar.unknown', $result );
 	}
 
+	/**
+	 * @group media
+	 */
 	public function test_strip_baseurl() {
 		$test = 'https://pressbooks.dev/upload/2017/08/foo-bar.png';
 		$result = \Pressbooks\Image\strip_baseurl( $test );
@@ -62,6 +81,9 @@ class ImageTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'https://pressbooks.dev/upload/zig/zag/foo-bar.png', $result );
 	}
 
+	/**
+	 * @group media
+	 */
 	public function test_fudge_factor() {
 		$before = (int) ini_get( 'memory_limit' );
 		$format = 'png';
@@ -72,6 +94,9 @@ class ImageTest extends \WP_UnitTestCase {
 		ini_set( 'memory_limit', $before );
 	}
 
+	/**
+	 * @group media
+	 */
 	public function test_proper_image_extension() {
 		$file = __DIR__ . '/data/pb.png';
 		$result = \Pressbooks\Image\proper_image_extension( $file, 'pb.jpg' );
@@ -81,6 +106,9 @@ class ImageTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'pb.unknown', $result );
 	}
 
+	/**
+	 * @group media
+	 */
 	public function test_get_dpi() {
 
 		$file = __DIR__ . '/data/template.php';
@@ -108,6 +136,9 @@ class ImageTest extends \WP_UnitTestCase {
 		$this->assertEquals( 72, $dpi );
 	}
 
+	/**
+	 * @group media
+	 */
 	public function test_get_aspect_ratio() {
 
 		$file = __DIR__ . '/data/template.php';
@@ -135,6 +166,9 @@ class ImageTest extends \WP_UnitTestCase {
 		$this->assertEquals( '1024:685', $aspect_ratio );
 	}
 
+	/**
+	 * @group media
+	 */
 	public function test_differences() {
 
 		$file1 = __DIR__ . '/data/template.php';
@@ -152,6 +186,9 @@ class ImageTest extends \WP_UnitTestCase {
 		$this->assertTrue( $distance > 0 );
 	}
 
+	/**
+	 * @group media
+	 */
 	public function test_is_bigger_version() {
 
 		$mountains = __DIR__ . '/data/mountains.jpg';
@@ -165,6 +202,9 @@ class ImageTest extends \WP_UnitTestCase {
 		$this->assertTrue( \Pressbooks\Image\is_bigger_version( $file3, $mountains ) );
 	}
 
+	/**
+	 * @group media
+	 */
 	public function test_maybe_swap_with_bigger() {
 		$id = $this->factory()->attachment->create_upload_object( __DIR__ . '/data/mountains.jpg' );
 
@@ -180,6 +220,9 @@ class ImageTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'blah-blah-blah', $new );
 	}
 
+	/**
+	 * @group media
+	 */
 	public function test_same_aspect_ratio() {
 
 		$file1 = __DIR__ . '/data/DosenmoorBirken1.jpg';

--- a/tests/test-integrations.php
+++ b/tests/test-integrations.php
@@ -4,6 +4,9 @@ class IntegrationsTest extends \WP_UnitTestCase {
 
 	use utilsTrait;
 
+	/**
+	 * @group integrations
+	 */
 	public function test_cloneRemoteBook() {
 
 		$source = 'https://pbtest.pressbooks.com';
@@ -47,6 +50,9 @@ class IntegrationsTest extends \WP_UnitTestCase {
 		$this->assertTrue( count( $cloned_items['media'] ) === 2 );
 	}
 
+	/**
+	 * @group integrations
+	 */
 	public function test_ImportUsingCloningApi() {
 
 		$source = 'https://pbtest.pressbooks.com';
@@ -71,7 +77,6 @@ class IntegrationsTest extends \WP_UnitTestCase {
 		}
 		$_POST['chapters'] = $post;
 		$this->assertTrue( $importer->import( $options ) );
-
 
 		// Check if imported chapters are in the correct position
 		$struct = \Pressbooks\Book::getBookStructure();
@@ -98,6 +103,9 @@ class IntegrationsTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'https://pressbooks.education/', get_post_meta( $post->ID, 'pb_media_attribution_adapted_url', true ) );
 	}
 
+	/**
+	 * @group integrations
+	 */
 	public function test_ImportPressbooksWxr() {
 		$this->_book();
 		$meta_post = ( new \Pressbooks\Metadata() )->getMetaPost();

--- a/tests/test-interactive-content.php
+++ b/tests/test-interactive-content.php
@@ -4,15 +4,21 @@ class Interactive_ContentTest extends \WP_UnitTestCase {
 
 	/**
 	 * @var \Pressbooks\Interactive\Content
+	 * @group interactivecontent
 	 */
 	protected $content;
 
+	/**
+	 * @group interactivecontent
+	 */
 	public function setUp() {
 		parent::setUp();
 		$this->content = new \Pressbooks\Interactive\Content();
 	}
 
-
+	/**
+	 * @group interactivecontent
+	 */
 	public function test_deleteIframesNotOnWhitelist() {
 		$raw = '
 		Test One
@@ -47,6 +53,9 @@ class Interactive_ContentTest extends \WP_UnitTestCase {
 			$this->assertNotContains( '<p>', $result );
 	}
 
+	/**
+	 * @group interactivecontent
+	 */
 	public function test_replaceIframes() {
 		$html = '
 		<p>Test</p>
@@ -61,6 +70,9 @@ class Interactive_ContentTest extends \WP_UnitTestCase {
 		$this->assertContains( 'excluded from this version of the text', $result );
 	}
 
+	/**
+	 * @group interactivecontent
+	 */
 	public function test_allowIframesInHtml() {
 		$user_id = $this->factory()->user->create( [ 'role' => 'administrator' ] );
 		wp_set_current_user( $user_id );
@@ -68,6 +80,9 @@ class Interactive_ContentTest extends \WP_UnitTestCase {
 		$this->assertTrue( ! empty( $allowed['iframe'] ) );
 	}
 
+	/**
+	 * @group interactivecontent
+	 */
 	public function test_replaceOembed() {
 
 		$data = new \StdClass();
@@ -87,6 +102,9 @@ class Interactive_ContentTest extends \WP_UnitTestCase {
 		$this->assertContains( 'excluded from this version of the text', $result );
 	}
 
+	/**
+	 * @group interactivecontent
+	 */
 	public function test_replaceInteractiveTags() {
 
 		$html = '
@@ -102,11 +120,17 @@ class Interactive_ContentTest extends \WP_UnitTestCase {
 		$this->assertContains( 'excluded from this version of the text', $result );
 	}
 
+	/**
+	 * @group interactivecontent
+	 */
 	public function test_addExtraOembedProviders() {
 		$providers = $this->content->addExtraOembedProviders( [] );
 		$this->assertNotEmpty( $providers );
 	}
 
+	/**
+	 * @group interactivecontent
+	 */
 	public function test_deleteOembedCaches() {
 		$this->content->deleteOembedCaches( 1 );
 		$this->content->deleteOembedCaches();
@@ -116,6 +140,9 @@ class Interactive_ContentTest extends \WP_UnitTestCase {
 		$this->assertEmpty( $id );
 	}
 
+	/**
+	 * @group interactivecontent
+	 */
 	public function test_mediaElementConfiguration() {
 		$s['_foo'] = 'bar';
 		$s['autoRewind'] = true;

--- a/tests/test-interactive-h5p.php
+++ b/tests/test-interactive-h5p.php
@@ -4,20 +4,30 @@ class Interactive_H5PTest extends \WP_UnitTestCase {
 
 	/**
 	 * @var \Pressbooks\Interactive\H5P
+	 * @group interactivecontent
 	 */
 	protected $h5p;
 
+
+	/**
+	 * @group interactivecontent
+	 */
 	public function setUp() {
 		parent::setUp();
 		$blade = \Pressbooks\Container::get( 'Blade' );
 		$this->h5p = new \Pressbooks\Interactive\H5P( $blade );
 	}
 
-
+	/**
+	 * @group interactivecontent
+	 */
 	public function test_isActive() {
 		$this->assertTrue( is_bool( $this->h5p->isActive() ) );
 	}
 
+	/**
+	 * @group interactivecontent
+	 */
 	public function test_replaceShortcode() {
 		$result = $this->h5p->replaceShortcode( [] );
 		$this->assertContains( '<div ', $result );
@@ -30,12 +40,18 @@ class Interactive_H5PTest extends \WP_UnitTestCase {
 		$this->assertContains( 'excluded from this version of the text', $result );
 	}
 
+	/**
+	 * @group interactivecontent
+	 */
 	public function test_override() {
 		global $shortcode_tags;
 		$this->h5p->override();
 		$this->assertArrayHasKey( 'h5p', $shortcode_tags );
 	}
 
+	/**
+	 * @group interactivecontent
+	 */
 	public function test_replaceCloneable() {
 		$content = '[h5p id="1"][h5p id=\'2\' something="else"][h5p id=3]';
 		$result = $this->h5p->replaceUncloneable( $content );

--- a/tests/test-interactive-phet.php
+++ b/tests/test-interactive-phet.php
@@ -4,15 +4,22 @@ class Interactive_PhetTest extends \WP_UnitTestCase {
 
 	/**
 	 * @var \Pressbooks\Interactive\Phet
+	 * @group interactivecontent
 	 */
 	protected $phet;
 
+	/**
+	 * @group interactivecontent
+	 */
 	public function setUp() {
 		parent::setUp();
 		$blade = \Pressbooks\Container::get( 'Blade' );
 		$this->phet = new \Pressbooks\Interactive\Phet( $blade );
 	}
 
+	/**
+	 * @group interactivecontent
+	 */
 	public function test_registerEmbedHandlerForWeb() {
 		global $wp_embed;
 		unset( $wp_embed->handlers[10][ $this->phet::EMBED_ID ] );
@@ -20,6 +27,9 @@ class Interactive_PhetTest extends \WP_UnitTestCase {
 		$this->assertNotEmpty( $wp_embed->handlers[10][ $this->phet::EMBED_ID ] );
 	}
 
+	/**
+	 * @group interactivecontent
+	 */
 	public function test_registerEmbedHandlerForExport() {
 		global $wp_embed;
 		unset( $wp_embed->handlers[10][ $this->phet::EMBED_ID ] );

--- a/tests/test-l10n.php
+++ b/tests/test-l10n.php
@@ -2,6 +2,10 @@
 
 class L10nTest extends \WP_UnitTestCase {
 
+
+	/**
+	 * @group localization
+	 */
 	public function test_get_locale() {
 
 		$locale = \Pressbooks\L10n\get_locale();
@@ -9,12 +13,18 @@ class L10nTest extends \WP_UnitTestCase {
 		$this->assertTrue( is_string( $locale ) );
 	}
 
+	/**
+	 * @group localization
+	 */
 	public function test_load_plugin_textdomain() {
 
 		\Pressbooks\L10n\load_plugin_textdomain();
 		$this->assertTrue( true ); // Did not crash
 	}
 
+	/**
+	 * @group localization
+	 */
 	public function test_include_core_overrides() {
 
 		$overrides = \Pressbooks\L10n\include_core_overrides();
@@ -23,6 +33,9 @@ class L10nTest extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'My Sites', $overrides );
 	}
 
+	/**
+	 * @group localization
+	 */
 	public function test_override_core_strings() {
 
 		$text = 'My Sites';
@@ -35,6 +48,9 @@ class L10nTest extends \WP_UnitTestCase {
 		$this->assertNotEquals( $text, $translated ); // 'My Sites' should be 'My Books', 'Mes Livres', ...
 	}
 
+	/**
+	 * @group localization
+	 */
 	public function test_set_locate() {
 
 		$this->assertTrue(
@@ -42,6 +58,9 @@ class L10nTest extends \WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * @group localization
+	 */
 	public function test_set_root_locate() {
 
 		$this->assertTrue(
@@ -49,18 +68,27 @@ class L10nTest extends \WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * @group localization
+	 */
 	public function test_supported_languages() {
 
 		$supported_languages = \Pressbooks\L10n\supported_languages();
 		$this->assertTrue( is_array( $supported_languages ) );
 	}
 
+	/**
+	 * @group localization
+	 */
 	public function test_wplang_codes() {
 
 		$wplang_codes = \Pressbooks\L10n\wplang_codes();
 		$this->assertTrue( is_array( $wplang_codes ) );
 	}
 
+	/**
+	 * @group localization
+	 */
 	public function test_romanize() {
 
 		$this->assertEquals( \Pressbooks\L10n\romanize( 1 ), 'I' );
@@ -70,6 +98,9 @@ class L10nTest extends \WP_UnitTestCase {
 		$this->assertEquals( \Pressbooks\L10n\romanize( 1975 ), 'MCMLXXV' );
 	}
 
+	/**
+	 * @group localization
+	 */
 	public function test_install_book_locale() {
 
 		// Test for incorrect meta_key

--- a/tests/test-licensing.php
+++ b/tests/test-licensing.php
@@ -6,17 +6,21 @@ class LicensingTest extends \WP_UnitTestCase {
 
 	/**
 	 * @var \Pressbooks\Licensing()
+	 * @group licensing
 	 */
 	protected $licensing;
 
 	/**
-	 *
+	 * @group licensing
 	 */
 	public function setUp() {
 		parent::setUp();
 		$this->licensing = new \Pressbooks\Licensing();
 	}
 
+	/**
+	 * @group licensing
+	 */
 	public function test_getSupportedTypes() {
 		// Insert custom term
 		wp_insert_term(
@@ -49,11 +53,17 @@ class LicensingTest extends \WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'fake-records', $result );
 	}
 
+	/**
+	 * @group licensing
+	 */
 	public function test_disableTranslation() {
 		$var = $this->licensing->disableTranslation( 'a', 'b', 'c' );
 		$this->assertEquals( 'b', $var );
 	}
 
+	/**
+	 * @group licensing
+	 */
 	public function test_doLicense() {
 		$new_post = [
 			'post_title' => 'Test Chapter',
@@ -97,6 +107,7 @@ class LicensingTest extends \WP_UnitTestCase {
 
 	/**
 	 * @expectedIncorrectUsage Pressbooks\Licensing::doLicense
+	 * @group licensing
 	 */
 	public function test_doLicenseDeprecrated() {
 		$result = $this->licensing->doLicense( [], 0, 'Hello World!' );
@@ -105,6 +116,9 @@ class LicensingTest extends \WP_UnitTestCase {
 		$this->assertContains( 'Test Blog', $result ); // Book name
 	}
 
+	/**
+	 * @group licensing
+	 */
 	public function test_getWebLicenseHtml() {
 
 		$xml = new \SimpleXMLElement( '<book><title>Hello World!</title></book>' );
@@ -122,6 +136,9 @@ class LicensingTest extends \WP_UnitTestCase {
 		$this->assertContains( '</div>', $result );
 	}
 
+	/**
+	 * @group licensing
+	 */
 	public function test_getLicense() {
 		$result = $this->licensing->getLicense( 'public-domain', 'Herman Melville', 'https://mobydick.whale', 'Moby Dick', 1851 );
 		$this->assertEquals( $result, '<div class="license-attribution"><p><img src="' . get_template_directory_uri() . '/packages/buckram/assets/images/public-domain.svg" alt="Icon for the Public Domain license" /></p><p>This work (<a href="https://mobydick.whale">Moby Dick</a> by Herman Melville) is free of known copyright restrictions.</p></div>' );
@@ -131,16 +148,25 @@ class LicensingTest extends \WP_UnitTestCase {
 		$this->assertEquals( $result, '<div class="license-attribution"><p><img src="' . get_template_directory_uri() . '/packages/buckram/assets/images/cc-by.svg" alt="Icon for the Creative Commons Attribution 4.0 International License" /></p><p><a rel="cc:attributionURL" href="https://mobydick.whale" property="dc:title">Moby Dick</a> by <span property="cc:attributionName">Herman Melville</span> is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>, except where otherwise noted.</p></div>' );
 	}
 
+	/**
+	 * @group licensing
+	 */
 	public function test_getUrlForLicense() {
 		$result = $this->licensing->getUrlForLicense( 'public-domain' );
 		$this->assertEquals( $result, 'https://creativecommons.org/publicdomain/mark/1.0/' );
 	}
 
+	/**
+	 * @group licensing
+	 */
 	public function test_getLicenseFromUrl() {
 		$result = $this->licensing->getLicenseFromUrl( 'https://creativecommons.org/publicdomain/mark/1.0/' );
 		$this->assertEquals( $result, 'public-domain' );
 	}
 
+	/**
+	 * @group licensing
+	 */
 	public function test_getNameForLicense() {
 		$result = $this->licensing->getNameForLicense( 'public-domain' );
 		$this->assertEquals( $result, 'Public Domain' );

--- a/tests/test-media.php
+++ b/tests/test-media.php
@@ -1,7 +1,9 @@
 <?php
 
 class MediaTest extends \WP_UnitTestCase {
-
+	/**
+	 * @group media
+	 */
 	public function test_add_mime_types() {
 
 		$supportedFileExtensions = [ 'mp4', 'webm', 'ogv', 'ogg', 'mp3', 'aac', 'vorbis' ];
@@ -19,6 +21,9 @@ class MediaTest extends \WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'baz', $mimes );
 	}
 
+	/**
+	 * @group media
+	 */
 	public function test_is_valid_media() {
 
 		$goodFiles = [
@@ -51,6 +56,7 @@ class MediaTest extends \WP_UnitTestCase {
 
 
 	/**
+	 * @group media
 	 * @see https://github.com/pressbooks/pressbooks/issues/263
 	 */
 	public function test_force_wrap_images() {
@@ -74,6 +80,9 @@ class MediaTest extends \WP_UnitTestCase {
 		$this->assertStringEndsWith( '</a></div>', $converted );
 	}
 
+	/**
+	 * @group media
+	 */
 	public function test_force_attach_media() {
 		global $post_ID;
 		$post_ID = '42';
@@ -83,6 +92,9 @@ class MediaTest extends \WP_UnitTestCase {
 		$this->assertEquals( $return['post_id'], 42 );
 	}
 
+	/**
+	 * @group media
+	 */
 	public function test_mime_type() {
 		$mime = \Pressbooks\Media\mime_type( __DIR__ . '/data/htmlbook.html' );
 		$this->assertContains( 'html', $mime );
@@ -91,6 +103,9 @@ class MediaTest extends \WP_UnitTestCase {
 		$this->assertContains( 'jpeg', $mime );
 	}
 
+	/**
+	 * @group media
+	 */
 	public function test_extract_id_from_media() {
 		$media_img = [
 			0 => '<img src="https://pressbooks.test/app/uploads/sites/2/2018/06/IMG_5863-e1530742020691-225x300.jpg" alt="" width="225" height="300" class="wp-image-33 size-medium" srcset="https://pressbooks.test/app/uploads/sites/2/2018/06/IMG_5863-e1530742020691-225x300.jpg 225w, https://pressbooks.test/app/uploads/sites/2/2018/06/IMG_5863-e1530742020691-65x87.jpg 65w, https://pressbooks.test/app/uploads/sites/2/2018/06/IMG_5863-e1530742020691-350x467.jpg 350w, https://pressbooks.test/app/uploads/sites/2/2018/06/IMG_5863-e1530742020691.jpg 480w" sizes="(max-width: 225px) 100vw, 225px" />',
@@ -109,6 +124,9 @@ class MediaTest extends \WP_UnitTestCase {
 		$this->assertEquals( [], $result );
 	}
 
+	/**
+	 * @group media
+	 */
 	public function test_intersect_media_ids() {
 		$book_media    = [
 			90 => 'https://pressbooks.test/app/uploads/sites/2/2018/07/Movie-on-2018-07-16-at-2.19-PM.mp4',
@@ -130,6 +148,9 @@ class MediaTest extends \WP_UnitTestCase {
 		$this->assertEquals( [], $result );
 	}
 
+	/**
+	 * @group media
+	 */
 	public function test_strip_baseurl() {
 		$test = 'https://pressbooks.dev/upload/2017/08/foo-bar.mp3';
 		$result = \Pressbooks\Media\strip_baseurl( $test );

--- a/tests/test-metaboxes.php
+++ b/tests/test-metaboxes.php
@@ -5,6 +5,9 @@ require_once( PB_PLUGIN_DIR . 'inc/admin/metaboxes/namespace.php' );
 
 class MetaboxesTest extends \WP_UnitTestCase {
 
+	/**
+	 * @group metaboxes
+	 */
 	public function test_title_update() {
 
 		$title = get_option( 'blogname' );
@@ -18,6 +21,9 @@ class MetaboxesTest extends \WP_UnitTestCase {
 		$this->assertEquals( $option, $title );
 	}
 
+	/**
+	 * @group metaboxes
+	 */
 	public function test_add_meta_boxes() {
 
 		global $wp_meta_boxes;
@@ -34,6 +40,9 @@ class MetaboxesTest extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'additional-catalog-information', $c->metadata['metadata'] );
 	}
 
+	/**
+	 * @group metaboxes
+	 */
 	public function test_status_visibility_box() {
 		\Pressbooks\Metadata\init_book_data_models();
 
@@ -77,6 +86,9 @@ class MetaboxesTest extends \WP_UnitTestCase {
 		$this->assertContains( '<input type="checkbox" name="glossary_visibility" id="glossary_visibility"', $buffer );
 	}
 
+	/**
+	 * @group metaboxes
+	 */
 	public function test_publish_fields_save() {
 
 		\Pressbooks\Metadata\init_book_data_models();
@@ -181,6 +193,9 @@ class MetaboxesTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'private', $post->post_status );
 	}
 
+	/**
+	 * @group metaboxes
+	 */
 	public function test_part_save_box() {
 		$post = [ 'post_status' => 'draft'];
 		ob_start();
@@ -197,6 +212,9 @@ class MetaboxesTest extends \WP_UnitTestCase {
 		$this->assertContains( '<input name="save" id="publish" type="submit"', $buffer );
 	}
 
+	/**
+	 * @group metaboxes
+	 */
 	public function test_metadata_save_box() {
 		$post = [ 'post_status' => 'draft'];
 		ob_start();

--- a/tests/test-metadata.php
+++ b/tests/test-metadata.php
@@ -6,21 +6,24 @@ class MetadataTest extends \WP_UnitTestCase {
 
 	/**
 	 * @var \Pressbooks\Metadata
+	 * @group metadata
 	 */
 	protected $metadata;
 
 	/**
 	 * @var \Pressbooks\Taxonomy
+	 * @group metadata
 	 */
 	protected $taxonomy;
 
 	/**
 	 * @var \Pressbooks\Contributors
+	 * @group metadata
 	 */
 	protected $contributor;
 
 	/**
-	 *
+	 * @group metadata
 	 */
 	public function setUp() {
 		parent::setUp();
@@ -34,6 +37,7 @@ class MetadataTest extends \WP_UnitTestCase {
 
 	/**
 	 * @see \Pressbooks\Metadata::jsonSerialize
+	 * @group metadata
 	 */
 	public function test_Metadata_JsonSerialize() {
 		$result = json_encode( $this->metadata );
@@ -42,18 +46,27 @@ class MetadataTest extends \WP_UnitTestCase {
 
 	}
 
+	/**
+	 * @group metadata
+	 */
 	public function test_get_microdata_elements() {
 
 		$result = \Pressbooks\Metadata\get_microdata_elements();
 		$this->assertContains( '<meta', $result );
 	}
 
+	/**
+	 * @group metadata
+	 */
 	public function test_get_seo_meta_elements() {
 
 		$result = \Pressbooks\Metadata\get_seo_meta_elements();
 		$this->assertContains( '<meta', $result );
 	}
 
+	/**
+	 * @group metadata
+	 */
 	public function test_show_expanded_metadata() {
 		$result = \Pressbooks\Metadata\show_expanded_metadata();
 		$this->assertFalse( $result );
@@ -62,6 +75,9 @@ class MetadataTest extends \WP_UnitTestCase {
 		$this->assertTrue( $result );
 	}
 
+	/**
+	 * @group metadata
+	 */
 	public function test_has_expanded_metadata() {
 		$meta_post_id = $this->metadata->getMetaPostId();
 		$this->assertEquals( 0, $meta_post_id );
@@ -85,6 +101,9 @@ class MetadataTest extends \WP_UnitTestCase {
 		$this->assertTrue( $result );
 	}
 
+	/**
+	 * @group metadata
+	 */
 	public function test_book_information_to_schema() {
 		$book_information = [
 			'pb_authors' => 'Herman Melville',
@@ -99,6 +118,9 @@ class MetadataTest extends \WP_UnitTestCase {
 		$this->assertEquals( $result['identifier']['value'], 'my_doi' );
 	}
 
+	/**
+	 * @group metadata
+	 */
 	public function test_schema_to_book_information() {
 		$schema = [
 			'@context' => 'http://schema.org',
@@ -188,6 +210,9 @@ class MetadataTest extends \WP_UnitTestCase {
 		$this->assertEquals( $result['pb_copyright_holder'], 'Test 6' );
 	}
 
+	/**
+	 * @group metadata
+	 */
 	public function test_section_information_to_schema() {
 		$section_information = [
 			'pb_title' => 'Loomings',
@@ -207,6 +232,9 @@ class MetadataTest extends \WP_UnitTestCase {
 		$this->assertEquals( $result['identifier']['value'], 'my_doi' );
 	}
 
+	/**
+	 * @group metadata
+	 */
 	public function test_schema_to_section_information() {
 		$book_schema = [
 			'@context' => 'http://schema.org',
@@ -271,6 +299,9 @@ class MetadataTest extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'pb_section_license', $result );
 	}
 
+	/**
+	 * @group metadata
+	 */
 	public function test_get_thema_subjects() {
 		$result = \Pressbooks\Metadata\get_thema_subjects();
 		$this->assertArrayHasKey( 'Y', $result );
@@ -280,11 +311,17 @@ class MetadataTest extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( '1', $result );
 	}
 
+	/**
+	 * @group metadata
+	 */
 	public function test_get_subject_from_thema() {
 		$result = \Pressbooks\Metadata\get_subject_from_thema( '1KBC-CA-JM' );
 		$this->assertEquals( 'Nova Scotia: South Shore & Kejimkujik National Park', $result );
 	}
 
+	/**
+	 * @group metadata
+	 */
 	public function test_is_bisac() {
 		$result = \Pressbooks\Metadata\is_bisac( 'AB' );
 		$this->assertFalse( $result );
@@ -292,6 +329,9 @@ class MetadataTest extends \WP_UnitTestCase {
 		$this->assertTrue( $result );
 	}
 
+	/**
+	 * @group metadata
+	 */
 	public function test_postStatiiConversion() {
 		$val = $this->metadata->postStatiiConversion( 'wrong', 'wrong' );
 		$this->assertEquals( 'wrong', $val );
@@ -312,6 +352,9 @@ class MetadataTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'web-only', $val );
 	}
 
+	/**
+	 * @group metadata
+	 */
 	public function test_upgradeToPressbooksFive() {
 		$interactive = \Pressbooks\Interactive\Content::init();
 		$this->_book();
@@ -331,6 +374,9 @@ class MetadataTest extends \WP_UnitTestCase {
 		$this->assertContains( '<iframe width="560" height="315" src="https://www.youtube.com/embed/JgIhGTpKTwM" frameborder="0"></iframe>', $content );
 	}
 
+	/**
+	 * @group metadata
+	 */
 	public function test_get_section_information() {
 		$this->_book();
 		$chapters = get_posts( ['post_type' => 'chapter', 'posts_per_page' => 1 ] );
@@ -340,6 +386,9 @@ class MetadataTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'Or, A Chapter to Test', $section_information['pb_subtitle'] );
 	}
 
+	/**
+	 * @group metadata
+	 */
 	public function test_add_json_ld_metadata() {
 		$this->_book();
 		ob_start();
@@ -348,6 +397,9 @@ class MetadataTest extends \WP_UnitTestCase {
 		$this->assertStringStartsWith( '<script type="application/ld+json">{"@context":"http:\/\/schema.org","@type":"Book"', $buffer );
 	}
 
+	/**
+	 * @group metadata
+	 */
 	public function test_add_citation_metadata() {
 		$this->_book();
 		$this->taxonomy->registerTaxonomies();

--- a/tests/test-modules-export-export.php
+++ b/tests/test-modules-export-export.php
@@ -4,11 +4,17 @@ use Pressbooks\Container;
 
 class ExportMock extends \Pressbooks\Modules\Export\Export {
 
+	/**
+	 * @group export
+	 */
 	function convert() {
 		$this->outputPath = \Pressbooks\Utility\create_tmp_file();
 		return true;
 	}
 
+	/**
+	 * @group export
+	 */
 	function validate() {
 		return file_exists( $this->outputPath );
 	}
@@ -20,11 +26,12 @@ class Modules_Export_ExportTest extends \WP_UnitTestCase {
 
 	/**
 	 * @var \ExportMock
+	 * @group export
 	 */
 	protected $export;
 
 	/**
-	 *
+	 * @group export
 	 */
 	public function moduleProvider() {
 		return [
@@ -46,7 +53,7 @@ class Modules_Export_ExportTest extends \WP_UnitTestCase {
 	}
 
 	/**
-	 *
+	 * @group export
 	 */
 	public function moduleProviderHtml() {
 		return [
@@ -56,7 +63,7 @@ class Modules_Export_ExportTest extends \WP_UnitTestCase {
 	}
 
 	/**
-	 *
+	 * @group export
 	 */
 	public function setUp() {
 		parent::setUp();
@@ -64,6 +71,9 @@ class Modules_Export_ExportTest extends \WP_UnitTestCase {
 		do_action( 'pb_pre_export' );
 	}
 
+	/**
+	 * @group export
+	 */
 	public function test_getExportStylePath() {
 
 		$this->_book( 'pressbooks-luther' );
@@ -86,6 +96,9 @@ class Modules_Export_ExportTest extends \WP_UnitTestCase {
 	//      $this->markTestIncomplete();
 	//  }
 
+	/**
+	 * @group export
+	 */
 	public function test_getExportScriptPath() {
 
 		$this->_book( 'pressbooks-luther' );
@@ -100,6 +113,9 @@ class Modules_Export_ExportTest extends \WP_UnitTestCase {
 		$this->assertFalse( $path );
 	}
 
+	/**
+	 * @group export
+	 */
 	public function test_shouldParseSubsections() {
 
 		$val = $this->export->shouldParseSubsections();
@@ -111,6 +127,9 @@ class Modules_Export_ExportTest extends \WP_UnitTestCase {
 	//      $this->markTestIncomplete();
 	//  }
 
+	/**
+	 * @group export
+	 */
 	public function test_createTmpFile() {
 
 		$file = $this->export->createTmpFile();
@@ -120,6 +139,9 @@ class Modules_Export_ExportTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'Hello world!', file_get_contents( $file ) );
 	}
 
+	/**
+	 * @group export
+	 */
 	public function test_timestampedFileName() {
 
 		$this->_book();
@@ -136,6 +158,9 @@ class Modules_Export_ExportTest extends \WP_UnitTestCase {
 		$this->assertNotContains( '+', $file );
 	}
 
+	/**
+	 * @group export
+	 */
 	public function test_nonce_AND_verifyNonce() {
 
 		$time1 = time();
@@ -154,6 +179,9 @@ class Modules_Export_ExportTest extends \WP_UnitTestCase {
 		$this->assertFalse( $this->export->verifyNonce( $time3, $nonce3 ) );
 	}
 
+	/**
+	 * @group export
+	 */
 	public function test_mimeType() {
 
 		$i = $this->export;
@@ -161,6 +189,9 @@ class Modules_Export_ExportTest extends \WP_UnitTestCase {
 		$this->assertStringStartsWith( 'image/png', $mime );
 	}
 
+	/**
+	 * @group export
+	 */
 	public function test_getExportFolder() {
 
 		$this->_book();
@@ -172,6 +203,9 @@ class Modules_Export_ExportTest extends \WP_UnitTestCase {
 		$this->assertStringStartsWith( 'deny from all', file_get_contents( $path . '.htaccess' ) );
 	}
 
+	/**
+	 * @group export
+	 */
 	public function test_getLatestExportStylePath() {
 
 		$this->_book();
@@ -208,6 +242,9 @@ class Modules_Export_ExportTest extends \WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * @group export
+	 */
 	public function test_getLatestExportStyleUrl() {
 
 		$this->_book();
@@ -244,6 +281,9 @@ class Modules_Export_ExportTest extends \WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * @group export
+	 */
 	public function test_truncateExportStylesheets() {
 
 		$this->_book();
@@ -301,7 +341,9 @@ class Modules_Export_ExportTest extends \WP_UnitTestCase {
 		}
 	}
 
-
+	/**
+	 * @group export
+	 */
 	public function test_filters_useDocraptorInsteadOfPrince() {
 		$filters = new \Pressbooks\Modules\Export\Prince\Filters();
 		$this->assertTrue( is_bool( $filters->overridePrince() ) );
@@ -313,6 +355,7 @@ class Modules_Export_ExportTest extends \WP_UnitTestCase {
 	 * Verify XHTML content for good measure
 	 *
 	 * @dataProvider moduleProvider
+	 * @group export
 	 */
 	public function test_sanityChecks( $module, $prerequisite ) {
 
@@ -374,6 +417,9 @@ class Modules_Export_ExportTest extends \WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * @group export
+	 */
 	public function test_sanityCheckXhtmlWithoutBuckram() {
 
 		$this->_book( 'pressbooks-luther' ); // Use an old book.
@@ -399,6 +445,9 @@ class Modules_Export_ExportTest extends \WP_UnitTestCase {
 		unlink( $exporter->getOutputPath() );
 	}
 
+	/**
+	 * @group export
+	 */
 	public function test_sanityCheckXhtmlDebug() {
 		$this->_book();
 		$meta_post = ( new \Pressbooks\Metadata() )->getMetaPost();
@@ -426,6 +475,7 @@ class Modules_Export_ExportTest extends \WP_UnitTestCase {
 
 	/**
 	 * @dataProvider moduleProviderHtml
+	 * @group export
 	 */
 	public function test_sanityCheckOptimizeForPrint( $module, $prerequisite ) {
 		$this->_book();

--- a/tests/test-modules-export-table.php
+++ b/tests/test-modules-export-table.php
@@ -4,11 +4,13 @@ class Modules_Export_TableTest extends \WP_UnitTestCase {
 
 	/**
 	 * @var \Pressbooks\Modules\Export\Table
+	 * @group export
 	 */
 	protected $table;
 
 	/**
 	 * @var array
+	 * @group export
 	 */
 	protected $item = [
 		'ID' => '43761d21',
@@ -20,7 +22,7 @@ class Modules_Export_TableTest extends \WP_UnitTestCase {
 	];
 
 	/**
-	 *
+	 * @group export
 	 */
 	public function setUp() {
 		parent::setUp();
@@ -29,6 +31,9 @@ class Modules_Export_TableTest extends \WP_UnitTestCase {
 		$this->table = new \Pressbooks\Modules\Export\Table();
 	}
 
+	/**
+	 * @group export
+	 */
 	public function test_single_row() {
 		ob_start();
 		$this->table->single_row( $this->item );
@@ -36,22 +41,34 @@ class Modules_Export_TableTest extends \WP_UnitTestCase {
 		$this->assertContains( "<tr data-id='43761d21'", $buffer );
 	}
 
+	/**
+	 * @group export
+	 */
 	public function test_column_default() {
 		$x = $this->table->column_default( $this->item, 'ID' );
 		$this->assertEquals( '43761d21', $x );
 	}
 
+	/**
+	 * @group export
+	 */
 	public function test_column_file() {
 		$x = $this->table->column_file( $this->item );
 		$this->assertContains( "<div class='export-file-icon large pdf'", $x );
 		$this->assertContains( "Test-1547581888.pdf", $x );
 	}
 
+	/**
+	 * @group export
+	 */
 	public function test_column_pin() {
 		$x = $this->table->column_pin( $this->item );
 		$this->assertContains( "name='pin[43761d21]'", $x );
 	}
 
+	/**
+	 * @group export
+	 */
 	public function test_get_columns() {
 		$x = $this->table->get_columns();
 		$this->assertArrayHasKey( 'cb', $x );
@@ -63,6 +80,9 @@ class Modules_Export_TableTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'Date Exported', $x['exported'] );
 	}
 
+	/**
+	 * @group export
+	 */
 	public function test_get_sortable_columns() {
 		$x = $this->table->get_sortable_columns();
 		$this->assertArrayHasKey( 'file', $x );
@@ -71,22 +91,28 @@ class Modules_Export_TableTest extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'exported', $x );
 	}
 
+	/**
+	 * @group export
+	 */
 	public function test_get_bulk_actions() {
 		$x = $this->table->get_bulk_actions();
 		$this->assertArrayHasKey( 'delete', $x );
 	}
 
+	/**
+	 * @group export
+	 */
 	public function test_prepare_items() {
 		$this->table->prepare_items();
 		$this->assertTrue( is_array( $this->table->items ) );
 	}
 
+	/**
+	 * @group export
+	 */
 	public function test_inlineJs() {
 		$x = $this->table->inlineJs();
 		$this->assertContains( "var _pb_export_formats_map = ", $x );
 		$this->assertContains( "var _pb_export_pins_inventory =", $x );
 	}
-
-
-
 }

--- a/tests/test-modules-export.php
+++ b/tests/test-modules-export.php
@@ -3,17 +3,25 @@
 require_once( PB_PLUGIN_DIR . 'inc/modules/export/namespace.php' );
 
 class Modules_ExportTest extends \WP_UnitTestCase {
-
+	/**
+	 * @group export
+	 */
 	public function test_dependency_errors() {
 		$errors = \Pressbooks\Modules\Export\dependency_errors();
 		$this->assertTrue( is_array( $errors ) );
 	}
 
+	/**
+	 * @group export
+	 */
 	public function test_dependency_errors_msg() {
 		$error = \Pressbooks\Modules\Export\dependency_errors_msg();
 		$this->assertTrue( is_string( $error ) );
 	}
 
+	/**
+	 * @group export
+	 */
 	public function test_formats() {
 		$formats = \Pressbooks\Modules\Export\formats();
 		$this->assertArrayHasKey( 'standard', $formats );
@@ -22,6 +30,9 @@ class Modules_ExportTest extends \WP_UnitTestCase {
 		$this->assertTrue( is_array( $formats['exotic'] ) );
 	}
 
+	/**
+	 * @group export
+	 */
 	public function test_filetypes() {
 		$filetypes = \Pressbooks\Modules\Export\filetypes();
 		$this->assertArrayHasKey( 'print_pdf', $filetypes );
@@ -30,6 +41,9 @@ class Modules_ExportTest extends \WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * @group export
+	 */
 	public function test_get_name_from_filetype_slug() {
 		$type = \Pressbooks\Modules\Export\get_name_from_filetype_slug( 'print-pdf' );
 		$this->assertEquals( 'Print PDF', $type );
@@ -37,6 +51,9 @@ class Modules_ExportTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'Wtfbbq', $type );
 	}
 
+	/**
+	 * @group export
+	 */
 	public function test_get_name_from_module_classname() {
 		$type = \Pressbooks\Modules\Export\get_name_from_module_classname( '\Pressbooks\Modules\Export\Prince\Pdf' );
 		$this->assertEquals( 'Digital PDF', $type );
@@ -44,6 +61,9 @@ class Modules_ExportTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'Docx', $type );
 	}
 
+	/**
+	 * @group export
+	 */
 	public function test_template_data() {
 		$data = \Pressbooks\Modules\Export\template_data();
 		$this->assertArrayHasKey( 'export_form_url', $data );

--- a/tests/test-modules-import.php
+++ b/tests/test-modules-import.php
@@ -2,11 +2,16 @@
 
 
 class ImportMock extends \Pressbooks\Modules\Import\Import {
-
+	/**
+	 * @group import
+	 */
 	function setCurrentImportOption( array $upload ) {
 		return true;
 	}
 
+	/**
+	 * @group import
+	 */
 	function import( array $current_import ) {
 		return true;
 	}
@@ -19,22 +24,29 @@ class Modules_ImportTest extends \WP_UnitTestCase {
 
 	/**
 	 * @var \ImportMock
+	 * @group import
 	 */
 	protected $import;
 
 
 	/**
-	 *
+	 * @group import
 	 */
 	public function setUp() {
 		parent::setUp();
 		$this->import = new \ImportMock();
 	}
 
+	/**
+	 * @group import
+	 */
 	public function test_revokeCurrentImport() {
 		$this->assertTrue( is_bool( $this->import->revokeCurrentImport() ) );
 	}
 
+	/**
+	 * @group import
+	 */
 	public function test_createTmpFile() {
 
 		$file = $this->import->createTmpFile();
@@ -44,6 +56,9 @@ class Modules_ImportTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'Hello world!', file_get_contents( $file ) );
 	}
 
+	/**
+	 * @group import
+	 */
 	public function test_isFormSubmission() {
 
 		$this->assertFalse( $this->import::isFormSubmission() );

--- a/tests/test-namespace.php
+++ b/tests/test-namespace.php
@@ -6,6 +6,7 @@ class NamespaceTest extends \WP_UnitTestCase {
 
 	/**
 	 * Test PB style class initializations
+	 * @group namespace
 	 */
 	public function test_classInitConventions() {
 		$this->_book();

--- a/tests/test-options.php
+++ b/tests/test-options.php
@@ -8,6 +8,7 @@ class OptionsMock extends \Pressbooks\Options {
 	 *
 	 * @see upgrade()
 	 * @var int
+	 * @group options
 	 */
 	const VERSION = 1;
 
@@ -15,6 +16,7 @@ class OptionsMock extends \Pressbooks\Options {
 	 * Export options.
 	 *
 	 * @var array
+	 * @group options
 	 */
 	public $options;
 
@@ -22,6 +24,7 @@ class OptionsMock extends \Pressbooks\Options {
 	 * Export defaults.
 	 *
 	 * @var array
+	 * @group options
 	 */
 	public $defaults;
 
@@ -29,6 +32,7 @@ class OptionsMock extends \Pressbooks\Options {
 	 * Constructor.
 	 *
 	 * @param array $options The retrieved options.
+	 * @group options
 	 */
 	function __construct( array $options ) {
 		$this->options = $options;
@@ -46,6 +50,9 @@ class OptionsMock extends \Pressbooks\Options {
 		}
 	}
 
+	/**
+	 * @group options
+	 */
 	function init() {
 		$_page = $_option = $this->getSlug();
 		$_section = $this->getSlug() . '_section';
@@ -66,11 +73,15 @@ class OptionsMock extends \Pressbooks\Options {
 
 	/**
 	 * Display the mock options page description.
+	 * @group options
 	 */
 	function display() {
 		echo '<p>' . 'Mock settings.' . '</p>';
 	}
 
+	/**
+	 * @group options
+	 */
 	function render() {
 	?>
 		<div class="wrap">
@@ -83,6 +94,9 @@ class OptionsMock extends \Pressbooks\Options {
 		</div> <?php
 	}
 
+	/**
+	 * @group options
+	 */
 	function upgrade( $version ) {
 		// Unnecessary.
 	}
@@ -91,6 +105,7 @@ class OptionsMock extends \Pressbooks\Options {
 	 * Get the slug for the mock options page.
 	 *
 	 * @return string $slug
+	 * @group options
 	 */
 	static function getSlug() {
 		return 'mock';
@@ -100,11 +115,15 @@ class OptionsMock extends \Pressbooks\Options {
 	 * Get the localized title of the mock options page.
 	 *
 	 * @return string $title
+	 * @group options
 	 */
 	static function getTitle() {
 		return 'Mock';
 	}
 
+	/**
+	 * @group options
+	 */
 	static function getDefaults() {
 		return [
 			'option_bool' => 1,
@@ -121,6 +140,7 @@ class OptionsMock extends \Pressbooks\Options {
 	 * @param array $defaults The input array of default values.
 	 *
 	 * @return array $defaults
+	 * @group options
 	 */
 	static function filterDefaults( $defaults ) {
 		return $defaults;
@@ -130,6 +150,7 @@ class OptionsMock extends \Pressbooks\Options {
 	 * Get an array of options which return booleans.
 	 *
 	 * @return array $options
+	 * @group options
 	 */
 	static function getBooleanOptions() {
 		return [ 'option_bool' ];
@@ -139,6 +160,7 @@ class OptionsMock extends \Pressbooks\Options {
 	 * Get an array of options which return strings.
 	 *
 	 * @return array $options
+	 * @group options
 	 */
 	static function getStringOptions() {
 		return [ 'option_string' ];

--- a/tests/test-pdfoptions.php
+++ b/tests/test-pdfoptions.php
@@ -3,6 +3,9 @@
 class PDFOptionsTest extends \WP_UnitTestCase {
 	use utilsTrait;
 
+	/**
+	 * @group themeoptions
+	 */
 	public function test_scssOverrides() {
 		$this->_book( 'pressbooks-luther' );
 
@@ -15,6 +18,9 @@ class PDFOptionsTest extends \WP_UnitTestCase {
 
 	}
 
+	/**
+	 * @group themeoptions
+	 */
 	public function test_replaceRunningContentTags() {
 		$result = \Pressbooks\Modules\ThemeOptions\PDFOptions::replaceRunningContentTags( '%section_title%' );
 		$this->assertEquals( '"" string(section-title) ""', $result );
@@ -22,6 +28,9 @@ class PDFOptionsTest extends \WP_UnitTestCase {
 		$this->assertEquals( '"foo"', $result );
 	}
 
+	/**
+	 * @group themeoptions
+	 */
 	public function test_replaceRunningContentStrings() {
 		$result = \Pressbooks\Modules\ThemeOptions\PDFOptions::replaceRunningContentStrings( 'string(section-title)' );
 		$this->assertEquals( '%section_title%', $result );

--- a/tests/test-posttype.php
+++ b/tests/test-posttype.php
@@ -19,17 +19,26 @@ use function \Pressbooks\PostType\{
 
 class PostTypeTest extends \WP_UnitTestCase {
 
+	/**
+	 * @group posttypes
+	 */
 	function onNotSuccessfulTest( Throwable $t ) {
 		// Switch back to english for other tests
 		unload_textdomain( 'pressbooks' );
 		parent::onNotSuccessfulTest( $t );
 	}
 
+	/**
+	 * @group posttypes
+	 */
 	function test_list_post_types() {
 		$v = list_post_types();
 		$this->assertTrue( is_array( $v ) );
 	}
 
+	/**
+	 * @group posttypes
+	 */
 	function test_register_post_types() {
 		global $wp_post_types;
 		$wp_post_types_old = $wp_post_types;
@@ -46,6 +55,9 @@ class PostTypeTest extends \WP_UnitTestCase {
 		$wp_post_types = $wp_post_types_old;
 	}
 
+	/**
+	 * @group posttypes
+	 */
 	function test_row_actions() {
 		$actions['do-not-touch'] = 1;
 		$actions['view'] = 1;
@@ -63,6 +75,9 @@ class PostTypeTest extends \WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'inline hide-if-no-js', $actions2 );
 	}
 
+	/**
+	 * @group posttypes
+	 */
 	function test_disable_months_dropdown() {
 		$this->assertTrue( disable_months_dropdown( false, 'glossary' ) );
 
@@ -70,6 +85,9 @@ class PostTypeTest extends \WP_UnitTestCase {
 		$this->assertFalse( disable_months_dropdown( false, 'imaginary-post-type' ) );
 	}
 
+	/**
+	 * @group posttypes
+	 */
 	function test_after_title() {
 		$x = new \StdClass();
 
@@ -93,6 +111,9 @@ class PostTypeTest extends \WP_UnitTestCase {
 		$this->assertContains( 'id="pb-post-type-notice"', $buffer );
 	}
 
+	/**
+	 * @group posttypes
+	 */
 	function test_wp_editor_settings() {
 
 		global $post;
@@ -110,6 +131,9 @@ class PostTypeTest extends \WP_UnitTestCase {
 		$this->assertTrue( $settings2['media_buttons'] === false );
 	}
 
+	/**
+	 * @group posttypes
+	 */
 	function test_display_post_states() {
 		$x = new \StdClass();
 
@@ -123,6 +147,9 @@ class PostTypeTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'Unlisted', $post_states['private'] );
 	}
 
+	/**
+	 * @group posttypes
+	 */
 	function test_register_meta() {
 		global $wp_meta_keys;
 		$wp_meta_keys_old = $wp_meta_keys;
@@ -136,6 +163,9 @@ class PostTypeTest extends \WP_UnitTestCase {
 		$wp_meta_keys = $wp_meta_keys_old;
 	}
 
+	/**
+	 * @group posttypes
+	 */
 	function test_register_post_statii() {
 		global $wp_post_statuses;
 		$wp_post_statuses_old = $wp_post_statuses;
@@ -147,6 +177,9 @@ class PostTypeTest extends \WP_UnitTestCase {
 		$wp_post_statuses = $wp_post_statuses_old;
 	}
 
+	/**
+	 * @group posttypes
+	 */
 	function test_add_post_types_rss() {
 		$args['feed'] = true;
 		$args = add_post_types_rss( $args );
@@ -155,6 +188,9 @@ class PostTypeTest extends \WP_UnitTestCase {
 		$this->assertTrue( is_array( $args['post_type'] ) );
 	}
 
+	/**
+	 * @group posttypes
+	 */
 	function test_add_posttypes_to_hypothesis() {
 		$posttypes = add_posttypes_to_hypothesis(
 			[
@@ -167,6 +203,9 @@ class PostTypeTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'chapters', $posttypes['chapter'] );
 	}
 
+	/**
+	 * @group posttypes
+	 */
 	function test_can_export() {
 		\Pressbooks\PostType\register_post_statii();
 		$pid = $this->factory()->post->create();
@@ -186,6 +225,9 @@ class PostTypeTest extends \WP_UnitTestCase {
 		$this->assertFalse( can_export( $pid ) );
 	}
 
+	/**
+	 * @group posttypes
+	 */
 	function test_get_post_type_label() {
 		$this->assertFalse( get_post_type_label( 'junk-post-type' ) );
 		$this->assertEquals( get_post_type_label( 'metadata' ), 'Book Information' );
@@ -196,6 +238,9 @@ class PostTypeTest extends \WP_UnitTestCase {
 		$this->assertEquals( get_post_type_label( 'glossary' ), 'Glossary' );
 	}
 
+	/**
+	 * @group posttypes
+	 */
 	function test_filter_post_type_label() {
 		$this->assertEquals( filter_post_type_label( 'Whatever I want', [ 'post_type' => 'unfiltered' ] ), 'Whatever I want' );
 		$this->assertEquals( filter_post_type_label( 'Chapter', [ 'post_type' => 'chapter' ] ), 'Chapter' );

--- a/tests/test-pressbooks.php
+++ b/tests/test-pressbooks.php
@@ -5,18 +5,22 @@ class PressbooksTest extends \WP_UnitTestCase {
 
 	/**
 	 * @var \Pressbooks\Pressbooks()
+	 * @group plugin
 	 */
 	protected $pb;
 
 
 	/**
-	 *
+	 * @group plugin
 	 */
 	public function setUp() {
 		parent::setUp();
 		$this->pb = new \Pressbooks\Pressbooks();
 	}
 
+	/**
+	 * @group plugin
+	 */
 	public function test_allowedBookThemes() {
 		$result = $this->pb->allowedBookThemes( [ 'pressbooks-book' => true, 'pressbooks-clarke' => true, 'pressbooks-fake' => true, 'twentyseventeen' => true ] );
 		$this->assertTrue( is_array( $result ) );
@@ -25,6 +29,9 @@ class PressbooksTest extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'pressbooks-clarke', $result );
 	}
 
+	/**
+	 * @group plugin
+	 */
 	public function test_allowedRootThemes() {
 		$result = $this->pb->allowedRootThemes( [ 'pressbooks-book' => true, 'pressbooks-clarke' => true, 'pressbooks-fake' => true, 'twentyseventeen' => true ] );
 		$this->assertTrue( is_array( $result ) );

--- a/tests/test-privacy.php
+++ b/tests/test-privacy.php
@@ -5,15 +5,20 @@ class GdprTest extends \WP_UnitTestCase {
 
 	/**
 	 * @var \Pressbooks\Privacy
+	 * @group privacy
 	 */
 	protected $privacy;
 
-
+	/**
+	 * @group privacy
+	 */
 	public function setUp() {
 		parent::setUp();
 		$this->privacy = new \Pressbooks\Privacy();
 	}
-
+	/**
+	 * @group privacy
+	 */
 	public function test_reschedulePrivacyDeleteOldExportFiles() {
 		$nochange = (object) [ 'hook' => 'cant_touch_this', 'interval' => 3600 ];
 		$event = $this->privacy->reschedulePrivacyCron( $nochange );
@@ -24,7 +29,9 @@ class GdprTest extends \WP_UnitTestCase {
 		$this->assertEquals( $event->schedule, 'twicedaily' );
 		$this->assertEquals( $event->interval, 43200 );
 	}
-
+	/**
+	 * @group privacy
+	 */
 	public function test_addPrivacyPolicyContent() {
 		// Doing it right
 		global $current_screen;

--- a/tests/test-redirect.php
+++ b/tests/test-redirect.php
@@ -9,6 +9,9 @@ class RedirectTest extends \WP_UnitTestCase {
 
 	use utilsTrait;
 
+	/**
+	 * @group redirect
+	 */
 	public function test_redirect() {
 		global $_pb_redirect_location;
 		$_pb_redirect_location = null;
@@ -18,18 +21,27 @@ class RedirectTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'https://pressbooks.com', $_pb_redirect_location );
 	}
 
+	/**
+	 * @group redirect
+	 */
 	public function test_flusher() {
 		delete_option( 'pressbooks_flusher' );
 		flusher();
 		$this->assertTrue( absint( get_option( 'pressbooks_flusher', 1 ) ) > 1 );
 	}
 
+	/**
+	 * @group redirect
+	 */
 	public function test_migrate_generated_content() {
 		$this->_book();
 		migrate_generated_content();
 		$this->assertTrue( true ); // Did not crash
 	}
 
+	/**
+	 * @group redirect
+	 */
 	public function test_trim_value() {
 		// Trim by reference
 		$val = '   test    ';
@@ -37,6 +49,9 @@ class RedirectTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'test', $val );
 	}
 
+	/**
+	 * @group redirect
+	 */
 	public function test_redirect_away_from_bad_urls() {
 		global $_pb_redirect_location;
 		$_pb_redirect_location = null;
@@ -106,6 +121,9 @@ class RedirectTest extends \WP_UnitTestCase {
 		$_pb_redirect_location = null;
 	}
 
+	/**
+	 * @group redirect
+	 */
 	public function test_programmatic_login() {
 		$this->assertFalse( \Pressbooks\Redirect\programmatic_login( 'nobody' ) );
 

--- a/tests/test-registration.php
+++ b/tests/test-registration.php
@@ -2,6 +2,9 @@
 
 class Registration extends \WP_UnitTestCase {
 
+	/**
+	 * @group registration
+	 */
 	function setUp() {
 		parent::setUp();
 		global $pagenow;
@@ -9,16 +12,26 @@ class Registration extends \WP_UnitTestCase {
 		add_filter( 'gettext', '\Pressbooks\Registration\custom_signup_text', 20, 3 );
 	}
 
+	/**
+	 * @group registration
+	 */
 	function tearDown() {
 		parent::tearDown();
 		remove_filter( 'gettext', '\Pressbooks\Registration\custom_signup_text' );
 	}
 
+
+	/**
+	 * @group registration
+	 */
 	public function test_custom_signup_text() {
 		$output = __( 'Create Site', 'pressbooks' );
 		$this->assertEquals( 'Create Book', $output );
 	}
 
+	/**
+	 * @group registration
+	 */
 	public function test_add_password_field() {
 
 		// Test for field label in output
@@ -28,6 +41,9 @@ class Registration extends \WP_UnitTestCase {
 		\Pressbooks\Registration\add_password_field( $e );
 	}
 
+	/**
+	 * @group registration
+	 */
 	public function test_validate_passwords() {
 
 		global $_POST;
@@ -64,6 +80,9 @@ class Registration extends \WP_UnitTestCase {
 		$this->assertEquals( 'Passwords do not match.', $content['errors']->get_error_message( 'password_1' ) );
 	}
 
+	/**
+	 * @group registration
+	 */
 	public function test_add_temporary_password() {
 
 		global $_POST;
@@ -83,6 +102,9 @@ class Registration extends \WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'password', $meta );
 	}
 
+	/**
+	 * @group registration
+	 */
 	public function test_add_hidden_password_field() {
 
 		global $_POST;

--- a/tests/test-remote-get-retry.php
+++ b/tests/test-remote-get-retry.php
@@ -2,6 +2,9 @@
 
 class RemoteGetRetryTest extends \WP_UnitTestCase {
 
+	/**
+	 * @group utility
+	 */
 	public function setUp() {
 		parent::setUp();
 
@@ -24,7 +27,9 @@ class RemoteGetRetryTest extends \WP_UnitTestCase {
 		});
 	}
 
-
+	/**
+	 * @group utility
+	 */
 	public function test_remote_get_retry() {
 
 		$response = \Pressbooks\Utility\remote_get_retry( 'http://example.com', [] );
@@ -32,6 +37,9 @@ class RemoteGetRetryTest extends \WP_UnitTestCase {
 		$this->assertEquals( $response['response']['code'], 200 );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_remote_get_single_retry() {
 
 		$response = \Pressbooks\Utility\remote_get_retry( 'http://example.com', [], 1 );

--- a/tests/test-sanitize.php
+++ b/tests/test-sanitize.php
@@ -2,6 +2,9 @@
 
 class SanitizeTest extends \WP_UnitTestCase {
 
+	/**
+	 * @group sanitize
+	 */
 	public function test_html5_to_xhtml11() {
 
 		$html = '<article style="font-weight:bold;">Foo</article><h1>Hello!</h1><command>Bar</command>';
@@ -12,6 +15,9 @@ class SanitizeTest extends \WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * @group sanitize
+	 */
 	public function test_html5_to_epub3() {
 
 		$html = '<article style="font-weight:bold;">Foo</article><h1>Hello!</h1><command>Bar</command>';
@@ -22,6 +28,9 @@ class SanitizeTest extends \WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * @group sanitize
+	 */
 	public function test_fix_audio_shortcode() {
 
 		\Pressbooks\Sanitize\fix_audio_shortcode();
@@ -32,6 +41,9 @@ class SanitizeTest extends \WP_UnitTestCase {
 		$this->assertFalse( strpos( $var, 'style=' ) );
 	}
 
+	/**
+	 * @group sanitize
+	 */
 	public function test_sanitize_xml_attribute() {
 
 		$var = 'Hello-World!';
@@ -44,6 +56,9 @@ class SanitizeTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'test', \Pressbooks\Sanitize\sanitize_xml_attribute( $var ) );
 	}
 
+	/**
+	 * @group sanitize
+	 */
 	public function test_sanitize_xml_id() {
 
 		$var = 'Hello-World!';
@@ -64,6 +79,9 @@ class SanitizeTest extends \WP_UnitTestCase {
 		$this->assertStringStartsWith( 'slug-', $test );
 	}
 
+	/**
+	 * @group sanitize
+	 */
 	public function test_remove_control_characters() {
 
 		$var = 'Hello-World!';
@@ -80,6 +98,9 @@ class SanitizeTest extends \WP_UnitTestCase {
 		$this->assertEquals( 8, mb_strlen( $test, 'UTF-8' ) );
 	}
 
+	/**
+	 * @group sanitize
+	 */
 	public function test_force_ascii() {
 
 		$var = 'Hello-World!';
@@ -101,6 +122,7 @@ class SanitizeTest extends \WP_UnitTestCase {
 	 * Generate a string containing all the ASCII control characters
 	 *
 	 * @return string
+	 * @group sanitize
 	 */
 	private function _generateControlCharacters() {
 
@@ -112,6 +134,9 @@ class SanitizeTest extends \WP_UnitTestCase {
 		return $controlCharacters;
 	}
 
+	/**
+	 * @group sanitize
+	 */
 	public function test_decode() {
 
 		$test = '&#48;&#49;&#50;&#51;&#52;&#53;&#038;&#54;&#55;&#56;&#57;';
@@ -123,6 +148,9 @@ class SanitizeTest extends \WP_UnitTestCase {
 		$this->assertEquals( '012345&#038;6789', $test );
 	}
 
+	/**
+	 * @group sanitize
+	 */
 	public function test_strip_br() {
 
 		$test = 'Hello <br /> World!';
@@ -142,6 +170,9 @@ class SanitizeTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'Hello    World!', $test );
 	}
 
+	/**
+	 * @group sanitize
+	 */
 	public function test_filter_title() {
 
 		// Acceptable Tags: <br />, <span> with class, <em>, and <strong>.
@@ -159,6 +190,9 @@ class SanitizeTest extends \WP_UnitTestCase {
 		$this->assertEquals( '<del>Keep me</del>', $test );
 	}
 
+	/**
+	 * @group sanitize
+	 */
 	public function test_canonicalize_url() {
 
 		$url = 'pressbooks.com/';
@@ -180,6 +214,9 @@ class SanitizeTest extends \WP_UnitTestCase {
 		$this->assertEquals( $url, \Pressbooks\Sanitize\canonicalize_url( $url ) );
 	}
 
+	/**
+	 * @group sanitize
+	 */
 	public function test_maybe_https() {
 
 		if ( isset( $_SERVER['HTTPS'] ) ) {
@@ -213,6 +250,9 @@ class SanitizeTest extends \WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * @group sanitize
+	 */
 	public function test_normalize_css_urls() {
 		// Relative font
 		$css = '@font-face { font-family: "Bergamot Ornaments"; src: url(themes-book/pressbooks-book/fonts/Bergamot-Ornaments.ttf) format("truetype"); font-weight: normal; font-style: normal; }';
@@ -243,6 +283,9 @@ class SanitizeTest extends \WP_UnitTestCase {
 		$this->assertContains( $template_directory_uri . '/packages/buckram/assets/images/icon-video.svg', Pressbooks\Sanitize\normalize_css_urls( $css ) );
 	}
 
+	/**
+	 * @group sanitize
+	 */
 	public function test_allow_post_content() {
 
 		global $allowedposttags;
@@ -252,6 +295,9 @@ class SanitizeTest extends \WP_UnitTestCase {
 		$this->assertTrue( $allowedposttags['h1']['xml:lang'] );
 	}
 
+	/**
+	 * @group sanitize
+	 */
 	public function test_clean_filename() {
 
 		$file = '../../hacker.php';
@@ -267,6 +313,9 @@ class SanitizeTest extends \WP_UnitTestCase {
 		$this->assertEquals( $file, 'フランス語.txt' );
 	}
 
+	/**
+	 * @group sanitize
+	 */
 	public function test_strip_container_tags() {
 
 		$test = '<HTML><div id="title-page"><h1 class="title">My Test Book</h1></div></HTML>';
@@ -299,6 +348,9 @@ TERRIBLE;
 		$this->assertEquals( '<p>No change</p>', $result );
 	}
 
+	/**
+	 * @group sanitize
+	 */
 	public function test_cleanup_css() {
 		$css = "body { font-family: 'Comic Sans' !important; }";
 		$this->assertEquals( $css, \Pressbooks\Sanitize\cleanup_css( $css ) );
@@ -310,6 +362,9 @@ TERRIBLE;
 		$this->assertEquals( '\\\A0', \Pressbooks\Sanitize\cleanup_css( $css ) );
 	}
 
+	/**
+	 * @group sanitize
+	 */
 	public function test_prettify() {
 		$val = '<div><p>Hello!</p></div>';
 		$result = \Pressbooks\Sanitize\prettify( $val );
@@ -322,6 +377,9 @@ PRETTY;
 		$this->assertEquals( trim( $pretty ), trim( $result ) );
 	}
 
+	/**
+	 * @group sanitize
+	 */
 	public function test_is_valid_timestamp() {
 		$this->assertTrue( \Pressbooks\Sanitize\is_valid_timestamp( 1 ) );
 		$this->assertTrue( \Pressbooks\Sanitize\is_valid_timestamp( '1' ) );
@@ -334,6 +392,9 @@ PRETTY;
 		$this->assertFalse( \Pressbooks\Sanitize\is_valid_timestamp( '+1000000' ) );
 	}
 
+	/**
+	 * @group sanitize
+	 */
 	public function test_reverse_wpautop() {
 		$raw = <<< RAW
 Hi there!
@@ -358,6 +419,9 @@ RAW;
 		$this->assertEquals( trim( $raw ), trim( $var ) );
 	}
 
+	/**
+	 * @group sanitize
+	 */
 	public function test_reverse_wpautop_accuracy() {
 		$raw = <<< RAW
 <strong>media attribution needs to be turned on in the Theme options.</strong>
@@ -393,7 +457,9 @@ RAW;
 		$this->assertEquals( normalize_whitespace( $raw ), normalize_whitespace( $reversed ) );
 	}
 
-
+	/**
+	 * @group sanitize
+	 */
 	public function test_sanitize_webbook_content() {
 		$content = <<< RAW
 <table border="1">
@@ -410,6 +476,9 @@ RAW;
 		$this->assertContains( '<p style="text-align: center">This should be centered.</p>', $result );
 	}
 
+	/**
+	 * @group sanitize
+	 */
 	public function test_filter_export_content() {
 		$content = <<< RAW
 <table border="1">

--- a/tests/test-sass.php
+++ b/tests/test-sass.php
@@ -8,18 +8,22 @@ class SassTest extends \WP_UnitTestCase {
 
 	/**
 	 * @var \Pressbooks\Sass
+	 * @group styles
 	 */
 	protected $sass;
 
 
 	/**
-	 *
+	 * @group styles
 	 */
 	public function setUp() {
 		parent::setUp();
 		$this->sass = Container::get( 'Sass' );
 	}
 
+	/**
+	 * @group styles
+	 */
 	public function test_paths() {
 
 		$this->assertNotEmpty( $this->sass->pathToPartials() );
@@ -35,6 +39,9 @@ class SassTest extends \WP_UnitTestCase {
 		$this->assertNotEmpty( $paths );
 	}
 
+	/**
+	 * @group styles
+	 */
 	public function test_getStringsToLocalize() {
 
 		$result = $this->sass->getStringsToLocalize();
@@ -47,6 +54,9 @@ class SassTest extends \WP_UnitTestCase {
 
 	}
 
+	/**
+	 * @group styles
+	 */
 	public function test_prependLocalizedVars() {
 
 		$scss = '/* Silence is golden. */';
@@ -59,6 +69,9 @@ class SassTest extends \WP_UnitTestCase {
 
 	}
 
+	/**
+	 * @group styles
+	 */
 	public function test_parseVariables() {
 		$scss = '$red: #d4002d !default;
 		$font-size:
@@ -85,7 +98,9 @@ class SassTest extends \WP_UnitTestCase {
 		$this->assertArrayNotHasKey( '_secret', $vars );
 	}
 
-
+	/**
+	 * @group styles
+	 */
 	public function test_compile() {
 		$scss = 'p { font-size: $foo }';
 		$this->sass->setVariables( [ 'foo' => 999 ] );

--- a/tests/test-searchandreplace.php
+++ b/tests/test-searchandreplace.php
@@ -6,16 +6,18 @@ class SearchResultTest extends \WP_UnitTestCase {
 
 	/**
 	 * @var \Pressbooks\Modules\SearchAndReplace\Result
+	 * @group searchandreplace
 	 */
 	protected $result;
 
 	/**
 	 * @var \Pressbooks\Modules\SearchAndReplace\Types\Content
+	 * @group searchandreplace
 	 */
 	protected $content;
 
 	/**
-	 *
+	 * @group searchandreplace
 	 */
 	public function setUp() {
 		parent::setUp();
@@ -23,6 +25,9 @@ class SearchResultTest extends \WP_UnitTestCase {
 		$this->content = new \Pressbooks\Modules\SearchAndReplace\Types\Content();
 	}
 
+	/**
+	 * @group searchandreplace
+	 */
 	public function test_singleLine() {
 		$this->result->search_plain = "line\rbreak";
 		$this->assertEquals( $this->result->singleLine(), false );
@@ -32,6 +37,9 @@ class SearchResultTest extends \WP_UnitTestCase {
 		$this->assertEquals( $this->result->singleLine(), true );
 	}
 
+	/**
+	 * @group searchandreplace
+	 */
 	public function test_regexValidate() {
 
 		$expr = "/known/i";
@@ -51,6 +59,9 @@ class SearchResultTest extends \WP_UnitTestCase {
 		$this->assertNotEquals( null, $result );
 	}
 
+	/**
+	 * @group searchandreplace
+	 */
 	public function test_searchAndReplace() {
 
 		$this->_book();

--- a/tests/test-shortcodes-attributions-attachments.php
+++ b/tests/test-shortcodes-attributions-attachments.php
@@ -6,18 +6,25 @@ class Shortcodes_Attributions_Attachments extends \WP_UnitTestCase {
 
 	/**
 	 * @var \Pressbooks\Shortcodes\Attributions\Attachments
+	 * @group attributions
 	 */
 	protected $att;
 
+	/**
+	 * @group attributions
+	 */
 	public function setUp() {
 		parent::setUp();
 
 		$this->att = $this->getMockBuilder( '\Pressbooks\Shortcodes\Attributions\Attachments' )
-						  ->setMethods( null )
-						  ->disableOriginalConstructor()
-						  ->getMock();
+						->setMethods( null )
+						->disableOriginalConstructor()
+						->getMock();
 	}
 
+	/**
+	 * @group attributions
+	 */
 	public function test_getInstance() {
 
 		$val = $this->att->init();
@@ -28,6 +35,9 @@ class Shortcodes_Attributions_Attachments extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'media_attributions', $shortcode_tags );
 	}
 
+	/**
+	 * @group attributions
+	 */
 	public function test_getAttributions() {
 
 		$result = $this->att->getAttributions( 'I have no <b>images</b>' );
@@ -35,6 +45,9 @@ class Shortcodes_Attributions_Attachments extends \WP_UnitTestCase {
 
 	}
 
+	/**
+	 * @group attributions
+	 */
 	public function test_getAttributionsMeta() {
 		$pid = $this->_createAttachment();
 		$url = get_post_meta( $pid, 'pb_media_attribution_title_url', true );
@@ -56,6 +69,9 @@ class Shortcodes_Attributions_Attachments extends \WP_UnitTestCase {
 
 	}
 
+	/**
+	 * @group attributions
+	 */
 	private function _createAttachment() {
 
 		$pid = $this->factory()->attachment->create_upload_object( __DIR__ . '/data/skates.jpg' );
@@ -69,6 +85,9 @@ class Shortcodes_Attributions_Attachments extends \WP_UnitTestCase {
 		return $pid;
 	}
 
+	/**
+	 * @group attributions
+	 */
 	public function test_attributionsContent() {
 		$attributions = [
 			33 => [
@@ -98,6 +117,9 @@ class Shortcodes_Attributions_Attachments extends \WP_UnitTestCase {
 		$this->assertEquals( '', $html );
 	}
 
+	/**
+	 * @group attributions
+	 */
 	public function test_getBookMedia() {
 		$this->assertEmpty( $this->att->getBookMedia() );
 		$pid = $this->_createAttachment();

--- a/tests/test-shortcodes-complex.php
+++ b/tests/test-shortcodes-complex.php
@@ -7,11 +7,12 @@ class Shortcodes_Complex extends \WP_UnitTestCase {
 
 	/**
 	 * @var \Pressbooks\Shortcodes\Complex\Complex
+	 * @group shortcodes
 	 */
 	protected $complex;
 
 	/**
-	 *
+	 * @group shortcodes
 	 */
 	public function setUp() {
 		parent::setUp();
@@ -22,6 +23,9 @@ class Shortcodes_Complex extends \WP_UnitTestCase {
 			->getMock();
 	}
 
+	/**
+	 * @group shortcodes
+	 */
 	public function test_getInstance() {
 		$val = $this->complex->init();
 
@@ -35,6 +39,9 @@ class Shortcodes_Complex extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'media', $shortcode_tags );
 	}
 
+	/**
+	 * @group shortcodes
+	 */
 	public function test_anchorShortcodeHandler() {
 		// Test an anchor with an ID.
 		$content = $this->complex->anchorShortCodeHandler( [ 'id' => 'my-anchor' ], '', 'anchor' );
@@ -55,6 +62,9 @@ class Shortcodes_Complex extends \WP_UnitTestCase {
 		$this->assertEmpty( $this->complex->anchorShortCodeHandler( [], '', 'anchor' ) );
 	}
 
+	/**
+	 * @group shortcodes
+	 */
 	public function test_columnsShortcodeHandler() {
 		// Test a column with no attributes.
 		$content = $this->complex->columnsShortCodeHandler( [], 'Call me Ishmael.', 'columns' );
@@ -89,6 +99,9 @@ class Shortcodes_Complex extends \WP_UnitTestCase {
 		$this->assertEmpty( $this->complex->columnsShortCodeHandler( [], '', 'columns' ) );
 	}
 
+	/**
+	 * @group shortcodes
+	 */
 	public function test_emailShortcodeHandler() {
 		// Test an email with no content.
 		$content = $this->complex->emailShortCodeHandler( [ 'address' => 'me@here.com' ], '', 'email' );
@@ -115,11 +128,17 @@ class Shortcodes_Complex extends \WP_UnitTestCase {
 		$this->assertEmpty( $this->complex->emailShortCodeHandler( [], '', 'email' ) );
 	}
 
+	/**
+	 * @group shortcodes
+	 */
 	public function test_equationShortcodeHandler() {
 		$content = $this->complex->equationShortCodeHandler( [], 'e^{\i \pi} + 1 = 0', 'equation' );
 		$this->assertEquals( "<p><img src='http://s0.wp.com/latex.php?latex=e%5E%7B%5Ci+%5Cpi%7D+%2B+1+%3D+0&#038;bg=ffffff&#038;fg=000000&#038;s=0&#038;zoom=1' alt='e^{\i \pi} + 1 = 0' title='e^{\i \pi} + 1 = 0' class='latex' /></p>\n", $content );
 	}
 
+	/**
+	 * @group shortcodes
+	 */
 	public function test_mediaShortcodeHandler() {
 		// Test a YouTube embed as a src attribute
 		$content = $this->complex->mediaShortCodeHandler( [ 'src' => 'https://www.youtube.com/watch?v=JgIhGTpKTwM' ], '', 'embed' );

--- a/tests/test-shortcodes-footnotes-footnotes.php
+++ b/tests/test-shortcodes-footnotes-footnotes.php
@@ -7,22 +7,26 @@ class Shortcodes_Footnotes extends \WP_UnitTestCase {
 
 	/**
 	 * @var \Pressbooks\Shortcodes\Footnotes\Footnotes
+	 * @group footnotes
 	 */
 	protected $fn;
 
 
 	/**
-	 *
+	 * @group footnotes
 	 */
 	public function setUp() {
 		parent::setUp();
 
 		$this->fn = $this->getMockBuilder( '\Pressbooks\Shortcodes\Footnotes\footnotes' )
-						 ->setMethods( null )// pass null to setMethods() to avoid mocking any method
-						 ->disableOriginalConstructor()// disable private constructor
-						 ->getMock();
+						->setMethods( null )// pass null to setMethods() to avoid mocking any method
+						->disableOriginalConstructor()// disable private constructor
+						->getMock();
 	}
 
+	/**
+	 * @group footnotes
+	 */
 	public function test_getInstance() {
 
 		$val = $this->fn->init();
@@ -33,6 +37,10 @@ class Shortcodes_Footnotes extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'footnote', $shortcode_tags );
 	}
 
+
+	/**
+	 * @group footnotes
+	 */
 	public function test_shortcodeHandler_numbered() {
 
 		global $id;
@@ -52,6 +60,10 @@ class Shortcodes_Footnotes extends \WP_UnitTestCase {
 		$this->assertEmpty( $this->fn->shortcodeHandler( [] ) );
 	}
 
+
+	/**
+	 * @group footnotes
+	 */
 	public function test_shortcodeHandler_notNumbered() {
 
 		global $id;
@@ -70,6 +82,9 @@ class Shortcodes_Footnotes extends \WP_UnitTestCase {
 	}
 
 
+	/**
+	 * @group footnotes
+	 */
 	public function test_footnoteContent_numbered() {
 
 		global $id;
@@ -90,6 +105,9 @@ class Shortcodes_Footnotes extends \WP_UnitTestCase {
 	}
 
 
+	/**
+	 * @group footnotes
+	 */
 	public function test_footnoteContent_notNumbered() {
 
 		global $id;
@@ -110,6 +128,9 @@ class Shortcodes_Footnotes extends \WP_UnitTestCase {
 	}
 
 
+	/**
+	 * @group footnotes
+	 */
 	public function test_ajaxFailure() {
 
 		$old_error_reporting = $this->_fakeAjax();
@@ -122,6 +143,10 @@ class Shortcodes_Footnotes extends \WP_UnitTestCase {
 		$this->_fakeAjaxDone( $old_error_reporting );
 	}
 
+
+	/**
+	 * @group footnotes
+	 */
 	public function test_convertWordFootnotes() {
 
 		$old_error_reporting = $this->_fakeAjax();

--- a/tests/test-shortcodes-generics.php
+++ b/tests/test-shortcodes-generics.php
@@ -7,11 +7,12 @@ class Shortcodes_Generics extends \WP_UnitTestCase {
 
 	/**
 	 * @var \Pressbooks\Shortcodes\Generics\Generics
+	 * @group shortcodes
 	 */
 	protected $generics;
 
 	/**
-	 *
+	 * @group shortcodes
 	 */
 	public function setUp() {
 		parent::setUp();
@@ -22,6 +23,9 @@ class Shortcodes_Generics extends \WP_UnitTestCase {
 			->getMock();
 	}
 
+	/**
+	 * @group shortcodes
+	 */
 	public function test_getInstance() {
 		$val = $this->generics->init();
 
@@ -31,6 +35,9 @@ class Shortcodes_Generics extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'blockquote', $shortcode_tags );
 	}
 
+	/**
+	 * @group shortcodes
+	 */
 	public function test_blockShortcodeHandler() {
 
 		// Test a straightforward tag.
@@ -44,6 +51,9 @@ class Shortcodes_Generics extends \WP_UnitTestCase {
 		$this->assertEmpty( $this->generics->blockShortcodeHandler( [], '', 'heading' ) );
 	}
 
+	/**
+	 * @group shortcodes
+	 */
 	public function test_multilineBlockShortcodeHandler() {
 
 		// Test a straightforward tag.
@@ -65,6 +75,9 @@ class Shortcodes_Generics extends \WP_UnitTestCase {
 		$this->assertEmpty( $this->generics->multilineBlockShortcodeHandler( [], '', 'blockquote' ) );
 	}
 
+	/**
+	 * @group shortcodes
+	 */
 	public function test_inlineShortcodeHandler() {
 
 		// Test a straightforward tag.

--- a/tests/test-shortcodes-glossary.php
+++ b/tests/test-shortcodes-glossary.php
@@ -6,9 +6,13 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 
 	/**
 	 * @var \Pressbooks\Shortcodes\Glossary\Glossary
+	 * @group glossary
 	 */
 	protected $gl;
 
+	/**
+	 * @group glossary
+	 */
 	public function setUp() {
 		parent::setUp();
 
@@ -23,7 +27,9 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 		$this->_createGlossaryTerms();
 		$this->gl->getGlossaryTerms( true ); // Reset cache
 	}
-
+	/**
+	 * @group glossary
+	 */
 	private function _createGlossaryTerms() {
 		$args1 = [
 			'post_type'    => 'glossary',
@@ -51,7 +57,9 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 		$p3 = $this->factory()->post->create_object( $args3 );
 		wp_set_object_terms( $p3, 'definitions', 'glossary-type' );
 	}
-
+	/**
+	 * @group glossary
+	 */
 	private function _createGlossaryPost() {
 
 		$args = [
@@ -64,7 +72,9 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 
 		return $pid;
 	}
-
+	/**
+	 * @group glossary
+	 */
 	public function test_getInstance() {
 
 		$val = $this->gl->init();
@@ -76,7 +86,9 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'pb_glossary', $shortcode_tags );
 
 	}
-
+	/**
+	 * @group glossary
+	 */
 	public function test_glossaryTerms() {
 		// assures alphabetical listing and format
 		$dl = $this->gl->glossaryTerms();
@@ -92,7 +104,9 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 		$this->assertEmpty( $dl );
 
 	}
-
+	/**
+	 * @group glossary
+	 */
 	public function test_glossaryTooltip() {
 		global $id;
 		$id = 42; // Fake it!
@@ -104,7 +118,9 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 		$result = $this->gl->glossaryTooltip( $pid, 'PHP' );
 		$this->assertEquals( 'PHP', $result );
 	}
-
+	/**
+	 * @group glossary
+	 */
 	public function test_getGlossaryTerms() {
 		$terms = $this->gl->getGlossaryTerms();
 		$this->assertEquals( 3, count( $terms ) );
@@ -127,6 +143,9 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 		$this->assertEquals( 'private', $terms['Cache Test']['status'] );
 	}
 
+	/**
+	 * @group glossary
+	 */
 	public function test_tooltipContent() {
 		$terms = $this->gl->getGlossaryTerms();
 
@@ -146,7 +165,9 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 		$this->assertContains( $definitions[0], $content );
 		$this->assertContains( $definitions[1], $content );
 	}
-
+	/**
+	 * @group glossary
+	 */
 	public function test_sanitizeGlossaryTerm() {
 		$data['post_type'] = 'imaginary-post-type';
 		$data['post_content'] = '<a href="https://google.com" onclick="event.preventDefault(); alert(\'evil!\');">All</a> is <strong>good.</strong>';
@@ -157,7 +178,9 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 		$results = $this->gl->sanitizeGlossaryTerm( $data );
 		$this->assertEquals( '<a href="https://google.com">All</a> is <strong>good.</strong>', $results['post_content'] );
 	}
-
+	/**
+	 * @group glossary
+	 */
 	public function test_backMatterAutoDisplay() {
 		// No change
 		$content = 'Hello';

--- a/tests/test-shortcodes-wikipublisher-glyphs.php
+++ b/tests/test-shortcodes-wikipublisher-glyphs.php
@@ -4,22 +4,26 @@ class Shortcodes_WikiPublisher_GlyphsTest extends \WP_UnitTestCase {
 
 	/**
 	 * @var \Pressbooks\Shortcodes\Wikipublisher\Glyphs
+	 * @group shortcodes
 	 */
 	protected $glyphs;
 
 
 	/**
-	 *
+	 * @group shortcodes
 	 */
 	public function setUp() {
 		parent::setUp();
 
 		$this->glyphs = $this->getMockBuilder( '\Pressbooks\Shortcodes\Wikipublisher\Glyphs' )
-							 ->setMethods( null )// pass null to setMethods() to avoid mocking any method
-							 ->disableOriginalConstructor()// disable private constructor
-							 ->getMock();
+							->setMethods( null )// pass null to setMethods() to avoid mocking any method
+							->disableOriginalConstructor()// disable private constructor
+							->getMock();
 	}
 
+	/**
+	 * @group shortcodes
+	 */
 	public function test_langShortcode_grk() {
 
 		$content = $this->glyphs->langShortcode(
@@ -39,6 +43,9 @@ class Shortcodes_WikiPublisher_GlyphsTest extends \WP_UnitTestCase {
 		$this->assertContains( '&#945;&#949;&#953;&#959;&#965;', $content );
 	}
 
+	/**
+	 * @group shortcodes
+	 */
 	public function test_langShortcode_he() {
 
 		$content = $this->glyphs->langShortcode(
@@ -50,6 +57,9 @@ class Shortcodes_WikiPublisher_GlyphsTest extends \WP_UnitTestCase {
 		$this->assertContains( '&#1463;&#1461;&#1460;&#1465;&#1467;', $content );
 	}
 
+	/**
+	 * @group shortcodes
+	 */
 	public function test_langShortcode_bad() {
 
 		$content = $this->glyphs->langShortcode(

--- a/tests/test-styles.php
+++ b/tests/test-styles.php
@@ -8,17 +8,21 @@ class StylesTest extends \WP_UnitTestCase {
 
 	/**
 	 * @var \Pressbooks\Styles
+	 * @group styles
 	 */
 	protected $cs;
 
 	/**
-	 *
+	 * @group styles
 	 */
 	public function setUp() {
 		parent::setUp();
 		$this->cs = Container::get( 'Styles' );
 	}
 
+	/**
+	 * @group styles
+	 */
 	public function test_custom_posts() {
 		global $wp_post_types;
 		$this->cs->registerPosts();
@@ -31,6 +35,9 @@ class StylesTest extends \WP_UnitTestCase {
 		$this->assertFalse( $this->cs->getPost( 'garbage' ) );
 	}
 
+	/**
+	 * @group styles
+	 */
 	public function test_basepath() {
 		$v1 = wp_get_theme( 'pressbooks-book' );
 		$this->assertNotEmpty( $this->cs->getDir( $v1, true ) );
@@ -40,6 +47,9 @@ class StylesTest extends \WP_UnitTestCase {
 		$this->assertNotEmpty( $this->cs->getDir( null, false ) );
 	}
 
+	/**
+	 * @group styles
+	 */
 	public function test_pathToScss() {
 		// V1
 		$v1 = wp_get_theme( 'pressbooks-luther' );
@@ -53,6 +63,9 @@ class StylesTest extends \WP_UnitTestCase {
 		$this->assertContains( '/assets/styles/', $this->cs->getPathToPrinceScss( $v2 ) );
 	}
 
+	/**
+	 * @group styles
+	 */
 	public function test_isCurrentThemeCompatible() {
 		// V1
 		$v1 = wp_get_theme( 'pressbooks-luther' );
@@ -66,10 +79,16 @@ class StylesTest extends \WP_UnitTestCase {
 		$this->assertFalse( $this->cs->isCurrentThemeCompatible( 999, $v2 ) );
 	}
 
+	/**
+	 * @group styles
+	 */
 	public function test_getBuckramVersion() {
 		$this->assertGreaterThanOrEqual( 0, version_compare( $this->cs->getBuckramVersion(), '0.2.0' ) );
 	}
 
+	/**
+	 * @group styles
+	 */
 	public function test_hasBuckram() {
 		$this->_book( 'pressbooks-luther' );
 		$this->assertFalse( $this->cs->hasBuckram() );
@@ -79,6 +98,9 @@ class StylesTest extends \WP_UnitTestCase {
 		$this->assertFalse( $this->cs->hasBuckram( 42 ) );
 	}
 
+	/**
+	 * @group styles
+	 */
 	public function test_applyOverrides() {
 		// V1
 		$this->_book( 'pressbooks-luther' );
@@ -96,6 +118,9 @@ class StylesTest extends \WP_UnitTestCase {
 		$this->assertContains( '// SCSS.', $result );
 	}
 
+	/**
+	 * @group styles
+	 */
 	public function test_customize() {
 		// V1
 		$this->_book( 'pressbooks-luther' );
@@ -109,7 +134,9 @@ class StylesTest extends \WP_UnitTestCase {
 		$this->assertContains( 'font-size:', $this->cs->customizePrince() );
 	}
 
-
+	/**
+	 * @group styles
+	 */
 	public function test_updateWebBookStyleSheet() {
 
 		$this->_book( 'pressbooks-clarke' ); // Pick a theme with some built-in $supported_languages
@@ -122,6 +149,9 @@ class StylesTest extends \WP_UnitTestCase {
 		$this->assertNotEmpty( file_get_contents( $file ) );
 	}
 
+	/**
+	 * @group styles
+	 */
 	public function test_maybeUpdateStyleSheets() {
 
 		$this->_book( 'pressbooks-book' );
@@ -138,6 +168,9 @@ class StylesTest extends \WP_UnitTestCase {
 		$this->assertEquals( $result, false );
 	}
 
+	/**
+	 * @group styles
+	 */
 	public function test_editor() {
 		$this->_book();
 
@@ -151,9 +184,4 @@ class StylesTest extends \WP_UnitTestCase {
 		$output = ob_get_clean();
 		$this->assertContains( '<h1>Custom Styles</h1>', $output );
 	}
-
-
-
-
-
 }

--- a/tests/test-taxonomy.php
+++ b/tests/test-taxonomy.php
@@ -8,11 +8,12 @@ class TaxonomyTest extends \WP_UnitTestCase {
 
 	/**
 	 * @var \Pressbooks\Taxonomy
+	 * @group taxonomies
 	 */
 	protected $taxonomy;
 
 	/**
-	 *
+	 * @group taxonomies
 	 */
 	public function setUp() {
 		parent::setUp();
@@ -34,18 +35,26 @@ class TaxonomyTest extends \WP_UnitTestCase {
 		$this->taxonomy = new Taxonomy( $stub1, $stub2 );
 	}
 
+	/**
+	 * @group taxonomies
+	 */
 	public function test_init() {
 		$instance = Taxonomy::init();
 		$this->assertTrue( $instance instanceof Taxonomy );
 	}
 
+	/**
+	 * @group taxonomies
+	 */
 	public function test_hooks() {
 		$this->_book();
 		$this->taxonomy->hooks( $this->taxonomy );
 		$this->assertEquals( 1000, has_filter( 'init', [ $this->taxonomy, 'maybeUpgrade' ] ) );
 	}
 
-
+	/**
+	 * @group taxonomies
+	 */
 	public function test_registerTaxonomies() {
 		global $wp_taxonomies;
 		$wp_taxonomies_old = $wp_taxonomies;
@@ -74,6 +83,9 @@ class TaxonomyTest extends \WP_UnitTestCase {
 		$wp_taxonomies = $wp_taxonomies_old;
 	}
 
+	/**
+	 * @group taxonomies
+	 */
 	public function test_insertTerms() {
 		if ( $exists = get_term_by( 'slug', 'standard', 'chapter-type' ) ) {
 			wp_delete_term( $exists->term_id, 'chapter-type' );
@@ -84,6 +96,9 @@ class TaxonomyTest extends \WP_UnitTestCase {
 		$this->assertInstanceOf( '\WP_Term', get_term_by( 'slug', 'standard', 'chapter-type' ) );
 	}
 
+	/**
+	 * @group taxonomies
+	 */
 	public function test_getters() {
 		$this->assertEquals( 'miscellaneous', $this->taxonomy->getFrontMatterType( 999 ) );
 		$this->assertEquals( 'miscellaneous', $this->taxonomy->getBackMatterType( 999 ) );
@@ -91,6 +106,9 @@ class TaxonomyTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'standard', $this->taxonomy->getChapterType( 999 ) );
 	}
 
+	/**
+	 * @group taxonomies
+	 */
 	public function test_convertMetaToTerm() {
 		$this->taxonomy->registerTaxonomies();
 
@@ -105,6 +123,9 @@ class TaxonomyTest extends \WP_UnitTestCase {
 		$this->assertEquals( 999, $results['term_taxonomy_id'] );
 	}
 
+	/**
+	 * @group taxonomies
+	 */
 	public function test_removeTaxonomyViewLinks() {
 		$arr = [ 'view' => 1, 'something_else' => 2 ];
 		$res = $this->taxonomy->removeTaxonomyViewLinks( $arr, null );

--- a/tests/test-theme.php
+++ b/tests/test-theme.php
@@ -1,23 +1,28 @@
 <?php
 
-class ThemeTest extends \WP_UnitTestCase
-{
-    use utilsTrait;
+class ThemeTest extends \WP_UnitTestCase {
+	use utilsTrait;
 
-    public function test_migrate_book_themes() {
-        $this->_book();
-        delete_option( 'pressbooks_theme_migration' );
-        \Pressbooks\Theme\migrate_book_themes();
-        $this->assertEquals( 4, get_option( 'pressbooks_theme_migration' ) );
-    }
+	/**
+	 * @group themes
+	 */
+	public function test_migrate_book_themes() {
+		$this->_book();
+		delete_option( 'pressbooks_theme_migration' );
+		\Pressbooks\Theme\migrate_book_themes();
+		$this->assertEquals( 4, get_option( 'pressbooks_theme_migration' ) );
+	}
 
-    public function test_update_template_root() {
-        $old = get_option( 'template_root' );
+	/**
+	 * @group themes
+	 */
+	public function test_update_template_root() {
+		$old = get_option( 'template_root' );
 
-        update_option( 'template_root', '/plugins/pressbooks/themes-book' );
-        \Pressbooks\Theme\update_template_root();
-        $this->assertEquals( '/themes', get_option( 'template_root' ) );
+		update_option( 'template_root', '/plugins/pressbooks/themes-book' );
+		\Pressbooks\Theme\update_template_root();
+		$this->assertEquals( '/themes', get_option( 'template_root' ) );
 
-        update_option( 'template_root', $old ); // Put back to normal
-    }
+		update_option( 'template_root', $old ); // Put back to normal
+	}
 }

--- a/tests/test-themelock.php
+++ b/tests/test-themelock.php
@@ -8,13 +8,20 @@ class ThemeLockTest extends \WP_UnitTestCase {
 
 	/**
 	 * @var Lock
+	 * @group themes
 	 */
 	protected $lock;
-	
+
+	/**
+	 * @group themes
+	 */
 	public function setUp() {
 		$this->lock = new Lock();
 	}
 
+	/**
+	 * @group themes
+	 */
 	public function test_init() {
 		$instance = Lock::init();
 		$this->assertTrue( $instance instanceof \Pressbooks\Theme\Lock );
@@ -23,6 +30,9 @@ class ThemeLockTest extends \WP_UnitTestCase {
 //	public function test_hooks() { // TODO
 //	}
 
+	/**
+	 * @group themes
+	 */
 	public function test_getLockDir() {
 
 		$result = $this->lock->getLockDir();
@@ -30,12 +40,18 @@ class ThemeLockTest extends \WP_UnitTestCase {
 		$this->assertEquals( true, substr( $result, -strlen( '/wp-content/uploads/pressbooks/lock' ) ) == '/wp-content/uploads/pressbooks/lock' );
 	}
 
+	/**
+	 * @group themes
+	 */
 	public function test_getLockDirURI() {
 		$result = $this->lock->getLockDirURI();
 
 		$this->assertEquals( true, substr( $result, -strlen( '/wp-content/uploads/pressbooks/lock' ) ) == '/wp-content/uploads/pressbooks/lock' );
 	}
 
+	/**
+	 * @group themes
+	 */
 	public function test_toggleThemeLock() {
 		$time = time() - 10;
 		$theme = wp_get_theme();
@@ -56,6 +72,9 @@ class ThemeLockTest extends \WP_UnitTestCase {
 		$this->assertEquals( $theme, $result );
 	}
 
+	/**
+	 * @group themes
+	 */
 	public function test_lockTheme() {
 		$time = time() - 10;
 		$theme = wp_get_theme();
@@ -72,6 +91,9 @@ class ThemeLockTest extends \WP_UnitTestCase {
 		$this->assertGreaterThanOrEqual( $time, $result['timestamp'] );
 	}
 
+	/**
+	 * @group themes
+	 */
 	public function test_copyAssets() {
 		// Delete all files in the lock directory before testing
 		array_map( 'unlink', array_filter( glob( $this->lock->getLockDir() . '/*' ), 'is_file' ) );
@@ -89,6 +111,9 @@ class ThemeLockTest extends \WP_UnitTestCase {
 		$this->assertFalse( file_exists( $this->lock->getLockDir() . '/index.php' ) );
 	}
 
+	/**
+	 * @group themes
+	 */
 	public function test_generateLock() {
 		$time = time();
 
@@ -107,6 +132,9 @@ class ThemeLockTest extends \WP_UnitTestCase {
 		$this->assertEquals( $result['timestamp'], $time );
 	}
 
+	/**
+	 * @group themes
+	 */
 	public function test_unlockTheme() {
 		$dir = $this->lock->getLockDir();
 		$this->lock->unlockTheme();
@@ -114,6 +142,9 @@ class ThemeLockTest extends \WP_UnitTestCase {
 		$this->assertEquals( false, is_dir( $dir ) );
 	}
 
+	/**
+	 * @group themes
+	 */
 	public function test_isLocked() {
 		update_option( 'pressbooks_export_options', [ 'theme_lock' => 1 ] );
 		$this->lock->generateLock( time() );
@@ -130,6 +161,9 @@ class ThemeLockTest extends \WP_UnitTestCase {
 		$this->assertEquals( false, $value );
 	}
 
+	/**
+	 * @group themes
+	 */
 	public function test_getLockData() {
 		$time = time() - 10;
 
@@ -152,6 +186,9 @@ class ThemeLockTest extends \WP_UnitTestCase {
 		$this->assertContains( 'zig-zag-zog', $result['features'] );
 	}
 
+	/**
+	 * @group themes
+	 */
 	public function test_globalComponentsPath() {
 		// Delete all files in the lock directory before testing
 		array_map( 'unlink', glob( $this->lock->getLockDir() . '/*' ) );

--- a/tests/test-themeoptions.php
+++ b/tests/test-themeoptions.php
@@ -6,20 +6,30 @@ class ThemeOptionsTest extends \WP_UnitTestCase {
 
 	/**
 	 * @var \Pressbooks\Modules\ThemeOptions\Admin
+	 * @group themeoptions
 	 */
 	protected $themeOptions;
 
+	/**
+	 * @group themeoptions
+	 */
 	public function setUp() {
 		parent::setUp();
 		$this->themeOptions = new \Pressbooks\Modules\ThemeOptions\Admin();
 	}
 
+	/**
+	 * @group themeoptions
+	 */
 	public function test_getTabs() {
 		$val = $this->themeOptions->getTabs();
 		$this->assertTrue( is_array( $val ) );
 		$this->assertArrayHasKey( 'web', $val );
 	}
 
+	/**
+	 * @group themeoptions
+	 */
 	public function test_loadTabs() {
 		global $wp_registered_settings;
 		$this->_book(); // We need Book Info now :(
@@ -28,11 +38,17 @@ class ThemeOptionsTest extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'pressbooks_theme_options_ebook', $wp_registered_settings );
 	}
 
+	/**
+	 * @group themeoptions
+	 */
 	public function test_setPermissions() {
 		$val = $this->themeOptions->setPermissions( '' );
 		$this->assertEquals( 'edit_others_posts', $val );
 	}
 
+	/**
+	 * @group themeoptions
+	 */
 	public function test_render() {
 		ob_start();
 		$this->themeOptions->render();
@@ -40,6 +56,9 @@ class ThemeOptionsTest extends \WP_UnitTestCase {
 		$this->assertContains( 'PDF Options</a>', $output );
 	}
 
+	/**
+	 * @group themeoptions
+	 */
 	public function test_afterSwitchTheme() {
 		$option = 'pressbooks_theme_options_pdf';
 		$val = get_option( $option, 'notset' );

--- a/tests/test-updates.php
+++ b/tests/test-updates.php
@@ -8,10 +8,12 @@ class UpdatesTest extends \WP_UnitTestCase {
 
 	/**
 	 * @var \Pressbooks\Updates
+	 * @group updates
 	 */
 	protected $updates;
 
 	/**
+	 * @group updates
 	 */
 	public function setUp() {
 		parent::setUp();
@@ -21,6 +23,9 @@ class UpdatesTest extends \WP_UnitTestCase {
 		$this->updates = new Updates();
 	}
 
+	/**
+	 * @group updates
+	 */
 	public function tearDown() {
 		parent::tearDown();
 		// Remove fake incompatible plugin
@@ -28,16 +33,25 @@ class UpdatesTest extends \WP_UnitTestCase {
 		unlink( WP_PLUGIN_DIR . '/pressbooks-hello.php' );
 	}
 
+	/**
+	 * @group updates
+	 */
 	public function test_init() {
 		$instance = Updates::init();
 		$this->assertTrue( $instance instanceof \Pressbooks\Updates );
 	}
 
+	/**
+	 * @group updates
+	 */
 	public function test_gitHubUpdater() {
 		$this->updates->gitHubUpdater();
 		$this->assertTrue( has_filter( 'puc_is_slug_in_use-pressbooks' ) );
 	}
 
+	/**
+	 * @group updates
+	 */
 	public function test_inPluginUpdateMessage() {
 		ob_start();
 		$this->updates->inPluginUpdateMessage( [ 'new_version' => '9.9.9.' ] );
@@ -53,30 +67,43 @@ class UpdatesTest extends \WP_UnitTestCase {
 //		// $this->assertContains( '<thead>', $buffer );
 //	}
 
+/**
+	 * @group updates
+	 */
 	public function test_getBaseName() {
 		$basename = $this->updates->getBaseName();
 		$this->assertContains( 'pressbooks', $basename );
 	}
 
+	/**
+	 * @group updates
+	 */
 	public function test_extraPluginHeaders() {
 		$headers = $this->updates->extraPluginHeaders( [] );
 		$this->assertArrayHasKey( 'PBTested', $headers );
 	}
 
+	/**
+	 * @group updates
+	 */
 	public function test_getUntestedPlugins() {
 		$list = $this->updates->getUntestedPlugins( '5.0.0' );
 		$this->assertTrue( is_array( $list ) );
 	}
 
+	/**
+	 * @group updates
+	 */
 	public function test_getPluginsWithHeader() {
 		$list = $this->updates->getPluginsWithHeader( Updates::VERSION_TESTED_HEADER );
 		$this->assertTrue( is_array( $list ) );
 	}
 
+	/**
+	 * @group updates
+	 */
 	public function test_getPluginsWithPressbooksInDescription() {
 		$list = $this->updates->getPluginsWithPressbooksInDescription();
 		$this->assertTrue( is_array( $list ) );
 	}
-
-
 }

--- a/tests/test-utility-percentageyield.php
+++ b/tests/test-utility-percentageyield.php
@@ -4,6 +4,7 @@ class PercentageYieldTest extends \WP_UnitTestCase {
 
 	/**
 	 * @return array
+	 * @group utility
 	 */
 	public function validRanges() {
 		return [
@@ -21,6 +22,7 @@ class PercentageYieldTest extends \WP_UnitTestCase {
 	 * @param int $start
 	 * @param int $end
 	 * @param int $ticks
+	 * @group utility
 	 */
 	public function test_tick( $start, $end, $ticks ) {
 		$chunks = (int) max( round( $ticks / ( $end - $start ) ), 1 );
@@ -41,6 +43,9 @@ class PercentageYieldTest extends \WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_tick_invalid_range() {
 		$ticks = 100;
 		$y = new \Pressbooks\Utility\PercentageYield( -999, 999, $ticks );
@@ -55,6 +60,9 @@ class PercentageYieldTest extends \WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_tick_dumb_range() {
 		$ticks = 100;
 		$y = new \Pressbooks\Utility\PercentageYield( 99, 99, $ticks );
@@ -69,6 +77,9 @@ class PercentageYieldTest extends \WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_yield_more_than_we_estimated() {
 		$ticks = 100;
 		$y = new \Pressbooks\Utility\PercentageYield( 1, 100, $ticks );
@@ -92,6 +103,9 @@ class PercentageYieldTest extends \WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_not_everything_is_yielded() {
 		// Nothing emitted
 		$loops = 0;

--- a/tests/test-utility.php
+++ b/tests/test-utility.php
@@ -4,6 +4,9 @@ class UtilityTest extends \WP_UnitTestCase {
 
 	use utilsTrait;
 
+	/**
+	 * @group utility
+	 */
 	public function test_getset() {
 
 		$array = [ 'hello' => 'world' ];
@@ -23,7 +26,9 @@ class UtilityTest extends \WP_UnitTestCase {
 		$this->assertEquals( \Pressbooks\Utility\getset( '_POST', 'nothing', 'something' ), 'something' );
 	}
 
-
+	/**
+	 * @group utility
+	 */
 	public function test_scandir_by_date() {
 
 		$files = \Pressbooks\Utility\scandir_by_date( __DIR__ );
@@ -34,7 +39,9 @@ class UtilityTest extends \WP_UnitTestCase {
 		$this->assertNotContains( 'data', $files );
 	}
 
-
+	/**
+	 * @group utility
+	 */
 	public function test_group_exports() {
 
 		$files = \Pressbooks\Utility\group_exports();
@@ -51,6 +58,9 @@ class UtilityTest extends \WP_UnitTestCase {
 	//      $this->markTestIncomplete();
 	//  }
 
+	/**
+	 * @group utility
+	 */
 	public function test_get_media_prefix() {
 		switch_to_blog( $this->factory()->blog->create() );
 		$prefix = \Pressbooks\Utility\get_media_prefix();
@@ -59,6 +69,9 @@ class UtilityTest extends \WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_get_media_path() {
 
 		$guid = 'http://pressbooks.dev/test/wp-content/uploads/sites/3/2015/11/foobar.jpg';
@@ -72,6 +85,9 @@ class UtilityTest extends \WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_latest_exports() {
 		$this->_book();
 		$user_id = $this->factory()->user->create( [ 'role' => 'contributor' ] );
@@ -89,6 +105,9 @@ class UtilityTest extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'wxr', $latest );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_add_sitemap_to_robots_txt_0() {
 
 		update_option( 'blog_public', 0 );
@@ -96,6 +115,9 @@ class UtilityTest extends \WP_UnitTestCase {
 		\Pressbooks\Utility\add_sitemap_to_robots_txt();
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_add_sitemap_to_robots_txt_1() {
 
 		update_option( 'blog_public', 1 );
@@ -103,6 +125,9 @@ class UtilityTest extends \WP_UnitTestCase {
 		\Pressbooks\Utility\add_sitemap_to_robots_txt();
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_do_sitemap_0() {
 
 		update_option( 'blog_public', 0 );
@@ -110,6 +135,9 @@ class UtilityTest extends \WP_UnitTestCase {
 		\Pressbooks\Utility\do_sitemap();
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_do_sitemap_1() {
 
 		update_option( 'blog_public', 1 );
@@ -117,6 +145,9 @@ class UtilityTest extends \WP_UnitTestCase {
 		\Pressbooks\Utility\do_sitemap();
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_create_tmp_file() {
 
 		$file = \Pressbooks\Utility\create_tmp_file();
@@ -130,36 +161,54 @@ class UtilityTest extends \WP_UnitTestCase {
 		fclose( $GLOBALS['my-very-own-resource-key'] );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_check_prince_install() {
 
 		$this->assertInternalType( 'bool', \Pressbooks\Utility\check_prince_install() );
 		$this->assertTrue( defined( 'PB_PRINCE_COMMAND' ) );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_check_epubcheck_install() {
 
 		$this->assertInternalType( 'bool', \Pressbooks\Utility\check_epubcheck_install() );
 		$this->assertTrue( defined( 'PB_EPUBCHECK_COMMAND' ) );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_check_kindlegen_install() {
 
 		$this->assertInternalType( 'bool', \Pressbooks\Utility\check_kindlegen_install() );
 		$this->assertTrue( defined( 'PB_KINDLEGEN_COMMAND' ) );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_check_xmllint_install() {
 
 		$this->assertInternalType( 'bool', \Pressbooks\Utility\check_xmllint_install() );
 		$this->assertTrue( defined( 'PB_XMLLINT_COMMAND' ) );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_check_saxonhe_install() {
 
 		$this->assertInternalType( 'bool', \Pressbooks\Utility\check_saxonhe_install() );
 		$this->assertTrue( defined( 'PB_SAXON_COMMAND' ) );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_show_experimental_features() {
 
 		$this->assertInternalType( 'bool', \Pressbooks\Utility\show_experimental_features() );
@@ -167,12 +216,18 @@ class UtilityTest extends \WP_UnitTestCase {
 
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_include_plugins() {
 
 		\Pressbooks\Utility\include_plugins();
 		$this->assertTrue( class_exists( 'custom_metadata_manager' ) );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_filter_plugins() {
 
 		$symbionts = [ 'a-plugin-that-does-not-exist/foobar.php' => 1 ];
@@ -183,11 +238,17 @@ class UtilityTest extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'a-plugin-that-does-not-exist/foobar.php', $filtered );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_install_plugins_tabs() {
 		$tabs = \Pressbooks\Utility\install_plugins_tabs( [] );
 		$this->assertArrayNotHasKey( 'featured', $tabs );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_file_upload_max_size() {
 
 		$maxSize = \Pressbooks\Utility\file_upload_max_size();
@@ -198,6 +259,9 @@ class UtilityTest extends \WP_UnitTestCase {
 
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_parse_size() {
 
 		$this->assertTrue( is_float( \Pressbooks\Utility\parse_size( '1' ) ) );
@@ -207,6 +271,9 @@ class UtilityTest extends \WP_UnitTestCase {
 		$this->assertEquals( 8388608, \Pressbooks\Utility\parse_size( '8M' ) );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_format_bytes() {
 
 		$this->assertEquals( '200 B', \Pressbooks\Utility\format_bytes( 200 ) );
@@ -231,7 +298,9 @@ class UtilityTest extends \WP_UnitTestCase {
 	//      $this->markTestIncomplete();
 	//  }
 
-
+	/**
+	 * @group utility
+	 */
 	public function test_template() {
 
 		$template = \Pressbooks\Utility\template(
@@ -254,18 +323,27 @@ class UtilityTest extends \WP_UnitTestCase {
 		$this->fail();
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_mail_from() {
 		$this->assertEquals( 'pressbooks@example.org', \Pressbooks\Utility\mail_from( '' ) );
 		define( 'WP_MAIL_FROM', 'hi@pressbooks.org' );
 		$this->assertEquals( 'hi@pressbooks.org', \Pressbooks\Utility\mail_from( '' ) );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_mail_from_name() {
 		$this->assertEquals( 'Pressbooks', \Pressbooks\Utility\mail_from_name( '' ) );
 		define( 'WP_MAIL_FROM_NAME', 'Ned' );
 		$this->assertEquals( 'Ned', \Pressbooks\Utility\mail_from_name( '' ) );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_rmrdir() {
 		$file = \Pressbooks\Utility\create_tmp_file();
 		$dirname = dirname( $file );
@@ -285,6 +363,9 @@ class UtilityTest extends \WP_UnitTestCase {
 		$this->assertFalse( is_dir( "$dirname/one" ) );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_rcopy() {
 		$uploads = wp_upload_dir();
 
@@ -310,6 +391,9 @@ class UtilityTest extends \WP_UnitTestCase {
 		$this->assertEquals( $return, false );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_rcopy_excludes() {
 		$uploads = wp_upload_dir();
 
@@ -350,6 +434,9 @@ class UtilityTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'test', file_get_contents( $dest . '/readme.txt' ) );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_rcopy_includes() {
 		$uploads = wp_upload_dir();
 
@@ -392,16 +479,25 @@ class UtilityTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'test', file_get_contents( $dest . '/readme.txt' ) );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_str_starts_with() {
 		$this->assertTrue( \Pressbooks\Utility\str_starts_with( 's0.wp.com', 's0.wp' ) );
 		$this->assertFalse( \Pressbooks\Utility\str_starts_with( 's0.wp.com', 'wp.com' ) );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_str_ends_with() {
 		$this->assertFalse( \Pressbooks\Utility\str_ends_with( 's0.wp.com', 's0.wp' ) );
 		$this->assertTrue( \Pressbooks\Utility\str_ends_with( 's0.wp.com', 'wp.com' ) );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_str_remove_prefix() {
 
 		$result = \Pressbooks\Utility\str_remove_prefix( 'foo foo foo bar', 'foo'  );
@@ -414,6 +510,9 @@ class UtilityTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'foo foo foo bar', $result );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_str_lreplace() {
 
 		$result = \Pressbooks\Utility\str_lreplace( 'foo', 'bar', 'foo foo foo bar' );
@@ -423,6 +522,9 @@ class UtilityTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'foo foo foo bar', $result );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_commaDelimitedStringSearch() {
 		$this->assertTrue( \Pressbooks\Utility\comma_delimited_string_search( 'foo', 'foo' ) );
 		$this->assertTrue( \Pressbooks\Utility\comma_delimited_string_search( 'foo,', 'foo' ) );
@@ -438,6 +540,9 @@ class UtilityTest extends \WP_UnitTestCase {
 		$this->assertFalse( \Pressbooks\Utility\comma_delimited_string_search( 'one,two,three,foo ', 'bar' ) );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_word_count() {
 
 		$content = 'This is four words.';
@@ -457,7 +562,9 @@ class UtilityTest extends \WP_UnitTestCase {
 		$this->assertEquals( 4, $count );
 	}
 
-
+	/**
+	 * @group utility
+	 */
 	public function test_absolute_path() {
 
 		$path = '/simple/path';
@@ -485,6 +592,9 @@ class UtilityTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'ftp://127.0.0.1/one/three/filename', \Pressbooks\Utility\absolute_path( $path ) );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_urls_have_same_host() {
 		$this->assertTrue( \Pressbooks\Utility\urls_have_same_host( 'https://pressbooks.com', 'https://pressbooks.com' ) );
 		$this->assertTrue( \Pressbooks\Utility\urls_have_same_host( 'https://book.pressbooks.com', 'https://pressbooks.com' ) );
@@ -497,22 +607,34 @@ class UtilityTest extends \WP_UnitTestCase {
 		$this->assertFalse( \Pressbooks\Utility\urls_have_same_host( 'pressbooks.com', 'pressbooks.com' ) ); // Not a fully qualified URL
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function get_generated_content_path() {
 		$path = \Pressbooks\Utility\get_generated_content_path();
 		$this->assertStringStartsWith( '/', $path );
 		$this->assertContains( '/pressbooks/', $path );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function get_generated_content_url() {
 		$url = \Pressbooks\Utility\get_generated_content_url();
 		$this->assertStringStartsWith( 'http', $url );
 		$this->assertContains( '/pressbooks/', $url );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_get_cache_path() {
 		$this->assertNotEmpty( \Pressbooks\Utility\get_cache_path() );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_oxford_comma() {
 		$this->assertEquals( '', \Pressbooks\Utility\oxford_comma( [] ) );
 		$vars[] = 'One Person';
@@ -525,6 +647,9 @@ class UtilityTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'One Person, Two People, Three People, and Four People', \Pressbooks\Utility\oxford_comma( $vars ) );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_oxford_comma_explode() {
 		$this->assertEmpty( \Pressbooks\Utility\oxford_comma_explode( '' ) );
 		$this->assertEquals( [ 'One Person', 'Two People' ], \Pressbooks\Utility\oxford_comma_explode( 'One Person and Two People' ) );
@@ -532,6 +657,9 @@ class UtilityTest extends \WP_UnitTestCase {
 		$this->assertEquals( [ 'andy', 'andrew', 'andrea', 'android' ], \Pressbooks\Utility\oxford_comma_explode( 'andy,andrew, andrea,  android' ) );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_is_assoc() {
 		$this->assertFalse( \Pressbooks\Utility\is_assoc( 'Doing it wrong' ) );
 		$this->assertFalse( \Pressbooks\Utility\is_assoc( [ 'a', 'b', 'c' ] ) );
@@ -540,6 +668,9 @@ class UtilityTest extends \WP_UnitTestCase {
 		$this->assertTrue( \Pressbooks\Utility\is_assoc( [ "a" => 'a', "b" => 'b', "c" => 'c' ] ) );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_empty_space() {
 		$this->assertFalse( \Pressbooks\Utility\empty_space( 'Hi' ) );
 		$this->assertFalse( \Pressbooks\Utility\empty_space( true ) );
@@ -549,17 +680,26 @@ class UtilityTest extends \WP_UnitTestCase {
 		$this->assertTrue( \Pressbooks\Utility\empty_space( false ) );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_main_contact_email() {
 		$email = \Pressbooks\Utility\main_contact_email();
 		$this->assertContains( '@', $email );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_str_lowercase_dash() {
 		$this->assertEquals( 'neural-networks', \Pressbooks\Utility\str_lowercase_dash( 'Neural Networks' ) );
 		$this->assertEmpty( \Pressbooks\Utility\str_lowercase_dash( '') );
 		$this->assertEquals( 'support--vector--machines', \Pressbooks\Utility\str_lowercase_dash( ' Support  Vector  MachINEs    ') );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_shortcode_att_replace() {
 
 		$c = '<h1>Test</h1><p>[pb_glossary hello=world id=111 foo=bar]Skatboards[/pb_glossary], not [pb_glossary hello=world id=222 foo=bar]death[/pb_glossary].</p><p>[some id=222]other shortcode[/some]</p>';
@@ -585,6 +725,9 @@ class UtilityTest extends \WP_UnitTestCase {
 		$this->assertEquals( '[pb_glossary hello=world id=&quot;999&quot; foo="111"]Skatboards[/pb_glossary][pb_glossary broken=\'pebkac\']Yes[/pb_glossary]', $x );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_do_shortcode_by_tags() {
 		$content = '[latex]e^{\i \pi} + 1 = 0[/latex][embed]https://image.png[/embed]';
 


### PR DESCRIPTION
This PR introduces `@group` tags to PHPUnit tests so devs can run a subset locally for efficiency (e.g. `vendor/bin/phpunit --configuration phpunit.xml --group themes`). Groups are as follows:

- activation
- analytics
- api
- attributions
- book
- branding
- cloner
- compatibility
- container
- contributors
- covergenerator
- customcss
- dashboard
- deletebook
- diagnostics
- editor
- eventstreams
- export
- footnotes
- glossary
- htmlbook
- htmlparser
- import
- integrations
- interactivecontent
- licensing
- localization
- media
- media
- metaboxes
- metadata
- namespace
- networkmanagers
- options
- organize
- plugin
- plugins
- posttypes
- privacy
- redirect
- registration
- sanitize
- searchandreplace
- shortcodes
- styles
- taxonomies
- themeoptions
- themes
- typography
- updates
- utility