### PR TITLE
test: try GitHub actions for PHPUnit

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -2,7 +2,7 @@ name: PHPUnit
 
 on:
   push:
-    branches: [ dev, master ]
+    branches: [ dev, master, github-actions ]
   pull_request:
     branches: [ dev ]
 
@@ -16,9 +16,21 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Install dependencies
+
+    - name: Cache Composer packages
+      id: composer-cache
+      uses: actions/cache@v2
+      with:
+        path: vendor
+        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-php-
+  
+    - name: Install Composer packages
       run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+
     - name: Install WP tests
       run: bash bin/install-wp-tests.sh wordpress_test root root localhost latest
+
     - name: Run tests
       run: composer test

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        php: [7.4, 7.3, 7.2]
+        php: [7.4, 7.3]
         os: [ubuntu-latest]
 
     name: PHPUnit - ${{ matrix.php }}

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -18,15 +18,6 @@ jobs:
 
     name: PHPUnit - ${{ matrix.php }}
 
-    services:
-      mysql:
-          image: mysql:5.7
-          env:
-              MYSQL_ALLOW_EMPTY_PASSWORD: yes
-              MYSQL_DATABASE: wordpress_test
-          ports:
-              - 3306
-
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -34,6 +25,7 @@ jobs:
     - name: Install OS dependencies
       run: |
         sudo apt-get install libxml2-utils ghostscript poppler-utils
+        sudo systemctl start mysql.service
         wget https://github.com/w3c/epubcheck/releases/download/v${{ matrix.epubcheck }}/epubcheck-${{ matrix.epubcheck }}.zip
         unzip epubcheck-${{ matrix.epubcheck }}.zip -d /opt/
         mv /opt/epubcheck-${{ matrix.epubcheck }} /opt/epubcheck
@@ -60,7 +52,7 @@ jobs:
       run: composer install
 
     - name: Install WP tests
-      run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1:3306 latest
+      run: bash bin/install-wp-tests.sh wordpress_test root root localhost latest
 
     - name: Run tests
       run: composer test

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -11,23 +11,41 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: ['ubuntu-latest']
-        php-versions: ['7.3', '7.4']
+        php: [7.4, 7.3, 7.2]
+        os: [ubuntu-latest]
+
+    name: PHPUnit - ${{ matrix.php }}
+
+    services:
+      mysql:
+          image: mysql:5.7
+          env:
+              MYSQL_ALLOW_EMPTY_PASSWORD: yes
+              MYSQL_DATABASE: wordpress_test
+          ports:
+              - 3306
 
     steps:
+    - name: Checkout code
     - uses: actions/checkout@v2
 
-    - name: Cache Composer packages
+    - name: Cache dependencies
       id: composer-cache
       uses: actions/cache@v2
       with:
         path: vendor
-        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-php-
-  
+        key: ${{ matrix.php }}-php-${{ hashFiles('**/composer.lock') }}
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php }}
+
+    - name: Downgrade Composer to 1.x
+      run: composer self-update --1
+
     - name: Install Composer packages
-      run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+      run: composer install -q --no-ansi --no-interaction --no-progress --prefer-dist
 
     - name: Install WP tests
       run: bash bin/install-wp-tests.sh wordpress_test root root localhost latest

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -29,7 +29,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
-    - name: Cache dependencies
+    - name: Install OS dependencies
+      run: sudo apt-get install default-jdk libxml2-utils ghostscript imagemagick poppler-utils unzip
+
+    - name: Cache Composer packages
       uses: actions/cache@v2
       with:
         path: vendor
@@ -44,7 +47,7 @@ jobs:
       run: composer self-update --1
 
     - name: Install Composer packages
-      run: composer install -q --no-ansi --no-interaction --no-progress --prefer-dist
+      run: composer install
 
     - name: Install WP tests
       run: bash bin/install-wp-tests.sh wordpress_test root root localhost latest

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -12,7 +12,9 @@ jobs:
     strategy:
       matrix:
         php: [7.4, 7.3]
