### PR TITLE
Remove redis cache widget from network dashboard and dashboard

### DIFF
--- a/inc/admin/dashboard/namespace.php
+++ b/inc/admin/dashboard/namespace.php
@@ -28,6 +28,9 @@ function replace_network_dashboard_widgets() {
 
 	// Remove unwanted dashboard widgets
 	unset( $wp_meta_boxes['dashboard-network']['side']['core']['dashboard_primary'] );
+	
+	// Remove third-party widgets
+	remove_meta_box( 'dashboard_rediscache', 'dashboard-network', 'normal' );
 
 	// Add our news feed.
 	$options = array_map(
@@ -81,6 +84,10 @@ function replace_dashboard_widgets() {
 			}
 		}
 	}
+	
+	// Remove third-party widgets
+	remove_meta_box( 'dashboard_rediscache', 'dashboard', 'normal' );
+	
 	// Replace with our own
 	$book_name = get_bloginfo( 'name' );
 	add_meta_box( 'pb_dashboard_widget_book', ( $book_name ? $book_name : __( 'My Book', 'pressbooks' ) ), __NAMESPACE__ . '\display_book_widget', 'dashboard', 'normal', 'high' );


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks/issues/1992

Test: make sure dashboard from the network and book level does not contain the Redis cache dashboard.
