### PR TITLE
Schema fix

### DIFF
--- a/inc/api/endpoints/controller/class-sectionmetadata.php
+++ b/inc/api/endpoints/controller/class-sectionmetadata.php
@@ -96,7 +96,7 @@ class SectionMetadata extends \WP_REST_Controller {
 					'type' => 'string',
 					'format' => 'uri',
 					'enum' => [
-						'http://bib.schema.org',
+						'http://schema.org',
 					],
 					'description' => __( 'The JSON-LD context.' ),
 					'context' => [ 'view' ],

--- a/inc/metadata/namespace.php
+++ b/inc/metadata/namespace.php
@@ -545,7 +545,7 @@ function schema_to_book_information( $book_schema ) {
 function section_information_to_schema( $section_information, $book_information ) {
 	$section_schema = [];
 
-	$section_schema['@context'] = 'http://bib.schema.org';
+	$section_schema['@context'] = 'http://schema.org';
 	$section_schema['@type'] = 'Chapter';
 
 	$mapped_section_properties = [

--- a/tests/test-metadata.php
+++ b/tests/test-metadata.php
@@ -251,7 +251,7 @@ class MetadataTest extends \WP_UnitTestCase {
 		];
 
 		$section_schema = [
-			'@context' => 'http://bib.schema.org',
+			'@context' => 'http://schema.org',
 			'@type' => 'Chapter',
 			'author' => [
 				'@type' => 'Person',


### PR DESCRIPTION
Remove bib prefix from schema.org references, per https://github.com/pressbooks/pressbooks/issues/1749. **Rationale:** 
> Until April 2019, we relied primarily on the 'hosted extensions' mechanism that used hosted subdomains of schema.org (such as bib.schema.org for the bibliography extension and autos.schema.org for the autos extension). Going forward, the content of these hosted extensions are being folded into schema.org, although each will retain an "entry point" page as before. (source)[https://schema.org/docs/extension.html]