-        os: [ubuntu-latest]
+        os: [ubuntu-18.04]
+        epubcheck: [4.2.4]
+        prince: [12.5.1-1]
 
     name: PHPUnit - ${{ matrix.php }}
 
@@ -30,7 +32,15 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Install OS dependencies
-      run: sudo apt-get install default-jdk libxml2-utils ghostscript imagemagick poppler-utils unzip
+      run: |
+        sudo apt-get install libxml2-utils ghostscript poppler-utils
+        wget https://github.com/w3c/epubcheck/releases/download/v${{ matrix.epubcheck }}/epubcheck-${{ matrix.epubcheck }}.zip
+        unzip epubcheck-${{ matrix.epubcheck }}.zip -d /opt/
+        mv /opt/epubcheck-${{ matrix.epubcheck }} /opt/epubcheck
+        rm epubcheck-${{ matrix.epubcheck }}.zip
+        wget https://www.princexml.com/download/${{ matrix.prince }}_ubuntu18.04_amd64.deb
+        sudo dpkg -i ${{ matrix.prince }}_ubuntu18.04_amd64.deb
+        rm ${{ matrix.prince }}_ubuntu18.04_amd64.deb
 
     - name: Cache Composer packages
       uses: actions/cache@v2
@@ -50,7 +60,7 @@ jobs:
       run: composer install
 
     - name: Install WP tests
-      run: bash bin/install-wp-tests.sh wordpress_test root root localhost latest
+      run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1:3306 latest
 
     - name: Run tests
       run: composer test

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -38,7 +38,7 @@ jobs:
         unzip epubcheck-${{ matrix.epubcheck }}.zip -d /opt/
         mv /opt/epubcheck-${{ matrix.epubcheck }} /opt/epubcheck
         rm epubcheck-${{ matrix.epubcheck }}.zip
-        wget https://www.princexml.com/download/${{ matrix.prince }}_ubuntu18.04_amd64.deb
+        wget https://www.princexml.com/download/prince_${{ matrix.prince }}_ubuntu18.04_amd64.deb
         sudo dpkg -i ${{ matrix.prince }}_ubuntu18.04_amd64.deb
         rm ${{ matrix.prince }}_ubuntu18.04_amd64.deb
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,4 +1,4 @@
-name: CI
+name: PHPUnit
 
 on:
   push:
@@ -8,16 +8,17 @@ on:
 
 jobs:
   build-test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: ['ubuntu-latest']
+        php-versions: ['7.3', '7.4']
 
     steps:
     - uses: actions/checkout@v2
-
-    - name: Install Dependencies
+    - name: Install dependencies
       run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
-      
-    - name: Install WP Tests
+    - name: Install WP tests
       run: bash bin/install-wp-tests.sh wordpress_test root root localhost latest
-      
-    - name: Run Tests
+    - name: Run tests
       run: composer test

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -38,9 +38,10 @@ jobs:
         unzip epubcheck-${{ matrix.epubcheck }}.zip -d /opt/
         mv /opt/epubcheck-${{ matrix.epubcheck }} /opt/epubcheck
         rm epubcheck-${{ matrix.epubcheck }}.zip
