### PR TITLE
Add book directory deletion verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage.xml
 node_modules
 tests/logs/
 vendor
+coverage-reports

--- a/composer.json
+++ b/composer.json
@@ -78,6 +78,10 @@
 			"vendor/bin/phpunit --configuration phpunit.xml --coverage-clover coverage.xml",
 			"@standards"
 		],
+		"test-coverage": [
+			"vendor/bin/phpunit --configuration phpunit.xml --coverage-clover coverage.xml --coverage-html=./coverage-reports",
+			"@standards"
+		],
 		"standards": [
 			"vendor/bin/phpcs --standard=phpcs.ruleset.xml *.php inc/ bin/"
 		],

--- a/composer.json
+++ b/composer.json
@@ -85,8 +85,8 @@
 		"standards": [
 			"vendor/bin/phpcs --standard=phpcs.ruleset.xml *.php inc/ bin/"
 		],
-    "fix": [
-      "vendor/bin/phpcbf --standard=phpcs.ruleset.xml *.php inc/ bin/"
-    ]
+		"fix": [
+			"vendor/bin/phpcbf --standard=phpcs.ruleset.xml *.php inc/ bin/"
+		]
 	}
 }

--- a/inc/api/endpoints/controller/class-directory.php
+++ b/inc/api/endpoints/controller/class-directory.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Pressbooks\Api\Endpoints\Controller;
+
+use Pressbooks\BookDirectory;
+
+class Directory extends \WP_REST_Controller {
+	const VERIFY_DELETION = 'verify_deletion';
+
+	/**
+	 * Books
+	 */
+	public function __construct() {
+		$this->namespace = 'pressbooks/v2';
+		$this->rest_base = 'directory';
+	}
+
+	/**
+	 *  Registers routes for Books
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace, '/' . $this->rest_base . '/' . self::VERIFY_DELETION, [
+				[
+					'methods' => \WP_REST_Server::READABLE,
+					'callback' => [ $this, 'verify_removal' ],
+				],
+			]
+		);
+	}
+
+	/**
+	 * @param WP_REST_Request $request
+	 *
+	 * @return bool
+	 */
+	public function verify_removal( $request ) {
+		$params = $request->get_query_params();
+		$sid = $params['sid'];
+		$removals = get_site_option( BookDirectory::DELETIONS_META_KEY, [] );
+		$index = array_search( $sid, $removals, true );
+
+		if ( false !== $index ) {
+			unset( $removals[ $index ] );
+			update_site_option( BookDirectory::DELETIONS_META_KEY, $removals );
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/inc/api/endpoints/controller/class-directory.php
+++ b/inc/api/endpoints/controller/class-directory.php
@@ -4,6 +4,10 @@ namespace Pressbooks\Api\Endpoints\Controller;
 
 use Pressbooks\BookDirectory;
 
+/**
+ * Class Directory
+ * @package Pressbooks\Api\Endpoints\Controller
+ */
 class Directory extends \WP_REST_Controller {
 	const VERIFY_DELETION = 'verify_deletion';
 

--- a/inc/api/endpoints/controller/class-directory.php
+++ b/inc/api/endpoints/controller/class-directory.php
@@ -4,10 +4,6 @@ namespace Pressbooks\Api\Endpoints\Controller;
 
 use Pressbooks\BookDirectory;
 
-/**
- * Class Directory
- * @package Pressbooks\Api\Endpoints\Controller
- */
 class Directory extends \WP_REST_Controller {
 	const VERIFY_DELETION = 'verify_deletion';
 

--- a/inc/api/namespace.php
+++ b/inc/api/namespace.php
@@ -135,6 +135,9 @@ function init_root() {
 
 	// Register Books
 	( new Endpoints\Controller\Books() )->register_routes();
+
+	// Register Directory endpoints
+	( new Endpoints\Controller\Directory() )->register_routes();
 }
 
 /**

--- a/inc/class-bookdirectory.php
+++ b/inc/class-bookdirectory.php
@@ -44,7 +44,8 @@ class BookDirectory {
 			self::hooks( self::$instance );
 		}
 
-		self::$delete_book_endpoint = getenv( 'CUSTOM_DELETE_BOOK_ENDPOINT' ) !== false ? getenv( 'CUSTOM_DELETE_BOOK_ENDPOINT' ) : self::DEFAULT_DELETE_BOOK_ENDPOINT;
+		self::$delete_book_endpoint = getenv( 'CUSTOM_DELETE_BOOK_ENDPOINT' ) !== false
+			? getenv( 'CUSTOM_DELETE_BOOK_ENDPOINT' ) : self::DEFAULT_DELETE_BOOK_ENDPOINT;
 
 		return self::$instance;
 	}

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -49,6 +49,7 @@ class ApiTest extends \WP_UnitTestCase {
 			'/pressbooks/v2/glossary/999/metadata',
 			'/pressbooks/v2/glossary/999/revisions',
 			'/pressbooks/v2/toc',
+			'/pressbooks/v2/directory/verify_deletion',
 		];
 		$server = $this->_setupBookApi();
 		foreach ( $endpoints as $endpoint ) {

--- a/tests/test-bookdirectory.php
+++ b/tests/test-bookdirectory.php
@@ -1,4 +1,11 @@
 <?php
+
+use Pressbooks\BookDirectory;
+
+
+/**
+ * @group bookDirectory
+ */
 class BookDirectoryTest extends \WP_UnitTestCase {
 	/**
 	 * @var BookDirectory
@@ -11,28 +18,22 @@ class BookDirectoryTest extends \WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		if ( ! defined( 'PB_BOOK_DIRECTORY_URL' ) ) {
-			define( 'PB_BOOK_DIRECTORY_URL', 'http://10.0.2.2:3000' );
-		}
-
-		$this->book_directory = new \Pressbooks\BookDirectory();
+		$this->book_directory = new BookDirectory();
 	}
 
-	/**
-	 * @group bookDirectory
-	 */
 	public function test_getInstance() {
 		$bookDirectory = $this->book_directory->init();
 		$this->assertInstanceOf( '\Pressbooks\BookDirectory', $bookDirectory );
 	}
 
-	/**
-	 * @group bookDirectory
-	 */
 	public function test_hooks() {
 		global $wp_filter;
 		$result = $this->book_directory->init();
 		$this->book_directory->hooks( $result );
 		$this->assertNotEmpty( $wp_filter );
+	}
+
+	public function test_deleteAction() {
+		$this->assertFalse( $this->book_directory->deleteAction( get_site() ) );
 	}
 }


### PR DESCRIPTION
@ho-man-chan , this PR addresses the deletion validation requirement for the book directory.

There is a new parameter 'sid' in the POST body for the deletion triggers that is sent to the delete endpoint of the book fetcher:
```
$data = [
		'sid'       => $sid,
		'network'   => 'https://' . $_SERVER['HTTP_HOST'],
		'book_id'   => $book_id,
	];
```
Once you receive parameter 'sid', you need to send it back to the network in a **GET** request to the validation deletion endpoint with the following format:

```
https://[ORIGIN NETWORK URL]/wp-json/pressbooks/v2/directory/verify_deletion?sid=[SID VALUE]
```

If you receive **true** as response then you can delete the book otherwise don't.

