### PR TITLE
Make New Athena Unicode typeface available in 'shapeshifter'

### DIFF
--- a/inc/class-styles.php
+++ b/inc/class-styles.php
@@ -644,6 +644,7 @@ class Styles {
 			'Cormorant Garamond' => __( 'Cormorant Garamond', 'pressbooks' ),
 			'Crimson Text' => __( 'Crimson Text', 'pressbooks' ),
 			'FreeFont Serif' => __( 'GNU FreeFont Serif', 'pressbooks' ),
+			'New Athena Unicode' => __( 'New Athena Unicode', 'pressbooks' ),
 			'Noto Serif' => __( 'Noto Serif', 'pressbooks' ),
 			'Sorts Mill Goudy' => __( 'Sorts Mill Goudy', 'pressbooks' ),
 			'Spectral' => __( 'Spectral', 'pressbooks' ),


### PR DESCRIPTION
Make the New Athena Unicode typeface available as a serif font option in 'shapeshifter.' Partial fix for https://github.com/pressbooks/ideas/issues/329