### PR TITLE
Escape my catalog output

### DIFF
--- a/inc/admin/class-catalog-list-table.php
+++ b/inc/admin/class-catalog-list-table.php
@@ -236,7 +236,7 @@ class Catalog_List_Table extends \WP_List_Table {
 		];
 
 		for ( $i = 1; $i <= Catalog::MAX_TAGS_GROUP; ++$i ) {
-			$columns[ "tag_{$i}" ] = ! empty( $profile[ "pb_catalog_tag_{$i}_name" ] ) ? $profile[ "pb_catalog_tag_{$i}_name" ] : __( 'Tag', 'pressbooks' ) . " $i";
+			$columns[ "tag_{$i}" ] = ! empty( $profile[ "pb_catalog_tag_{$i}_name" ] ) ? esc_html( strip_tags( $profile[ "pb_catalog_tag_{$i}_name" ] ) ) : __( 'Tag', 'pressbooks' ) . " $i";
 		}
 
 		$columns['featured'] = __( 'Featured', 'pressbooks' );

--- a/inc/class-catalog.php
+++ b/inc/class-catalog.php
@@ -754,7 +754,12 @@ class Catalog {
 			} elseif ( '%f' === $this->profileMetaKeys[ $key ] ) {
 				$val = (float) $val;
 			} else {
-				$val = (string) $val;
+				$val = HtmLawed::filter(
+					$val, [
+						'safe' => 1,
+						'deny_attribute' => 'style',
+					]
+				);
 			}
 
 			update_user_meta( $this->userId, $key, $val );

