### PR TITLE
Feature/add main landmark on new book page

### DIFF
--- a/hooks.php
+++ b/hooks.php
@@ -298,7 +298,7 @@ add_filter( 'akismet_debug_log', '__return_false' );
 add_filter( 'gettext', '\Pressbooks\Registration\custom_signup_text', 20, 3 );
 add_action( 'signup_extra_fields', '\Pressbooks\Registration\add_password_field', 9 );
 add_filter( 'wpmu_validate_user_signup', '\Pressbooks\Registration\validate_passwords' );
-add_action( 'wp_footer', '\Pressbooks\Registration\add_a11y');
+add_action( 'wp_footer', '\Pressbooks\Registration\add_a11y' );
 add_filter( 'add_signup_meta', '\Pressbooks\Registration\add_temporary_password', 99 );
 add_action( 'signup_blogform', '\Pressbooks\Registration\add_hidden_password_field' );
 add_filter( 'random_password', '\Pressbooks\Registration\override_password_generation' );

--- a/hooks.php
+++ b/hooks.php
@@ -298,6 +298,7 @@ add_filter( 'akismet_debug_log', '__return_false' );
 add_filter( 'gettext', '\Pressbooks\Registration\custom_signup_text', 20, 3 );
 add_action( 'signup_extra_fields', '\Pressbooks\Registration\add_password_field', 9 );
 add_filter( 'wpmu_validate_user_signup', '\Pressbooks\Registration\validate_passwords' );
+add_action( 'wp_footer', '\Pressbooks\Registration\add_a11y');
 add_filter( 'add_signup_meta', '\Pressbooks\Registration\add_temporary_password', 99 );
 add_action( 'signup_blogform', '\Pressbooks\Registration\add_hidden_password_field' );
 add_filter( 'random_password', '\Pressbooks\Registration\override_password_generation' );

--- a/inc/registration/namespace.php
+++ b/inc/registration/namespace.php
@@ -351,7 +351,7 @@ function check_for_strong_password( $pwd ) {
 }
 
 /**
- * Modifies the html of sign up page
+ * Add accessbility on create book page
  */
 function add_a11y() {
 

--- a/inc/registration/namespace.php
+++ b/inc/registration/namespace.php
@@ -349,3 +349,19 @@ function check_for_strong_password( $pwd ) {
 
 	return $errors;
 }
+
+/**
+ * Modifies the html of sign up page
+ */
+function add_a11y() {
+
+	echo '<script type="text/javascript">
+		jQuery( document ).ready( function( $ ) {
+
+			//https://core.trac.wordpress.org/ticket/48657
+			$(".mu_register.wp-signup-container").attr("role","main");
+
+		} );
+	</script>';
+
+}

--- a/tests/test-registration.php
+++ b/tests/test-registration.php
@@ -163,4 +163,16 @@ class Registration extends \WP_UnitTestCase {
 		$this->assertEmpty( $errors );
 	}
 
+	/**
+	 * @group registration
+	 */
+	public function test_add_a11y() {
+		$expected = '$(".mu_register.wp-signup-container").attr("role","main");';
+
+		ob_start();
+		\Pressbooks\Registration\add_a11y();
+		$buffer = ob_get_clean();
+		$this->assertContains( $expected, $buffer );
+	}
+
 }


### PR DESCRIPTION
### PR description
This PR adds accessibility role main to 'create a new book' sign up page.

### Context
Increase Pressbooks web accessibility.

### :shipit: How can this PR be tested?

- Checkout branch: feature/add-main-landmark-on-new-book-page
- Login to Pressbook.
- Click on 'Create a new book' on top-bar.
- View the source code of the 'Create a new book'.

![image](https://user-images.githubusercontent.com/21694293/69182091-5303d900-0ade-11ea-961f-b959a35f1e77.png)

![image](https://user-images.githubusercontent.com/21694293/69182057-42ebf980-0ade-11ea-8059-fa6e7fd23d1a.png)

**Test case 1: Verify 'Create a new book' page has role main**

1. Verify that the HTML `mu_register wp-signup-container` has the `role='main'` attribute.

![image](https://user-images.githubusercontent.com/21694293/69181888-f99baa00-0add-11ea-9546-89ce6689b80f.png)


### Unit tests
Confirm that all test pass by running the following command inside your vagrant machine :
``` composer test```

### Related tickets
[#1786](https://github.com/pressbooks/pressbooks/issues/1786)

### PR type
- [x] Feature
- [ ] Bug

### Other Related PRs:
- [ ] Depends on another PR (List dependencies below)