### PR TITLE
PB-1918 Escape special characters in image alt text

### DIFF
--- a/inc/modules/export/xhtml/class-xhtml11.php
+++ b/inc/modules/export/xhtml/class-xhtml11.php
@@ -739,6 +739,12 @@ class Xhtml11 extends ExportGenerator {
 		$images = $dom->getElementsByTagName( 'img' );
 		foreach ( $images as $image ) {
 			/** @var \DOMElement $image */
+			$old_alt = $image->getAttribute( 'alt' );
+			$new_alt = htmlspecialchars( $old_alt );
+			if ( $old_alt !== $new_alt ) {
+				$image->setAttribute( 'alt', $new_alt );
+				$changed = true;
+			}
 			$old_src = $image->getAttribute( 'src' );
 			if ( isset( $already_done[ $old_src ] ) ) {
 				$new_src = $already_done[ $old_src ];


### PR DESCRIPTION
Escape special characters in image alt text as part of XHTML export routine. Fixes https://github.com/pressbooks/pressbooks/issues/1918