### PR TITLE
Fix primary subject identifier for API books endpoint

### DIFF
--- a/inc/metadata/namespace.php
+++ b/inc/metadata/namespace.php
@@ -226,12 +226,10 @@ function book_information_to_schema( $book_information, $network_excluded_direct
 	}
 
 	if ( isset( $book_information['pb_primary_subject'] ) ) {
-		$name = Metadata\get_subject_from_thema( $book_information['pb_primary_subject'] );
 		$book_schema['about'][] = [
 			'@type' => 'Thing',
-			'identifier' => ( is_null( $name ) || ! $name ) ?
-						$book_information['pb_primary_subject'] : $name,
-			'name' => $name,
+			'identifier' => $book_information['pb_primary_subject'],
+			'name' => Metadata\get_subject_from_thema( $book_information['pb_primary_subject'] ),
 		];
 	}
 


### PR DESCRIPTION
This change set identifier as thema code instead name string.
When we clone a book, the clones tries to get the primary subject using thema code instead a string representing the subject name. 
This bug was introduced when I implemented changes in the API for directory fetcher.

Previous "about" API field structure:
```
about: [
  {
    @type: "Thing",
    identifier: "Musical instruments",
    name: "Musical instruments"
  },
  {
    @type: "Thing",
    identifier: "YPAD",
    name: "Educational: Music"
  }
],
```

In this fix:
```
about: [
  {
    @type: "Thing",
    identifier: "AVR", // Thema code
    name: "Musical instruments"
  },
  {
    @type: "Thing",
    identifier: "YPAD",
    name: "Educational: Music"
  }
],
```