### PR TITLE
Escape special characters in image alt and title properties

### DIFF
--- a/inc/modules/export/xhtml/class-xhtml11.php
+++ b/inc/modules/export/xhtml/class-xhtml11.php
@@ -603,7 +603,7 @@ class Xhtml11 extends ExportGenerator {
 	}
 
 	/**
-	 * Make sure that all images have properly escaped HTML characters in their alt and title attributes and are right sized for print
+	 * Ensure that all images have properly escaped HTML characters in their attributes and are right sized for print
 	 *
 	 * @param string $content The section content.
 	 *

--- a/inc/modules/export/xhtml/class-xhtml11.php
+++ b/inc/modules/export/xhtml/class-xhtml11.php
@@ -594,26 +594,22 @@ class Xhtml11 extends ExportGenerator {
 	protected function preProcessPostContent( $content, $id = null ) {
 		$content = apply_filters( 'the_export_content', $content );
 		$content = str_ireplace( [ '<b></b>', '<i></i>', '<strong></strong>', '<em></em>' ], '', $content );
-		$content = $this->fixAnnoyingCharacters( $content ); // is this used?
 		$content = $this->fixInternalLinks( $content, $id );
 		$content = $this->switchLaTexFormat( $content );
-		$content = $this->fixAltTags( $content );
-		if ( ! empty( $_GET['optimize-for-print'] ) ) {
-			$content = $this->fixImages( $content );
-		}
+		$content = $this->fixImages( $content );
 		$content = $this->tidy( $content );
 
 		return $content;
 	}
 
 	/**
-	 * Make sure that all images have properly escaped HTML characters in their alt and title attributes
+	 * Make sure that all images have properly escaped HTML characters in their alt and title attributes and are right sized for print
 	 *
 	 * @param string $content The section content.
 	 *
 	 * @return string
 	 */
-	protected function fixAltTags( $content ) {
+	protected function fixImages( $content ) {
 
 		if ( stripos( $content, '<img' ) === false ) {
 			// There are no <img> tags to look at, skip this
@@ -640,12 +636,28 @@ class Xhtml11 extends ExportGenerator {
 				$image->setAttribute( 'title', $new_title );
 				$changed = true;
 			}
-		}
 
-		if ( ! $changed ) {
-			return $content;
-		} else {
-			$content = $html5->saveHTML( $dom );
+			if ( ! empty( $_GET['optimize-for-print'] ) ) {
+				// Cheap cache
+				static $already_done = [];
+				$old_src = $image->getAttribute( 'src' );
+
+				if ( isset( $already_done[ $old_src ] ) ) {
+					$new_src = $already_done[ $old_src ];
+				} else {
+					$new_src = \Pressbooks\Image\maybe_swap_with_bigger( $old_src );
+				}
+				if ( $old_src !== $new_src ) {
+					$image->setAttribute( 'src', $new_src );
+					$image->removeAttribute( 'srcset' );
+					$changed = true;
+				}
+				$already_done[ $old_src ] = $new_src;
+			}
+
+			if ( $changed ) {
+				$content = $html5->saveHTML( $dom );
+			}
 			return $content;
 		}
 	}
@@ -763,46 +775,6 @@ class Xhtml11 extends ExportGenerator {
 			$content = $this->html5ToXhtml( $content );
 			return $content;
 		}
-	}
-
-	/**
-	 * Replace every image with the bigger original image
-	 *
-	 * @param $content
-	 *
-	 * @return string
-	 */
-	protected function fixImages( $content ) {
-
-		// Cheap cache
-		static $already_done = [];
-
-		$changed = false;
-		$html5 = new HtmlParser();
-		$dom = $html5->loadHTML( $content );
-
-		$images = $dom->getElementsByTagName( 'img' );
-		foreach ( $images as $image ) {
-			/** @var \DOMElement $image */
-			$old_src = $image->getAttribute( 'src' );
-			if ( isset( $already_done[ $old_src ] ) ) {
-				$new_src = $already_done[ $old_src ];
-			} else {
-				$new_src = \Pressbooks\Image\maybe_swap_with_bigger( $old_src );
-			}
-			if ( $old_src !== $new_src ) {
-				$image->setAttribute( 'src', $new_src );
-				$image->removeAttribute( 'srcset' );
-				$changed = true;
-			}
-			$already_done[ $old_src ] = $new_src;
-		}
-
-		if ( $changed ) {
-			$content = $html5->saveHTML( $dom );
-		}
-
-		return $content;
 	}
 
 	/**

--- a/inc/utility/namespace.php
+++ b/inc/utility/namespace.php
@@ -1499,11 +1499,13 @@ function initialize_sentry() {
 		$sentry_key = env( 'SENTRY_KEY' ) ?: '';
 		$sentry_organization = env( 'SENTRY_ORGANIZATION' ) ?: '';
 		$sentry_project = env( 'SENTRY_PROJECT' ) ?: '';
-		\Sentry\init( [
-			'dsn' => 'https://' . $sentry_key . '@' . $sentry_organization .
-				'.ingest.sentry.io/' . $sentry_project,
-			'environment' => env( 'WP_ENV' ) ?: 'staging',
-		] );
+		\Sentry\init(
+			[
+				'dsn' => 'https://' . $sentry_key . '@' . $sentry_organization .
+					'.ingest.sentry.io/' . $sentry_project,
+				'environment' => env( 'WP_ENV' ) ?: 'staging',
+			]
+		);
 		return true;
 	} catch ( \Exception $exception ) {
 		debug_error_log( 'Error initializing Sentry: ' . $exception->getMessage() );


### PR DESCRIPTION
Escape special characters in image alt and title properties as part of XHTML export routine. Proposed fix for #1918. 