### PR TITLE
Create individual book exclude option if not exist

### DIFF
--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -1204,6 +1204,7 @@ function privacy_settings_init() {
 				if ( update_site_meta( $current_book_id, DataCollector::BOOK_DIRECTORY_EXCLUDED, $updated_value ) ) {
 					update_blog_details( $current_book_id, [ 'last_updated' => current_time( 'mysql', true ) ] );
 				}
+
 				if ( $updated_value === 1 ) {
 					BookDirectory::init()->deleteBookFromDirectory( [ $current_book_id ] );
 				}
@@ -1341,7 +1342,10 @@ function privacy_latest_files_public_callback( $args ) {
  * @param $args
  */
 function book_directory_excluded_callback( $args ) {
-	$exclude_book = get_option( 'pb_book_directory_excluded', 0 );
+	if ( ! get_option( 'pb_book_directory_excluded' ) ) {
+		add_option( 'pb_book_directory_excluded', 0 );
+	}
+	$exclude_book = get_option( 'pb_book_directory_excluded');
 	$html = '<input type="radio" id="include-in-directory" name="pb_book_directory_excluded" value="0" ';
 	if ( ! $exclude_book ) {
 		$html .= 'checked="checked" ';

--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -1345,7 +1345,7 @@ function book_directory_excluded_callback( $args ) {
 	if ( ! get_option( 'pb_book_directory_excluded' ) ) {
 		add_option( 'pb_book_directory_excluded', 0 );
 	}
-	$exclude_book = get_option( 'pb_book_directory_excluded');
+	$exclude_book = get_option( 'pb_book_directory_excluded' );
 	$html = '<input type="radio" id="include-in-directory" name="pb_book_directory_excluded" value="0" ';
 	if ( ! $exclude_book ) {
 		$html .= 'checked="checked" ';

--- a/tests/test-privacy.php
+++ b/tests/test-privacy.php
@@ -88,12 +88,16 @@ class GdprTest extends \WP_UnitTestCase {
 	 * @group privacy
 	 */
 	public function test_bookDirectoryExcludedCallback() {
+		$this->_book();
+
 		ob_start();
 		book_directory_excluded_callback( [] );
 		$buffer = ob_get_clean();
 		$html_group = '<input type="radio" id="include-in-directory" name="pb_book_directory_excluded" value="0" checked="checked" /><label for="include-in-directory"> Yes. I want this book to be listed in the Pressbooks directory.</label><br /><input type="radio" id="exclude-from-directory" name="pb_book_directory_excluded" value="1" /><label for="exclude-from-directory"> No. Exclude this book from the Pressbooks directory.</label>';
-
 		$this->assertEquals( $buffer, $html_group );
+
+		$this->assertEquals( get_option( 'pb_book_directory_excluded' ), 0 );
+
 	}
 
 	/**


### PR DESCRIPTION
Problem:
When individual books are excluded for the very first time, the pb_book_directory_exclude is added but does not trigger the function to exclude because it listens to an update of the option. 

solution: The previous implementation only triggers when the option is updated and not when added. This PR adds the option when viewing the sharing and privacy menu. By doing so, when updating the option, it will always trigger the exclude function since WordPress treats it as an updated and not an addition of an option.