### PR TITLE
Fix PHP Notices (E_NOTICE) when cloning H5P

### DIFF
--- a/inc/cloner/class-cloner.php
+++ b/inc/cloner/class-cloner.php
@@ -622,6 +622,7 @@ class Cloner {
 		// POST internal request
 		$request = new \WP_REST_Request( 'POST', "/pressbooks/v2/$endpoint" );
 		$request->set_body_params( $term );
+		$request->set_param( '_fields', 'id' );
 		$response = rest_do_request( $request )->get_data();
 
 		// Inform user of failure, bail
@@ -1426,6 +1427,7 @@ class Cloner {
 		// POST internal request
 		$request = new \WP_REST_Request( 'POST', "/pressbooks/v2/$endpoint" );
 		$request->set_body_params( $section );
+		$request->set_param( '_fields', 'id' );
 		$response = rest_do_request( $request )->get_data();
 
 		// Inform user of failure, bail

--- a/inc/cloner/class-downloads.php
+++ b/inc/cloner/class-downloads.php
@@ -178,6 +178,7 @@ class Downloads {
 				$m = $known_media[ $attached_file ];
 				$request = new \WP_REST_Request( 'PATCH', "/wp/v2/media/{$pid}" );
 				$request->set_body_params( $this->createMediaPatch( $m ) );
+				$request->set_param( '_fields', 'id' );
 				rest_do_request( $request );
 				// Store a transitional state
 				$this->cloner->createTransition( 'attachment', $m->id, $pid );
@@ -387,6 +388,7 @@ class Downloads {
 				$m = $known_media[ $attached_file ];
 				$request = new \WP_REST_Request( 'PATCH', "/wp/v2/media/{$pid}" );
 				$request->set_body_params( $this->createMediaPatch( $m ) );
+				$request->set_param( '_fields', 'id' );
 				rest_do_request( $request );
 				// Store a transitional state
 				$this->cloner->createTransition( 'attachment', $m->id, $pid );


### PR DESCRIPTION
Cloning triggers 'the_content' but we don't use it. This caused PHP Notices with H5P because the shortcodes aren't fixed until the end of the process.

WordPress API let's us specify which fields we care about in `WP_REST_Controller::get_fields_for_response` when we do an internal `rest_do_request`

I've set it to `id` where possible.