--- a/templates/admin/catalog.php
+++ b/templates/admin/catalog.php
@@ -47,7 +47,7 @@ if ( 'edit_tags' == $_REQUEST['action'] ) :
 			<!-- Tags -->
 			<?php for ( $i = 1; $i <= $catalog::MAX_TAGS_GROUP; ++$i ) { ?>
 				<?php
-				$name = ! empty( $profile[ "pb_catalog_tag_{$i}_name" ] ) ? $profile[ "pb_catalog_tag_{$i}_name" ] : __( 'Tags', 'pressbooks' ) . " $i";
+				$name = ! empty( $profile["pb_catalog_tag_{$i}_name"] ) ? esc_html( strip_tags( $profile["pb_catalog_tag_{$i}_name"] ) ) : __( 'Tags', 'pressbooks' ) . " $i";
 				?>
 				<tr>
 

--- a/templates/pb-catalog.php
+++ b/templates/pb-catalog.php
@@ -169,7 +169,11 @@ $_current_user_id = $catalog->getUserId();
 	<?php // @codingStandardsIgnoreEnd ?>
 	<?php \Pressbooks\analytics\print_analytics(); ?>
 </head>
+<?php if ( ! empty( $profile['pb_catalog_color'] ) ) : ?>
+<body style="background-image: none !important;">
+<?php else : ?>
 <body>
+<?php endif ?>
 
 <div class="catalog-wrap">
 		<div class="log-wrap">	<!-- Login/Logout -->
@@ -190,7 +194,7 @@ $_current_user_id = $catalog->getUserId();
 			<?php endif; ?>
 		</div> <!-- end .log-wrap -->
 	<?php if ( ! empty( $profile['pb_catalog_color'] ) ) : ?>
-		<div id="catalog-sidebar" class="catalog-sidebar" style="background-color:<?php echo $profile['pb_catalog_color']; ?>">
+		<div id="catalog-sidebar" class="catalog-sidebar" style="background-color:<?php echo esc_attr( $profile['pb_catalog_color'] ); ?>">
 	<?php else : ?>
 		<div id="catalog-sidebar" class="catalog-sidebar">
 	<?php endif ?>
@@ -212,6 +216,7 @@ $_current_user_id = $catalog->getUserId();
 			</a>
 			<p class="about-blurb"><?php
 			if ( ! empty( $profile['pb_catalog_about'] ) ) {
+				$profile['pb_catalog_about'] = \Pressbooks\HtmLawed::filter( $profile['pb_catalog_about'], [ 'safe' => 1, 'deny_attribute' => 'style' ] );
 				echo preg_replace( '/<p[^>]*>(.*)<\/p[^>]*>/i', '$1', $profile['pb_catalog_about'] ); // Make valid HTML by removing first <p> and last </p>
 			}
 			?></p>
@@ -220,7 +225,7 @@ $_current_user_id = $catalog->getUserId();
 			<!-- Tags -->
 			<?php for ( $i = 1; $i <= 2; ++$i ) : ?>
 			<?php $tags = $catalog->getTags( $i, false ); ?>
-				<h3><?php echo ( ! empty( $profile[ "pb_catalog_tag_{$i}_name" ] ) ) ? $profile[ "pb_catalog_tag_{$i}_name" ] : __( 'Tag', 'pressbooks' ) . " $i"; ?></h3>
+				<h3><?php echo ( ! empty( $profile["pb_catalog_tag_{$i}_name"] ) ) ? esc_html( strip_tags( $profile["pb_catalog_tag_{$i}_name"] ) ) : __( 'Tag', 'pressbooks' ) . " $i"; ?></h3>
 				<ul>
 					<?php
 					foreach ( $tags as $val ) {

--- a/tests/test-admin-catalog-list-table.php
+++ b/tests/test-admin-catalog-list-table.php
@@ -1,0 +1,41 @@
+<?php
+
+// Legacy "My Catalog" code, WP_List_Table
+
+class Admin_CatalogListTableTest extends \WP_UnitTestCase {
+
+	/**
+	 * @var \Pressbooks\Admin\Catalog_List_Table
+	 * @group my_catalog
+	 */
+	protected $table;
+
+	/**
+	 * @group my_catalog
+	 */
+	public function setUp() {
+		parent::setUp();
+		$GLOBALS['hook_suffix'] = 'mock';
+		$_REQUEST['page'] = 'pb_catalog';
+		$this->table = new \Pressbooks\Admin\Catalog_List_Table();
+	}
+
+	/**
+	 * @group my_catalog
+	 */
+	public function test_get_columns() {
+		$user_id = $this->factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user_id );
+
+		$cols = $this->table->get_columns();
+		$this->assertEquals( 'Tag 1', $cols['tag_1'] );
+		$this->assertEquals( 'Tag 2', $cols['tag_2'] );
+
+		update_user_meta( $user_id, 'pb_catalog_tag_1_name', '<script>alert(1);</script>' );
+		update_user_meta( $user_id, 'pb_catalog_tag_2_name', '<script>alert(2);</script>' );
+		$cols = $this->table->get_columns();
+		$this->assertEquals( 'alert(1);', $cols['tag_1'] );
+		$this->assertEquals( 'alert(2);', $cols['tag_2'] );
+	}
+
+}

--- a/tests/test-catalog.php
+++ b/tests/test-catalog.php
@@ -1,0 +1,42 @@
+<?php
+
+// Legacy "My Catalog" code
+
+class CatalogTest extends \WP_UnitTestCase {
+
+	/**
+	 * @group my_catalog
+	 */
+	public function test_saveProfile() {
+
+		$user_id = $this->factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user_id );
+		$c = new \Pressbooks\Catalog( $user_id );
+
+		$items = [
+			'pb_catalog_about' => 'I am <script>alert(1);</script><b>cool</b>!',
+			'pb_catalog_url' => 'http://<script>alert(1);</script>/pressbooks',
+			'pb_catalog_color' => '#<script>alert(1);</script>1111',
+			'pb_garbage_key' => 'Hello World!',
+		];
+
+		$c->saveProfile( $items );
+
+		$this->assertEquals(
+			get_user_meta( $user_id, 'pb_catalog_about', true ),
+			'I am alert(1);<b>cool</b>!'
+		);
+
+		$this->assertEquals(
+			get_user_meta( $user_id, 'pb_catalog_url', true ),
+			'http://alert(1);/pressbooks'
+		);
+
+		$this->assertEquals(
+			get_user_meta( $user_id, 'pb_catalog_color', true ),
+			'#alert(1);1111'
+		);
+
+		$this->assertEmpty( get_user_meta( $user_id, 'pb_garbage_key', true ) );
+	}
+}


### PR DESCRIPTION
When this feature was developed 7 years ago (?!) it was implied that HTML tags were allowed. This PR sanitizes saving the HTML into the database. For things already in the database, it escapes.

It also fixes the "sidebar color" feature from 2016: https://github.com/pressbooks/pressbooks/commit/3756c22fddecc3f8301625d09bde70719ba07472

Time flies.