### PR TITLE
Fix XSS security vulnerability

### DIFF
--- a/inc/admin/metaboxes/namespace.php
+++ b/inc/admin/metaboxes/namespace.php
@@ -6,10 +6,13 @@
 
 namespace Pressbooks\Admin\Metaboxes;
 
+use function Pressbooks\Sanitize\sanitize_string;
 use PressbooksMix\Assets;
 use Pressbooks\Contributors;
 use Pressbooks\Licensing;
 use Pressbooks\Metadata;
+
+define( 'METADATA_CALLBACK_INDEX', 4 );
 
 /**
  * If the user updates the book's title, then also update the blog name
@@ -402,6 +405,9 @@ function add_meta_boxes() {
 			'group' => 'copyright',
 			'label' => __( 'Copyright Notice', 'pressbooks' ),
 			'description' => __( 'Enter a custom copyright notice, with whatever information you like. This will override the auto-generated copyright notice if All Rights Reserved or no license is selected, and will be inserted after the title page. If you select a Creative Commons license, the custom notice will appear after the license text in both the webbook and your exports.', 'pressbooks' ),
+			'sanitize_callback' => function ( ...$args ) {
+				return sanitize_string( $args[ METADATA_CALLBACK_INDEX ], true );
+			},
 		]
 	);
 
@@ -426,6 +432,9 @@ function add_meta_boxes() {
 			'group' => 'about-the-book',
 			'label' => __( 'Short Description', 'pressbooks' ),
 			'description' => __( 'A short paragraph about your book, for catalogs, reviewers etc. to quote.', 'pressbooks' ),
+			'sanitize_callback' => function ( ...$args ) {
+				return sanitize_string( $args[ METADATA_CALLBACK_INDEX ] );
+			},
 		]
 	);
 
@@ -435,6 +444,9 @@ function add_meta_boxes() {
 			'group' => 'about-the-book',
 			'label' => __( 'Long Description', 'pressbooks' ),
 			'description' => __( 'The full description of your book.', 'pressbooks' ),
+			'sanitize_callback' => function ( ...$args ) {
+				return sanitize_string( $args[ METADATA_CALLBACK_INDEX ], true );
+			},
 		]
 	);
 

--- a/inc/sanitize/namespace.php
+++ b/inc/sanitize/namespace.php
@@ -6,6 +6,8 @@
 
 namespace Pressbooks\Sanitize;
 
+use Pressbooks\HtmLawed;
+
 /**
  * Convert HTML5 tags to XHTML11 divs.
  *
@@ -814,4 +816,27 @@ function maybe_safer_unserialize( $original ) {
 		return safer_unserialize( $original );
 	}
 	return $original;
+}
+
+
+/**
+ * Sanitize an string for undesired XSS attacks allowing HTML but removing malicious code
+ * @param $value
+ * @param bool $allow_html
+ * @return string
+ */
+function sanitize_string( $value, $allow_html = false ) {
+
+	if ( $allow_html ) {
+
+		return HtmLawed::filter(
+			pb_decode( $value ), [
+				'safe' => 1,
+			]
+		);
+
+	}
+
+	return strip_tags( pb_decode ( $value ) );
+
 }

--- a/inc/sanitize/namespace.php
+++ b/inc/sanitize/namespace.php
@@ -837,6 +837,6 @@ function sanitize_string( $value, $allow_html = false ) {
 
 	}
 
-	return strip_tags( pb_decode ( $value ) );
+	return strip_tags( pb_decode( $value ) );
 
 }

