### PR TITLE
Support localization of Blade templates

### DIFF
--- a/languages/pressbooks.pot
+++ b/languages/pressbooks.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the same license as the Pressbooks plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Pressbooks 5.7.0-dev\n"
+"Project-Id-Version: Pressbooks 5.7.0\n"
 "Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks/\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-02-27T15:46:06+00:00\n"
+"POT-Creation-Date: 2019-02-28T19:37:55+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.1.0\n"
 "X-Domain: pressbooks\n"
@@ -1061,6 +1061,7 @@ msgstr ""
 #: inc/admin/diagnostics/namespace.php:29
 #: inc/admin/diagnostics/namespace.php:30
 #: inc/admin/laf/namespace.php:54
+#: templates/admin/diagnostics.blade.php:3
 msgid "Diagnostics"
 msgstr ""
 
@@ -1236,6 +1237,7 @@ msgstr ""
 
 #: inc/admin/laf/namespace.php:261
 #: inc/admin/laf/namespace.php:319
+#: templates/admin/export.blade.php:9
 #: templates/admin/export.php:136
 #: templates/admin/organize.php:64
 msgid "Export"
@@ -2341,6 +2343,7 @@ msgstr ""
 #: inc/modules/themeoptions/class-admin.php:88
 #: inc/modules/themeoptions/class-admin.php:89
 #: inc/modules/themeoptions/class-admin.php:138
+#: templates/admin/export.blade.php:56
 msgid "Theme Options"
 msgstr ""
 
@@ -3762,6 +3765,37 @@ msgstr ""
 msgid "Logo Or Image"
 msgstr ""
 
+#: templates/admin/export.blade.php:10
+msgid "You can select multiple formats below. Pressbooks keeps the last 3 exports of each file format. You can pin specific files to make sure they don't get deleted."
+msgstr ""
+
+#: templates/admin/export.blade.php:13
+msgid "Toggle panel: Export Options"
+msgstr ""
+
+#: templates/admin/export.blade.php:17
+msgid "Export Options"
+msgstr ""
+
+#: templates/admin/export.blade.php:26
+#: templates/admin/export.php:177
+msgid "Supported formats"
+msgstr ""
+
+#: templates/admin/export.blade.php:36
+#: templates/admin/export.php:189
+msgid "Other formats"
+msgstr ""
+
+#: templates/admin/export.blade.php:73
+#: templates/admin/export.php:226
+msgid "Export Your Book"
+msgstr ""
+
+#: templates/admin/export.blade.php:78
+msgid "Latest Exports"
+msgstr ""
+
 #: templates/admin/dashboard.php:34
 msgid "Dashboard Settings"
 msgstr ""
@@ -3842,6 +3876,26 @@ msgstr ""
 msgid "There are no results."
 msgstr ""
 
+#: templates/admin/diagnostics.blade.php:4
+msgid "Please submit this information with any bug reports."
+msgstr ""
+
+#: templates/admin/diagnostics.blade.php:7
+msgid "View Source"
+msgstr ""
+
+#: templates/admin/diagnostics.blade.php:9
+msgid "Regenerate Webbook Stylesheet"
+msgstr ""
+
+#: templates/admin/diagnostics.blade.php:10
+msgid "If your webbook stylesheet has issues, it may help to regenerate it."
+msgstr ""
+
+#: templates/admin/diagnostics.blade.php:11
+msgid "Regenerate Stylesheet"
+msgstr ""
+
 #: templates/admin/export.php:137
 msgid "You can export multiple file formats by selecting your Export Format Options below. Pressbooks saves your last %s batches of exported files."
 msgstr ""
@@ -3858,20 +3912,8 @@ msgstr ""
 msgid "EPUB (for Nook, iBooks, Kobo etc.)"
 msgstr ""
 
-#: templates/admin/export.php:177
-msgid "Supported formats"
-msgstr ""
-
-#: templates/admin/export.php:189
-msgid "Other formats"
-msgstr ""
-
 #: templates/admin/export.php:211
 msgid "Your Theme Options"
