### PR TITLE
Checking sentry environment variables

### DIFF
--- a/hooks.php
+++ b/hooks.php
@@ -346,11 +346,11 @@ add_filter( 'init', [ '\Pressbooks\BookDirectory', 'init' ], 10, 2 );
 // Sentry initializer - Only for staging and production environments
 // -------------------------------------------------------------------------------------------------------------------
 if (
-	defined( 'WP_ENV' ) &&
+	! is_null( env( 'WP_ENV' ) ) &&
 	WP_ENV !== 'development' &&
-	defined( 'SENTRY_KEY' ) &&
-	defined( 'SENTRY_ORGANIZATION' ) &&
-	defined( 'SENTRY_PROJECT' )
+	! is_null( env( 'SENTRY_KEY' ) ) &&
+	! is_null( env( 'SENTRY_ORGANIZATION' ) ) &&
+	! is_null( env( 'SENTRY_PROJECT' ) )
 ) {
 	add_action( 'init', '\Pressbooks\Utility\initialize_sentry', 9999 );
 }


### PR DESCRIPTION
Related issue: https://github.com/pressbooks/private/issues/319

Previous this change we are using [PHP defined function](https://www.php.net/manual/en/function.defined.php) to check if Sentry environment variable exists. This function check if constant exists or not. 
Certainly those variables could be constants in WP installation and/or environment variables defined using [Illuminate helper](https://github.com/illuminate/support/blob/master/helpers.php#L130). It will depend of the environment configuration in each installation.
Looks like in Staging those are not constant anymore, but still are environment variables.

In order to be sure those environment variables are created correctly, I change it by _is_null_ function, which is more accurate for check if the environment variable exists (even if it is additionally a constant or not).

I tested it on Staging and it works. An issue was thrown in Sentry: https://sentry.io/organizations/pressbooks/issues/1994528590/events/f39761b4a35443f1b89fb2b50399f4a8/