### PR TITLE
Feature/nested shortcodes #1826

### DIFF
--- a/inc/shortcodes/glossary/class-glossary.php
+++ b/inc/shortcodes/glossary/class-glossary.php
@@ -292,7 +292,7 @@ class Glossary {
 
 		foreach ( $glossary_terms as $glossary_term_id => $glossary_term ) {
 			$identifier = "$id-$glossary_term_id";
-			$content .= '<div class="glossary__tooltip" id="' . $identifier . '" hidden>' . wpautop( do_shortcode($glossary_term) ) . '</div>';
+			$content .= '<div class="glossary__tooltip" id="' . $identifier . '" hidden>' . wpautop( do_shortcode( $glossary_term ) ) . '</div>';
 		}
 
 		$content .= '</div>';
@@ -330,6 +330,7 @@ class Glossary {
 					'em' => [],
 					'p' => [],
 					'strong' => [],
+
 				]
 			);
 		}

--- a/inc/shortcodes/glossary/class-glossary.php
+++ b/inc/shortcodes/glossary/class-glossary.php
@@ -292,7 +292,7 @@ class Glossary {
 
 		foreach ( $glossary_terms as $glossary_term_id => $glossary_term ) {
 			$identifier = "$id-$glossary_term_id";
-			$content .= '<div class="glossary__tooltip" id="' . $identifier . '" hidden>' . wpautop( $glossary_term ) . '</div>';
+			$content .= '<div class="glossary__tooltip" id="' . $identifier . '" hidden>' . wpautop( do_shortcode($glossary_term) ) . '</div>';
 		}
 
 		$content .= '</div>';

--- a/tests/test-shortcodes-glossary.php
+++ b/tests/test-shortcodes-glossary.php
@@ -56,6 +56,13 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 			'post_status'  => 'publish',
 		];
 
+		$args5 = [
+			'post_type'    => 'glossary',
+			'post_title'   => 'Evolutionary Learning',
+			'post_content' => 'Evolutionary algorithms are a heuristic-based approach to solving problems that cannot be easily solved in polynomial time. [media src="https://www.youtube.com/watch?v=L--IxUH4fac" caption="Introduction to evolutionary algorithms" /]',
+			'post_status'  => 'publish',
+		];
+
 		$p1 = $this->factory()->post->create_object( $args1 );
 		wp_set_object_terms( $p1, 'definitions', 'glossary-type' );
 		$p2 = $this->factory()->post->create_object( $args2 );
@@ -64,6 +71,9 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 		wp_set_object_terms( $p3, 'definitions', 'glossary-type' );
 		$p4 = $this->factory()->post->create_object( $args4 );
 		wp_set_object_terms( $p4, 'id-test', 'glossary-type' );
