### PR TITLE
Restore add types hook

### DIFF
--- a/hooks.php
+++ b/hooks.php
@@ -136,6 +136,7 @@ add_filter( 'plupload_default_params', '\Pressbooks\Media\force_attach_media' );
 // -------------------------------------------------------------------------------------------------------------------
 
 add_filter( 'upload_mimes', '\Pressbooks\Media\add_mime_types' );
+add_filter( 'upload_mimes', '\Pressbooks\Media\add_lord_of_the_files_types', 11 );
 add_filter( 'lotf_get_mime_aliases', '\Pressbooks\Media\get_lord_of_the_files_mime_aliases', 10, 2 );
 add_action( 'plugins_loaded', [ '\Pressbooks\Interactive\Content', 'init' ] );
 

--- a/inc/media/namespace.php
+++ b/inc/media/namespace.php
@@ -76,12 +76,11 @@ function unknown_upload_types( $existing_mimes ) {
  */
 function add_lord_of_the_files_types( $existing_mimes = [] ) {
 	$upload_filetype_mimes = [];
-	$lord_of_the_files_activated = ( is_plugin_active_for_network( 'blob-mimes/index.php' ) || is_plugin_active( 'blob-mimes/h5p.php' ) ) && method_exists( '\blobfolio\wp\bm\mime', 'get_aliases' );
+	$lord_of_the_files_activated = ( is_plugin_active_for_network( 'blob-mimes/index.php' ) || is_plugin_active( 'blob-mimes/h5p.php' ) ) && class_exists( 'blobfolio\\wp\\bm\\mime\\aliases' );
 	if ( $lord_of_the_files_activated ) {
 		foreach ( unknown_upload_types( $existing_mimes ) as $k => $v ) {
-			$extra_mime_alias = \blobfolio\wp\bm\mime::get_aliases( $k );
-			if ( $extra_mime_alias ) {
-				$upload_filetype_mimes[ $k ] = $extra_mime_alias[0]; // The first MIME entry is the official (or most conventional) media type
+			if ( isset( \blobfolio\wp\bm\mime\aliases::TYPES[$k] ) ) {
+				$upload_filetype_mimes[ $k ] = \blobfolio\wp\bm\mime\aliases::TYPES[$k][0];
 			}
 		}
 	}

--- a/inc/media/namespace.php
+++ b/inc/media/namespace.php
@@ -79,8 +79,8 @@ function add_lord_of_the_files_types( $existing_mimes = [] ) {
 	$lord_of_the_files_activated = ( is_plugin_active_for_network( 'blob-mimes/index.php' ) || is_plugin_active( 'blob-mimes/h5p.php' ) ) && class_exists( 'blobfolio\\wp\\bm\\mime\\aliases' );
 	if ( $lord_of_the_files_activated ) {
 		foreach ( unknown_upload_types( $existing_mimes ) as $k => $v ) {
-			if ( isset( \blobfolio\wp\bm\mime\aliases::TYPES[$k] ) ) {
-				$upload_filetype_mimes[ $k ] = \blobfolio\wp\bm\mime\aliases::TYPES[$k][0];
+			if ( isset( \blobfolio\wp\bm\mime\aliases::TYPES[ $k ] ) ) {
+				$upload_filetype_mimes[ $k ] = \blobfolio\wp\bm\mime\aliases::TYPES[ $k ][0];
 			}
 		}
 	}


### PR DESCRIPTION
This PR applies the fixed recommended by @joshstoik1 implementing a slight variation to read the type extension details from the first index `\blobfolio\wp\bm\mime\aliases::TYPES`, we do this because we only add types by extension.

https://github.com/pressbooks/pressbooks/issues/1981#issuecomment-660538820

Thanks, @joshstoik1 !!!