### PR TITLE
fixed post type scope during callback

### DIFF
--- a/inc/api/endpoints/controller/class-posts.php
+++ b/inc/api/endpoints/controller/class-posts.php
@@ -44,13 +44,12 @@ class Posts extends \WP_REST_Posts_Controller {
 	 * @return array
 	 */
 	public function overrideQueryArgs( $args ) {
-
 		// TODO: $args come from \Pressbooks\Book::getBookStructure, we should consolidate this somewhere?
 
 		$args['post_status'] = 'any';
 		// orderby menu_order causes issues duplicating records in the REST API for custom post types
 		// using menu_order in REST API is not reilable because is not unique and mess the WP_Query
-		$args['orderby'] = $this->post_type === 'glossary' ? 'id' : 'menu_order';
+		$args['orderby'] = $args['post_type'] === 'glossary' ? 'id' : 'menu_order';
 		$args['order'] = 'ASC';
 
 		return $args;


### PR DESCRIPTION
I debug different scenarios of this "simple" change and this was causing a side effect in the importing routine because `$this->post_type` could be undefined some times and also the link could be lost because is being used as a filter callback and not as a regular php object

### Solution

I replaced the usage of `$this->post_type` inside the filter callback to do it in a more WP_Rest API way `$args['post_type']` and it works as expected both things :)

### Expected results

* Books are properly imported with glossary 
* Books could be cloned with full glossary
* Full Glossary is being exposed correctly through the API