-        wget https://www.princexml.com/download/prince_${{ matrix.prince }}_ubuntu18.04_amd64.deb
-        sudo dpkg -i ${{ matrix.prince }}_ubuntu18.04_amd64.deb
-        rm ${{ matrix.prince }}_ubuntu18.04_amd64.deb
+        prince_os=${matrix.os | sed 's/-//g'}
+        wget https://www.princexml.com/download/prince_${{ matrix.prince }}_${{ prince_os }}_amd64.deb
+        sudo dpkg -i prince_${{ matrix.prince }}_${{ prince_os }}_amd64.deb
+        rm prince_${{ matrix.prince }}_${{ prince_os }}_amd64.deb
 
     - name: Cache Composer packages
       uses: actions/cache@v2

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   phpunit:
-    runs-on: ${{ matrix.operating-system }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         php: [7.4, 7.3, 7.2]

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -2,7 +2,7 @@ name: PHPUnit
 
 on:
   push:
-    branches: [ dev, master, github-actions ]
+    branches: [ dev, master ]
   pull_request:
     branches: [ dev ]
 
@@ -68,13 +68,13 @@ jobs:
     - name: Install WP tests
       run: bash bin/install-wp-tests.sh wordpress_test root root localhost latest
 
+    - name: Run tests
+      run: vendor/bin/phpunit --configuration phpunit.xml
+      if: matrix.php != 7.3
+
     - name: Run tests with coverage
       run: vendor/bin/phpunit --configuration phpunit.xml --coverage-clover coverage.xml
       if: matrix.php == 7.3
-
-    - name: Run tests without coverage
-      run: vendor/bin/phpunit --configuration phpunit.xml
-      if: matrix.php != 7.3
 
     # TODO: Enable this once Travis is disabled.
     # - name: Upload coverage to Codecov

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -46,7 +46,7 @@ jobs:
         php-version: ${{ matrix.php }}
         tools: composer:v1
         coverage: none
-      if: ${{ matrix.php }} != 7.3
+      if: matrix.php != 7.3
 
     - name: Setup PHP with coverage
       uses: shivammathur/setup-php@v2
@@ -54,7 +54,7 @@ jobs:
         php-version: ${{ matrix.php }}
         tools: composer:v1
         coverage: pcov
-      if: ${{ matrix.php }} == 7.3
+      if: matrix.php == 7.3
 
     - name: Install Composer packages
       run: composer install
@@ -63,18 +63,18 @@ jobs:
       run: |
         composer require pcov/clobber
         vendor/bin/pcov clobber
-      if: ${{ matrix.php }} == 7.3
+      if: matrix.php == 7.3
 
     - name: Install WP tests
       run: bash bin/install-wp-tests.sh wordpress_test root root localhost latest
 
     - name: Run tests with coverage
       run: vendor/bin/phpunit --configuration phpunit.xml --coverage-clover coverage.xml
-      if: ${{ matrix.php }} == 7.3
+      if: matrix.php == 7.3
 
     - name: Run tests without coverage
       run: vendor/bin/phpunit --configuration phpunit.xml
-      if: ${{ matrix.php }} != 7.3
+      if: matrix.php != 7.3
 
     # TODO: Enable this once Travis is disabled.
     # - name: Upload coverage to Codecov

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -2,7 +2,7 @@ name: PHPUnit
 
 on:
   push:
-    branches: [ dev, master ]
+    branches: [ dev, master, github-actions ]
   pull_request:
     branches: [ dev ]
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        php: [7.4, 7.3]
+        php: [7.3]
         os: [ubuntu-18.04]
         epubcheck: [4.2.4]
         prince: [12.5-1]

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -56,14 +56,14 @@ jobs:
         coverage: pcov
       if: ${{ matrix.php }} == 7.3
 
+    - name: Install Composer packages
+      run: composer install
+
     - name: Setup PCOV
       run: |
         composer require pcov/clobber
         vendor/bin/pcov clobber
       if: ${{ matrix.php }} == 7.3
-
-    - name: Install Composer packages
-      run: composer install
 
     - name: Install WP tests
       run: bash bin/install-wp-tests.sh wordpress_test root root localhost latest

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -44,9 +44,23 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php }}
+        tools: composer:v1
+        coverage: none
+      if: ${{ matrix.php }} != 7.3
 
-    - name: Downgrade Composer to 1.x
-      run: composer self-update --1
+    - name: Setup PHP with coverage
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php }}
+        tools: composer:v1
+        coverage: pcov
+      if: ${{ matrix.php }} == 7.3
+
+    - name: Setup PCOV
+      run: |
+        composer require pcov/clobber
+        vendor/bin/pcov clobber
+      if: ${{ matrix.php }} == 7.3
 
     - name: Install Composer packages
       run: composer install
@@ -54,5 +68,14 @@ jobs:
     - name: Install WP tests
       run: bash bin/install-wp-tests.sh wordpress_test root root localhost latest
 