--- a/inc/sanitize/namespace.php
+++ b/inc/sanitize/namespace.php
@@ -827,16 +827,6 @@ function maybe_safer_unserialize( $original ) {
  */
 function sanitize_string( $value, $allow_html = false ) {
 
-	if ( $allow_html ) {
-
-		return HtmLawed::filter(
-			pb_decode( $value ), [
-				'safe' => 1,
-			]
-		);
-
-	}
-
-	return strip_tags( pb_decode( $value ) );
+	return $allow_html ? HtmLawed::filter( pb_decode( $value ), [ 'safe' => 1 ] ) : strip_tags( pb_decode( $value ) );
 
 }

--- a/tests/test-book.php
+++ b/tests/test-book.php
@@ -54,7 +54,12 @@ class BookTest extends \WP_UnitTestCase {
 		// Returns cached export value, with $blog_id as param
 		global $blog_id;
 		delete_post_meta( $page['ID'], 'pb_export' );
-		wp_update_post( [ 'ID' => $page['ID'], 'post_status' => 'draft' ] );
+		wp_update_post(
+			[
+				'ID' => $page['ID'],
+				'post_status' => 'draft',
+			]
+		);
 		$structure = $book::getBookStructure( $blog_id );
 		$this->assertTrue( count( $structure['__orphans'] ) === 1 );
 		$vals = array_values( $structure['__orphans'] );
@@ -63,7 +68,12 @@ class BookTest extends \WP_UnitTestCase {
 
 		// Returns latest export value no cache
 		delete_post_meta( $page['ID'], 'pb_export' );
-		wp_update_post( [ 'ID' => $page['ID'], 'post_status' => 'draft' ] );
+		wp_update_post(
+			[
+				'ID' => $page['ID'],
+				'post_status' => 'draft',
+			]
+		);
 		$book::deleteBookObjectCache();
 		$structure = $book::getBookStructure();
 		$this->assertTrue( count( $structure['__orphans'] ) === 1 );
@@ -94,7 +104,12 @@ class BookTest extends \WP_UnitTestCase {
 
 		// Returns cached export value
 		delete_post_meta( $page['ID'], 'pb_export' );
-		wp_update_post( [ 'ID' => $page['ID'], 'post_status' => 'draft' ] );
+		wp_update_post(
+			[
+				'ID' => $page['ID'],
+				'post_status' => 'draft',
+			]
+		);
 		$contents = $book::getBookContents();
 		$this->assertTrue( count( $contents['__orphans'] ) === 1 );
 		$vals = array_values( $contents['__orphans'] );
@@ -103,7 +118,12 @@ class BookTest extends \WP_UnitTestCase {
 
 		// Returns latest export value no cache
 		delete_post_meta( $page['ID'], 'pb_export' );
-		wp_update_post( [ 'ID' => $page['ID'], 'post_status' => 'draft' ] );
+		wp_update_post(
+			[
+				'ID' => $page['ID'],
+				'post_status' => 'draft',
+			]
+		);
 		$book::deleteBookObjectCache();
 		$contents = $book::getBookContents();
 		$this->assertTrue( count( $contents['__orphans'] ) === 1 );
@@ -170,18 +190,18 @@ class BookTest extends \WP_UnitTestCase {
 		$result = $book::getSubsections( 0 );
 		$this->assertEquals( false, $result );
 
-		$test = "<h1>Hi there!<b></b></h1><p>How are you?</p>";
+		$test = '<h1>Hi there!<b></b></h1><p>How are you?</p>';
 		$id = $book::getBookStructure()['front-matter'][0]['ID'];
 		$this->factory()->post->update_object( $id, [ 'post_content' => $test ] );
 		$result = $book::getSubsections( $id );
 		$this->assertArrayHasKey( "front-matter-{$id}-section-1", $result );
-		$this->assertEquals( 'Hi there!', $result["front-matter-{$id}-section-1"] );
+		$this->assertEquals( 'Hi there!', $result[ "front-matter-{$id}-section-1" ] );
 
 		$test = "<H1 style='font-size:small;'>Hi there! Hope you're doing good.<B></B></H1><P>How are you?</P>"; // ALL CAPS, texturized
 		$this->factory()->post->update_object( $id, [ 'post_content' => $test ] );
 		$result = $book::getSubsections( $id );
 		$this->assertArrayHasKey( "front-matter-{$id}-section-1", $result );
-		$this->assertEquals( 'Hi there! Hope you&#8217;re doing good.', $result["front-matter-{$id}-section-1"] );
+		$this->assertEquals( 'Hi there! Hope you&#8217;re doing good.', $result[ "front-matter-{$id}-section-1" ] );
 
 		$test = "<h2>Hi there! Hope you're doing good.<b></b></h2><p>How are you?</p>"; // H2
 		$this->factory()->post->update_object( $id, [ 'post_content' => $test ] );
@@ -211,7 +231,7 @@ class BookTest extends \WP_UnitTestCase {
 		$this->_book();
 		$book = \Pressbooks\Book::getInstance();
 
-		$test = "<h1>Hi there!<b></b></h1><p>How are you?.</p>";
+		$test = '<h1>Hi there!<b></b></h1><p>How are you?.</p>';
 		$result = $book::tagSubsections( $test, 0 );
 		$this->assertEquals( false, $result );
 
@@ -229,7 +249,7 @@ class BookTest extends \WP_UnitTestCase {
 		$result = $book::tagSubsections( $test, $id );
 		$this->assertContains( "<h1 class=\"section-header foo bar\" id=\"front-matter-{$id}-section-1\"", $result );
 
-		$test = "<h2>Hi there!<b></b></h2><p>How are you?</p>"; // H2
+		$test = '<h2>Hi there!<b></b></h2><p>How are you?</p>'; // H2
 		$result = $book::tagSubsections( $test, $id );
 		$this->assertEquals( false, $result );
 	}
@@ -279,7 +299,7 @@ class BookTest extends \WP_UnitTestCase {
 		$user_id = $this->factory()->user->create( [ 'role' => 'administrator' ] );
 		wp_set_current_user( $user_id );
 
-		$url = $book::getFirst( false, true);
+		$url = $book::getFirst( false, true );
 		$this->assertContains( 'example.org/', $url );
 		$post_id = $book::getFirst( true, true );
 		$this->assertTrue( is_integer( $post_id ) );
@@ -310,7 +330,12 @@ class BookTest extends \WP_UnitTestCase {
 		$this->assertEquals( 1, $book::getChapterNumber( $one['ID'] ) );
 		$this->assertEquals( 2, $book::getChapterNumber( $two['ID'] ) );
 
-		wp_update_post( [ 'ID' => $one['ID'], 'post_status' => 'private' ] );
+		wp_update_post(
+			[
+				'ID' => $one['ID'],
+				'post_status' => 'private',
+			]
+		);
 		$book::deleteBookObjectCache();
 
 		$this->assertEquals( 0, $book::getChapterNumber( $one['ID'], 'webbook' ) );
@@ -324,5 +349,30 @@ class BookTest extends \WP_UnitTestCase {
 		$this->assertEquals( 0, $book::getChapterNumber( $two['ID'] ) );
 		$this->assertEquals( 0, $book::getChapterNumber( $one['ID'], 'exports' ) );
 		$this->assertEquals( 0, $book::getChapterNumber( $two['ID'] ), 'exports' );
+	}
+
+	public function test_getSanitizedBookAboutInfo() {
+
+		$this->_book();
+		$mp = ( new \Pressbooks\Metadata() )->getMetaPost();
+
+		$c = custom_metadata_manager::instance();
+
+		$c->admin_init();
+		$c->init_metadata();
+
+		\Pressbooks\Admin\Metaboxes\add_meta_boxes();
+
+		$field_slug = 'pb_about_50';
+
+		$field = $c->get_field( $field_slug, 'about-the-book', 'metadata' );
+
+		$_POST[ $field_slug ] = '<img src=# onerror=alert(document.cookie) /> hello xss';
+
+		$c->save_metadata_field( $field_slug, $field, 'metadata', $mp->ID );
+
+		$value = $c->get_metadata_field_value( $field_slug, $field, 'metadata', $mp->ID );
+
+		$this->assertEquals( ' hello xss', $value[0] );
 	}
 }

--- a/tests/test-book.php
+++ b/tests/test-book.php
@@ -379,7 +379,7 @@ class BookTest extends \WP_UnitTestCase {
 		$_POST[ $about_extended_field ] = $xss_string;
 		$c->save_metadata_field( $about_extended_field, $field, 'metadata', $mp->ID );
 		$value = $c->get_metadata_field_value( $about_extended_field, $field, 'metadata', $mp->ID );
-		$this->assertEquals( ' hello xss', $value[0] );
+		$this->assertEquals( '<img src="#" alt="image" /> hello xss', $value[0] );
 
 		$copyright_field = 'pb_custom_copyright';
 
@@ -387,7 +387,7 @@ class BookTest extends \WP_UnitTestCase {
 		$_POST[ $copyright_field ] = $xss_string;
 		$c->save_metadata_field( $copyright_field, $field, 'metadata', $mp->ID );
 		$value = $c->get_metadata_field_value( $copyright_field, $field, 'metadata', $mp->ID );
-		$this->assertEquals( ' hello xss', $value[0] );
+		$this->assertEquals( '<img src="#" alt="image" /> hello xss', $value[0] );
 
 	}
 }

--- a/tests/test-book.php
+++ b/tests/test-book.php
@@ -363,16 +363,31 @@ class BookTest extends \WP_UnitTestCase {
 
 		\Pressbooks\Admin\Metaboxes\add_meta_boxes();
 
-		$field_slug = 'pb_about_50';
+		$xss_string = '<img src=# onerror=alert(document.cookie) /> hello xss';
 
-		$field = $c->get_field( $field_slug, 'about-the-book', 'metadata' );
+		$about_field = 'pb_about_50';
 
-		$_POST[ $field_slug ] = '<img src=# onerror=alert(document.cookie) /> hello xss';
-
-		$c->save_metadata_field( $field_slug, $field, 'metadata', $mp->ID );
-
-		$value = $c->get_metadata_field_value( $field_slug, $field, 'metadata', $mp->ID );
-
+		$field = $c->get_field( $about_field, 'about-the-book', 'metadata' );
+		$_POST[ $about_field ] = $xss_string;
+		$c->save_metadata_field( $about_field, $field, 'metadata', $mp->ID );
+		$value = $c->get_metadata_field_value( $about_field, $field, 'metadata', $mp->ID );
 		$this->assertEquals( ' hello xss', $value[0] );
+
+		$about_extended_field = 'pb_about_unlimited';
+
+		$field = $c->get_field( $about_extended_field, 'about-the-book', 'metadata' );
+		$_POST[ $about_extended_field ] = $xss_string;
+		$c->save_metadata_field( $about_extended_field, $field, 'metadata', $mp->ID );
+		$value = $c->get_metadata_field_value( $about_extended_field, $field, 'metadata', $mp->ID );
+		$this->assertEquals( ' hello xss', $value[0] );
+
+		$copyright_field = 'pb_custom_copyright';
+
+		$field = $c->get_field( $copyright_field, 'copyright', 'metadata' );
+		$_POST[ $copyright_field ] = $xss_string;
+		$c->save_metadata_field( $copyright_field, $field, 'metadata', $mp->ID );
+		$value = $c->get_metadata_field_value( $copyright_field, $field, 'metadata', $mp->ID );
+		$this->assertEquals( ' hello xss', $value[0] );
+
 	}
 }

--- a/tests/test-sanitize.php
+++ b/tests/test-sanitize.php
@@ -567,4 +567,35 @@ RAW;
 		$this->assertFalse( $result );
 	}
 
+	/**
+	 * @group sanitize
+	 */
+	public function test_sanitize_string() {
+
+		$test = '<img src=# onerror=alert(document.cookie)>HTML not allowed';
+		$test = \Pressbooks\Sanitize\sanitize_string( $test );
+		$this->assertEquals( 'HTML not allowed', $test );
+
+		$test = '<img src=# onerror=alert(document.cookie)> HTML is allowed';
+		$test = \Pressbooks\Sanitize\sanitize_string( $test, true );
+		$this->assertEquals( '<img src="#" alt="image" /> HTML is allowed' , $test);
+
+		$test = '&lt;img src=# onerror=alert(document.cookie)&gt; HTML should be cleaned';
+		$test = \Pressbooks\Sanitize\sanitize_string( $test );
+		$this->assertEquals( ' HTML should be cleaned', $test );
+
+		$test = '&lt;img src=# onerror=alert(document.cookie)&gt; encoded HTML';
+		$test = \Pressbooks\Sanitize\sanitize_string( $test, true );
+		$this->assertEquals( '<img src="#" alt="image" /> encoded HTML', $test );
+
+		$test = '<IMG SRC=javascript:alert("XSS")>';
+		$test = \Pressbooks\Sanitize\sanitize_string( $test, true );
+		$this->assertEquals( '<img src="denied:javascript:alert(" alt="image" />', $test );
+
+		$test = '\<a onmouseover="alert(document.cookie)"\>xxs link\</a\>';
+		$test = \Pressbooks\Sanitize\sanitize_string( $test, true );
+		$this->assertEquals( '\<a>xxs link\</a>', $test );
+
+	}
+
 }


### PR DESCRIPTION
Related issues #2066 and [#404](https://github.com/pressbooks/private/issues/404)

This security fix clean and sanitize metadata book info metaboxes to prevent XSS attacks on fields that allows HTML input, this uses [Htmlawed](https://www.bioinformatics.org/phplabware/internal_utilities/htmLawed/htmLawed_README.htm) to filter and sanitize the input values.

### How to test

#### Requirements:

* Access to the latest Pressbooks admin interface

#### Steps:

* Enter to the admin interface
* Select any book and go to the book info page
* Try to fill any **wysiwyg** and **textareas** with malicious XSS strings and open the book front page of that book to see the safe sanitized values printed
* TIP you can use the following [XSS Filter Evasion Cheat Sheet](https://owasp.org/www-community/xss-filter-evasion-cheatsheet)
* You can try to test any input field metabox in the book info with the previous step, those values are already being properly escaped in the cover front page

### Notes

Two tests were added

[Functional test](https://github.com/pressbooks/pressbooks/pull/2072/files#diff-26db17a6755a6258d67c7522a3695bc626a34b87eadc4ded774722e22410ac9aR354)

[Unit test](https://github.com/pressbooks/pressbooks/pull/2072/files#diff-2cfd1565eaadffbe2d162d17535363549cd763bb62396d88845dcc9a2e9a96b9R573)