### PR TITLE
Remove redis widget in root dashboard

### DIFF
--- a/inc/admin/dashboard/namespace.php
+++ b/inc/admin/dashboard/namespace.php
@@ -58,6 +58,9 @@ function replace_root_dashboard_widgets() {
 	remove_meta_box( 'dashboard_activity', 'dashboard', 'normal' );
 	remove_meta_box( 'dashboard_site_health', 'dashboard', 'normal' );
 
+	// Remove third-party widgets
+	remove_meta_box( 'dashboard_rediscache', 'dashboard', 'normal' );
+
 	// Add our news feed.
 	$options = array_map(
 		'stripslashes_deep', get_site_option(


### PR DESCRIPTION
Test: 

1. Visit yournetwork.com/wp/wp-admin/
2. Check that the Redis widget does not appear in the dashboard.

![image](https://user-images.githubusercontent.com/21694293/90514533-4ecd2080-e12f-11ea-8857-d780cd9150c5.png)
