### PR TITLE
Search and replace XSS vulnerability fix

### DIFF
--- a/inc/admin/metaboxes/namespace.php
+++ b/inc/admin/metaboxes/namespace.php
@@ -12,7 +12,9 @@ use Pressbooks\Contributors;
 use Pressbooks\Licensing;
 use Pressbooks\Metadata;
 
+// @codeCoverageIgnoreStart
 define( 'METADATA_CALLBACK_INDEX', 4 );
+// @codeCoverageIgnoreEnd
 
 /**
  * If the user updates the book's title, then also update the blog name

--- a/inc/modules/searchandreplace/class-search.php
+++ b/inc/modules/searchandreplace/class-search.php
@@ -6,6 +6,8 @@
 
 namespace Pressbooks\Modules\SearchAndReplace;
 
+use function Pressbooks\Sanitize\sanitize_string;
+
 abstract class Search {
 
 	/** @var mixed */
@@ -96,7 +98,7 @@ abstract class Search {
 			$replace = str_replace( '\\', '\\\\', $replace );
 			$replace = str_replace( '$', '\\$', $replace );
 		}
-		$this->replace = $replace;
+		$this->replace = sanitize_string( $replace, true );
 		$results = $this->searchForPattern( $search, $limit, $offset, $orderby );
 		if ( is_array( $results ) && $save ) {
 			$this->replace( $results );

--- a/tests/test-searchandreplace.php
+++ b/tests/test-searchandreplace.php
@@ -77,6 +77,12 @@ class SearchResultTest extends \WP_UnitTestCase {
 		foreach ( $results as $result ) {
 			$this->assertContains( 'sadness', $result->content );
 		}
+
+		$this->content->regex = false;
+		$results = $this->content->searchAndReplace( 'sadness', '<img src=# onerror=alert(document.cookie)>', 0, 0, 'asc', true );
+		foreach ( $results as $result ) {
+			$this->assertContains( '<img src="#" alt="image" />', $result->content );
+		}
 	}
 
 }


### PR DESCRIPTION
Related issue  [#253](https://github.com/pressbooks/private/issues/253)

This security fix clean and sanitize the replace values for the search and replace tool allowing HTML input, this uses [Htmlawed](https://www.bioinformatics.org/phplabware/internal_utilities/htmLawed/htmLawed_README.htm) to filter and sanitize the input values.

### How to test

#### Requirements:

* Access to the latest Pressbooks admin interface

#### Steps:

* Enter to the admin interface
* Locate some content string that you want to replace in any of the book pages
* Go to the search and replace tool
* Fill the `Search For:` input with the string you want to replace
* Fill the `Replace With:` input with the malicious XSS string and open the book page that contains the string you want to replace and review if the value was sanitized and replaced.
* TIP you can use the following [XSS Filter Evasion Cheat Sheet](https://owasp.org/www-community/xss-filter-evasion-cheatsheet)

### Notes

One test assertion was added

[Unit test](https://github.com/pressbooks/pressbooks/pull/2074/files#diff-7da96664eefdf1b1ce1d8ef40cd1967888f53c5e8544ca76ab95319c8affe8ffR81)