### PR TITLE
Add Source Sans Pro to list of 'shapeshifter' fonts

### DIFF
--- a/inc/class-styles.php
+++ b/inc/class-styles.php
@@ -660,6 +660,7 @@ class Styles {
 			'Raleway' => __( 'Raleway', 'pressbooks' ),
 			'Roboto' => __( 'Roboto', 'pressbooks' ),
 			'Rubik' => __( 'Rubik', 'pressbooks' ),
+			'Source Sans Pro' => __( 'Source Sans Pro', 'pressbooks' ),
 		];
 
 		return [


### PR DESCRIPTION
Makes the Source Sans Pro typeface available as a choice in our 'shapeshifter' feature.