### PR TITLE
add editor format to support write right to left

### DIFF
--- a/inc/editor/namespace.php
+++ b/inc/editor/namespace.php
@@ -202,6 +202,22 @@ function mce_before_init_insert_formats( $init_array ) {
 			'wrapper' => false,
 		],
 		[
+			'title' => __( 'Write right to left', 'pressbooks' ),
+			'block' => 'p',
+			'styles' => [
+				'direction' => 'rtl'
+			],
+			'wrapper' => false,
+		],
+		[
+			'title' => __( 'Write left to right', 'pressbooks' ),
+			'block' => 'p',
+			'styles' => [
+				'direction' => 'ltr'
+			],
+			'wrapper' => false,
+		],
+		[
 			'title' => __( 'Tight tracking', 'pressbooks' ),
 			'block' => 'span',
 			'classes' => 'tight',

--- a/inc/editor/namespace.php
+++ b/inc/editor/namespace.php
@@ -205,7 +205,7 @@ function mce_before_init_insert_formats( $init_array ) {
 			'title' => __( 'Write right to left', 'pressbooks' ),
 			'block' => 'p',
 			'styles' => [
-				'direction' => 'rtl'
+				'direction' => 'rtl',
 			],
 			'wrapper' => false,
 		],
@@ -213,7 +213,7 @@ function mce_before_init_insert_formats( $init_array ) {
 			'title' => __( 'Write left to right', 'pressbooks' ),
 			'block' => 'p',
 			'styles' => [
-				'direction' => 'ltr'
+				'direction' => 'ltr',
 			],
 			'wrapper' => false,
 		],


### PR DESCRIPTION
Fix issue: #1815

Created a new format in editor called 'Write right to left' and 'Write left to right', which adds a CSS style direction: rtl or direction: ltr to content. The writing direction will persist since it is stored as a style in html. See editor text for raw html output.

See video link below for a demonstration:

https://drive.google.com/file/d/1LgBjI60-LfRH03ckuTFmMF_hKXQ9Ky_i/view?usp=sharing