### PR TITLE
Fix missing user messages (pb_notice) when something goes wrong with H5P cloning

### DIFF
--- a/inc/cloner/class-cloner.php
+++ b/inc/cloner/class-cloner.php
@@ -391,7 +391,7 @@ class Cloner {
 	 * @throws \Exception
 	 * @return \Generator
 	 */
-	public function cloneBookGenerator() {
+	public function cloneBookGenerator() : \Generator {
 
 		yield 1 => __( 'Looking up the source book', 'pressbooks' );
 		if ( ! $this->setupSource() ) {

--- a/inc/covergenerator/class-generator.php
+++ b/inc/covergenerator/class-generator.php
@@ -187,14 +187,16 @@ abstract class Generator {
 
 	/**
 	 * Generate cover
-	 * 20 - 100
+	 * Yields an estimated percentage slice of: 20 - 100
 	 *
 	 * @see pressbooks/templates/admin/generator.php
+	 *
+	 * @param string $format
 	 *
 	 * @return \Generator
 	 * @throws \Exception
 	 */
-	public static function formGenerator( $format ) {
+	public static function formGenerator( $format ) : \Generator {
 		wp_cache_delete( 'pressbooks_cg_options', 'options' ); // WordPress Core caches this key in the "options" group
 		wp_cache_delete( 'alloptions', 'options' );
 		$cg_options = get_option( 'pressbooks_cg_options' );

--- a/inc/modules/export/class-export.php
+++ b/inc/modules/export/class-export.php
@@ -752,7 +752,7 @@ abstract class Export {
 	 *
 	 * @return \Generator
 	 */
-	static function exportGenerator( $modules ) {
+	static function exportGenerator( $modules ) : \Generator {
 		/**
 		 * Maximum execution time, in seconds. If set to zero, no time limit
 		 * Overrides PHP's max_execution_time of a Nginx->PHP-FPM->PHP configuration

--- a/inc/modules/export/class-exportgenerator.php
+++ b/inc/modules/export/class-exportgenerator.php
@@ -13,12 +13,12 @@ abstract class ExportGenerator extends Export {
 	 *
 	 * @return \Generator
 	 */
-	abstract function convertGenerator(): \Generator;
+	abstract function convertGenerator() : \Generator;
 
 	/**
 	 * Mandatory validate method, check the sanity of $this->outputPath
 	 *
 	 * @return \Generator
 	 */
-	abstract function validateGenerator(): \Generator;
+	abstract function validateGenerator() : \Generator;
 }

--- a/inc/modules/export/epub/class-epub201.php
+++ b/inc/modules/export/epub/class-epub201.php
@@ -276,12 +276,12 @@ class Epub201 extends ExportGenerator {
 	}
 
 	/**
-	 * 1 to 80
+	 * Yields an estimated percentage slice of: 1 to 80
 	 *
 	 * @return \Generator
 	 * @throws \Exception
 	 */
-	function convertGenerator(): \Generator {
+	public function convertGenerator() : \Generator {
 
 		yield 1 => $this->generatorPrefix . __( 'Initializing', 'pressbooks' );
 
@@ -346,12 +346,12 @@ class Epub201 extends ExportGenerator {
 	}
 
 	/**
-	 * 80 to 100
+	 * Yields an estimated percentage slice of: 80 to 100
 	 *
 	 * @return \Generator
 	 * @throws \Exception
 	 */
-	function validateGenerator(): \Generator {
+	public function validateGenerator() : \Generator {
 		yield 80 => $this->generatorPrefix . __( 'Validating file', 'pressbooks' );
 
 		// Epubcheck command, (quiet flag requires version 3.0.1+)
@@ -644,13 +644,13 @@ class Epub201 extends ExportGenerator {
 
 
 	/**
-	 * 10 to 75
+	 * Yields an estimated percentage slice of: 10 to 75
 	 * Create OEBPS/* files.
 	 *
 	 * @return \Generator
 	 * @throws \Exception
 	 */
-	protected function createOEBPSGenerator( $book_contents, $metadata ) {
+	protected function createOEBPSGenerator( $book_contents, $metadata ) : \Generator {
 
 		// First, setup and affect $this->stylesheet
 		yield 10 => $this->generatorPrefix . __( 'Compiling styles', 'pressbooks' );
@@ -1243,13 +1243,13 @@ class Epub201 extends ExportGenerator {
 
 
 	/**
-	 * 30-40
+	 * Yields an estimated percentage slice of: 30-40
 	 *
 	 * @param array $book_contents
 	 * @param array $metadata
 	 * @return \Generator
 	 */
-	protected function createFrontMatterGenerator( $book_contents, $metadata ) {
+	protected function createFrontMatterGenerator( $book_contents, $metadata ) : \Generator {
 		$front_matter_printf = '<div class="front-matter %1$s" id="%2$s">';
 		$front_matter_printf .= '<div class="front-matter-title-wrap"><h3 class="front-matter-number">%3$s</h3><h1 class="front-matter-title">%4$s</h1>%5$s</div>';
 		$front_matter_printf .= '<div class="ugc front-matter-ugc">%6$s</div>%7$s';
@@ -1399,13 +1399,13 @@ class Epub201 extends ExportGenerator {
 
 
 	/**
-	 * 40-50
+	 * Yields an estimated percentage slice of: 40-50
 	 *
 	 * @param array $book_contents
 	 * @param array $metadata
 	 * @return \Generator
 	 */
-	protected function createPartsAndChaptersGenerator( $book_contents, $metadata ) {
+	protected function createPartsAndChaptersGenerator( $book_contents, $metadata ) : \Generator {
 		$part_printf = '<div class="part %1$s" id="%2$s">';
 		$part_printf .= '<div class="part-title-wrap"><h3 class="part-number">%3$s</h3><h1 class="part-title">%4$s</h1></div>%5$s';
 		$part_printf .= '</div>';
@@ -1672,13 +1672,13 @@ class Epub201 extends ExportGenerator {
 
 
 	/**
-	 * 50-60
+	 * Yields an estimated percentage slice of: 50-60
 	 *
 	 * @param array $book_contents
 	 * @param array $metadata
 	 * @return \Generator
 	 */
-	protected function createBackMatterGenerator( $book_contents, $metadata ) {
+	protected function createBackMatterGenerator( $book_contents, $metadata ) : \Generator {
 		$back_matter_printf = '<div class="back-matter %1$s" id="%2$s">';
 		$back_matter_printf .= '<div class="back-matter-title-wrap"><h3 class="back-matter-number">%3$s</h3><h1 class="back-matter-title">%4$s</h1>%5$s</div>';
 		$back_matter_printf .= '<div class="ugc back-matter-ugc">%6$s</div>%7$s';

--- a/inc/modules/export/epub/class-epub3.php
+++ b/inc/modules/export/epub/class-epub3.php
@@ -172,10 +172,10 @@ class Epub3 extends Epub201 {
 	 * @return \Generator
 	 * @throws \Exception
 	 */
-	function convertGenerator(): \Generator {
+	function convertGenerator() : \Generator {
 		// HTML5 targeted css
 		$this->extraCss = $this->dir . '/templates/epub3/css/css3.css';
-		return parent::convertGenerator();
+		yield from parent::convertGenerator();
 	}
 
 	/**

--- a/inc/modules/export/xhtml/class-xhtml11.php
+++ b/inc/modules/export/xhtml/class-xhtml11.php
@@ -170,12 +170,12 @@ class Xhtml11 extends ExportGenerator {
 	}
 
 	/**
-	 * 1 to 80
+	 * Yields an estimated percentage slice of: 1 to 80
 	 *
 	 * @return \Generator
 	 * @throws \Exception
 	 */
-	public function convertGenerator(): \Generator {
+	public function convertGenerator() : \Generator {
 		yield 1 => $this->generatorPrefix . __( 'Initializing', 'pressbooks' );
 
 		yield from $this->transformGenerator();
@@ -208,12 +208,12 @@ class Xhtml11 extends ExportGenerator {
 	}
 
 	/**
-	 * 80 to 100
+	 * Yields an estimated percentage slice of: 80 to 100
 	 *
 	 * @return \Generator
 	 * @throws \Exception
 	 */
-	public function validateGenerator(): \Generator {
+	public function validateGenerator() : \Generator {
 		yield 80 => $this->generatorPrefix . __( 'Validating file', 'pressbooks' );
 
 		// Xmllint params
@@ -283,12 +283,12 @@ class Xhtml11 extends ExportGenerator {
 	}
 
 	/**
-	 * 10 to 75
+	 * Yields an estimated percentage slice of: 10 to 75
 	 *
 	 * @return \Generator
 	 * @throws \Exception
 	 */
-	public function transformGenerator() {
+	public function transformGenerator() : \Generator {
 
 		do_action( 'pb_pre_export' );
 
@@ -1192,13 +1192,13 @@ class Xhtml11 extends ExportGenerator {
 
 
 	/**
-	 * 50 to 60
+	 * Yields an estimated percentage slice of: 50 to 60
 	 *
 	 * @param array $book_contents
 	 * @param array $metadata
 	 * @return \Generator
 	 */
-	protected function echoFrontMatterGenerator( $book_contents, $metadata ) {
+	protected function echoFrontMatterGenerator( $book_contents, $metadata ) : \Generator {
 		$front_matter_printf = '<div class="front-matter %1$s" id="%2$s" title="%3$s">';
 		$front_matter_printf .= '<div class="front-matter-title-wrap"><h3 class="front-matter-number">%4$s</h3><h1 class="front-matter-title">%5$s</h1>%6$s</div>';
 		$front_matter_printf .= '<div class="ugc front-matter-ugc">%7$s</div>%8$s%9$s';
@@ -1305,13 +1305,13 @@ class Xhtml11 extends ExportGenerator {
 
 
 	/**
-	 * 60 to 70
+	 * Yields an estimated percentage slice of: 60 to 70
 	 *
 	 * @param array $book_contents
 	 * @param array $metadata
 	 * @return \Generator
 	 */
-	protected function echoPartsAndChaptersGenerator( $book_contents, $metadata ) {
+	protected function echoPartsAndChaptersGenerator( $book_contents, $metadata ) : \Generator {
 		$part_printf = '<div class="part %1$s" id="%2$s">';
 		$part_printf .= '<div class="part-title-wrap"><h3 class="part-number">%3$s</h3><h1 class="part-title">%4$s</h1></div>%5$s';
 		$part_printf .= '</div>';
@@ -1488,13 +1488,13 @@ class Xhtml11 extends ExportGenerator {
 
 
 	/**
-	 * 70 to 80
+	 * Yields an estimated percentage slice of: 70 to 80
 	 *
 	 * @param array $book_contents
 	 * @param array $metadata
 	 * @return \Generator
 	 */
-	protected function echoBackMatterGenerator( $book_contents, $metadata ) {
+	protected function echoBackMatterGenerator( $book_contents, $metadata ) : \Generator {
 		$back_matter_printf = '<div class="back-matter %1$s" id="%2$s" title="%3$s">';
 		$back_matter_printf .= '<div class="back-matter-title-wrap"><h3 class="back-matter-number">%4$s</h3><h1 class="back-matter-title">%5$s</h1>%6$s</div>';
 		$back_matter_printf .= '<div class="ugc back-matter-ugc">%7$s</div>%8$s%9$s';

--- a/inc/modules/import/class-import.php
+++ b/inc/modules/import/class-import.php
@@ -278,7 +278,7 @@ abstract class Import {
 	 *
 	 * @return \Generator
 	 */
-	static function doImportGenerator( array $current_import ) {
+	static function doImportGenerator( array $current_import ) : \Generator {
 
 		// Set post status
 		$current_import['default_post_status'] = ( isset( $_POST['show_imports_in_web'] ) ) ? 'publish' : 'private'; // @codingStandardsIgnoreLine

--- a/inc/modules/import/class-importgenerator.php
+++ b/inc/modules/import/class-importgenerator.php
@@ -13,5 +13,5 @@ abstract class ImportGenerator extends Import {
 	 *
 	 * @return \Generator
 	 */
-	abstract public function importGenerator( array $current_import ): \Generator;
+	abstract public function importGenerator( array $current_import ) : \Generator;
 }

--- a/inc/modules/import/epub/class-epub201.php
+++ b/inc/modules/import/epub/class-epub201.php
@@ -202,7 +202,7 @@ class Epub201 extends ImportGenerator {
 
 	/**
 	 * Parse OPF manifest nodes
-	 * 40-95
+	 * Yields an estimated percentage slice of: 40 - 95
 	 *
 	 * @param \SimpleXMLElement $xml
 	 * @param array $match_ids

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -120,7 +120,7 @@ function get_all( $key ) {
 		}
 		$messages = array_merge( $messages, $_SESSION[ $key ] );
 	}
-	$transient = get_transient( $key . get_current_user_id() );
+	$transient = get_site_transient( $key . get_current_user_id() );
 	if ( ! empty( $transient ) ) {
 		if ( ! is_array( $transient ) ) {
 			$transient = [ $transient ];
@@ -136,8 +136,9 @@ function get_all( $key ) {
  */
 function add( $msg, $key ) {
 	$use_non_blocking_session = use_non_blocking_session();
+	$current_user_id = get_current_user_id();
 	if ( $use_non_blocking_session ) {
-		$messages = get_transient( $key . get_current_user_id() );
+		$messages = get_site_transient( "{$key}{$current_user_id}" );
 	} else {
 		$messages = $_SESSION[ $key ] ?? [];
 	}
@@ -149,7 +150,7 @@ function add( $msg, $key ) {
 	}
 	$messages[] = $msg;
 	if ( $use_non_blocking_session ) {
-		set_transient( $key . get_current_user_id(), $messages, 5 * MINUTE_IN_SECONDS );
+		set_site_transient( "{$key}{$current_user_id}", $messages, 15 * MINUTE_IN_SECONDS );
 	} else {
 		$_SESSION[ $key ] = $messages;
 	}
@@ -160,5 +161,5 @@ function add( $msg, $key ) {
  */
 function flush_all( $key ) {
 	unset( $_SESSION[ $key ] );
-	delete_transient( $key . get_current_user_id() );
+	delete_site_transient( $key . get_current_user_id() );
 }

--- a/inc/utility/class-percentageyield.php
+++ b/inc/utility/class-percentageyield.php
@@ -81,7 +81,7 @@ class PercentageYield {
 	 *
 	 * @return \Generator
 	 */
-	public function tick( $msg, $emit = true ) {
+	public function tick( $msg, $emit = true ) : \Generator {
 		$percentage = $this->j;
 		if ( $percentage < $this->start ) {
 			$percentage = $this->start;

--- a/tests/test-admin-laf.php
+++ b/tests/test-admin-laf.php
@@ -144,9 +144,9 @@ class Admin_LafTest extends \WP_UnitTestCase {
 
 	function test_admin_notices() {
 		$_SESSION['pb_errors'] = 'One';
-		set_transient( 'pb_errors' . get_current_user_id(), 'Two' );
+		set_site_transient( 'pb_errors' . get_current_user_id(), 'Two' );
 		$_SESSION['pb_notices'] = 'Three';
-		set_transient( 'pb_notices' . get_current_user_id(), 'Four' );
+		set_site_transient( 'pb_notices' . get_current_user_id(), 'Four' );
 		ob_start();
 		\Pressbooks\Admin\Laf\admin_notices();
 		$buffer = ob_get_clean();
@@ -154,10 +154,10 @@ class Admin_LafTest extends \WP_UnitTestCase {
 
 		$_SESSION['pb_errors'][] = 'One';
 		$_SESSION['pb_errors'][] = 'Two';
-		set_transient( 'pb_errors' . get_current_user_id(), [ 'Three', 'Four' ] );
+		set_site_transient( 'pb_errors' . get_current_user_id(), [ 'Three', 'Four' ] );
 		$_SESSION['pb_notices'][] = 'Five';
 		$_SESSION['pb_notices'][] = 'Six';
-		set_transient( 'pb_notices' . get_current_user_id(), [ 'Seven', 'Eight' ] );
+		set_site_transient( 'pb_notices' . get_current_user_id(), [ 'Seven', 'Eight' ] );
 		ob_start();
 		\Pressbooks\Admin\Laf\admin_notices();
 		$buffer = ob_get_clean();


### PR DESCRIPTION
When cloning a whole book we do `switch_to_blog()` and the notice gets set in the wrong place. Changed to use site transients instead.

Set Generator return type to be strict, catch mistakes.