-msgstr ""
-
-#: templates/admin/export.php:226
-msgid "Export Your Book"
 msgstr ""
 
 #: templates/admin/export.php:247
@@ -4099,6 +4141,14 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
+#: templates/admin/incompatible-plugins.blade.php:9
+msgid "Plugin"
+msgstr ""
+
+#: templates/admin/incompatible-plugins.blade.php:10
+msgid "Tested up to Pressbooks version"
+msgstr ""
+
 #: templates/admin/trash.php:21
 msgid "Restore deleted chapters, parts, front and back matter, and glossary terms"
 msgstr ""
@@ -4153,6 +4203,19 @@ msgstr ""
 
 #: templates/pb-catalog.php:268
 msgid "Pressbooks: the CMS for Books."
+msgstr ""
+
+#: templates/interactive/audio.blade.php:3
+msgid "An audio element has been excluded from this version of the text. You can listen to it online here:"
+msgstr ""
+
+#: templates/interactive/shared.blade.php:3
+#: templates/interactive/oembed.blade.php:11
+msgid "An interactive or media element has been excluded from this version of the text. You can view it online here:"
+msgstr ""
+
+#: templates/interactive/video.blade.php:3
+msgid "A video element has been excluded from this version of the text. You can watch it online here:"
 msgstr ""
 
 #. translators: 1: URL to Composer documentation, 2: URL to Pressbooks latest releases

--- a/languages/pressbooks.pot
+++ b/languages/pressbooks.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-02-28T19:52:40+00:00\n"
+"POT-Creation-Date: 2019-02-28T20:00:35+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.1.0\n"
 "X-Domain: pressbooks\n"
@@ -616,6 +616,7 @@ msgid "Your PDF page size is set to %1$s &times; %2$s, and your PDF cover will b
 msgstr ""
 
 #: inc/admin/covergenerator/namespace.php:422
+#: templates/admin/export.blade.php:55
 #: templates/admin/export.php:218
 msgid "Change Theme"
 msgstr ""

--- a/languages/pressbooks.pot
+++ b/languages/pressbooks.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2019-02-28T19:37:55+00:00\n"
+"POT-Creation-Date: 2019-02-28T19:52:40+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.1.0\n"
 "X-Domain: pressbooks\n"
@@ -3787,6 +3787,10 @@ msgstr ""
 msgid "Other formats"
 msgstr ""
 
+#: templates/admin/export.blade.php:54
+msgid "Your Theme"
+msgstr ""
+
 #: templates/admin/export.blade.php:73
 #: templates/admin/export.php:226
 msgid "Export Your Book"
@@ -3878,6 +3882,10 @@ msgstr ""
 
 #: templates/admin/diagnostics.blade.php:4
 msgid "Please submit this information with any bug reports."
+msgstr ""
+
+#: templates/admin/diagnostics.blade.php:5
+msgid "To copy the system info, click below then press Ctrl + C (PC) or Cmd + C (Mac)."
 msgstr ""
 
 #: templates/admin/diagnostics.blade.php:7

