### PR TITLE
Removing Site Health and Dashboard primary from user's dashboard

### DIFF
--- a/inc/admin/dashboard/namespace.php
+++ b/inc/admin/dashboard/namespace.php
@@ -115,10 +115,16 @@ function lowly_user() {
 	global $wp_meta_boxes;
 	// https://github.com/pressbooks/pressbooks/issues/2041:  Remove health status and primary (WP news) widgets
 	if ( array_key_exists( 'dashboard-user', $wp_meta_boxes ) ) {
-		if ( array_key_exists( 'dashboard_primary', $wp_meta_boxes['dashboard-user']['side']['core'] ) ) {
+		if (
+			array_key_exists( 'side', $wp_meta_boxes['dashboard-user'] ) &&
+			array_key_exists( 'dashboard_primary', $wp_meta_boxes['dashboard-user']['side']['core'] )
+		) {
 			unset( $wp_meta_boxes['dashboard-user']['side']['core']['dashboard_primary'] );
 		}
-		if ( array_key_exists( 'dashboard_site_health', $wp_meta_boxes['dashboard-user']['normal']['core'] ) ) {
+		if (
+			array_key_exists( 'normal', $wp_meta_boxes['dashboard-user'] ) &&
+			array_key_exists( 'dashboard_site_health', $wp_meta_boxes['dashboard-user']['normal']['core'] )
+		) {
 			unset( $wp_meta_boxes['dashboard-user']['normal']['core']['dashboard_site_health'] );
 		}
 	}

--- a/inc/admin/dashboard/namespace.php
+++ b/inc/admin/dashboard/namespace.php
@@ -112,6 +112,17 @@ function replace_dashboard_widgets() {
  * A widget for /wp-admin/user/ in case someone without adequate permissions lands here (SSO, atypical config, ...)
  */
 function lowly_user() {
+	global $wp_meta_boxes;
+	// https://github.com/pressbooks/pressbooks/issues/2041:  Remove health status and primary (WP news) widgets
+	if ( array_key_exists( 'dashboard-user', $wp_meta_boxes ) ) {
+		if ( array_key_exists( 'dashboard_primary', $wp_meta_boxes['dashboard-user']['side']['core'] ) ) {
+			unset( $wp_meta_boxes['dashboard-user']['side']['core']['dashboard_primary'] );
+		}
+		if ( array_key_exists( 'dashboard_site_health', $wp_meta_boxes['dashboard-user']['normal']['core'] ) ) {
+			unset( $wp_meta_boxes['dashboard-user']['normal']['core']['dashboard_site_health'] );
+		}
+	}
+
 	add_meta_box(
 		'pb_dashboard_widget_book_permissions',
 		__( 'Book Permissions', 'pressbooks' ),

--- a/tests/test-admin-dashboard.php
+++ b/tests/test-admin-dashboard.php
@@ -61,6 +61,40 @@ class Admin_DashboardTest extends \WP_UnitTestCase {
 	/**
 	 * @group dashboard
 	 */
+	public function test_lowly_user_remove_healthy_and_wp_news_widgets() {
+		global $wp_meta_boxes;
+		// Mock dashboard user, by default the dashboard will be admin in this test
+		$wp_meta_boxes['dashboard-user'] = [
+			'normal' => [
+				'core' => [
+					'dashboard_site_health' => [
+						'id' => 'dashboard_site_health',
+						'title' => 'Site Health Status',
+						'callback' => 'wp_dashboard_site_health',
+						'args' => [ '__widget_basename' => 'Site Health Status' ],
+					],
+				],
+			],
+			'side' => [
+				'core' => [
+					'dashboard_primary' => [
+						'id' => 'dashboard_primary',
+						'title' => 'WordPress Events and News',
+						'callback' => 'wp_dashboard_events_news',
+						'args' => [ '__widget_basename' => 'WordPress Events and News' ],
+					],
+				],
+			]
+		];
+		\Pressbooks\Admin\Dashboard\lowly_user();
+		$this->assertFalse( isset( $wp_meta_boxes['dashboard-user']['normal']['high']['dashboard_primary'] ) );
+		$this->assertFalse( isset( $wp_meta_boxes['dashboard-user']['normal']['high']['dashboard_site_health'] ) );
+	}
+
+
+	/**
+	 * @group dashboard
+	 */
 	public function test_lowly_user_callback() {
 		ob_start();
 		\Pressbooks\Admin\Dashboard\lowly_user_callback();


### PR DESCRIPTION
Related issue: https://github.com/pressbooks/pressbooks/issues/2041
This change will remove Site Health and Dashboard Primary (WP News) widgets from user's dashboard.

### How to test
- Login as an admin user
- Go to wp/wp-admin/user dashboard page
- Check Site Health and WP news widgets are not present.