-    - name: Run tests
-      run: composer test
+    - name: Run tests with coverage
+      run: vendor/bin/phpunit --configuration phpunit.xml --coverage-clover coverage.xml
+      if: ${{ matrix.php }} == 7.3
+
+    - name: Run tests without coverage
+      run: vendor/bin/phpunit --configuration phpunit.xml
+      if: ${{ matrix.php }} != 7.3
+
+    # - name: Upload coverage to Codecov
+    #   uses: codecov/codecov-action@v1
+    #   if: ${{ matrix.php }} == 7.3

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        php: [7.3]
+        php: [7.3] # TODO: Add 7.4 and fix the errors.
         os: [ubuntu-18.04]
         epubcheck: [4.2.4]
         prince: [12.5-1]
@@ -76,6 +76,7 @@ jobs:
       run: vendor/bin/phpunit --configuration phpunit.xml
       if: ${{ matrix.php }} != 7.3
 
+    # TODO: Enable this once Travis is disabled.
     # - name: Upload coverage to Codecov
     #   uses: codecov/codecov-action@v1
     #   if: ${{ matrix.php }} == 7.3

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -14,7 +14,7 @@ jobs:
         php: [7.4, 7.3]
         os: [ubuntu-18.04]
         epubcheck: [4.2.4]
-        prince: [12.5.1-1]
+        prince: [12.5-1]
 
     name: PHPUnit - ${{ matrix.php }}
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -7,7 +7,7 @@ on:
     branches: [ dev ]
 
 jobs:
-  build-test:
+  phpunit:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
@@ -27,10 +27,9 @@ jobs:
 
     steps:
     - name: Checkout code
-    - uses: actions/checkout@v2
+      uses: actions/checkout@v2
 
     - name: Cache dependencies
-      id: composer-cache
       uses: actions/cache@v2
       with:
         path: vendor

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -15,6 +15,7 @@ jobs:
         os: [ubuntu-18.04]
         epubcheck: [4.2.4]
         prince: [12.5-1]
+        wordpress: [5.6.2]
 
     name: PHPUnit - ${{ matrix.php }}
 
@@ -66,7 +67,7 @@ jobs:
       if: matrix.php == 7.3
 
     - name: Install WP tests
-      run: bash bin/install-wp-tests.sh wordpress_test root root localhost latest
+      run: bash bin/install-wp-tests.sh wordpress_test root root localhost ${{ matrix.wordpress }}
 
     - name: Run tests
       run: vendor/bin/phpunit --configuration phpunit.xml

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [ dev, master ]
+  pull_request:
+    branches: [ dev ]
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Dependencies
+      run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+      
+    - name: Install WP Tests
+      run: bash bin/install-wp-tests.sh wordpress_test root root localhost latest
+      
+    - name: Run Tests
+      run: composer test

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -38,10 +38,9 @@ jobs:
         unzip epubcheck-${{ matrix.epubcheck }}.zip -d /opt/
         mv /opt/epubcheck-${{ matrix.epubcheck }} /opt/epubcheck
         rm epubcheck-${{ matrix.epubcheck }}.zip
-        prince_os=${matrix.os | sed 's/-//g'}
-        wget https://www.princexml.com/download/prince_${{ matrix.prince }}_${{ prince_os }}_amd64.deb
-        sudo dpkg -i prince_${{ matrix.prince }}_${{ prince_os }}_amd64.deb
-        rm prince_${{ matrix.prince }}_${{ prince_os }}_amd64.deb
+        wget https://www.princexml.com/download/prince_${{ matrix.prince }}_ubuntu18.04_amd64.deb
+        sudo dpkg -i prince_${{ matrix.prince }}_ubuntu18.04_amd64.deb
+        rm prince_${{ matrix.prince }}_ubuntu18.04_amd64.deb
 
     - name: Cache Composer packages
       uses: actions/cache@v2


### PR DESCRIPTION
This PR adds a simple Github Action for running PHPUnit tests. It does not change the current Travis CI configuration at all, but could be seen as a starting point for migrating to Github Actions for all CI.

Workflow results can be seen here: https://github.com/greatislander/pressbooks/actions/workflows/phpunit.yml