--- a/readme.txt
+++ b/readme.txt
@@ -42,6 +42,7 @@ See [5.7.0 Milestone](https://github.com/pressbooks/pressbooks/milestone/60?clos
 
 #### Not so obvious:
 
+* Support localization of Blade templates: [#1616](https://github.com/pressbooks/pressbooks/pull/1616)
 * Fix E_NOTICE in user catalog: [#1614](https://github.com/pressbooks/pressbooks/pull/1614)
 * Add support for WordPress 5.1: [#1608](https://github.com/pressbooks/pressbooks/pull/1608)
 * Add Google Maps to iframe whitelist ([#1570](https://github.com/pressbooks/pressbooks/issues/1570))

--- a/templates/admin/diagnostics.blade.php
+++ b/templates/admin/diagnostics.blade.php
@@ -1,13 +1,13 @@
 {!! $notices or '' !!}
 <div class="wrap">
-	<h1>{{ __( 'Diagnostics', 'pressbooks' ) }}</h1>
-	<p>{{ __( 'Please submit this information with any bug reports.', 'pressbooks' ) }}</p>
-	<textarea style="width: 800px; max-width: 100%; height: 600px; background: #fff; font-family: monospace;" readonly="readonly" onclick="this.focus(); this.select()" title="{{ _e( 'To copy the system info, click below then press Ctrl + C (PC) or Cmd + C (Mac).', 'pressbooks' ) }}">{{ $output }}</textarea>
+	<h1><?php _e( 'Diagnostics', 'pressbooks' ) ?></h1>
+	<p><?php _e( 'Please submit this information with any bug reports.', 'pressbooks' ) ?></p>
+	<textarea style="width: 800px; max-width: 100%; height: 600px; background: #fff; font-family: monospace;" readonly="readonly" onclick="this.focus(); this.select()" title="{{ _e( 'To copy the system info, click below then press Ctrl + C (PC) or Cmd + C (Mac).', 'pressbooks' ) ?>">{{ $output }}</textarea>
 	@if($is_book)
-		<h2>{{ __( 'View Source', 'pressbooks' ) }}</h2>
+		<h2><?php _e( 'View Source', 'pressbooks' ) ?></h2>
 		<p>{!! sprintf( __( '<a href="%s">View your book&rsquo;s XHTML source</a> to diagnose issues you may be encountering with your PDF exports.', 'pressbooks' ), home_url() . '/format/xhtml?debug=prince' ) !!}</p>
-		<h2>{{ __( 'Regenerate Webbook Stylesheet', 'pressbooks' ) }}</h2>
-		<p>{{ __( 'If your webbook stylesheet has issues, it may help to regenerate it.', 'pressbooks' ) }}</p>
-		<p><form action="{{ $regenerate_webbook_stylesheet_url }}" method="post"><input type="submit" name="submit" id="submit" class="button button-primary" value="{{ __( 'Regenerate Stylesheet', 'pressbooks' ) }}" /></form></p>
+		<h2><?php _e( 'Regenerate Webbook Stylesheet', 'pressbooks' ) ?></h2>
+		<p><?php _e( 'If your webbook stylesheet has issues, it may help to regenerate it.', 'pressbooks' ) ?></p>
+		<p><form action="{{ $regenerate_webbook_stylesheet_url }}" method="post"><input type="submit" name="submit" id="submit" class="button button-primary" value="<?php _e( 'Regenerate Stylesheet', 'pressbooks' ) ?>" /></form></p>
 	@endif
 </div>

--- a/templates/admin/diagnostics.blade.php
+++ b/templates/admin/diagnostics.blade.php
@@ -2,7 +2,7 @@
 <div class="wrap">
 	<h1><?php _e( 'Diagnostics', 'pressbooks' ) ?></h1>
 	<p><?php _e( 'Please submit this information with any bug reports.', 'pressbooks' ) ?></p>
-	<textarea style="width: 800px; max-width: 100%; height: 600px; background: #fff; font-family: monospace;" readonly="readonly" onclick="this.focus(); this.select()" title="{{ _e( 'To copy the system info, click below then press Ctrl + C (PC) or Cmd + C (Mac).', 'pressbooks' ) ?>">{{ $output }}</textarea>
+	<textarea style="width: 800px; max-width: 100%; height: 600px; background: #fff; font-family: monospace;" readonly="readonly" onclick="this.focus(); this.select()" title="<?php _e( 'To copy the system info, click below then press Ctrl + C (PC) or Cmd + C (Mac).', 'pressbooks' ) ?>">{{ $output }}</textarea>
 	@if($is_book)
 		<h2><?php _e( 'View Source', 'pressbooks' ) ?></h2>
 		<p>{!! sprintf( __( '<a href="%s">View your book&rsquo;s XHTML source</a> to diagnose issues you may be encountering with your PDF exports.', 'pressbooks' ), home_url() . '/format/xhtml?debug=prince' ) !!}</p>

--- a/templates/admin/export.blade.php
+++ b/templates/admin/export.blade.php
@@ -6,15 +6,15 @@
 	 */
 	?>
     {!! do_action( 'pb_top_of_export_page' ) !!}
-    <h1>{{ __( 'Export', 'pressbooks') }}</h1>
-    <p>{{ __( 'You can select multiple formats below. Pressbooks keeps the last 3 exports of each file format. You can pin specific files to make sure they don\'t get deleted.', 'pressbooks') }}</p>
+    <h1><?php _e( 'Export', 'pressbooks' ) ?></h1>
+    <p><?php _e( 'You can select multiple formats below. Pressbooks keeps the last 3 exports of each file format. You can pin specific files to make sure they don\'t get deleted.', 'pressbooks' ) ?></p>
     <div id="export-options" class="postbox">
 		<button type="button" class="handlediv" aria-expanded="true">
-			<span class="screen-reader-text">{{ __( 'Toggle panel: Export Options', 'pressbooks') }}</span>
+			<span class="screen-reader-text"><?php _e( 'Toggle panel: Export Options', 'pressbooks' ) ?></span>
 			<span class="toggle-indicator" aria-hidden="true"></span>
 		</button>
         <h2>
-			<span>{{ __( 'Export Options', 'pressbooks') }}</span>
+			<span><?php _e( 'Export Options', 'pressbooks' ) ?></span>
 		</h2>
         <div class="inside">
             <form id="pb-export-form" action="{{ $export_form_url }}" method="POST">
@@ -23,7 +23,7 @@
 						{{-- Supported Formats --}}
 						<div class="supported-formats">
 							<fieldset class="standard">
-								<legend>{{ __( 'Supported formats', 'pressbooks' ) }}:</legend>
+								<legend><?php _e( 'Supported formats', 'pressbooks' ) ?>:</legend>
 								@foreach($formats['standard'] as $key => $value)
 									<input type="checkbox" id="{{$key}}" name="export_formats[{{$key}}]" value="1" {{isset( $dependency_errors[ $key ] ) ? 'disabled' : ''}}/><label
 											for="{{$key}}"> {{$value}}</label><br/>
@@ -33,7 +33,7 @@
 						{{-- Other Formats --}}
 						<div class="other-formats">
 							<fieldset class="exotic">
-								<legend>{{ __( 'Other formats', 'pressbooks' ) }}:</legend>
+								<legend><?php _e( 'Other formats', 'pressbooks' ) ?>:</legend>
 								@foreach($formats['exotic'] as $key => $value)
 									<input type="checkbox" id="{{$key}}" name="export_formats[{{$key}}]" value="1" {{isset( $dependency_errors[ $key ] ) ? 'disabled' : ''}}/><label
 											for="{{$key}}"> {{$value}}</label><br/>
@@ -51,9 +51,9 @@
                         </div>
 						{{-- Theme Controls --}}
 						<div class="theme-controls">
-							<p><b>{{  __( 'Your Theme', 'pressbooks' ) }}:</b> {!! $theme_name !!}</p>
-							<p><a class="button" href="{{ get_bloginfo( 'url' ) }}/wp-admin/themes.php">{{  __( 'Change Theme', 'pressbooks' ) }}</a></p>
-							<p><a class="" href="{{ get_bloginfo( 'url' ) }}/wp-admin/themes.php?page=pressbooks_theme_options">{{ __( 'Theme Options', 'pressbooks' ) }}</a></p>
+							<p><b>{{  __( 'Your Theme', 'pressbooks' ) ?>:</b> {!! $theme_name !!}</p>
+							<p><a class="button" href="{{ get_bloginfo( 'url' ) }}/wp-admin/themes.php">{{  __( 'Change Theme', 'pressbooks' ) ?></a></p>
+							<p><a class="" href="{{ get_bloginfo( 'url' ) }}/wp-admin/themes.php?page=pressbooks_theme_options"><?php _e( 'Theme Options', 'pressbooks' ) ?></a></p>
 						</div>
                     </div>
                 </div>
@@ -70,12 +70,12 @@
         </div>
     </div>
     <div class="export-control">
-        <p><input id="pb-export-button" type="button" class="button button-hero button-primary generate" value="{{ __( 'Export Your Book', 'pressbooks' ) }}"/></p>
+        <p><input id="pb-export-button" type="button" class="button button-hero button-primary generate" value="<?php _e( 'Export Your Book', 'pressbooks' ) ?>"/></p>
 		<progress id="pb-sse-progressbar" max="100"></progress>
 		<p><b><span id="pb-sse-minutes"></span><span id="pb-sse-seconds"></span></b> <span id="pb-sse-info" aria-live="polite"></span></p>
     </div>
     <div class="clear"></div>
-    <h1>{{ __( 'Latest Exports', 'pressbooks') }}</h1>
+    <h1><?php _e( 'Latest Exports', 'pressbooks' ) ?></h1>
     <div id="pin-notifications" class="screen-reader-text" aria-live="assertive"></div>
 	<?php
 	/**

--- a/templates/admin/export.blade.php
+++ b/templates/admin/export.blade.php
@@ -52,7 +52,7 @@
 						{{-- Theme Controls --}}
 						<div class="theme-controls">
 							<p><b><?php _e( 'Your Theme', 'pressbooks' ) ?>:</b> {!! $theme_name !!}</p>
-							<p><a class="button" href="{{ get_bloginfo( 'url' ) }}/wp-admin/themes.php">{{  __( 'Change Theme', 'pressbooks' ) ?></a></p>
+							<p><a class="button" href="{{ get_bloginfo( 'url' ) }}/wp-admin/themes.php"><?php _e( 'Change Theme', 'pressbooks' ) ?></a></p>
 							<p><a class="" href="{{ get_bloginfo( 'url' ) }}/wp-admin/themes.php?page=pressbooks_theme_options"><?php _e( 'Theme Options', 'pressbooks' ) ?></a></p>
 						</div>
                     </div>

--- a/templates/admin/export.blade.php
+++ b/templates/admin/export.blade.php
@@ -51,7 +51,7 @@
                         </div>
 						{{-- Theme Controls --}}
 						<div class="theme-controls">
-							<p><b>{{  __( 'Your Theme', 'pressbooks' ) ?>:</b> {!! $theme_name !!}</p>
+							<p><b><?php _e( 'Your Theme', 'pressbooks' ) ?>:</b> {!! $theme_name !!}</p>
 							<p><a class="button" href="{{ get_bloginfo( 'url' ) }}/wp-admin/themes.php">{{  __( 'Change Theme', 'pressbooks' ) ?></a></p>
 							<p><a class="" href="{{ get_bloginfo( 'url' ) }}/wp-admin/themes.php?page=pressbooks_theme_options"><?php _e( 'Theme Options', 'pressbooks' ) ?></a></p>
 						</div>

--- a/templates/admin/incompatible-plugins.blade.php
+++ b/templates/admin/incompatible-plugins.blade.php
@@ -6,15 +6,15 @@
     <table class="{{ $table_class ?? '' }}" cellspacing="0">
         <thead>
         <tr>
-            <th>{{ __( 'Plugin', 'pressbooks') }}</th>
-            <th>{{ __( 'Tested up to Pressbooks version', 'pressbooks') }}</th>
+            <th><?php _e( 'Plugin', 'pressbooks' ) ?></th>
+            <th><?php _e( 'Tested up to Pressbooks version', 'pressbooks' ) ?></th>
         </tr>
         </thead>
         <tbody>
         @foreach ( $plugins as $plugin )
             <tr>
                 <td>{{ $plugin['Name'] }}</td>
-                <td>{{ ! empty( $plugin[\Pressbooks\Updates::VERSION_TESTED_HEADER] ) ? $plugin[\Pressbooks\Updates::VERSION_TESTED_HEADER] : __( 'Unknown', 'pressbooks' ) }}</td>
+                <td>{{ ! empty( $plugin[\Pressbooks\Updates::VERSION_TESTED_HEADER] ) ? $plugin[\Pressbooks\Updates::VERSION_TESTED_HEADER] : __( 'Unknown', 'pressbooks' ) ?></td>
             </tr>
         @endforeach
         </tbody>

--- a/templates/interactive/audio.blade.php
+++ b/templates/interactive/audio.blade.php
@@ -1,6 +1,6 @@
 <div class="textbox interactive-content interactive-content--audio">
     <span class="interactive-content__icon"></span>
-	<p>{{ __( 'An audio element has been excluded from this version of the text. You can listen to it online here:', 'pressbooks' ) }}
+	<p><?php _e( 'An audio element has been excluded from this version of the text. You can listen to it online here:', 'pressbooks' ) ?>
 	<a href="{{ $url }}{{ \Pressbooks\Interactive\Content::ANCHOR }}" title="{{ $title }}">{{ $url }}</a>
     </p>
 </div>

--- a/templates/interactive/oembed.blade.php
+++ b/templates/interactive/oembed.blade.php
@@ -8,7 +8,7 @@
         @if ($provider_name)
             {{  sprintf( __( 'A %s element has been excluded from this version of the text. You can view it online here:', 'pressbooks' ), $provider_name ) }}
         @else
-            {{ __( 'An interactive or media element has been excluded from this version of the text. You can view it online here:', 'pressbooks' ) }}
+            <?php _e( 'An interactive or media element has been excluded from this version of the text. You can view it online here:', 'pressbooks' ) ?>
 		@endif
 		<a href="{{ $url }}{{ \Pressbooks\Interactive\Content::ANCHOR }}" title="{{ $title }}">{{ $url }}</a>
     </p>

--- a/templates/interactive/shared.blade.php
+++ b/templates/interactive/shared.blade.php
@@ -1,6 +1,6 @@
 <div class="textbox interactive-content">
     <span class="interactive-content__icon"></span>
-    <p>{{ __( 'An interactive or media element has been excluded from this version of the text. You can view it online here:', 'pressbooks' ) }}
+    <p><?php _e( 'An interactive or media element has been excluded from this version of the text. You can view it online here:', 'pressbooks' ) ?>
 	<a href="{{ $url }}{{ \Pressbooks\Interactive\Content::ANCHOR }}" title="{{ $title }}">{{ $url }}</a>
     </p>
 </div>

--- a/templates/interactive/video.blade.php
+++ b/templates/interactive/video.blade.php
@@ -1,6 +1,6 @@
 <div class="textbox interactive-content interactive-content--video">
     <span class="interactive-content__icon"></span>
-    <p>{{ __( 'A video element has been excluded from this version of the text. You can watch it online here:', 'pressbooks' ) }}
+    <p><?php _e( 'A video element has been excluded from this version of the text. You can watch it online here:', 'pressbooks' ) ?>
 		<a href="{{ $url }}{{ \Pressbooks\Interactive\Content::ANCHOR }}" title="{{ $title }}">{{ $url }}</a>
     </p>
 </div>


### PR DESCRIPTION
Blade templates with WordPress localization code in `{{ __() }}` doesn't get picked up by `wp i18n make-pot`. If you use a normal PHP snippet for these (`<?php _e() ?>`), it works.

See also:

+ https://github.com/pressbooks/pressbooks-lti-provider/pull/37
+ https://github.com/pressbooks/pressbooks-cas-sso/pull/27 
+ https://github.com/pressbooks/pressbooks-saml-sso/pull/19