### PR TITLE
Fix html parsing errors in wp-admin (Fix #1650)

### DIFF
--- a/inc/admin/attachments/namespace.php
+++ b/inc/admin/attachments/namespace.php
@@ -103,7 +103,7 @@ function render_attachment_license_options( $post_id, $license_meta ) {
 	$licenses = ( new Licensing() )->getSupportedTypes();
 	$html = "<select name='attachments[$post_id][pb_media_attribution_license]' id='attachments-{$post_id}-pb_media_attribution_license'>";
 
-	$html .= '<option value=""></option>';
+	$html .= '<option value="">&nbsp;</option>';
 	foreach ( $licenses as $key => $license ) {
 		$html .= "<option value='{$key}'" . selected( $license_meta, $key, false ) . ">{$license['desc']}</option>";
 	}

--- a/inc/admin/covergenerator/namespace.php
+++ b/inc/admin/covergenerator/namespace.php
@@ -459,7 +459,7 @@ function pressbooks_cg_front_background_image_callback( $args ) {
 	/* translators: 1: minimum width, 2: minimum height, 3: aspect ratio width, 4: aspect ratio height */
 	$html .= '<p class="description front-background-image-description' . ( isset( $option['front_background_image'] ) ? ' hidden' : '' ) . '">' . sprintf( __( 'Your image must be at least %1$s pixels in width by %2$s pixels in height, with an aspect ratio of %3$s to %4$s.', 'pressbooks' ), round( $width ), round( $height ), $numeric_width, $numeric_height ) . '</p>';
 	$html .= '<div class="front-background-image-preview-wrap' . ( isset( $option['front_background_image'] ) ? '' : ' hidden' ) . '">';
-	$html .= '<p><img class="front-background-image" src="' . ( isset( $option['front_background_image'] ) ? $option['front_background_image'] : '' ) . '" /></p>';
+	$html .= '<p><img class="front-background-image" alt="Front Cover Background Image" src="' . ( isset( $option['front_background_image'] ) ? $option['front_background_image'] : 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=' ) . '" /></p>'; // Fallback to Tiny 26 bytes GIF
 	$html .= '<p><input type="button" class="button button-primary delete-front-background-image" value="' . __( 'Delete Background Image', 'pressbooks' ) . '" /></p>';
 	$html .= '</div>';
 	echo $html;
@@ -476,7 +476,7 @@ function pressbooks_cg_text_transform_callback( $args ) {
 	foreach ( $args as $key => $val ) {
 		$html .= "<option value='" . $key . "' " . selected( $key, $option['text_transform'], false ) . ">$val</option>";
 	}
-	$html .= '<select>';
+	$html .= '</select>';
 	echo $html;
 }
 
@@ -529,7 +529,7 @@ function pressbooks_cg_ppi_callback( $args ) {
 		$custom .= ' selected';
 	}
 	$html .= "<option value=''" . $custom . '>' . __( 'Custom&hellip;', 'pressbooks' ) . '</option>';
-	$html .= '<select>';
+	$html .= '</select>';
 	echo $html;
 }
 

--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -24,7 +24,7 @@ use Pressbooks\Metadata;
  */
 function add_footer_link() {
 	printf(
-		'<p id="footer-left" class="alignleft"><span id="footer-thankyou">%1$s</span> &bull; %2$s &bull; %3$s &bull; %4$s &bull; %5$s</p>',
+		'<span id="footer-thankyou">%1$s</span> &bull; %2$s &bull; %3$s &bull; %4$s &bull; %5$s',
 		sprintf(
 			__( 'Powered by %s', 'pressbooks' ),
 			sprintf(

--- a/inc/admin/metaboxes/namespace.php
+++ b/inc/admin/metaboxes/namespace.php
@@ -1024,9 +1024,9 @@ function metadata_subject_box( $post ) {
 	}
 	?>
 	<div class="custom-metadata-field select">
-		<label for="pb_primary_subject"><?php _e( 'Primary Subject', 'pressbooks' ); ?></label>
+		<label for="primary-subject"><?php _e( 'Primary Subject', 'pressbooks' ); ?></label>
 		<select id="primary-subject" name="pb_primary_subject">
-			<option value=""></option>
+			<option value="">&nbsp;</option>
 			<?php foreach ( \Pressbooks\Metadata\get_thema_subjects() as $subject_group ) { ?>
 			<optgroup label="<?php echo $subject_group['label']; ?>">
 				<?php foreach ( $subject_group['children'] as $key => $value ) { ?>
@@ -1038,9 +1038,9 @@ function metadata_subject_box( $post ) {
 		<span class="description"><?php printf( __( 'This appears on the web homepage of your book and helps categorize it in your network catalog (if applicable). Use %s to determine which subject category is best for your book.', 'pressbooks' ), sprintf( '<a href="%1$s">%2$s</a>', 'https://www.editeur.org/151/Thema', __( 'these instructions', 'pressbooks' ) ) ); ?></span>
 	</div>
 	<div class="custom-metadata-field select">
-		<label for="pb_additional_subjects"><?php _e( 'Additional Subject(s)', 'pressbooks' ); ?></label>
+		<label for="additional-subjects"><?php _e( 'Additional Subject(s)', 'pressbooks' ); ?></label>
 		<select id="additional-subjects" name="pb_additional_subjects[]" multiple>
-			<option value=""></option>
+			<option value="">&nbsp;</option>
 			<?php foreach ( \Pressbooks\Metadata\get_thema_subjects( true ) as $subject_group ) { ?>
 			<optgroup label="<?php echo $subject_group['label']; ?>">
 				<?php foreach ( $subject_group['children'] as $key => $value ) { ?>
@@ -1092,12 +1092,12 @@ function contributor_add_form() {
 	wp_nonce_field( 'contributor-meta', 'contributor_meta_nonce' );
 	?>
 	<div class="form-field contributor-first-name-wrap">
-		<label for="contributor_first_name"><?php _e( 'First Name', 'pressbooks' ); ?></label>
+		<label for="contributor-first-name"><?php _e( 'First Name', 'pressbooks' ); ?></label>
 		<input type="text" name="contributor_first_name" id="contributor-first-name" value="" class="contributor-first-name-field" />
 		<p>
 	</div>
 	<div class="form-field contributor-last-name-wrap">
-		<label for="contributor_last_name"><?php _e( 'Last Name', 'pressbooks' ); ?></label>
+		<label for="contributor-last-name"><?php _e( 'Last Name', 'pressbooks' ); ?></label>
 		<input type="text" name="contributor_last_name" id="contributor-last-name" value="" class="contributor-last-name-field" />
 	</div>
 	<?php
@@ -1114,14 +1114,14 @@ function contributor_edit_form( $term ) {
 	}
 	?>
 	<tr class="form-field contributor-first-name-wrap">
-		<th scope="row"><label for="contributor_first_name"><?php _e( 'First Name', 'pressbooks' ); ?></label></th>
+		<th scope="row"><label for="contributor-first-name"><?php _e( 'First Name', 'pressbooks' ); ?></label></th>
 		<td>
 			<?php wp_nonce_field( 'contributor-meta', 'contributor_meta_nonce' ); ?>
 			<input type="text" name="contributor_first_name" id="contributor-first-name" value="<?php echo esc_attr( $firstname ); ?>" class="contributor-first-name-field"  />
 		</td>
 	</tr>
 	<tr class="form-field contributor-last-name-wrap">
-		<th scope="row"><label for="contributor_last_name"><?php _e( 'Last Name', 'pressbooks' ); ?></label></th>
+		<th scope="row"><label for="contributor-last-name"><?php _e( 'Last Name', 'pressbooks' ); ?></label></th>
 		<td>
 			<input type="text" name="contributor_last_name" id="contributor-last-name" value="<?php echo esc_attr( $lastname ); ?>" class="contributor-last-name-field"  />
 		</td>

--- a/inc/image/namespace.php
+++ b/inc/image/namespace.php
@@ -478,7 +478,7 @@ function render_cover_image_box( $form_id, $cover_pid, $image_url, $ajax_action,
 				<p><img id="cover_image_preview" src="<?php echo $image_url; ?>" style="width:auto;height:100px;" alt="cover_image"/><br/>
 					<button id="delete_cover_button" name="<?php echo $image_url; ?>" type="button" class="button-secondary"><?php _e( 'Delete', 'pressbooks' ); ?></button>
 				</p>
-				<p><input type="file" name="<?php echo $form_id; ?>" value="" id="<?php echo $form_id; ?>"/></p>
+				<p><input type="file" name="<?php echo $form_id; ?>" id="<?php echo $form_id; ?>"/></p>
 				<input type="hidden" id="cover_pid" name="cover_pid" value="<?php echo $cover_pid; ?>"/>
 			<?php } else { ?>
 				<p><img id="cover_image_preview" src="<?php echo \Pressbooks\Image\default_cover_url(); ?>" style="width:auto;height:100px;" alt="cover_image"/></p>

--- a/inc/l10n/namespace.php
+++ b/inc/l10n/namespace.php
@@ -16,7 +16,7 @@ namespace Pressbooks\L10n;
 function supported_languages() {
 
 	$languages = [
-		'' => '',
+		'' => '&nbsp;',
 		'af' => 'Afrikaans',
 		'sq' => 'Albanian',
 		'ar' => 'Arabic',

--- a/symbionts/custom-metadata/custom_metadata.php
+++ b/symbionts/custom-metadata/custom_metadata.php
@@ -1185,19 +1185,9 @@ class custom_metadata_manager {
 		$readonly_str = ( ! empty( $field->readonly ) ) ? ' readonly="readonly"' : '';
 		$placeholder_str = ( in_array( $field->field_type, $this->_field_types_that_support_placeholder ) && ! empty( $field->placeholder ) ) ? ' placeholder="' . esc_attr( $field->placeholder ) . '"' : '';
 
-		$label_str = sprintf( '<label for="%s">%s</label>', esc_attr( $field_slug ), esc_html( $field->label ) );
-
-		// Define an array of field types that need the <label> AFTER the <input>
-		$label_after_field_types = array( 'checkbox' );
-
-		// Show the label now if the current field_type is not on the list
-		if ( ! in_array( $field->field_type, $label_after_field_types ) )
-			echo $label_str;
-
 		// check if there is a default value and set it if no value currently set
 		if ( empty( $value ) && in_array( $field->field_type, $this->_field_types_that_support_default_value ) && ! empty( $field->default_value ) )
 			$value = sanitize_text_field( $field->default_value );
-
 
 		// if value is empty set to an empty string
 		if ( empty( $value ) )
@@ -1206,40 +1196,57 @@ class custom_metadata_manager {
 		// make sure $value is an array
 		$value = (array) $value;
 
+		// Set a unique HTML ID
+		$has_more_than_one_value = count( $value ) > 1;
+		$html_id = $has_more_than_one_value ? "{$field_slug}_1" : $field_slug; // HTML ID must be unique
+
+		// Define an array of field types that need the <label> AFTER the <input>
+		// Show the label now if the current field_type is not on the list
+		$label_after_field_types = array( 'checkbox' );
+		$label_str = sprintf( '<label for="%s">%s</label>', esc_attr( $html_id ), esc_html( $field->label ) );
+		if ( ! in_array( $field->field_type, $label_after_field_types ) )
+			echo $label_str;
+
 		$count = 1;
 		$container_class = sanitize_html_class( $field_slug );
 		$container_class .= ( $cloneable ) ? ' cloneable' : '';
 		foreach ( $value as $v ) :
+			if ( in_array( $field->field_type, [ 'multi_select', 'taxonomy_checkbox', 'taxonomy_multi_select' ] ) ) {
+				// fields that save as arrays are not part of the foreach, otherwise they would display for each value, which is not the desired behaviour
+				continue;
+			}
+
 			$container_id = $field_slug . '-' . $count;
+			$html_id = $has_more_than_one_value ? "{$field_slug}_{$count}" : $field_slug;
 			printf( '<div class="%s" id="%s">', esc_attr( $container_class ), esc_attr( $container_id ) );
 
 			switch ( $field->field_type ) :
 				case 'text' :
-					printf( '<input type="text" id="%s" name="%s" value="%s"%s%s/>', esc_attr( $field_slug ), esc_attr( $field_id ), esc_attr( $v ), $readonly_str, $placeholder_str );
+					printf( '<input type="text" id="%s" name="%s" value="%s"%s%s/>', esc_attr( $html_id ), esc_attr( $field_id ), esc_attr( $v ), $readonly_str, $placeholder_str );
 					break;
 				case 'password' :
-					printf( '<input type="password" id="%s" name="%s" value="%s"%s%s/>', esc_attr( $field_slug ), esc_attr( $field_id ), esc_attr( $v ), $readonly_str, $placeholder_str );
+					printf( '<input type="password" id="%s" name="%s" value="%s"%s%s/>', esc_attr( $html_id ), esc_attr( $field_id ), esc_attr( $v ), $readonly_str, $placeholder_str );
 					break;
 				case 'email' :
-					printf( '<input type="email" id="%s" name="%s" value="%s"%s%s/>', esc_attr( $field_slug ), esc_attr( $field_id ), esc_attr( $v ), $readonly_str, $placeholder_str );
+					printf( '<input type="email" id="%s" name="%s" value="%s"%s%s/>', esc_attr( $html_id ), esc_attr( $field_id ), esc_attr( $v ), $readonly_str, $placeholder_str );
 					break;
 				case 'tel' :
-					printf( '<input type="tel" id="%s" name="%s" value="%s"%s%s/>', esc_attr( $field_slug ), esc_attr( $field_id ), esc_attr( $v ), $readonly_str, $placeholder_str );
+					printf( '<input type="tel" id="%s" name="%s" value="%s"%s%s/>', esc_attr( $html_id ), esc_attr( $field_id ), esc_attr( $v ), $readonly_str, $placeholder_str );
 					break;
 				case 'link' :
-					printf( '<input type="text" id="%s" name="%s" value="%s" %s%s/>', esc_attr( $field_slug ), esc_attr( $field_id ), esc_attr( $v ), $readonly_str, $placeholder_str );
+					printf( '<input type="text" id="%s" name="%s" value="%s" %s%s/>', esc_attr( $html_id ), esc_attr( $field_id ), esc_attr( $v ), $readonly_str, $placeholder_str );
 					printf( '<input type="button" class="button custom-metadata-link-button" value="%s"/>', esc_attr( $field->link_modal_button_text ) );
 					break;
 				case 'number' :
 					$min = ( ! empty( $field->min ) ) ? ' min="' . (int) $field->min . '"': '';
 					$max = ( ! empty( $field->max ) ) ? ' max="' . (int) $field->max . '"': '';
-					printf( '<input type="number" id="%s" name="%s" value="%s"%s%s%s%s/>', esc_attr( $field_slug ), esc_attr( $field_id ), esc_attr( $v ), $readonly_str, $placeholder_str, $min, $max );
+					printf( '<input type="number" id="%s" name="%s" value="%s"%s%s%s%s/>', esc_attr( $html_id ), esc_attr( $field_id ), esc_attr( $v ), $readonly_str, $placeholder_str, $min, $max );
 					break;
 				case 'textarea' :
-					printf( '<textarea id="%s" name="%s"%s%s>%s</textarea>', esc_attr( $field_slug ), esc_attr( $field_id ), $readonly_str, $placeholder_str, esc_textarea( $v ) );
+					printf( '<textarea id="%s" name="%s"%s%s>%s</textarea>', esc_attr( $html_id ), esc_attr( $field_id ), $readonly_str, $placeholder_str, esc_textarea( $v ) );
 					break;
 				case 'checkbox' :
-					printf( '<input type="checkbox" id="%s" name="%s" %s/>', esc_attr( $field_slug ), esc_attr( $field_id ), checked( $v, 'on', false ) );
+					printf( '<input type="checkbox" id="%s" name="%s" %s/>', esc_attr( $html_id ), esc_attr( $field_id ), checked( $v, 'on', false ) );
 					break;
 				case 'radio' :
 					foreach ( $field->values as $value_slug => $value_label ) {
@@ -1253,7 +1260,7 @@ class custom_metadata_manager {
 				case 'select' :
 					$select2 = ( $field->select2 ) ? ' class="custom-metadata-select2" ' : ' ';
 					$select2 .= ( $field->placeholder ) ? ' data-placeholder="'. esc_attr( $field->placeholder ) . '" ' : ' data-placeholder="" ';
-					printf( '<select id="%s" name="%s"%s>', esc_attr( $field_slug ), esc_attr( $field_id ), $select2 );
+					printf( '<select id="%s" name="%s"%s>', esc_attr( $html_id ), esc_attr( $field_id ), $select2 );
 					foreach ( $field->values as $value_slug => $value_label ) {
 						printf( '<option value="%s"%s>', esc_attr( $value_slug ), selected( $v, $value_slug, false ) );
 						echo esc_html( $value_label );
@@ -1263,18 +1270,18 @@ class custom_metadata_manager {
 					break;
 				case 'datepicker' :
 					$datepicker_value = ! empty( $v ) ? esc_attr( date( 'm/d/Y', $v ) ) : '';
-					printf( '<input type="text" name="%s" value="%s"%s%s/>', esc_attr( $field_id ), $datepicker_value, $readonly_str, $placeholder_str );
+					printf( '<input type="text" id="%s" name="%s" value="%s"%s%s/>', esc_attr( $html_id ), esc_attr( $field_id ), $datepicker_value, $readonly_str, $placeholder_str );
 					break;
 				case 'colorpicker':
-					printf( '<input type="text" name="%s" value="%s"%s%s/>', esc_attr( $field_id ), esc_attr( $v ), $readonly_str, $placeholder_str );
+					printf( '<input type="text" id="%s" name="%s" value="%s"%s%s/>', esc_attr( $html_id ), esc_attr( $field_id ), esc_attr( $v ), $readonly_str, $placeholder_str );
 					break;
 				case 'datetimepicker' :
 					$datetimepicker_value = ! empty( $v ) ? esc_attr( date( 'm/d/Y G:i', $v ) ) : '';
-					printf( '<input type="text" name="%s" value="%s"%s%s/>', esc_attr( $field_id ), $datetimepicker_value, $readonly_str, $placeholder_str );
+					printf( '<input type="text" id="%s" name="%s" value="%s"%s%s/>', esc_attr( $html_id ), esc_attr( $field_id ), $datetimepicker_value, $readonly_str, $placeholder_str );
 					break;
 				case 'timepicker' :
 					$timepicker = ! empty( $v ) ? esc_attr( date( 'G:i', $v ) ) : '';
-					printf( '<input type="text" name="%s" value="%s"%s%s/>', esc_attr( $field_id ), $timepicker, $readonly_str, $placeholder_str );
+					printf( '<input type="text" id="%s" name="%s" value="%s"%s%s/>', esc_attr( $html_id ), esc_attr( $field_id ), $timepicker, $readonly_str, $placeholder_str );
 					break;
 				case 'wysiwyg' :
 					$wysiwyg_args = apply_filters( 'custom_metadata_manager_wysiwyg_args_field_' . $field_id, $this->default_editor_args, $field_slug, $field, $object_type, $object_id );
@@ -1283,7 +1290,7 @@ class custom_metadata_manager {
 				case 'upload' :
 					$_attachment_id = $this->get_metadata_field_value( $field_slug . '_attachment_id', $field, $object_type, $object_id );
 					$attachment_id = array_shift( array_values( $_attachment_id ) ); // get the first value in the array
-					printf( '<input type="text" name="%s" value="%s" class="custom-metadata-upload-url"%s%s/>', esc_attr( $field_id ), esc_attr( $v ), $readonly_str, $placeholder_str );
+					printf( '<input type="text" id="%s" name="%s" value="%s" class="custom-metadata-upload-url"%s%s/>', esc_attr( $html_id ), esc_attr( $field_id ), esc_attr( $v ), $readonly_str, $placeholder_str );
 					printf( '<input type="button" data-uploader-title="%s" data-uploader-button-text="%s" class="button custom-metadata-upload-button" value="%s"/>', esc_attr( $field->upload_modal_title ), esc_attr( $field->upload_modal_button_text ), esc_attr( $field->upload_modal_title ) );
 					printf( '<input type="button" class="button custom-metadata-clear-button" value="%s"/>', $field->upload_clear_button_text );
 					printf( '<input type="hidden" name="%s" value="%s" class="custom-metadata-upload-id"/>', esc_attr( $field_id . '_attachment_id' ), esc_attr( $attachment_id ) );
@@ -1296,8 +1303,8 @@ class custom_metadata_manager {
 					}
 					$select2 = ( $field->select2 ) ? ' class="custom-metadata-select2" ' : ' ';
 					$select2 .= ( $field->placeholder ) ? ' data-placeholder="'. esc_attr( $field->placeholder ) . '" ' : ' data-placeholder="" ';
-					printf( '<select name="%s" id="%s"%s>', esc_attr( $field_id ), esc_attr( $field_slug ), $select2 );
-						echo '<option value=""></option>';
+					printf( '<select name="%s" id="%s"%s>', esc_attr( $field_id ), esc_attr( $html_id ), $select2 );
+						echo '<option value="">&nbsp;</option>';
 					foreach ( $terms as $term ) {
 						printf( '<option value="%s"%s>%s</option>', esc_attr( $term->slug ), selected( $v, $term->slug, false ), esc_html( $term->name ) );
 					}
@@ -1333,16 +1340,15 @@ class custom_metadata_manager {
 
 
 		if ( in_array( $field->field_type, $this->_always_multiple_fields ) ) :
-			$container_id = $field_slug . '-' . 1;
+			$container_id = $field_slug . '-' . $count;
 			printf( '<div class="%s" id="%s">', esc_attr( $container_class ), esc_attr( $container_id ) );
 
-
-			// fields that save as arrays are not part of the foreach, otherwise they would display for each value, which is not the desired behaviour
+			// fields that save as arrays were not part of the above foreach, otherwise they would have displayed for each value, which is not the desired behaviour
 			switch ( $field->field_type ) :
 				case 'multi_select' :
 					$select2 = ( $field->select2 ) ? ' class="custom-metadata-select2" ' : ' ';
 					$select2 .= ( $field->placeholder ) ? ' data-placeholder="'. esc_attr( $field->placeholder ) . '" ' : ' data-placeholder="" ';
-					printf( '<select id="%s" name="%s"%smultiple>', esc_attr( $field_slug ), esc_attr( $field_id ), $select2 );
+					printf( '<select id="%s" name="%s"%smultiple>', esc_attr( $html_id ), esc_attr( $field_id ), $select2 );
 					$ordered_values = $field->select2 ? $this->_order_multi_select( $field->values, $value ) : $field->values;
 					foreach ( $ordered_values as $value_slug => $value_label ) {
 						printf( '<option value="%s"%s>', esc_attr( $value_slug ), selected( in_array( $value_slug, $value ), true, false ) );
@@ -1372,7 +1378,7 @@ class custom_metadata_manager {
 					}
 					$select2 = ( $field->select2 ) ? ' class="custom-metadata-select2" ' : ' ';
 					$select2 .= ( $field->placeholder ) ? ' data-placeholder="'. esc_attr( $field->placeholder ) . '" ' : ' data-placeholder="" ';
-					printf( '<select name="%s" id="%s"%smultiple>', esc_attr( $field_id ), esc_attr( $field_slug ), $select2 );
+					printf( '<select name="%s" id="%s"%smultiple>', esc_attr( $field_id ), esc_attr( $html_id ), $select2 );
 					$ordered_terms = $field->select2 ? $this->_order_taxonomy_multi_select( $terms, $value ) : $terms;
 					foreach ( $ordered_terms as $term ) {
 						printf( '<option value="%s"%s>%s</option>', esc_attr( $term->slug ), selected( in_array( $term->slug, $value ), true, false ), esc_html( $term->name ) );

--- a/symbionts/custom-metadata/js/custom-metadata-manager.js
+++ b/symbionts/custom-metadata/js/custom-metadata-manager.js
@@ -23,6 +23,7 @@
 			id_name = split_id[0] + '-' + instance_num;
 			$clone.attr( 'id', id_name );
 			$clone.children('input').removeAttr('value');
+			$clone.children('input').removeAttr('id');
 			$clone.insertAfter( $last ).hide().fadeIn().find( ':input' ).not( ':input[type=button]' ).val(''); // todo: figure out if default value
 		});
 

--- a/templates/admin/covergenerator.php
+++ b/templates/admin/covergenerator.php
@@ -119,7 +119,7 @@ if ( $dependency_errors ) {
 																											title="<?php echo esc_attr( $file ); ?>"></span></a>
 							<div class="file-actions">
 								<a href="<?php echo( $download_form_url . $file ); ?>"><span class="dashicons dashicons-download"></span></a>
-								<button class="delete" type="submit" name="submit" src="" value="Delete"
+								<button class="delete" type="submit" name="submit" value="Delete"
 										onclick="if ( !confirm('<?php esc_attr_e( 'Are you sure you want to delete this?', 'pressbooks' ); ?>' ) ) { return false }"><span
 											class="dashicons dashicons-trash"></span></button>
 							</div>
@@ -135,7 +135,7 @@ if ( $dependency_errors ) {
 			<?php if ( ! empty( $covers ) && current_user_can( 'manage_network' ) ) : ?>
 				<form class="delete-all" action="<?php echo $delete_all_form_url; ?>" method="post">
 					<input type="hidden" name="delete_all_covers" value="1"/>
-					<button class="button" type="submit" name="submit" src="" value="Delete All Covers"
+					<button class="button" type="submit" name="submit" value="Delete All Covers"
 							onclick="if ( !confirm('<?php esc_attr_e( 'Are you sure you want to delete ALL your current covers?', 'pressbooks' ); ?>' ) ) { return false }"><?php _e( 'Delete All Covers', 'pressbooks' ); ?></button>
 				</form>
 			<?php endif; ?>

--- a/templates/admin/organize.php
+++ b/templates/admin/organize.php
@@ -106,7 +106,7 @@ if ( isset( $ebook_options['ebook_start_point'] ) && ! empty( $ebook_options['eb
 				<table id="part_<?php echo $part['ID']; ?>" class="wp-list-table widefat fixed striped chapters">
 					<thead>
 						<tr>
-							<th scope="col" id="title" class="has-row-actions manage-column column-title column-primary">
+							<th scope="col" id="title_<?php echo $part['ID']; ?>" class="has-row-actions manage-column column-title column-primary">
 								<?php if ( $can_edit ) { ?>
 									<a href="<?php echo admin_url( 'post.php?post=' . $part['ID'] . '&action=edit' ); ?>"><?php echo $part['post_title']; ?></a>
 								<?php } else { ?>
@@ -134,7 +134,7 @@ if ( isset( $ebook_options['ebook_start_point'] ) && ! empty( $ebook_options['eb
 
 					<?php if ( count( $part['chapters'] ) > 0 ) : ?>
 
-					<tbody id="the-list">
+					<tbody id="the-list-<?php echo $part['ID']; ?>">
 					<?php
 					$chapters = count( $part['chapters'] );
 					$c = 1; // Start the chapter counter
@@ -260,7 +260,7 @@ endif;
 		<table id="<?php echo $slug; ?>" class="wp-list-table widefat fixed striped <?php echo $slug; ?>">
 			<thead>
 				<tr>
-					<th scope="col" id="title" class="has-row-actions manage-column column-title column-primary"><?php echo $name; ?></th>
+					<th scope="col" id="title_<?php echo $slug; ?>" class="has-row-actions manage-column column-title column-primary"><?php echo $name; ?></th>
 					<th><?php _e( 'Authors', 'pressbooks' ); ?></th>
 					<?php if ( false === $disable_comments ) : ?>
 					<th><?php _e( 'Comments', 'pressbooks' ); ?></th>
@@ -271,7 +271,7 @@ endif;
 				</tr>
 			</thead>
 
-			<tbody id="the-list">
+			<tbody id="the-list-<?php echo $slug; ?>">
 			<?php
 			$sections = count( $book_structure[ $slug ] );
 			$s = 1; // Start the counter


### PR DESCRIPTION
This fixes all the html parsing errors I could find.

The remaining "nags" coming from https://validator.w3.org/nu/ are warnings, not errors, and they come from WordPress, not Pressbooks.

For our Book Info page, [I followed these steps](https://s.codepen.io/stevef/debug/VRZdGJ). The WCAG 2.1 parsing error bookmarklet removed everything. I was left with zero errors.

