### PR TITLE
H5P Activities anchor

### DIFF
--- a/inc/interactive/class-h5p.php
+++ b/inc/interactive/class-h5p.php
@@ -224,7 +224,7 @@ class H5P {
 	}
 
 	/**
-	 * This hook add a HTML wrapper to identify each hp5 activity
+	 * This hook adds a HTML wrapper to identify each hp5 activity
 	 * @param $html
 	 * @param $content array this array holds the custom post type information (h5p)
 	 * @return string

--- a/inc/interactive/class-h5p.php
+++ b/inc/interactive/class-h5p.php
@@ -32,7 +32,7 @@ class H5P {
 		if ( is_file( WP_PLUGIN_DIR . '/h5p/autoloader.php' ) ) {
 			require_once( WP_PLUGIN_DIR . '/h5p/autoloader.php' );
 		}
-		add_filter( 'print_h5p_content', [$this, 'generateCustomH5pWrapper'] , 10, 2);
+		add_filter( 'print_h5p_content', [ $this, 'generateCustomH5pWrapper' ], 10, 2 );
 	}
 
 	/**
@@ -138,7 +138,7 @@ class H5P {
 			$wpdb->suppress_errors( $suppress );
 		}
 
-		$h5p_id = isset( $atts['id'] ) ? (int)$atts['id'] : 0;
+		$h5p_id = isset( $atts['id'] ) ? (int) $atts['id'] : 0;
 
 		// H5P Content
 		if ( $h5p_id ) {
@@ -156,7 +156,7 @@ class H5P {
 			'interactive.h5p', [
 				'title' => $h5p_title,
 				'url' => $h5p_url,
-				'id' => $h5p_id ? '#'.self::SHORTCODE.'-'.$h5p_id : ''
+				'id' => $h5p_id ? '#' . self::SHORTCODE . '-' . $h5p_id : '',
 			]
 		);
 	}
@@ -229,9 +229,8 @@ class H5P {
 	 * @param $content array this array holds the custom post type information (h5p)
 	 * @return string
 	 */
-	public function generateCustomH5pWrapper($html, array $content)
-	{
-		return '<div id="'.self::SHORTCODE.'-' .$content['id']. '">'.$html.'</div>';
+	public function generateCustomH5pWrapper( $html, array $content ) {
+		return '<div id="' . self::SHORTCODE . '-' . $content['id'] . '">' . $html . '</div>';
 	}
 
 }

--- a/inc/interactive/class-h5p.php
+++ b/inc/interactive/class-h5p.php
@@ -32,6 +32,7 @@ class H5P {
 		if ( is_file( WP_PLUGIN_DIR . '/h5p/autoloader.php' ) ) {
 			require_once( WP_PLUGIN_DIR . '/h5p/autoloader.php' );
 		}
+		add_filter( 'print_h5p_content', [$this, 'generateCustomH5pWrapper'] , 10, 2);
 	}
 
 	/**
@@ -137,7 +138,7 @@ class H5P {
 			$wpdb->suppress_errors( $suppress );
 		}
 
-		$h5p_id = isset( $atts['id'] ) ? intval( $atts['id'] ) : 0;
+		$h5p_id = isset( $atts['id'] ) ? (int)$atts['id'] : 0;
 
 		// H5P Content
 		if ( $h5p_id ) {
@@ -150,16 +151,14 @@ class H5P {
 				// Do nothing
 			}
 		}
-
 		// HTML
-		$html = $this->blade->render(
-			'interactive.shared', [
+		return $this->blade->render(
+			'interactive.h5p', [
 				'title' => $h5p_title,
 				'url' => $h5p_url,
+				'id' => $h5p_id ? '#'.self::SHORTCODE.'-'.$h5p_id : ''
 			]
 		);
-
-		return $html;
 	}
 
 	/**
@@ -222,6 +221,17 @@ class H5P {
 			}
 		}
 		return $ids;
+	}
+
+	/**
+	 * This hook add a HTML wrapper to identify each hp5 activity
+	 * @param $html
+	 * @param $content array this array holds the custom post type information (h5p)
+	 * @return string
+	 */
+	public function generateCustomH5pWrapper($html, array $content)
+	{
+		return '<div id="'.self::SHORTCODE.'-' .$content['id']. '">'.$html.'</div>';
 	}
 
 }

--- a/inc/modules/export/htmlbook/class-htmlbook.php
+++ b/inc/modules/export/htmlbook/class-htmlbook.php
@@ -533,7 +533,7 @@ class HTMLBook extends Export {
 				if ( $fragment ) {
 					// Check if a fragment is considered external, don't change the URL if we find a match
 					$external_anchors = [ \Pressbooks\Interactive\Content::ANCHOR ];
-					if ( in_array( "#{$fragment}", $external_anchors, true ) ) {
+					if ( in_array( "#{$fragment}", $external_anchors, true ) || str_starts_with( $fragment, 'h5p' ) ) {
 						continue;
 					} else {
 						$link->setAttribute( 'href', "#{$fragment}" );

--- a/inc/modules/export/xhtml/class-xhtml11.php
+++ b/inc/modules/export/xhtml/class-xhtml11.php
@@ -708,7 +708,7 @@ class Xhtml11 extends ExportGenerator {
 				if ( $fragment ) {
 					// Check if a fragment is considered external, don't change the URL if we find a match
 					$external_anchors = [ \Pressbooks\Interactive\Content::ANCHOR ];
-					if ( in_array( "#{$fragment}", $external_anchors, true ) ) {
+					if ( in_array( "#{$fragment}", $external_anchors, true ) || str_starts_with( $fragment, 'h5p' ) ) {
 						continue;
 					} else {
 						$link->setAttribute( 'href', "#{$fragment}" );

--- a/templates/interactive/h5p.blade.php
+++ b/templates/interactive/h5p.blade.php
@@ -1,0 +1,6 @@
+<div class="textbox interactive-content">
+	<span class="interactive-content__icon"></span>
+	<p>{{ __( 'An interactive H5P element has been excluded from this version of the text. You can view it online here:', 'pressbooks' ) }}
+		<a href="{{ $url.$id }}" title="{{ $title }}">{{ $url }}</a>
+	</p>
+</div>


### PR DESCRIPTION
Related Issue https://github.com/pressbooks/ideas/issues/356

This change adds a custom anchor name instead the default one #pb-interactive-content for h5p activities, with this change users will be able to link a specific activity from anywhere.

## Note

This change will require an upstream change into the h5p plugin I already sent a [PR](https://github.com/h5p/h5p-wordpress-plugin/pull/122)

### How to test it

1. Meanwhile the upstream change gets merged you should modify directly the plugin in your vendor directory in order to add the custom hook to append the desired anchor into the output, doing the changes the upstream [PR](https://github.com/h5p/h5p-wordpress-plugin/pull/122)

2. Create some h5p activities and export your book, see your new anchors and review if they link you directly to the activity
3. Remember you can't add the same h5p activities in the same chapter or page because both are going to have the same anchor because are the same thing.
4. All the anchors will follow the following structure: `#h5p-ID` where ID is the activity identifier.

