### PR TITLE
Reset password loop (fix #1683)

### DIFF
--- a/hooks.php
+++ b/hooks.php
@@ -176,6 +176,7 @@ add_filter( 'init', '\Pressbooks\Redirect\rewrite_rules_for_format', 1 );
 add_filter( 'init', '\Pressbooks\Redirect\rewrite_rules_for_catalog', 1 );
 add_filter( 'init', '\Pressbooks\Redirect\rewrite_rules_for_open', 1 );
 add_action( 'plugins_loaded', '\Pressbooks\Redirect\migrate_generated_content', 1 );
+add_filter( 'login_redirect', '\Pressbooks\Redirect\break_reset_password_loop', 10, 3 );
 
 // -------------------------------------------------------------------------------------------------------------------
 // Sitemap

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -29,6 +29,9 @@ function session_start() {
 		if ( ! headers_sent() ) {
 			ini_set( 'session.use_only_cookies', true );
 			ini_set( 'session.cookie_domain', COOKIE_DOMAIN );
+			if ( is_ssl() ) {
+				ini_set( 'session.cookie_secure', true );
+			}
 
 			$options = [];
 			if ( use_non_blocking_session() ) {

--- a/inc/redirect/namespace.php
+++ b/inc/redirect/namespace.php
@@ -585,7 +585,7 @@ function break_reset_password_loop( $redirect_to, $requested_redirect_to, $user 
 		if ( $parsed_url === false ) {
 			return $redirect_to;
 		}
-		if ( strpos( $parsed_url['path'], 'wp-login.php' ) === false ) {
+		if ( strpos( $parsed_url['path'] ?? '', 'wp-login.php' ) === false ) {
 			return $redirect_to;
 		}
 		parse_str( $parsed_url['query'] ?? '', $parsed_query );

--- a/inc/redirect/namespace.php
+++ b/inc/redirect/namespace.php
@@ -590,10 +590,8 @@ function break_reset_password_loop( $redirect_to, $requested_redirect_to, $user 
 		}
 		parse_str( $parsed_url['query'] ?? '', $parsed_query );
 		if ( isset( $parsed_query['action'] ) && ( $parsed_query['action'] === 'resetpass' || $parsed_query['action'] === 'rp' ) ) {
-			if ( empty( $parsed_query['key'] ) ) {
-				// Break the loop
-				return admin_url();
-			}
+			// Break the loop
+			return admin_url();
 		}
 	}
 	return $redirect_to;

--- a/inc/redirect/namespace.php
+++ b/inc/redirect/namespace.php
@@ -35,52 +35,10 @@ function location( $href ) {
 
 
 /**
- * Change redirect upon login to user's My Catalog page
- *
- * @param string $redirect_to
- * @param string $request_redirect_to
- * @param \WP_User $user
- *
- * @return string
- */
-function login( $redirect_to, $request_redirect_to, $user ) {
-
-	if ( false === is_a( $user, 'WP_User' ) ) {
-		// Unknown user, bail with default
-		return $redirect_to;
-	}
-
-	if ( is_super_admin( $user->ID ) ) {
-		// This is an admin, don't mess
-		return $redirect_to;
-	}
-
-	$blogs = get_blogs_of_user( $user->ID );
-	if ( array_key_exists( get_current_blog_id(), $blogs ) ) {
-		// Yes, user has access to this blog
-		return $redirect_to;
-	}
-
-	if ( $user->primary_blog ) {
-		// Force redirect the user to their blog or, if they have more than one, to their catalog, bypass wp_safe_redirect()
-		if ( count( $blogs ) > 1 ) {
-			$redirect = get_blogaddress_by_id( $user->primary_blog ) . 'wp-admin/index.php?page=pb_catalog';
-		} else {
-			$redirect = get_blogaddress_by_id( $user->primary_blog ) . 'wp-admin/';
-		}
-		location( $redirect );
-	}
-
-	// User has no primary_blog? Make them sign-up for one
-	return network_site_url( '/wp-signup.php' );
-}
-
-
-/**
  * Centralize flush_rewrite_rules() in one single function so that rule does not kill the other
  */
 function flusher() {
-	$number = 3; // Increment this number when you need to re-run flush_rewrite_rules()
+	$number = 3; // Increment this number when you need to re-run flush_rewrite_rules() on next code deployment
 	if ( absint( get_option( 'pressbooks_flusher', 1 ) ) < $number ) {
 		flush_rewrite_rules( false );
 		update_option( 'pressbooks_flusher', $number );

--- a/tests/test-redirect.php
+++ b/tests/test-redirect.php
@@ -134,4 +134,23 @@ class RedirectTest extends \WP_UnitTestCase {
 		$this->assertEquals( $logged_in->user_login, $user->user_login );
 	}
 
+	public function test_break_reset_password_loop() {
+		$user_id = $this->factory()->user->create( [ 'role' => 'subscriber' ] );
+		$user = get_userdata( $user_id );
+		$requested_redirect_to = 'ignored';
+
+		$redirect_to = 'wp-login.php?action=resetpass';
+		$url = \Pressbooks\Redirect\break_reset_password_loop( $redirect_to, $requested_redirect_to, $user );
+		$this->assertEquals( admin_url(), $url );
+
+		$redirect_to = 'wp-login.php?action=rp';
+		$requested_redirect_to = 'ignored';
+		$url = \Pressbooks\Redirect\break_reset_password_loop( $redirect_to, $requested_redirect_to, $user );
+		$this->assertEquals( admin_url(), $url );
+
+		$user = new WP_Error();
+		$url = \Pressbooks\Redirect\break_reset_password_loop( $redirect_to, $requested_redirect_to, $user );
+		$this->assertNotEquals( admin_url(), $url );
+	}
+
 }

--- a/tests/test-redirect.php
+++ b/tests/test-redirect.php
@@ -148,6 +148,11 @@ class RedirectTest extends \WP_UnitTestCase {
 		$url = \Pressbooks\Redirect\break_reset_password_loop( $redirect_to, $requested_redirect_to, $user );
 		$this->assertEquals( admin_url(), $url );
 
+		$redirect_to = '';
+		$url = \Pressbooks\Redirect\break_reset_password_loop( $redirect_to, $requested_redirect_to, $user );
+		$this->assertNotEquals( admin_url(), $url );
+
+		$redirect_to = 'wp-login.php?action=rp';
 		$user = new WP_Error();
 		$url = \Pressbooks\Redirect\break_reset_password_loop( $redirect_to, $requested_redirect_to, $user );
 		$this->assertNotEquals( admin_url(), $url );


### PR DESCRIPTION
Breaks "The user enters a new password and confirms it but is redirected to a login page with an error, even though the password has successfully been saved" loop.