+		$p5 = $this->factory()->post->create_object( $args5 );
+		wp_set_object_terms( $p5, 'glossary-media', 'glossary-type' );
+
 	}
 	/**
 	 * @group glossary
@@ -73,7 +83,7 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 		$args = [
 			'post_type'    => 'glossary',
 			'post_title'   => 'PHP',
-			'post_content' => 'A "popular" general-purpose <script>scripting</script> language that is <em>especially</em> suited to web development.',
+			'post_content' => 'A "popular" general-purpose <script>scripting</script> language that is <em>especially</em> suited to web development. [media src="https://www.youtube.com/watch?v=L--IxUH4fac" caption="Introduction to evolutionary algorithms" /]',
 			'post_status'  => 'publish',
 		];
 		$pid  = $this->factory()->post->create_object( $args );
@@ -100,11 +110,13 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 	public function test_glossaryTerms() {
 		// assures alphabetical listing and format
 		$dl = $this->gl->glossaryTerms();
-		$this->assertEquals( '<dl data-type="glossary"><dt data-type="glossterm"><dfn id="dfn-machine-learning-ml">Machine Learning (ML)</dfn></dt><dd data-type="glossdef"><p>Machine learning is a method of data analysis that automates analytical model building</p>
+		$this->assertEquals( '<dl data-type="glossary"><dt data-type="glossterm"><dfn id="dfn-evolutionary-learning">Evolutionary Learning</dfn></dt><dd data-type="glossdef"><p>Evolutionary algorithms are a heuristic-based approach to solving problems that cannot be easily solved in polynomial time. [media src="https://www.youtube.com/watch?v=L--IxUH4fac" caption="Introduction to evolutionary algorithms" /]</p>
+</dd><dt data-type="glossterm"><dfn id="dfn-machine-learning-ml">Machine Learning (ML)</dfn></dt><dd data-type="glossdef"><p>Machine learning is a method of data analysis that automates analytical model building</p>
 </dd><dt data-type="glossterm"><dfn id="dfn-neural-network">Neural Network</dfn></dt><dd data-type="glossdef"><p>A computer system modeled on the human brain and <a href="https://en.wikipedia.org/wiki/Nervous_system" target="_blank">nervous system</a>.</p>
 </dd><dt data-type="glossterm"><dfn id="dfn-support-vector-machine">Support Vector Machine</dfn></dt><dd data-type="glossdef"><p>An algorithm that uses a nonlinear mapping to transform the original training data into a higher dimension</p>
 </dd></dl>'
 		, $dl );
+
 		// assures found by type
 		$dl = $this->gl->glossaryTerms( 'definitions' );
 		$this->assertEquals( '<dl data-type="glossary"><dt data-type="glossterm"><dfn id="dfn-support-vector-machine">Support Vector Machine</dfn></dt><dd data-type="glossdef"><p>An algorithm that uses a nonlinear mapping to transform the original training data into a higher dimension</p>
@@ -115,6 +127,10 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 		// // Assures 'id' is sanitized to pass checks
 		$dl = $this->gl->glossaryTerms( 'id-test' );
 		$this->assertEquals( '<dl data-type="glossary"><dt data-type="glossterm"><dfn id="dfn-machine-learning-ml">Machine Learning (ML)</dfn></dt><dd data-type="glossdef"><p>Machine learning is a method of data analysis that automates analytical model building</p>
+</dd></dl>', $dl );
+		// Assures short code media caption is in content
+		$dl = $this->gl->glossaryTerms( 'glossary-media' );
+		$this->assertEquals( '<dl data-type="glossary"><dt data-type="glossterm"><dfn id="dfn-evolutionary-learning">Evolutionary Learning</dfn></dt><dd data-type="glossdef"><p>Evolutionary algorithms are a heuristic-based approach to solving problems that cannot be easily solved in polynomial time. [media src="https://www.youtube.com/watch?v=L--IxUH4fac" caption="Introduction to evolutionary algorithms" /]</p>
 </dd></dl>', $dl );
 	}
 	/**
@@ -136,7 +152,7 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 	 */
 	public function test_getGlossaryTerms() {
 		$terms = $this->gl->getGlossaryTerms();
-		$this->assertEquals( 4, count( $terms ) );
+		$this->assertEquals( 5, count( $terms ) );
 		$this->assertEquals( 'A computer system modeled on the human brain and <a href="https://en.wikipedia.org/wiki/Nervous_system" target="_blank">nervous system</a>.', $terms['Neural Network']['content'] );
 		$this->assertEquals( 'else,something', $terms['Neural Network']['type'] );
 		$this->assertEquals( 'publish', $terms['Neural Network']['status'] );
@@ -174,9 +190,16 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 		}
 
 		$content = $this->gl->tooltipContent( 'Hello World' );
+
+		var_dump($content);
+
 		$this->assertContains( '<div class="glossary">', $content );
 		$this->assertContains( $definitions[0], $content );
 		$this->assertContains( $definitions[1], $content );
