### PR TITLE
Add aria-labels to footnotes in text and return to footnote button (fix #1693)

### DIFF
--- a/inc/shortcodes/footnotes/class-footnotes.php
+++ b/inc/shortcodes/footnotes/class-footnotes.php
@@ -97,7 +97,7 @@ class Footnotes {
 		$num = count( $footnotes );
 		$numlabel = "$id-$num";
 
-		$retval = '<a class="footnote" title="' . \Pressbooks\Sanitize\sanitize_xml_attribute( wp_strip_all_tags( $content ) ) . '" id="return-footnote-' . $numlabel . '" href="#footnote-' . $numlabel . '"><sup class="footnote">[';
+		$retval = '<a class="footnote" title="' . \Pressbooks\Sanitize\sanitize_xml_attribute( wp_strip_all_tags( $content ) ) . '" id="return-footnote-' . $numlabel . '" href="#footnote-' . $numlabel . '" aria-label="Footnote ' . $num .'"><sup class="footnote">[';
 
 		if ( $this->numbered[ $id ] ) {
 			$retval .= $num;
@@ -144,7 +144,7 @@ class Footnotes {
 		foreach ( $footnotes as $num => $footnote ) {
 			$num++;
 			$numlabel = "$id-$num";
-			$content .= '<li id="footnote-' . $numlabel . '">' . make_clickable( $footnote ) . ' <a href="#return-footnote-' . $numlabel . '" class="return-footnote">&crarr;</a></li>';
+			$content .= '<li id="footnote-' . $numlabel . '">' . make_clickable( $footnote ) . ' <a href="#return-footnote-' . $numlabel . '" class="return-footnote" aria-label="Return to footnote '. $num .'">&crarr;</a></li>';
 		}
 
 		if ( $this->numbered[ $id ] ) {

--- a/inc/shortcodes/footnotes/class-footnotes.php
+++ b/inc/shortcodes/footnotes/class-footnotes.php
@@ -97,7 +97,7 @@ class Footnotes {
 		$num = count( $footnotes );
 		$numlabel = "$id-$num";
 
-		$retval = '<a class="footnote" title="' . \Pressbooks\Sanitize\sanitize_xml_attribute( wp_strip_all_tags( $content ) ) . '" id="return-footnote-' . $numlabel . '" href="#footnote-' . $numlabel . '" aria-label="Footnote ' . $num .'"><sup class="footnote">[';
+		$retval = '<a class="footnote" title="' . \Pressbooks\Sanitize\sanitize_xml_attribute( wp_strip_all_tags( $content ) ) . '" id="return-footnote-' . $numlabel . '" href="#footnote-' . $numlabel . '" aria-label="Footnote ' . $num . '"><sup class="footnote">[';
 
 		if ( $this->numbered[ $id ] ) {
 			$retval .= $num;
@@ -144,7 +144,7 @@ class Footnotes {
 		foreach ( $footnotes as $num => $footnote ) {
 			$num++;
 			$numlabel = "$id-$num";
-			$content .= '<li id="footnote-' . $numlabel . '">' . make_clickable( $footnote ) . ' <a href="#return-footnote-' . $numlabel . '" class="return-footnote" aria-label="Return to footnote '. $num .'">&crarr;</a></li>';
+			$content .= '<li id="footnote-' . $numlabel . '">' . make_clickable( $footnote ) . ' <a href="#return-footnote-' . $numlabel . '" class="return-footnote" aria-label="Return to footnote ' . $num . '">&crarr;</a></li>';
 		}
 
 		if ( $this->numbered[ $id ] ) {

--- a/tests/test-shortcodes-footnotes-footnotes.php
+++ b/tests/test-shortcodes-footnotes-footnotes.php
@@ -80,6 +80,8 @@ class Shortcodes_Footnotes extends \WP_UnitTestCase {
 		$content = $this->fn->shortcodeHandler( [ 'suptext' => 'Foo' ], 'Well this is awkward...' );
 		$this->assertContains( '[*Foo]</sup></a>', $content );
 
+		$this->assertContains( 'aria-label="Footnote 3"', $content );
+
 		$this->assertContains( '#footnote-999-3', $content );
 	}
 
@@ -103,6 +105,7 @@ class Shortcodes_Footnotes extends \WP_UnitTestCase {
 		$this->assertContains( 'First.', $content );
 		$this->assertContains( 'Second.', $content );
 		$this->assertContains( 'Third.', $content );
+		$this->assertContains( 'aria-label="Return to footnote 2', $content );
 		$this->assertContains( '</ol></div>', $content );
 	}
 
@@ -126,6 +129,7 @@ class Shortcodes_Footnotes extends \WP_UnitTestCase {
 		$this->assertContains( 'First.', $content );
 		$this->assertContains( 'Second.', $content );
 		$this->assertContains( 'Third.', $content );
+		$this->assertContains( 'aria-label="Return to footnote 2', $content );
 		$this->assertContains( '</ul></div>', $content );
 	}
 

--- a/tests/test-shortcodes-footnotes-footnotes.php
+++ b/tests/test-shortcodes-footnotes-footnotes.php
@@ -55,6 +55,8 @@ class Shortcodes_Footnotes extends \WP_UnitTestCase {
 		$content = $this->fn->shortcodeHandler( [ 'suptext' => 'Foo' ], 'Well this is awkward...' );
 		$this->assertContains( '[3. Foo]</sup></a>', $content );
 
+		$this->assertContains( 'aria-label="Footnote 3"', $content );
+
 		$this->assertContains( '#footnote-1-3', $content );
 
 		$this->assertEmpty( $this->fn->shortcodeHandler( [] ) );


### PR DESCRIPTION
fix #1693 