### PR TITLE
Support install using github-updater.

### DIFF
--- a/pressbooks.php
+++ b/pressbooks.php
@@ -2,6 +2,8 @@
 /*
 Plugin Name: Pressbooks
 Plugin URI: https://pressbooks.org
+GitHub Plugin URI: pressbooks/pressbooks
+Release Asset: true
 Description: Simple Book Production
 Version: 5.9.1-dev
 Author: Pressbooks (Book Oven Inc.)


### PR DESCRIPTION
This is a very simple change, just adding meta-data to force github-updater to use releases when installing pressbooks. 

github-updater is smart enough to be able to install without this, but pressbooks doesn't work due to missing dependencies. These dependencies are already in the release files, which will facilitate this workflow.