+
+//		WP shortcode not running...
+//	 	$this->assertContains( '<iframe', do_shortcode("[latex]asd[/latex]") );
+
 	}
 	/**
 	 * @group glossary

--- a/tests/test-shortcodes-glossary.php
+++ b/tests/test-shortcodes-glossary.php
@@ -178,13 +178,15 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 		$this->assertContains( $definitions[0], $content );
 		$this->assertContains( $definitions[1], $content );
 
-		//Initialize shortcode hooks
+		// Initialize shortcode hooks
 		$this->_book();
 		\Pressbooks\Shortcodes\Complex\Complex::init();
 
+		// Testing glossary to support shortcodes
 		$content_with_shortcode = 'Evolutionary algorithms are a heuristic-based approach to solving problems that cannot be easily solved in polynomial time. [media src="https://www.youtube.com/watch?v=L--IxUH4fac" caption="Introduction to evolutionary algorithms" /]';
 		$content_with_shortcode = do_shortcode($content_with_shortcode);
 
+		// Testing media caption
 		$this->assertContains( '<figure', $content_with_shortcode );
 		$this->assertContains( 'Evolutionary algorithms are a heuristic-based approach to solving problems that cannot be easily solved in polynomial time.', $content_with_shortcode );
 		$this->assertContains( '<iframe', $content_with_shortcode );

--- a/tests/test-shortcodes-glossary.php
+++ b/tests/test-shortcodes-glossary.php
@@ -56,13 +56,6 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 			'post_status'  => 'publish',
 		];
 
-		$args5 = [
-			'post_type'    => 'glossary',
-			'post_title'   => 'Evolutionary Learning',
-			'post_content' => 'Evolutionary algorithms are a heuristic-based approach to solving problems that cannot be easily solved in polynomial time. [media src="https://www.youtube.com/watch?v=L--IxUH4fac" caption="Introduction to evolutionary algorithms" /]',
-			'post_status'  => 'publish',
-		];
-
 		$p1 = $this->factory()->post->create_object( $args1 );
 		wp_set_object_terms( $p1, 'definitions', 'glossary-type' );
 		$p2 = $this->factory()->post->create_object( $args2 );
@@ -71,9 +64,6 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 		wp_set_object_terms( $p3, 'definitions', 'glossary-type' );
 		$p4 = $this->factory()->post->create_object( $args4 );
 		wp_set_object_terms( $p4, 'id-test', 'glossary-type' );
-		$p5 = $this->factory()->post->create_object( $args5 );
-		wp_set_object_terms( $p5, 'glossary-media', 'glossary-type' );
-
 	}
 	/**
 	 * @group glossary
@@ -83,7 +73,7 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 		$args = [
 			'post_type'    => 'glossary',
 			'post_title'   => 'PHP',
-			'post_content' => 'A "popular" general-purpose <script>scripting</script> language that is <em>especially</em> suited to web development. [media src="https://www.youtube.com/watch?v=L--IxUH4fac" caption="Introduction to evolutionary algorithms" /]',
+			'post_content' => 'A "popular" general-purpose <script>scripting</script> language that is <em>especially</em> suited to web development.',
 			'post_status'  => 'publish',
 		];
 		$pid  = $this->factory()->post->create_object( $args );
@@ -110,13 +100,11 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 	public function test_glossaryTerms() {
 		// assures alphabetical listing and format
 		$dl = $this->gl->glossaryTerms();
-		$this->assertEquals( '<dl data-type="glossary"><dt data-type="glossterm"><dfn id="dfn-evolutionary-learning">Evolutionary Learning</dfn></dt><dd data-type="glossdef"><p>Evolutionary algorithms are a heuristic-based approach to solving problems that cannot be easily solved in polynomial time. [media src="https://www.youtube.com/watch?v=L--IxUH4fac" caption="Introduction to evolutionary algorithms" /]</p>
-</dd><dt data-type="glossterm"><dfn id="dfn-machine-learning-ml">Machine Learning (ML)</dfn></dt><dd data-type="glossdef"><p>Machine learning is a method of data analysis that automates analytical model building</p>
+		$this->assertEquals( '<dl data-type="glossary"><dt data-type="glossterm"><dfn id="dfn-machine-learning-ml">Machine Learning (ML)</dfn></dt><dd data-type="glossdef"><p>Machine learning is a method of data analysis that automates analytical model building</p>
 </dd><dt data-type="glossterm"><dfn id="dfn-neural-network">Neural Network</dfn></dt><dd data-type="glossdef"><p>A computer system modeled on the human brain and <a href="https://en.wikipedia.org/wiki/Nervous_system" target="_blank">nervous system</a>.</p>
 </dd><dt data-type="glossterm"><dfn id="dfn-support-vector-machine">Support Vector Machine</dfn></dt><dd data-type="glossdef"><p>An algorithm that uses a nonlinear mapping to transform the original training data into a higher dimension</p>
 </dd></dl>'
 		, $dl );
-
 		// assures found by type
 		$dl = $this->gl->glossaryTerms( 'definitions' );
 		$this->assertEquals( '<dl data-type="glossary"><dt data-type="glossterm"><dfn id="dfn-support-vector-machine">Support Vector Machine</dfn></dt><dd data-type="glossdef"><p>An algorithm that uses a nonlinear mapping to transform the original training data into a higher dimension</p>
@@ -127,10 +115,6 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 		// // Assures 'id' is sanitized to pass checks
 		$dl = $this->gl->glossaryTerms( 'id-test' );
 		$this->assertEquals( '<dl data-type="glossary"><dt data-type="glossterm"><dfn id="dfn-machine-learning-ml">Machine Learning (ML)</dfn></dt><dd data-type="glossdef"><p>Machine learning is a method of data analysis that automates analytical model building</p>
-</dd></dl>', $dl );
-		// Assures short code media caption is in content
-		$dl = $this->gl->glossaryTerms( 'glossary-media' );
-		$this->assertEquals( '<dl data-type="glossary"><dt data-type="glossterm"><dfn id="dfn-evolutionary-learning">Evolutionary Learning</dfn></dt><dd data-type="glossdef"><p>Evolutionary algorithms are a heuristic-based approach to solving problems that cannot be easily solved in polynomial time. [media src="https://www.youtube.com/watch?v=L--IxUH4fac" caption="Introduction to evolutionary algorithms" /]</p>
 </dd></dl>', $dl );
 	}
 	/**
@@ -152,7 +136,7 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 	 */
 	public function test_getGlossaryTerms() {
 		$terms = $this->gl->getGlossaryTerms();
-		$this->assertEquals( 5, count( $terms ) );
+		$this->assertEquals( 4, count( $terms ) );
 		$this->assertEquals( 'A computer system modeled on the human brain and <a href="https://en.wikipedia.org/wiki/Nervous_system" target="_blank">nervous system</a>.', $terms['Neural Network']['content'] );
 		$this->assertEquals( 'else,something', $terms['Neural Network']['type'] );
 		$this->assertEquals( 'publish', $terms['Neural Network']['status'] );
@@ -190,15 +174,23 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 		}
 
 		$content = $this->gl->tooltipContent( 'Hello World' );
