### PR TITLE
Setup ID order for glossary REST endpoint

### DIFF
--- a/inc/api/endpoints/controller/class-posts.php
+++ b/inc/api/endpoints/controller/class-posts.php
@@ -48,7 +48,9 @@ class Posts extends \WP_REST_Posts_Controller {
 		// TODO: $args come from \Pressbooks\Book::getBookStructure, we should consolidate this somewhere?
 
 		$args['post_status'] = 'any';
-		$args['orderby'] = 'menu_order';
+		// orderby menu_order causes issues duplicating records in the REST API for custom post types
+		// using menu_order in REST API is not reilable because is not unique and mess the WP_Query
+		$args['orderby'] = $this->post_type === 'glossary' ? 'id' : 'menu_order';
 		$args['order'] = 'ASC';
 
 		return $args;

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -281,8 +281,7 @@ class ApiTest extends \WP_UnitTestCase {
 		$data = $response->get_data();
 
 		$this->assertEquals( 2, count( $data ) );
-		$this->assertEquals( 'Synapse', $data[0]['title']['rendered'] );
-		$this->assertEquals( 'ML', $data[1]['title']['rendered'] );
+		$this->assertEquals( 'ML', $data[0]['title']['rendered'] );
 	}
 
 }

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -245,4 +245,44 @@ class ApiTest extends \WP_UnitTestCase {
 		$this->assertInstanceOf( '\WP_User', get_user_by( 'slug', 'batchuser002' ) );
 	}
 
+	/**
+	 * Test /pressbooks/v2/glossary
+	 * @group api
+	 */
+	public function test_glossaryApi() {
+
+		$server = $this->_setupBookApi();
+
+		$term1 = [
+			'post_type'    => 'glossary',
+			'post_title'   => 'Synapse',
+			'post_content' => 'Definition',
+			'post_status'  => 'publish',
+		];
+		$term2 = [
+			'post_type'    => 'glossary',
+			'post_title'   => 'Not done',
+			'post_content' => 'This term is not done so the status is private.',
+			'post_status'  => 'private',
+		];
+		$term3 = [
+			'post_type'    => 'glossary',
+			'post_title'   => 'ML',
+			'post_content' => 'Machine learning is a method of data analysis that automates analytical model building',
+			'post_status'  => 'publish',
+		];
+
+		$this->factory()->post->create_object( $term1 );
+		$this->factory()->post->create_object( $term2 );
+		$this->factory()->post->create_object( $term3 );
+
+		$request = new \WP_REST_Request( 'GET', '/pressbooks/v2/glossary' );
+		$response = $server->dispatch( $request );
+		$data = $response->get_data();
+
+		$this->assertEquals( 2, count( $data ) );
+		$this->assertEquals( 'Synapse', $data[0]['title']['rendered'] );
+		$this->assertEquals( 'ML', $data[1]['title']['rendered'] );
+	}
+
 }

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -1,5 +1,7 @@
 <?php
 
+use Pressbooks\Api\Endpoints\Controller\Posts;
+
 use function \Pressbooks\Metadata\book_information_to_schema;
 
 class ApiTest extends \WP_UnitTestCase {
@@ -253,6 +255,8 @@ class ApiTest extends \WP_UnitTestCase {
 
 		$server = $this->_setupBookApi();
 
+		$controller = new Posts('glossary');
+
 		$term1 = [
 			'post_type'    => 'glossary',
 			'post_title'   => 'Synapse',
@@ -281,7 +285,8 @@ class ApiTest extends \WP_UnitTestCase {
 		$data = $response->get_data();
 
 		$this->assertEquals( 2, count( $data ) );
-		$this->assertEquals( 'ML', $data[0]['title']['rendered'] );
+		$this->assertEquals( 'Synapse', $data[0]['title']['rendered'] );
+		$this->assertEquals( 'ML', $data[1]['title']['rendered'] );
 	}
 
 }


### PR DESCRIPTION
Related Issue [#729](https://github.com/pressbooks/pressbooks-book/issues/729)

We are using `"rest_glossary_query"` hook to modify the default ordering column with 

```php
$args['post_status'] = 'any';
$args['orderby'] = 'menu_order';
$args['order'] = 'ASC';
```

The problem with ordering params by `menu_order` could result in duplicated values during the REST API query because is not a reliable ordering field during pagination because is not unique and not all fields has this value set, also there is a [known bug related](https://core.trac.wordpress.org/ticket/46294)

## Side effects

This behavior is affecting the cloning routine because is not grabbing all the glossary items from the API and those missing items were replaced by `no post`, also duplicated entries are being created in the cloned books.

With this PR all the glossary terms will be fetched without issues and it will run only on the REST API endpoint scope

### How to test

Query the API to search any of the missing glossary terms, and review also that is not going to have duplicated values


### Tip
I created the following script to fetch all the glossary terms for ANY pressbooks network to grab all the glossary terms in no time

```javascript
import axios from 'axios'
import fs from 'fs'

process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';

const book_url = 'https://pressbooks.test/introductiontopsychology';

const url = '${book_url}/wp-json/pressbooks/v2/glossary?per_page=100&_fields[]=title&_fields[]=id&page=';

async function fetchTerms(page=1) {
    console.log('fetching page '+page)
    try {
        const {headers,data} = await axios.get(`${url}${page}`)
        if (parseInt(headers['x-wp-totalpages'],10) > page) {
            return data.concat(await fetchTerms(page + 1))
        }
        return data;
    }catch(e) {
        console.log(e)
    }
}

const items = await fetchTerms(1);

items.sort((a, b) => a.id - b.id)

const terms = items.map((term)=>{
    return `${term.id} - ${term.title.rendered}\n`
})

fs.writeFile('fullglossary.json',JSON.stringify(terms),function(err){
    if(err){
        console.log(err)
    }
    console.log('done')
})
```

If you run the previous script you'll get a `fullglossary.json` file with all the glossary terms exposed through the API 