### PR TITLE
Pb 1823 bulk add users

### DIFF
--- a/hooks-admin.php
+++ b/hooks-admin.php
@@ -356,3 +356,7 @@ add_filter( 'gettext', '\Pressbooks\Utility\change_recommendations_sentence', 10
 // Theme check
 add_action( 'admin_init', '\Pressbooks\Theme\check_required_themes' );
 add_action( 'admin_init', '\Pressbooks\Theme\check_upgraded_customcss' );
+
+if ($is_book) {
+	add_action( 'init', [ '\Pressbooks\Admin\Users\UserBulk', 'init' ] );
+}

--- a/hooks-admin.php
+++ b/hooks-admin.php
@@ -357,6 +357,6 @@ add_filter( 'gettext', '\Pressbooks\Utility\change_recommendations_sentence', 10
 add_action( 'admin_init', '\Pressbooks\Theme\check_required_themes' );
 add_action( 'admin_init', '\Pressbooks\Theme\check_upgraded_customcss' );
 
-if ( $is_book ) {
-	add_action( 'init', [ '\Pressbooks\Admin\Users\UserBulk', 'init' ] );
-}
+// Bulk add users
+add_action( 'init', [ '\Pressbooks\Admin\Users\UserBulk', 'init' ] );
+

--- a/hooks-admin.php
+++ b/hooks-admin.php
@@ -357,6 +357,6 @@ add_filter( 'gettext', '\Pressbooks\Utility\change_recommendations_sentence', 10
 add_action( 'admin_init', '\Pressbooks\Theme\check_required_themes' );
 add_action( 'admin_init', '\Pressbooks\Theme\check_upgraded_customcss' );
 
-if ($is_book) {
+if ( $is_book ) {
 	add_action( 'init', [ '\Pressbooks\Admin\Users\UserBulk', 'init' ] );
 }

--- a/inc/admin/users/class-userbulk.php
+++ b/inc/admin/users/class-userbulk.php
@@ -208,7 +208,7 @@ class UserBulk {
 		}
 
 		$html_output = ! empty( $output_errors ) ? sprintf( '<div role="status" class="updated notice is-dismissible"><p>%s</p></div>', $output_success ) : '';
-		$html_output .= ! empty ( $output_success ) ? sprintf( '<div role="alert" class="error notice is-dismissible"><p>%s</p></div>', $output_errors ) : '';
+		$html_output .= ! empty( $output_success ) ? sprintf( '<div role="alert" class="error notice is-dismissible"><p>%s</p></div>', $output_errors ) : '';
 		return $html_output;
 	}
 }

--- a/inc/admin/users/class-userbulk.php
+++ b/inc/admin/users/class-userbulk.php
@@ -86,16 +86,17 @@ class UserBulk {
 	 * @return bool|array
 	 */
 	public function bulkAddUsers() {
-		if ( empty( $_POST ) || empty( $_POST['users'] ) || ! check_admin_referer( self::SLUG ) ) {
+		if ( empty( $_POST ) || empty( $_POST['role'] ) || empty( $_POST['users'] ) || ! check_admin_referer( self::SLUG ) ) {
 			return false;
 		}
 
 		$_POST = array_map( 'trim', $_POST );
 		$role = $_POST['role'];
-		$users = array_unique( preg_split( '/\r\n|\r|\n/', $_POST['users'] ) );
+		$emails_input = array_unique( preg_split( '/\r\n|\r|\n/', $_POST['users'] ) );
+		$emails = array_map( 'sanitize_text_field', $emails_input );
 		$results = [];
 
-		foreach ( $users as $email ) {
+		foreach ( $emails as $email ) {
 			$existing_user = get_user_by( 'email', $email );
 
 			if ( false !== $existing_user ) {
@@ -150,11 +151,11 @@ class UserBulk {
 
 	/**
 	 * @param string $email
-	 * @return bool|array
+	 * @return array
 	 */
 	public function generateUserNameFromEmail( string $email ) {
 		if ( ! filter_var( $email, FILTER_VALIDATE_EMAIL ) ) {
-			return false;
+			return [ 'errors' => new \WP_Error( 'pb_email', __( 'Invalid email address', 'users' ) ) ];
 		}
 
 		$i = 1;

--- a/inc/admin/users/class-userbulk.php
+++ b/inc/admin/users/class-userbulk.php
@@ -37,7 +37,9 @@ class UserBulk {
 	 * @param UserBulk $obj
 	 */
 	static public function hooks( UserBulk $obj ) {
-		add_action( 'admin_menu', [ $obj, 'addMenu' ] );
+		if ( \Pressbooks\Book::isBook() ) {
+			add_action( 'admin_menu', [ $obj, 'addMenu' ] );
+		}
 	}
 
 	public function __construct() {

--- a/inc/admin/users/class-userbulk.php
+++ b/inc/admin/users/class-userbulk.php
@@ -2,7 +2,6 @@
 
 namespace Pressbooks\Admin\Users;
 
-use Jenssegers\Blade\Blade;
 use Pressbooks\Container;
 
 class UserBulk {
@@ -75,14 +74,14 @@ class UserBulk {
 		$html = $this->blade->render(
 			self::TEMPLATE, [
 				'form_url'  => self_admin_url( sprintf( '/users.php?page=%s', self::SLUG ) ),
-				'nonce'     => self::SLUG
+				'nonce'     => self::SLUG,
 			]
 		);
 		echo $html;
 	}
 
 	/**
-	 * @return array
+	 * @return bool|array
 	 */
 	public function bulkAddUsers() {
 		if ( empty( $_POST ) || ! check_admin_referer( self::SLUG ) ) {
@@ -90,11 +89,11 @@ class UserBulk {
 		}
 
 		$_POST = array_map( 'trim', $_POST );
-		$role = $_POST[ 'role' ];
+		$role = $_POST['role'];
 		$users = array_unique( preg_split( '/\r\n|\r|\n/', $_POST['users'] ) );
 		$results = [];
 
-		foreach( $users as $email ) {
+		foreach ( $users as $email ) {
 			$existing_user = get_user_by( 'email', $email );
 
 			if ( false !== $existing_user ) {
@@ -108,10 +107,12 @@ class UserBulk {
 				$result = $this->createUser( $email, $role );
 			}
 
-			array_push( $results, [
-				'email'  => $email,
-				'status' => $result
-			] );
+			array_push(
+				$results, [
+					'email'  => $email,
+					'status' => $result,
+				]
+			);
 		}
 
 		return $results;
@@ -125,11 +126,11 @@ class UserBulk {
 	public function createUser( string $email, string $role ) {
 		$user_details = $this->generateUserNameFromEmail( $email );
 
-		if ( is_wp_error( $user_details[ 'errors' ] ) && $user_details[ 'errors' ]->has_errors() ) {
-			return $user_details[ 'errors' ];
+		if ( is_wp_error( $user_details['errors'] ) && $user_details['errors']->has_errors() ) {
+			return $user_details['errors'];
 		}
 
-		$user_name = $user_details[ 'user_name' ];
+		$user_name = $user_details['user_name'];
 		$unique_username = apply_filters( 'pre_user_login', $this->sanitizeUser( wp_unslash( $user_name ), true ) );
 
 		// link newly created user to book
@@ -147,7 +148,7 @@ class UserBulk {
 
 	/**
 	 * @param string $email
-	 * @return array|bool
+	 * @return bool|array
 	 */
 	public function generateUserNameFromEmail( string $email ) {
 		if ( ! filter_var( $email, FILTER_VALIDATE_EMAIL ) ) {
@@ -195,12 +196,12 @@ class UserBulk {
 	 */
 	public function getBulkResultHtml( array $results ) : string {
 		$output_success = sprintf( '%s:%s', __( 'Users successfully added to this book', 'users' ), '<br />' );
-		$output_errors = sprintf( '%s:%s', __( 'The following users could not be added', 'users' ) , '<br />' );
+		$output_errors = sprintf( '%s:%s', __( 'The following users could not be added', 'users' ), '<br />' );
 
-		foreach( $results as $result ) {
-			if ( is_wp_error( $result[ 'status' ] ) ) {
-				$error_messages = implode( ' ', $result[ 'status' ]->get_error_messages() );
-				$output_errors .= sprintf( "<b>%s</b>. %s %s", $result['email'], $error_messages, '<br />' );
+		foreach ( $results as $result ) {
+			if ( is_wp_error( $result['status'] ) ) {
+				$error_messages = implode( ' ', $result['status']->get_error_messages() );
+				$output_errors .= sprintf( '<b>%s</b>. %s %s', $result['email'], $error_messages, '<br />' );
 			} else {
 				$output_success .= sprintf( '<b>%s</b><br />', $result['email'] );
 			}

--- a/inc/admin/users/class-userbulk.php
+++ b/inc/admin/users/class-userbulk.php
@@ -84,7 +84,7 @@ class UserBulk {
 	 * @return bool|array
 	 */
 	public function bulkAddUsers() {
-		if ( empty( $_POST ) || ! check_admin_referer( self::SLUG ) ) {
+		if ( empty( $_POST ) || empty( $_POST['users'] ) || ! check_admin_referer( self::SLUG ) ) {
 			return false;
 		}
 
@@ -104,7 +104,7 @@ class UserBulk {
 					]
 				);
 			} else {
-				$result = $this->createUser( $email, $role );
+				$result = $this->linkNewUserToBook( $email, $role );
 			}
 
 			array_push(
@@ -123,7 +123,7 @@ class UserBulk {
 	 * @param string $role
 	 * @return WP_Error|bool
 	 */
-	public function createUser( string $email, string $role ) {
+	public function linkNewUserToBook( string $email, string $role ) {
 		$user_details = $this->generateUserNameFromEmail( $email );
 
 		if ( is_wp_error( $user_details['errors'] ) && $user_details['errors']->has_errors() ) {
@@ -195,8 +195,10 @@ class UserBulk {
 	 * @return string
 	 */
 	public function getBulkResultHtml( array $results ) : string {
-		$output_success = sprintf( '%s:%s', __( 'Users successfully added to this book', 'users' ), '<br />' );
-		$output_errors = sprintf( '%s:%s', __( 'The following users could not be added', 'users' ), '<br />' );
+		$output_success = '';
+		$output_errors = '';
+		$success_subtitle = sprintf( '%s:%s', __( 'Users successfully added to this book', 'users' ), '<br />' );
+		$error_subtitle = sprintf( '%s:%s', __( 'The following users could not be added', 'users' ), '<br />' );
 
 		foreach ( $results as $result ) {
 			if ( is_wp_error( $result['status'] ) ) {
@@ -207,8 +209,8 @@ class UserBulk {
 			}
 		}
 
-		$html_output = ! empty( $output_errors ) ? sprintf( '<div role="status" class="updated notice is-dismissible"><p>%s</p></div>', $output_success ) : '';
-		$html_output .= ! empty( $output_success ) ? sprintf( '<div role="alert" class="error notice is-dismissible"><p>%s</p></div>', $output_errors ) : '';
+		$html_output = ! empty( $output_success ) ? sprintf( '<div role="status" id="bulk-success" class="updated notice is-dismissible"><p>%s%s</p></div>', $success_subtitle, $output_success ) : '';
+		$html_output .= ! empty( $output_errors ) ? sprintf( '<div role="alert" id="bulk-errors" class="error notice is-dismissible"><p>%s%s</p></div>', $error_subtitle, $output_errors ) : '';
 		return $html_output;
 	}
 }

--- a/inc/admin/users/class-userbulk.php
+++ b/inc/admin/users/class-userbulk.php
@@ -207,8 +207,8 @@ class UserBulk {
 			}
 		}
 
-		$html_output = sprintf( '<div role="status" class="updated notice is-dismissible"><p>%s</p></div>', $output_success );
-		$html_output .= sprintf( '<div role="alert" class="error notice is-dismissible"><p>%s</p></div>', $output_errors );
+		$html_output = ! empty( $output_errors ) ? sprintf( '<div role="status" class="updated notice is-dismissible"><p>%s</p></div>', $output_success ) : '';
+		$html_output .= ! empty ( $output_success ) ? sprintf( '<div role="alert" class="error notice is-dismissible"><p>%s</p></div>', $output_errors ) : '';
 		return $html_output;
 	}
 }

--- a/inc/admin/users/class-userbulk.php
+++ b/inc/admin/users/class-userbulk.php
@@ -176,7 +176,7 @@ class UserBulk {
 	 *
 	 * @return string
 	 */
-	public function sanitizeUser( $username ) {
+	public function sanitizeUser( $username ) : string {
 		$unique_username = sanitize_user( $username, true );
 		$unique_username = strtolower( $unique_username );
 		$unique_username = preg_replace( '/[^a-z0-9]/', '', $unique_username );

--- a/templates/admin/user_bulk_new.blade.php
+++ b/templates/admin/user_bulk_new.blade.php
@@ -1,0 +1,30 @@
+<div class="wrap">
+	<h1>{{ __( 'Bulk Add New User', 'user' ) }}</h1>
+	<form method="POST" action="{{ $form_url }}" method="post">
+		<?php echo wp_nonce_field( $nonce ); ?>
+		<h2>{{ __('Bulk add users', 'user') }}</h2>
+
+		<table class="form-table" role="none">
+			<tr>
+				<th><label for="provision">{{ __('Emails', 'user') }}</label></th>
+				<td>
+					<div class="form-field term-description-wrap">
+						<textarea name="users" id="users" rows="5" cols="50" spellcheck="false"></textarea>
+						<p>{{ __('One entry per line', 'user') }}</p>
+					</div>
+				</td>
+			</tr>
+
+			<tr class="form-field">
+				<th scope="row"><label for="adduser-role"><?php _e( 'Role' ); ?></label></th>
+				<td><select name="role" id="adduser-role">
+						<?php wp_dropdown_roles( get_option( 'default_role' ) ); ?>
+					</select>
+				</td>
+			</tr>
+
+		</table>
+
+		{!! get_submit_button() !!}
+	</form>
+</div>

--- a/templates/admin/user_bulk_new.blade.php
+++ b/templates/admin/user_bulk_new.blade.php
@@ -1,7 +1,7 @@
 <div class="wrap">
 	<h1>{{ __( 'Bulk Add New Users', 'user' ) }}</h1>
 	<form method="POST" action="{{ $form_url }}" method="post">
-		<?php echo wp_nonce_field( $nonce ); ?>
+		@php echo wp_nonce_field( $nonce ); @endphp
 		<h2>{{ __('Bulk add users', 'user') }}</h2>
 		<table class="form-table" role="none">
 			<tr>
@@ -14,9 +14,9 @@
 				</td>
 			</tr>
 			<tr class="form-field">
-				<th scope="row"><label for="adduser-role"><?php _e( 'Role' ); ?></label></th>
+				<th scope="row"><label for="adduser-role">@php _e( 'Role' ); @endphp</label></th>
 				<td><select name="role" id="adduser-role">
-						<?php wp_dropdown_roles( get_option( 'default_role' ) ); ?>
+						@php wp_dropdown_roles( get_option( 'default_role' ) ); @endphp
 					</select>
 				</td>
 			</tr>

--- a/templates/admin/user_bulk_new.blade.php
+++ b/templates/admin/user_bulk_new.blade.php
@@ -1,5 +1,5 @@
 <div class="wrap">
-	<h1>{{ __( 'Bulk Add New User', 'user' ) }}</h1>
+	<h1>{{ __( 'Bulk Add New Users', 'user' ) }}</h1>
 	<form method="POST" action="{{ $form_url }}" method="post">
 		<?php echo wp_nonce_field( $nonce ); ?>
 		<h2>{{ __('Bulk add users', 'user') }}</h2>

--- a/templates/admin/user_bulk_new.blade.php
+++ b/templates/admin/user_bulk_new.blade.php
@@ -3,7 +3,6 @@
 	<form method="POST" action="{{ $form_url }}" method="post">
 		<?php echo wp_nonce_field( $nonce ); ?>
 		<h2>{{ __('Bulk add users', 'user') }}</h2>
-
 		<table class="form-table" role="none">
 			<tr>
 				<th><label for="provision">{{ __('Emails', 'user') }}</label></th>
@@ -14,7 +13,6 @@
 					</div>
 				</td>
 			</tr>
-
 			<tr class="form-field">
 				<th scope="row"><label for="adduser-role"><?php _e( 'Role' ); ?></label></th>
 				<td><select name="role" id="adduser-role">
@@ -22,9 +20,7 @@
 					</select>
 				</td>
 			</tr>
-
 		</table>
-
-		{!! get_submit_button() !!}
+		{!! get_submit_button( __( 'Add users', 'users' ) ) !!}
 	</form>
 </div>

--- a/tests/test-userbulk.php
+++ b/tests/test-userbulk.php
@@ -151,7 +151,7 @@ class UserBulkTest extends \WP_UnitTestCase {
 		$valid_email = 'validemail@pressbooks.com';
 		$valid_user_data = $this->user_bulk->generateUserNameFromEmail( $valid_email );
 
-		$this->assertFalse( $invalid_user_name );
+		$this->assertInstanceOf( WP_Error::class, $invalid_user_name['errors'] );
 		$this->assertEquals( 'validemail', $valid_user_data['user_name'] );
 		$this->assertEquals( $valid_email, $valid_user_data['user_email'] );
 		$this->assertFalse( $valid_user_data['errors']->has_errors() );

--- a/tests/test-userbulk.php
+++ b/tests/test-userbulk.php
@@ -84,7 +84,7 @@ class UserBulkTest extends \WP_UnitTestCase {
 		$_POST['role'] = 'contributor';
 		$_POST['submit'] = 'Add users';
 
-		$this->factory()->user->create_and_get(
+		$this->factory()->user->create(
 			[
 				'user_login' => 'existinguser',
 				'user_email' => 'existinguser@pressbooks.com',
@@ -92,7 +92,7 @@ class UserBulkTest extends \WP_UnitTestCase {
 			]
 		);
 
-		$this->factory()->user->create_and_get(
+		$this->factory()->user->create(
 			[
 				'user_login' => 'existinguser2',
 				'user_email' => 'existinguser2@pressbooks.com',
@@ -105,6 +105,107 @@ class UserBulkTest extends \WP_UnitTestCase {
 		foreach( $results as $r ) {
 			$this->assertTrue( in_array( $r['email'], $this->post_users ) );
 			$this->assertTrue( $r['status'] );
+		}
+	}
+
+	/**
+	 * @group userbulk
+	 */
+	public function test_linkNewUserToBook() {
+		$existing_user = $this->factory()->user->create_and_get(
+			[
+				'user_login' => 'contributor',
+				'user_email' => 'contributor@pressbooks.com',
+			]
+		);
+		$new_user_email = 'newuseremail@testdomain.com';
+		$wp_error = $this->user_bulk->linkNewUserToBook( $existing_user->user_email, 'editor' );
+		$success = $this->user_bulk->linkNewUserToBook( $new_user_email, 'editor' );
+
+		$this->assertTrue( $wp_error instanceof WP_Error ); // cannot link existing users
+		$this->assertTrue( $success );
+	}
+
+	/**
+	 * @group userbulk
+	 */
+	public function test_generateUserNameFromEmail() {
+		$invalid_email = 'invalid@email@.com';
+		$invalid_user_name = $this->user_bulk->generateUserNameFromEmail( $invalid_email );
+		$valid_email = 'validemail@pressbooks.com';
+		$valid_user_data = $this->user_bulk->generateUserNameFromEmail( $valid_email );
+
+		$this->assertFalse( $invalid_user_name );
+		$this->assertEquals( 'validemail', $valid_user_data['user_name'] );
+		$this->assertEquals( $valid_email, $valid_user_data['user_email'] );
+		$this->assertFalse( $valid_user_data['errors']->has_errors() );
+
+		// Persist user in order to test user login deduplication
+		$this->factory()->user->create(
+			[
+				'user_login' => 'validemail',
+				'user_email' => 'validemail@pressbooks.com',
+			]
+		);
+		$valid_email_existing_username = 'validemail@gmail.com';
+		$valid_user_data_dedup = $this->user_bulk->generateUserNameFromEmail( $valid_email_existing_username );
+
+		$this->assertEquals( 'validemail1', $valid_user_data_dedup['user_name'] );
+		$this->assertEquals( $valid_email_existing_username, $valid_user_data_dedup['user_email'] );
+		$this->assertFalse( $valid_user_data_dedup['errors']->has_errors() );
+	}
+
+	/**
+	 * @group userbulk
+	 */
+	public function test_sanitizeUser() {
+		$this->assertEquals( 'test', $this->user_bulk->sanitizeUser( 'test' ) );
+		$this->assertEquals( 'test', $this->user_bulk->sanitizeUser( '(:test:)' ) );
+		$this->assertEquals( 'tst1', $this->user_bulk->sanitizeUser( 'tst' ) );
+		$this->assertEquals( 'tst1', $this->user_bulk->sanitizeUser( '(:tst:)' ) );
+		$this->assertEquals( 'yo11', $this->user_bulk->sanitizeUser( 'yo' ) );
+		$this->assertEquals( 'yo11', $this->user_bulk->sanitizeUser( '(:yo:)' ) );
+		$this->assertEquals( '1111a', $this->user_bulk->sanitizeUser( '1111' ) );
+		$this->assertEquals( '1a11', $this->user_bulk->sanitizeUser( '1' ) );
+	}
+
+	/**
+	 * @group userbulk
+	 */
+	public function test_getBulkResultHtml() {
+		$success = [];
+		$errors = [];
+
+		foreach( $this->post_users as $email ) {
+			if ( rand( 0, 1 ) ) {
+				array_push( $success, [
+					'email'     => $email,
+					'status'    => true
+				] );
+			} else {
+				array_push( $errors, [
+					'email'     => $email,
+					'status'    => new WP_Error( 1, 'WP error message' )
+				] );
+			}
+		}
+
+		$html = $this->user_bulk->getBulkResultHtml( array_merge( $success, $errors ) );
+		$parser = new HtmlParser( true );
+		$doc = $parser->loadHTML( $html );
+
+		if ( ! empty( $success ) ) {
+			$success_message_str = $doc->getElementById( 'bulk-success' )->textContent;
+			foreach( $success as $result ) {
+				$this->assertTrue( false !== strpos( $success_message_str, $result['email'] ) );
+			}
+		}
+
+		if ( ! empty( $errors ) ) {
+			$error_message_str = $doc->getElementById( 'bulk-errors' )->textContent;
+			foreach( $errors as $result ) {
+				$this->assertTrue( false !== strpos( $error_message_str, $result['email'] ) );
+			}
 		}
 	}
 }

--- a/tests/test-userbulk.php
+++ b/tests/test-userbulk.php
@@ -5,8 +5,6 @@ use Pressbooks\HtmlParser;
 
 class UserBulkTest extends \WP_UnitTestCase {
 
-	use utilsTrait;
-
 	/**
 	 * @var UserBulk
 	 */

--- a/tests/test-userbulk.php
+++ b/tests/test-userbulk.php
@@ -33,8 +33,11 @@ class UserBulkTest extends \WP_UnitTestCase {
 	 * @group userbulk
 	 */
 	public function test_hooks() {
-		$this->user_bulk->hooks( $this->user_bulk );
-		$this->assertEquals( true, has_action( 'admin_menu', [ $this->user_bulk, 'addMenu' ] ) );
+		global $wp_filter;
+		$result = $this->user_bulk->init();
+		$this->assertInstanceOf( UserBulk::class, $result );
+		$this->user_bulk->hooks( $result );
+		$this->assertNotEmpty( $wp_filter );
 	}
 
 	/**

--- a/tests/test-userbulk.php
+++ b/tests/test-userbulk.php
@@ -1,0 +1,45 @@
+<?php
+
+use Pressbooks\Admin\Users\UserBulk;
+
+class UserBulkTest extends \WP_UnitTestCase {
+
+	use utilsTrait;
+
+	/**
+	 * @var \Pressbooks\Admin\Users\UserBulk
+	 */
+	protected $user_bulk;
+
+	/**
+	 *
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->user_bulk = new UserBulk();
+	}
+
+	/**
+	 * @group userbulk
+	 */
+	public function test_hooks() {
+		$this->user_bulk->hooks( $this->user_bulk );
+		$this->assertEquals( true, has_action( 'admin_menu', [ $this->user_bulk, 'addMenu' ] ) );
+	}
+
+	/**
+	 * @group userbulk
+	 */
+	public function test_init() {
+		$instance = UserBulk::init();
+		$this->assertTrue( $instance instanceof UserBulk );
+	}
+
+	/**
+	 * @group userbulk
+	 */
+	public function test_addMenu() {
+		$this->user_bulk->addMenu( );
+		$this->assertTrue( true ); // Did not crash
+	}
+}

--- a/tests/test-userbulk.php
+++ b/tests/test-userbulk.php
@@ -66,7 +66,7 @@ class UserBulkTest extends \WP_UnitTestCase {
 		$user_rol_dropdown = $doc->getElementById( 'adduser-role' );
 
 		$this->assertTrue( $doc instanceof \DOMDocument );
-		$this->assertEquals( 1, $doc->getElementsByTagName( 'form' )->count() );
+		$this->assertEquals( 1, $doc->getElementsByTagName( 'form' )->length );
 		$this->assertInstanceOf( DOMElement::class, $users_input );
 		$this->assertInstanceOf( DOMElement::class, $user_rol_dropdown );
 		$this->assertEquals( 'users', $users_input->getAttribute( 'name' ) );

--- a/tests/test-userbulk.php
+++ b/tests/test-userbulk.php
@@ -13,6 +13,17 @@ class UserBulkTest extends \WP_UnitTestCase {
 	protected $user_bulk;
 
 	/**
+	 * @var array
+	 */
+	protected $post_users = [
+		'existinguser@pressbooks.com',
+		'existinguser2@pressbooks.com',
+		'existinguser@gmail.com',
+		'newuser@gmail.com',
+		'newuser3@gmail.com',
+	];
+
+	/**
 	 * Test setup
 	 */
 	public function setUp() {
@@ -48,14 +59,52 @@ class UserBulkTest extends \WP_UnitTestCase {
 	 * @group userbulk
 	 */
 	public function test_printMenu() {
-		ob_start(); // begin collecting output
+		ob_start();
 		$this->user_bulk->printMenu();
 		$html = ob_get_clean();
-
 		$parser = new HtmlParser( true );
 		$doc = $parser->loadHTML( $html );
-		$form = $doc->getElementsByTagName( 'form' )[0];
+		$users_input = $doc->getElementById( 'users' );
+		$user_rol_dropdown = $doc->getElementById( 'adduser-role' );
 
 		$this->assertTrue( $doc instanceof \DOMDocument );
+		$this->assertEquals( 1, $doc->getElementsByTagName( 'form' )->count() );
+		$this->assertInstanceOf( DOMElement::class, $users_input );
+		$this->assertInstanceOf( DOMElement::class, $user_rol_dropdown );
+		$this->assertEquals( 'users', $users_input->getAttribute( 'name' ) );
+		$this->assertEquals( 'role', $user_rol_dropdown->getAttribute( 'name' ) );
+	}
+
+	/**
+	 * @group userbulk
+	 */
+	public function test_bulkAddUsers() {
+		$_REQUEST['_wpnonce'] = wp_create_nonce( 'user_bulk_new' );
+		$_POST['users'] = implode( "\r\n", $this->post_users );
+		$_POST['role'] = 'contributor';
+		$_POST['submit'] = 'Add users';
+
+		$this->factory()->user->create_and_get(
+			[
+				'user_login' => 'existinguser',
+				'user_email' => 'existinguser@pressbooks.com',
+				'role'       => 'author',
+			]
+		);
+
+		$this->factory()->user->create_and_get(
+			[
+				'user_login' => 'existinguser2',
+				'user_email' => 'existinguser2@pressbooks.com',
+				'role'       => 'author',
+			]
+		);
+
+		$results = $this->user_bulk->bulkAddUsers();
+
+		foreach( $results as $r ) {
+			$this->assertTrue( in_array( $r['email'], $this->post_users ) );
+			$this->assertTrue( $r['status'] );
+		}
 	}
 }

--- a/tests/test-userbulk.php
+++ b/tests/test-userbulk.php
@@ -1,18 +1,19 @@
 <?php
 
 use Pressbooks\Admin\Users\UserBulk;
+use Pressbooks\HtmlParser;
 
 class UserBulkTest extends \WP_UnitTestCase {
 
 	use utilsTrait;
 
 	/**
-	 * @var \Pressbooks\Admin\Users\UserBulk
+	 * @var UserBulk
 	 */
 	protected $user_bulk;
 
 	/**
-	 *
+	 * Test setup
 	 */
 	public function setUp() {
 		parent::setUp();
@@ -41,5 +42,20 @@ class UserBulkTest extends \WP_UnitTestCase {
 	public function test_addMenu() {
 		$this->user_bulk->addMenu( );
 		$this->assertTrue( true ); // Did not crash
+	}
+
+	/**
+	 * @group userbulk
+	 */
+	public function test_printMenu() {
+		ob_start(); // begin collecting output
+		$this->user_bulk->printMenu();
+		$html = ob_get_clean();
+
+		$parser = new HtmlParser( true );
+		$doc = $parser->loadHTML( $html );
+		$form = $doc->getElementsByTagName( 'form' )[0];
+
+		$this->assertTrue( $doc instanceof \DOMDocument );
 	}
 }

--- a/tests/test-userbulk.php
+++ b/tests/test-userbulk.php
@@ -76,6 +76,21 @@ class UserBulkTest extends \WP_UnitTestCase {
 	/**
 	 * @group userbulk
 	 */
+	public function test_printMenuException() {
+		$_REQUEST['_wpnonce'] = 'fsdflkjdfsiofueriu';
+		$_POST['users'] = implode( "\r\n", $this->post_users );
+		$_POST['role'] = 'contributor';
+		$_POST['submit'] = 'Add users';
+
+		ob_start();
+		$this->user_bulk->printMenu();
+		$html = ob_get_clean();
+		$this->assertNotFalse( strpos( $html, 'class="error notice is-dismissible"' ) );
+	}
+
+	/**
+	 * @group userbulk
+	 */
 	public function test_bulkAddUsers() {
 		$_REQUEST['_wpnonce'] = wp_create_nonce( 'user_bulk_new' );
 		$_POST['users'] = implode( "\r\n", $this->post_users );


### PR DESCRIPTION
### PR description
This PR allows to bulk add users to a book through a new submenu available in the book context.

### Context
Some Pressbooks users create collaborative books and is time consuming adding users individually, e.g., professors assigning several students as book contributors.

### :shipit: How can this PR be tested?

- Checkout branch: pb_1823_bulk_add_users
- Navigate to any book
- Click on the 'Bulk add' submenu located under the 'Users' menu.
![Bulk Add ‹ The onboarding process — Pressbooks](https://user-images.githubusercontent.com/8563418/68733663-06c80e80-059d-11ea-95a9-df69ee375b70.png)

**Test case 1:**

1.  In the textbox, enter emails as follows:
- 1 email address of an existing user that is not linked to the current book.
- 1 new email address.
- 1 new email with an username that is less than 3 characters long.

**Note:** New email addresses should not be previously used or waiting for user email confirmation.
 
2.  Select a role from the dropdown and click "Add users".

:ok_hand:  **Expected results:**

1.  A WordPress confirmation message should appear displaying the list of email addresses that were associated to the book, e.g.:
![Success](https://user-images.githubusercontent.com/8563418/68798692-6fa29b80-061c-11ea-86a3-a2669f5118bb.png)
2. The user associated to the existing email address should be added to the book.
3. 1 email confirmation should be sent to every new user. After activating the accounts by clicking on the links of the confirmation emails, new users should be added to the book.
4.  In the case of the user email that had less than 3 characters, the account associated to the book should have an username that is 4 characters long, the email address remains the same.
5. All users added in bulk must have the role that was selected in the dropdown when submitting the form.

**Test case 2:**

1.  Add a new email with an existing username but different domain, submit the form and activate the user by clicking the activation link that was sent for that account. 

:ok_hand:  **Expected results:**
1.  A new user account is created and associated to the book, the username has been disambiguated and the email address remains the same.

**Test case 3**
1.  Add a new email  but do not activate it.
2.  Add the same email.

:ok_hand:  **Expected results:**
1.  You will receive an activation email.
2.  As long as you have not activated the email, you would not be able to add emails that contains the same username.
3.  You should see an error message similar to the one below:
![Error-message](https://user-images.githubusercontent.com/8563418/68798441-0cb10480-061c-11ea-8b66-dec9b3834f65.png)

**More tests welcome!**

### Considerations / Specs
If a user with one of the email addresses already exists in the network, that user should be added to the book. If one does not exist, a new user invitation should be sent, using the text string that precedes the @ sign for the user name. If a username already exists for the string or the string is not 4 characters long, extra characters should be added for disambiguation/padding. Following the completion of the activity, some kind of status message should be shown to the user who added the new users.

### Unit tests
Confirm that all test pass by running the following command inside your vagrant machine :
```/usr/bin/php /srv/www/pressbooks.test/current/vendor/phpunit/phpunit/phpunit --group userbulk --configuration /srv/www/pressbooks.test/current/web/app/plugins/pressbooks/phpunit.xml```

### Related tickets
[#1823](https://github.com/pressbooks/pressbooks/issues/1823)

### PR type
- [x] Feature
- [ ] Bug

### Other Related PRs:
- [ ] Depends on another PR (List dependencies below)