-
-		var_dump($content);
-
 		$this->assertContains( '<div class="glossary">', $content );
 		$this->assertContains( $definitions[0], $content );
 		$this->assertContains( $definitions[1], $content );
 
-//		WP shortcode not running...
-//	 	$this->assertContains( '<iframe', do_shortcode("[latex]asd[/latex]") );
+		//Initialize shortcode hooks
+		$this->_book();
+		\Pressbooks\Shortcodes\Complex\Complex::init();
+
+		$content_with_shortcode = 'Evolutionary algorithms are a heuristic-based approach to solving problems that cannot be easily solved in polynomial time. [media src="https://www.youtube.com/watch?v=L--IxUH4fac" caption="Introduction to evolutionary algorithms" /]';
+		$content_with_shortcode = do_shortcode($content_with_shortcode);
+
+		$this->assertContains( '<figure', $content_with_shortcode );
+		$this->assertContains( 'Evolutionary algorithms are a heuristic-based approach to solving problems that cannot be easily solved in polynomial time.', $content_with_shortcode );
+		$this->assertContains( '<iframe', $content_with_shortcode );
+		$this->assertContains( 'L--IxUH4fac', $content_with_shortcode );
+		$this->assertContains( '<figcaption', $content_with_shortcode );
+		$this->assertContains( 'Introduction to evolutionary algorithms', $content_with_shortcode );
 
 	}
 	/**

--- a/tests/test-shortcodes-glossary.php
+++ b/tests/test-shortcodes-glossary.php
@@ -184,7 +184,7 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 
 		// Testing glossary to support shortcodes
 		$content_with_shortcode = 'Evolutionary algorithms are a heuristic-based approach to solving problems that cannot be easily solved in polynomial time. [media src="https://www.youtube.com/watch?v=L--IxUH4fac" caption="Introduction to evolutionary algorithms" /]';
-		$content_with_shortcode = do_shortcode($content_with_shortcode);
+		$content_with_shortcode = do_shortcode( $content_with_shortcode );
 
 		// Testing media caption
 		$this->assertContains( '<figure', $content_with_shortcode );


### PR DESCRIPTION
### PR description
This PR allows nested shortcodes (a shortcode within a shortcode) in post content and glossary.

### Context
Some Pressbooks users want to add latex in footnotes, footnotes in blockquotes, media/captions in a glossary, and footnotes in a textbox.

### :shipit: How can this PR be tested?

- Checkout branch: feature/nested-shortcodes
- Navigate to any post/book content
- Click on the 'edit' or the title of the content.
![image](https://user-images.githubusercontent.com/21694293/68959279-ba96ed00-079b-11ea-8382-6c754ce905a8.png)

**Test case 1: Latex in a footnote**

1.  In the post body editor, click on the footnote option and type the following:
- a footnote [latex]\(x^2 + y^2 = z^2\)[/latex]

**Note:** You can also type directly using shortcodes [footnotes]a footnote [latex]\(x^2 + y^2 = z^2\)[/latex][/footnotes]

**Test case 2: Footnote in a blockquote**

1.  In the post body editor, type the following:
- [blockquote][footnote]a footnote/footnote][/blockquote]

:ok_hand:  **Expected results:**

1. A blockquote will have a footnote number reference and additional footnote is added.

**Test case 3: Media/caption in glossary**

1.  In the post body editor, insert a glossary Term
2. Enter a term in the input. ex: Evolutionary algorithms
3. Enter a media shortcode in the description input. ex: [media src="https://www.youtube.com/watch?v=L--IxUH4fac" caption="Introduction to evolutionary algorithms" /]

:ok_hand:  **Expected results:**
1. Glossary terms are displayed at the end of the book content.
2. Clicking on the term will show a tooltip box with the description and the media video along with a caption.

**Test case 4: Glossary List in back matter**

1.  Create a back matter in a book.
2. Set the type to Glossary.

:ok_hand:  **Expected results:**
1. The backmatter has all the glossary terms along with a video and caption.

**Test case 5: Export formats**

1. Export the book in all formats.
2. Verify the results from test cases above are still valid.

:ok_hand:  **Expected results:**
1. All format except '.odt' produces similar results as above test case.

**Note:** Media/caption content references the source of the book content, and will NOT show the actual video.

**More tests welcome!**

### Considerations
Media videos will not display properly for small screens. Styling the iframe to 'width:auto' will fix it.

### Unit tests
Confirm that all test pass by running the following command inside your vagrant machine :
``` composer test```

### Related tickets
[#1826](https://github.com/pressbooks/pressbooks/issues/1826)

### PR type
- [x] Feature
- [ ] Bug

### Other Related PRs:
- [ ] Depends on another PR (List dependencies below)