### PR TITLE
Whitelists and registers two new oEmbed providers

### DIFF
--- a/inc/interactive/class-content.php
+++ b/inc/interactive/class-content.php
@@ -25,6 +25,8 @@ class Content {
 		'phet.colorado.edu',
 		'cdn.knightlab.com',
 		'www.openassessments.org',
+		'www.openassessments.com',
+		'lumenlearning.com',
 		'players.brightcove.net',
 		'preview-players.brightcove.net',
 		'//docs.google.com/forms/',
@@ -346,8 +348,10 @@ class Content {
 		// Format (string), Provider (string), Is format a regular expression? (bool)
 		$providers['#https?://mathembed\.com/latex\?inputText=.*#i'] = [ 'https://mathembed.com/oembed', true ];
 		$providers['#https?://www\.openassessments\.org/assessments/.*#i'] = [ 'https://www.openassessments.org/oembed.json', true ];
+		$providers['#https?://www\.openassessments\.com/assessments/.*#i'] = [ 'https://www.openassessments.com/oembed.json', true ];
 		$providers['://cdn.knightlab.com/libs/timeline*'] = [ 'https://oembed.knightlab.com/timeline/', false ];
 		$providers['://uploads.knightlab.com/storymapjs/*/index.html'] = [ 'https://oembed.knightlab.com/storymap/', false ];
+		$providers['#https?://assessments\.lumenlearning\.com/.*#i'] = [ 'https://assessments.lumenlearning.com/oembed.json', true ];
 
 		return $providers;
 	}


### PR DESCRIPTION
Fixes https://github.com/pressbooks/ideas/issues/285 by whitelisting and adding support for auto oembeds for Open Embeddable Assessments hosted at `openassessments.com` and `assessments.lumenlearning.com`