### PR TITLE
Fixed anchor sanitization and the failing fonts test

### DIFF
--- a/inc/admin/metaboxes/namespace.php
+++ b/inc/admin/metaboxes/namespace.php
@@ -435,7 +435,7 @@ function add_meta_boxes() {
 			'label' => __( 'Short Description', 'pressbooks' ),
 			'description' => __( 'A short paragraph about your book, for catalogs, reviewers etc. to quote.', 'pressbooks' ),
 			'sanitize_callback' => function ( ...$args ) {
-				return sanitize_string( $args[ METADATA_CALLBACK_INDEX ] );
+				return sanitize_string( $args[ METADATA_CALLBACK_INDEX ], true );
 			},
 		]
 	);

--- a/inc/sanitize/namespace.php
+++ b/inc/sanitize/namespace.php
@@ -827,6 +827,6 @@ function maybe_safer_unserialize( $original ) {
  */
 function sanitize_string( $value, $allow_html = false ) {
 
-	return $allow_html ? HtmLawed::filter( pb_decode( wp_kses_stripslashes( $value ) ), [ 'safe' => 1 ] ) : strip_tags( pb_decode( $value ) );
+	return $allow_html ? HtmLawed::filter( pb_decode( stripslashes_from_strings_only( $value ) ), [ 'safe' => 1 ] ) : strip_tags( pb_decode( $value ) );
 
 }

--- a/inc/sanitize/namespace.php
+++ b/inc/sanitize/namespace.php
@@ -827,6 +827,6 @@ function maybe_safer_unserialize( $original ) {
  */
 function sanitize_string( $value, $allow_html = false ) {
 
-	return $allow_html ? HtmLawed::filter( pb_decode( $value ), [ 'safe' => 1 ] ) : strip_tags( pb_decode( $value ) );
+	return $allow_html ? HtmLawed::filter( pb_decode( wp_kses_stripslashes( $value ) ), [ 'safe' => 1 ] ) : strip_tags( pb_decode( $value ) );
 
 }

--- a/tests/test-book.php
+++ b/tests/test-book.php
@@ -389,5 +389,11 @@ class BookTest extends \WP_UnitTestCase {
 		$value = $c->get_metadata_field_value( $copyright_field, $field, 'metadata', $mp->ID );
 		$this->assertEquals( '<img src="#" alt="image" /> hello xss', $value[0] );
 
+		$field = $c->get_field( $about_extended_field, 'about-the-book', 'metadata' );
+		$_POST[ $about_extended_field ] = '<a href="https://pressbooks.org">Link</a>';
+		$c->save_metadata_field( $about_extended_field, $field, 'metadata', $mp->ID );
+		$value = $c->get_metadata_field_value( $about_extended_field, $field, 'metadata', $mp->ID );
+		$this->assertEquals( '<a href="https://pressbooks.org">Link</a>', $value[0] );
+
 	}
 }

--- a/tests/test-book.php
+++ b/tests/test-book.php
@@ -371,7 +371,7 @@ class BookTest extends \WP_UnitTestCase {
 		$_POST[ $about_field ] = $xss_string;
 		$c->save_metadata_field( $about_field, $field, 'metadata', $mp->ID );
 		$value = $c->get_metadata_field_value( $about_field, $field, 'metadata', $mp->ID );
-		$this->assertEquals( ' hello xss', $value[0] );
+		$this->assertEquals( '<img src="#" alt="image" /> hello xss', $value[0] );
 
 		$about_extended_field = 'pb_about_unlimited';
 

--- a/tests/test-globaltypography.php
+++ b/tests/test-globaltypography.php
@@ -80,15 +80,14 @@ class GlobalTypographyTest extends \WP_UnitTestCase {
 		foreach ( $fontpacks as $val ) {
 			$baseurl = $val['baseurl'];
 			foreach ( $val['files'] as $font => $font_url ) {
-				$status = '404 Not Found';
 				$url = $baseurl . $font_url;
 				$headers = wp_get_http_headers( $url );
-				if ( $headers && isset( $headers['status'] ) ) {
-					$status = $headers['status'];
+				if ( $headers && isset( $headers['location'] ) ) {
+					$font_url = $headers['location'];
 				} else {
 					$this->assertTrue( false, "Cannot download: {$url}" );
 				}
-				$this->assertNotContains( $status, '404', "404 Not Found: {$url}" );
+				$this->assertContains( "https://raw.githubusercontent.com", $font_url );
 			}
 		}
 	}

--- a/tests/test-sanitize.php
+++ b/tests/test-sanitize.php
@@ -592,10 +592,13 @@ RAW;
 		$test = \Pressbooks\Sanitize\sanitize_string( $test, true );
 		$this->assertEquals( '<img src="denied:javascript:alert(" alt="image" />', $test );
 
-		$test = '\<a onmouseover="alert(document.cookie)"\>xxs link\</a\>';
+		$test = '<a onmouseover="alert(document.cookie)">xxs link</a\>';
 		$test = \Pressbooks\Sanitize\sanitize_string( $test, true );
-		$this->assertEquals( '\<a>xxs link\</a>', $test );
+		$this->assertEquals( '<a>xxs link</a>', $test );
 
+		$test = '<a href="https://pressbooks.org" onmouseover="alert(document.cookie)">xxs link</a>';
+		$test = \Pressbooks\Sanitize\sanitize_string( $test, true );
+		$this->assertEquals( '<a href="https://pressbooks.org">xxs link</a>', $test );
 	}
 
 }


### PR DESCRIPTION
Related issue #2088 

### Problem

When links are being saved all the attributes quotes are being scaped this was not allowing`HtmLawed` to recognize a valid href schema.

### Solution

I added a `wp_kses_stripslashes` on the sanitization function that will only remove scaped quotes in html attributes that needs to be sanitized

Also two unit test assertions were added

### How to test

1. Try to save an anchor link into the fields allows HTML with some XSS strings
2. Wellformed urls will be saved in the href attribute other malicious tags should be striped