### PR TITLE
Fix bugs for book directory exclude (2043)

### DIFF
--- a/inc/admin/network/class-sharingandprivacyoptions.php
+++ b/inc/admin/network/class-sharingandprivacyoptions.php
@@ -232,7 +232,7 @@ class SharingAndPrivacyOptions extends \Pressbooks\Options {
 
 	/**
 	 *  Returns all public book ids. Can filter by in catalog
-	 * @return array    Non catalog books
+	 * @return array    public books
 	 */
 	static function getPublicBooks( $only_non_catalog = true ) {
 		global $wpdb;

--- a/inc/admin/network/class-sharingandprivacyoptions.php
+++ b/inc/admin/network/class-sharingandprivacyoptions.php
@@ -234,7 +234,7 @@ class SharingAndPrivacyOptions extends \Pressbooks\Options {
 	 *  Returns all public book ids. Can filter by in catalog
 	 * @return array    public books
 	 */
-	static function getPublicBooks( $only_non_catalog = true ) {
+	static function getPublicBooks( $only_non_catalog = false ) {
 		global $wpdb;
 
 		$public = Book::PUBLIC;
@@ -273,6 +273,7 @@ class SharingAndPrivacyOptions extends \Pressbooks\Options {
 	 * @return array   Responses from actions
 	 */
 	static function excludeNonCatalogBooksFromDirectoryAction( array $book_ids, bool $revert = false ) {
+
 		$is_deleted = [];
 
 		if ( ! $revert ) {

--- a/inc/admin/network/class-sharingandprivacyoptions.php
+++ b/inc/admin/network/class-sharingandprivacyoptions.php
@@ -254,14 +254,15 @@ class SharingAndPrivacyOptions extends \Pressbooks\Options {
 			$sql_where = str_lreplace( ') AND ', ') ', $sql_where );
 		}
 
-		$sql = "SELECT
-					b.blog_id AS id,
-					MAX(IF(b.meta_key='{$public}',CAST(b.meta_value AS UNSIGNED),null)) AS public,
-					MAX(IF(b.meta_key='{$in_catalog}',CAST(b.meta_value AS UNSIGNED),null)) AS inCatalog
-				FROM {$wpdb->blogmeta} b
-				GROUP BY id
-				{$sql_where}
-				";
+		$sql = "
+			SELECT
+				b.blog_id AS id,
+				MAX(IF(b.meta_key='{$public}',CAST(b.meta_value AS UNSIGNED),null)) AS public,
+				MAX(IF(b.meta_key='{$in_catalog}',CAST(b.meta_value AS UNSIGNED),null)) AS inCatalog
+			FROM {$wpdb->blogmeta} b
+			GROUP BY id
+			{$sql_where}
+			";
 
 		return array_map( 'intval', array_column( $wpdb->get_results( $sql, 'ARRAY_A' ), 'id' ) ); // @codingStandardsIgnoreLine
 	}

--- a/inc/class-bookdirectory.php
+++ b/inc/class-bookdirectory.php
@@ -132,7 +132,7 @@ class BookDirectory {
 
 			$data = [
 				'sid'       => $sid,
-				'network'   => 'https://' . $_SERVER['HTTP_HOST'],
+				'network'   => network_home_url(),
 				'book_ids'   => $book_ids,
 			];
 

--- a/tests/test-bookdirectory.php
+++ b/tests/test-bookdirectory.php
@@ -36,4 +36,5 @@ class BookDirectoryTest extends \WP_UnitTestCase {
 	public function test_deleteAction() {
 		$this->assertFalse( $this->book_directory->deleteAction( get_site() ) );
 	}
+
 }

--- a/tests/test-privacy.php
+++ b/tests/test-privacy.php
@@ -104,27 +104,42 @@ class GdprTest extends \WP_UnitTestCase {
 		// assume the first blog is the main wp site and not a book
 		$this->assertIsArray( SharingAndPrivacyOptions::getPublicBooks() );
 		$this->assertCount( 0, SharingAndPrivacyOptions::getPublicBooks() );
+		$this->assertCount( 0, SharingAndPrivacyOptions::getPublicBooks( false ) );
 		$this->assertCount( 0, SharingAndPrivacyOptions::getPublicBooks( true ) );
 
 		$this->_book();
 		$this->assertCount( 1, SharingAndPrivacyOptions::getPublicBooks() );
+		$this->assertCount( 1, SharingAndPrivacyOptions::getPublicBooks( false ) );
+		$this->assertCount( 1, SharingAndPrivacyOptions::getPublicBooks( true ) );
 
 		update_site_meta( get_current_blog_id(), \Pressbooks\DataCollector\Book::IN_CATALOG, 1 );
+		$this->assertCount( 1, SharingAndPrivacyOptions::getPublicBooks() );
+		$this->assertCount( 1, SharingAndPrivacyOptions::getPublicBooks( false ) );
 		$this->assertCount( 0, SharingAndPrivacyOptions::getPublicBooks( true ) );
 
 		update_site_meta( get_current_blog_id(), \Pressbooks\DataCollector\Book::IN_CATALOG, 0 );
+		$this->assertCount( 1, SharingAndPrivacyOptions::getPublicBooks() );
+		$this->assertCount( 1, SharingAndPrivacyOptions::getPublicBooks(false) );
 		$this->assertCount( 1, SharingAndPrivacyOptions::getPublicBooks( true ) );
 
 		$this->_book();
 		update_site_meta( get_current_blog_id(), \Pressbooks\DataCollector\Book::PUBLIC, 0 );
 		update_site_meta( get_current_blog_id(), \Pressbooks\DataCollector\Book::IN_CATALOG, 1 );
-		$this->assertCount( 1, SharingAndPrivacyOptions::getPublicBooks( true ) );
+		$this->assertCount( 1, SharingAndPrivacyOptions::getPublicBooks() );
+		$this->assertCount( 1, SharingAndPrivacyOptions::getPublicBooks( false ) );
 		$this->assertCount( 1, SharingAndPrivacyOptions::getPublicBooks( true ) );
 
 		update_site_meta( get_current_blog_id(), \Pressbooks\DataCollector\Book::PUBLIC, 1 );
 		update_site_meta( get_current_blog_id(), \Pressbooks\DataCollector\Book::IN_CATALOG, 0 );
-		$this->assertCount( 2, SharingAndPrivacyOptions::getPublicBooks( true ) );
 		$this->assertCount( 2, SharingAndPrivacyOptions::getPublicBooks() );
+		$this->assertCount( 2, SharingAndPrivacyOptions::getPublicBooks( false ) );
+		$this->assertCount( 2, SharingAndPrivacyOptions::getPublicBooks( true ) );
+
+		update_site_meta( get_current_blog_id(), \Pressbooks\DataCollector\Book::IN_CATALOG, 1 );
+		$this->assertCount( 2, SharingAndPrivacyOptions::getPublicBooks() );
+		$this->assertCount( 2, SharingAndPrivacyOptions::getPublicBooks( false ) );
+		$this->assertCount( 1, SharingAndPrivacyOptions::getPublicBooks( true ) );
+
 	}
 
 	/**


### PR DESCRIPTION
Fixes the following issues:
https://github.com/pressbooks/pressbooks/issues/2043
https://github.com/pressbooks/pressbooks/issues/2044

Test:
1. Reverting the network book exclude will update all public books.
2. In textopress.com (or any network with subdomain as their book URL configuration), at the book level, excluding the book will delete it from the directory.