### PR TITLE
Use PDF/UA-1 for digital distribution PDFs (fix #1695)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 dist: xenial
+services:
+  - mysql
 language: php
 sudo: required
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: php
 sudo: required
 notifications:
@@ -34,9 +35,9 @@ before_install:
 - unzip epubcheck-4.1.1.zip -d /opt/
 - mv /opt/epubcheck-4.1.1 /opt/epubcheck
 - rm epubcheck-4.1.1.zip
-- wget https://www.princexml.com/download/prince_11.3-1_ubuntu14.04_amd64.deb
-- sudo dpkg -i prince_11.3-1_ubuntu14.04_amd64.deb
-- rm prince_11.3-1_ubuntu14.04_amd64.deb
+- wget https://www.princexml.com/download/prince_12.5-1_ubuntu16.04_amd64.deb
+- sudo dpkg -i prince_12.5-1_ubuntu16.04_amd64.deb
+- rm prince_12.5-1_ubuntu16.04_amd64.deb
 - source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION && nvm use $TRAVIS_NODE_VERSION
 install:
 - node -v

--- a/inc/modules/export/prince/class-pdf.php
+++ b/inc/modules/export/prince/class-pdf.php
@@ -113,7 +113,7 @@ class Pdf extends Export {
 		$this->truncateExportStylesheets( 'prince' );
 		$timestamp = time();
 		$css = $this->kneadCss();
-		$css_file = \Pressbooks\Container::get( 'Sass' )->pathToUserGeneratedCss() . "/prince-$timestamp.css";
+		$css_file = Container::get( 'Sass' )->pathToUserGeneratedCss() . "/prince-$timestamp.css";
 		\Pressbooks\Utility\put_contents( $css_file, $css );
 
 		// --------------------------------------------------------------------
@@ -126,11 +126,16 @@ class Pdf extends Export {
 		if ( defined( 'WP_ENV' ) && ( WP_ENV === 'development' ) ) {
 			$prince->setInsecure( true );
 		}
+
 		if ( $this->pdfProfile && $this->pdfOutputIntent ) {
 			$prince->setPDFProfile( $this->pdfProfile );
 			$prince->setPDFOutputIntent( $this->pdfOutputIntent );
-
+		} elseif ( stripos( get_class( $this ), 'print' ) === false && empty( $this->pdfProfile ) ) {
+			// PDF for digital distribution without any PB_PDF_PROFILE
+			// Use PDF/UA-1, enhanced for accessibility.
+			$prince->setPDFProfile( 'PDF/UA-1' );
 		}
+
 		$prince->addStyleSheet( $css_file );
 		if ( $this->exportScriptPath ) {
 			$prince->addScript( $this->exportScriptPath );


### PR DESCRIPTION
Requires Princexml 12 or Docraptor Pipeline 7

See:
 
 + https://www.princexml.com/doc-prince/#pdf-profiles
 + https://docraptor.com/blog/pipeline-7-with-flexbox-support-and-prince-12/

Digital PDFs will be (more) accessible.

Note: `--taged-pdf` not supported by Docraptor so "use the same PDF style we have been using for print, but add the --tagged-pdf option" is not something we will be doing at this time. Print PDFs will continue to be focused on printing the PDF, not reading the PDF on a computer.

