### PR TITLE
Added filter to remove unnecessary prefix

### DIFF
--- a/hooks.php
+++ b/hooks.php
@@ -306,6 +306,7 @@ add_action( 'wp_footer', '\Pressbooks\Registration\add_a11y' );
 add_filter( 'add_signup_meta', '\Pressbooks\Registration\add_temporary_password', 99 );
 add_action( 'signup_blogform', '\Pressbooks\Registration\add_hidden_password_field' );
 add_filter( 'random_password', '\Pressbooks\Registration\override_password_generation' );
+add_filter( 'lostpassword_url', '\Pressbooks\Registration\remove_wp_prefix', 12 );
 
 // Email configuration
 add_filter( 'wp_mail_from', '\Pressbooks\Utility\mail_from' );

--- a/inc/registration/namespace.php
+++ b/inc/registration/namespace.php
@@ -371,5 +371,5 @@ function add_a11y() {
  * only if the book name is not wp
  */
 function remove_wp_prefix( $lostpassword_url ) {
-	return preg_replace('/(.*[^\/])\/wp\/(.*)(\/wp-login.php)(.*)/i', "$1/$2$3$4", $lostpassword_url);
+	return preg_replace( '/(.*[^\/])\/wp\/(.*)(\/wp-login.php)(.*)/i', '$1/$2$3$4', $lostpassword_url );
 }

--- a/inc/registration/namespace.php
+++ b/inc/registration/namespace.php
@@ -368,7 +368,8 @@ function add_a11y() {
 
 /**
  * Remove unwanted and unnecessary Bedrock's prefix in Lost Url link
+ * only if the book name is not wp
  */
 function remove_wp_prefix( $lostpassword_url ) {
-	return str_replace( '/wp/', '/', $lostpassword_url );
+	return preg_replace('/(.*[^\/])\/wp\/(.*)(\/wp-login.php)(.*)/i', "$1/$2$3$4", $lostpassword_url);
 }

--- a/inc/registration/namespace.php
+++ b/inc/registration/namespace.php
@@ -367,8 +367,8 @@ function add_a11y() {
 }
 
 /**
- * Remove unwanted and unnecessary Bedrock's prefix in Lost Url
+ * Remove unwanted and unnecessary Bedrock's prefix in Lost Url link
  */
-function remove_wp_prefix($lostpassword_url) {
-    return str_replace('/wp/', '/', $lostpassword_url);
+function remove_wp_prefix( $lostpassword_url ) {
+	return str_replace( '/wp/', '/', $lostpassword_url );
 }

--- a/inc/registration/namespace.php
+++ b/inc/registration/namespace.php
@@ -365,3 +365,10 @@ function add_a11y() {
 	</script>';
 
 }
+
+/**
+ * Remove unwanted and unnecessary Bedrock's prefix in Lost Url
+ */
+function remove_wp_prefix($lostpassword_url) {
+    return str_replace('/wp/', '/', $lostpassword_url);
+}

--- a/tests/test-login.php
+++ b/tests/test-login.php
@@ -7,17 +7,25 @@ class Login extends \WP_UnitTestCase {
 	 */
 	public function test_if_wp_prefix_is_removed() {
 
-		$scenario1 = 'https://institution.pressbooks.pub/wp/booktitle/wp-login.php?action=lostpassword';
-		$expected = 'https://institution.pressbooks.pub/booktitle/wp-login.php?action=lostpassword';
+		$scenario1 = 'https://network.pressbooks.pub/wp/booktitle/wp-login.php?action=lostpassword';
+		$expected = 'https://network.pressbooks.pub/booktitle/wp-login.php?action=lostpassword';
 
 		$actual = \Pressbooks\Registration\remove_wp_prefix($scenario1);
 
 		$this->assertEquals($expected, $actual);
 
-		$scenario = 'https://institution.pressbooks.pub/wp/wp-login.php?action=lostpassword';
-		$expected = 'https://institution.pressbooks.pub/wp-login.php?action=lostpassword';
+		$scenario2 = 'https://network.pressbooks.pub/wp/wp-login.php?action=lostpassword';
+		$expected = 'https://network.pressbooks.pub/wp/wp-login.php?action=lostpassword';
 
-		$actual = \Pressbooks\Registration\remove_wp_prefix($scenario);
+		$actual = \Pressbooks\Registration\remove_wp_prefix($scenario2);
+
+		$this->assertEquals($expected, $actual);
+
+
+		$scenario3 = 'https://network.pressbooks.pub/wp-login.php?action=lostpassword';
+		$expected = 'https://network.pressbooks.pub/wp-login.php?action=lostpassword';
+
+		$actual = \Pressbooks\Registration\remove_wp_prefix($scenario3);
 
 		$this->assertEquals($expected, $actual);
 

--- a/tests/test-login.php
+++ b/tests/test-login.php
@@ -9,7 +9,7 @@ class Login extends \WP_UnitTestCase {
 
 		$this->assertEquals(
 			'https://network.pressbooks.pub/booktitle/wp-login.php?action=lostpassword',
-			\Pressbooks\Registration\remove_wp_prefix( 'https://network.pressbooks.pub/booktitle/wp-login.php?action=lostpassword' )
+			\Pressbooks\Registration\remove_wp_prefix( 'https://network.pressbooks.pub/wp/booktitle/wp-login.php?action=lostpassword' )
 		);
 
 		$this->assertEquals(

--- a/tests/test-login.php
+++ b/tests/test-login.php
@@ -7,28 +7,20 @@ class Login extends \WP_UnitTestCase {
 	 */
 	public function test_if_wp_prefix_is_removed() {
 
-		$scenario1 = 'https://network.pressbooks.pub/wp/booktitle/wp-login.php?action=lostpassword';
-		$expected = 'https://network.pressbooks.pub/booktitle/wp-login.php?action=lostpassword';
+		$this->assertEquals(
+			'https://network.pressbooks.pub/booktitle/wp-login.php?action=lostpassword',
+			\Pressbooks\Registration\remove_wp_prefix( 'https://network.pressbooks.pub/booktitle/wp-login.php?action=lostpassword' )
+		);
 
-		$actual = \Pressbooks\Registration\remove_wp_prefix($scenario1);
+		$this->assertEquals(
+			'https://network.pressbooks.pub/wp/wp-login.php?action=lostpassword',
+			\Pressbooks\Registration\remove_wp_prefix( 'https://network.pressbooks.pub/wp/wp-login.php?action=lostpassword' )
+		);
 
-		$this->assertEquals($expected, $actual);
-
-		$scenario2 = 'https://network.pressbooks.pub/wp/wp-login.php?action=lostpassword';
-		$expected = 'https://network.pressbooks.pub/wp/wp-login.php?action=lostpassword';
-
-		$actual = \Pressbooks\Registration\remove_wp_prefix($scenario2);
-
-		$this->assertEquals($expected, $actual);
-
-
-		$scenario3 = 'https://network.pressbooks.pub/wp-login.php?action=lostpassword';
-		$expected = 'https://network.pressbooks.pub/wp-login.php?action=lostpassword';
-
-		$actual = \Pressbooks\Registration\remove_wp_prefix($scenario3);
-
-		$this->assertEquals($expected, $actual);
-
+		$this->assertEquals(
+			'https://network.pressbooks.pub/wp-login.php?action=lostpassword',
+			\Pressbooks\Registration\remove_wp_prefix( 'https://network.pressbooks.pub/wp-login.php?action=lostpassword' )
+		);
 
 	}
 

--- a/tests/test-login.php
+++ b/tests/test-login.php
@@ -5,22 +5,6 @@ class Login extends \WP_UnitTestCase {
 	/**
 	 * @group Login
 	 */
-	function setUp()
-	{
-		parent::setUp();
-	}
-
-	/**
-	 * @group registration
-	 */
-	function tearDown()
-	{
-		parent::tearDown();
-	}
-
-	/**
-	 * @group Login
-	 */
 	public function test_if_wp_prefix_is_removed() {
 
 		$scenario1 = 'https://institution.pressbooks.pub/wp/booktitle/wp-login.php?action=lostpassword';

--- a/tests/test-login.php
+++ b/tests/test-login.php
@@ -1,0 +1,43 @@
+<?php
+
+class Login extends \WP_UnitTestCase {
+
+	/**
+	 * @group Login
+	 */
+	function setUp()
+	{
+		parent::setUp();
+	}
+
+	/**
+	 * @group registration
+	 */
+	function tearDown()
+	{
+		parent::tearDown();
+	}
+
+	/**
+	 * @group Login
+	 */
+	public function test_if_wp_prefix_is_removed() {
+
+		$scenario1 = 'https://institution.pressbooks.pub/wp/booktitle/wp-login.php?action=lostpassword';
+		$expected = 'https://institution.pressbooks.pub/booktitle/wp-login.php?action=lostpassword';
+
+		$actual = \Pressbooks\Registration\remove_wp_prefix($scenario1);
+
+		$this->assertEquals($expected, $actual);
+
+		$scenario = 'https://institution.pressbooks.pub/wp/wp-login.php?action=lostpassword';
+		$expected = 'https://institution.pressbooks.pub/wp-login.php?action=lostpassword';
+
+		$actual = \Pressbooks\Registration\remove_wp_prefix($scenario);
+
+		$this->assertEquals($expected, $actual);
+
+
+	}
+
+}


### PR DESCRIPTION
Solves #2061 

Ready for PR @SteelWagstaff @richard015ar @ho-man-chan 

I think we should apply this unharmful fix and later work on the `wp/` Bedrock's stuff (for instance naming a book (wp), review the possibility to get rid of `/wp` entirely but this would require a full regression testing, this change is only focused on the lost password url