### PR TITLE
Add Log module for track information in S3 and/or cloudwatch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,10 @@
 		"vanilla/htmlawed": "^2.2",
 		"docraptor/docraptor": "1.3",
 		"fale/isbn": "^3.0",
-		"sentry/sdk": "2.1.0"
+		"sentry/sdk": "2.1.0",
+		"aws/aws-sdk-php": "^3.173",
+		"monolog/monolog": "^2.2",
+		"maxbanton/cwh": "^2.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,19 +4,104 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f0ce557cd6cb5c667719526bcaf6f466",
+    "content-hash": "0b967ff08d09beb07e673d0252c143b0",
     "packages": [
+        {
+            "name": "aws/aws-sdk-php",
+            "version": "3.173.19",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/aws/aws-sdk-php.git",
+                "reference": "63c6feca49bf4083f33bf250401c0c286759e101"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/63c6feca49bf4083f33bf250401c0c286759e101",
+                "reference": "63c6feca49bf4083f33bf250401c0c286759e101",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-simplexml": "*",
+                "guzzlehttp/guzzle": "^5.3.3|^6.2.1|^7.0",
+                "guzzlehttp/promises": "^1.0",
+                "guzzlehttp/psr7": "^1.4.1",
+                "mtdowling/jmespath.php": "^2.5",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "andrewsville/php-token-reflection": "^1.4",
+                "aws/aws-php-sns-message-validator": "~1.0",
+                "behat/behat": "~3.0",
+                "doctrine/cache": "~1.4",
+                "ext-dom": "*",
+                "ext-openssl": "*",
+                "ext-pcntl": "*",
+                "ext-sockets": "*",
+                "nette/neon": "^2.3",
+                "paragonie/random_compat": ">= 2",
+                "phpunit/phpunit": "^4.8.35|^5.4.3",
+                "psr/cache": "^1.0",
+                "psr/simple-cache": "^1.0",
+                "sebastian/comparator": "^1.2.3"
+            },
+            "suggest": {
+                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
+                "doctrine/cache": "To use the DoctrineCacheAdapter",
+                "ext-curl": "To send requests using cURL",
+                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",
+                "ext-sockets": "To use client-side monitoring"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Aws\\": "src/"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Amazon Web Services",
+                    "homepage": "http://aws.amazon.com"
+                }
+            ],
+            "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
+            "homepage": "http://aws.amazon.com/sdkforphp",
+            "keywords": [
+                "amazon",
+                "aws",
+                "cloud",
+                "dynamodb",
+                "ec2",
+                "glacier",
+                "s3",
+                "sdk"
+            ],
+            "time": "2021-03-01T19:15:59+00:00"
+        },
         {
             "name": "clue/stream-filter",
             "version": "v1.4.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/clue/php-stream-filter.git",
+                "url": "https://github.com/clue/stream-filter.git",
                 "reference": "5a58cc30a8bd6a4eb8f856adf61dd3e013f53f71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/clue/php-stream-filter/zipball/5a58cc30a8bd6a4eb8f856adf61dd3e013f53f71",
+                "url": "https://api.github.com/repos/clue/stream-filter/zipball/5a58cc30a8bd6a4eb8f856adf61dd3e013f53f71",
                 "reference": "5a58cc30a8bd6a4eb8f856adf61dd3e013f53f71",
                 "shasum": ""
             },
@@ -1374,6 +1459,197 @@
                 "xml"
             ],
             "time": "2019-07-25T07:03:26+00:00"
+        },
+        {
+            "name": "maxbanton/cwh",
+            "version": "v2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/maxbanton/cwh.git",
+                "reference": "55445da8e6cb62f3ce7cb186c23c848b270134ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/maxbanton/cwh/zipball/55445da8e6cb62f3ce7cb186c23c848b270134ca",
+                "reference": "55445da8e6cb62f3ce7cb186c23c848b270134ca",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-sdk-php": "^3.18",
+                "monolog/monolog": "^2.0",
+                "php": "^7.2 || ^8"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5 || ^9.4",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "suggest": {
+                "maxbanton/dd": "Minimalistic dump-and-die function for easy debugging"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Maxbanton\\Cwh\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Max Leonov",
+                    "email": "hi@maxleonov.pw",
+                    "homepage": "https://maxleonov.pw"
+                }
+            ],
+            "description": "AWS CloudWatch Handler for Monolog library",
+            "homepage": "https://github.com/maxbanton/cwh",
+            "keywords": [
+                "aws",
+                "cloudwatch",
+                "monolog"
+            ],
+            "time": "2020-11-17T15:34:20+00:00"
+        },
+        {
+            "name": "monolog/monolog",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "1cb1cde8e8dd0f70cc0fe51354a59acad9302084"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/1cb1cde8e8dd0f70cc0fe51354a59acad9302084",
+                "reference": "1cb1cde8e8dd0f70cc0fe51354a59acad9302084",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2",
+                "psr/log": "^1.0.1"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                "doctrine/couchdb": "~1.0@dev",
+                "elasticsearch/elasticsearch": "^7",
+                "graylog2/gelf-php": "^1.4.2",
+                "mongodb/mongodb": "^1.8",
+                "php-amqplib/php-amqplib": "~2.4",
+                "php-console/php-console": "^3.1.3",
+                "phpspec/prophecy": "^1.6.1",
+                "phpstan/phpstan": "^0.12.59",
+                "phpunit/phpunit": "^8.5",
+                "predis/predis": "^1.1",
+                "rollbar/rollbar": "^1.3",
+                "ruflin/elastica": ">=0.90 <7.0.1",
+                "swiftmailer/swiftmailer": "^5.3|^6.0"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-mbstring": "Allow to work properly with unicode symbols",
+                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                "php-console/php-console": "Allow sending log messages to Google Chrome",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "https://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "time": "2020-12-14T13:15:25+00:00"
+        },
+        {
+            "name": "mtdowling/jmespath.php",
+            "version": "2.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jmespath/jmespath.php.git",
+                "reference": "42dae2cbd13154083ca6d70099692fef8ca84bfb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/42dae2cbd13154083ca6d70099692fef8ca84bfb",
+                "reference": "42dae2cbd13154083ca6d70099692fef8ca84bfb",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.4 || ^7.0 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.17"
+            },
+            "require-dev": {
+                "composer/xdebug-handler": "^1.4",
+                "phpunit/phpunit": "^4.8.36 || ^7.5.15"
+            },
+            "bin": [
+                "bin/jp.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "JmesPath\\": "src/"
+                },
+                "files": [
+                    "src/JmesPath.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Declaratively specify how to extract elements from a JSON document",
+            "keywords": [
+                "json",
+                "jsonpath"
+            ],
+            "time": "2020-07-31T21:01:56+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -3117,6 +3393,178 @@
             "time": "2018-07-08T19:19:57+00:00"
         },
         {
+            "name": "php-mock/php-mock",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-mock/php-mock.git",
+                "reference": "a3142f257153b71c09bf9146ecf73430b3818b7c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-mock/php-mock/zipball/a3142f257153b71c09bf9146ecf73430b3818b7c",
+                "reference": "a3142f257153b71c09bf9146ecf73430b3818b7c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0 || ^8.0",
+                "phpunit/php-text-template": "^1 || ^2"
+            },
+            "replace": {
+                "malkusch/php-mock": "*"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.0 || ^9.0",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "suggest": {
+                "php-mock/php-mock-phpunit": "Allows integration into PHPUnit testcase with the trait PHPMock."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "autoload.php"
+                ],
+                "psr-4": {
+                    "phpmock\\": [
+                        "classes/",
+                        "tests/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "WTFPL"
+            ],
+            "authors": [
+                {
+                    "name": "Markus Malkusch",
+                    "email": "markus@malkusch.de",
+                    "homepage": "http://markus.malkusch.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP-Mock can mock built-in PHP functions (e.g. time()). PHP-Mock relies on PHP's namespace fallback policy. No further extension is needed.",
+            "homepage": "https://github.com/php-mock/php-mock",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "function",
+                "mock",
+                "stub",
+                "test",
+                "test double"
+            ],
+            "time": "2020-12-11T19:20:04+00:00"
+        },
+        {
+            "name": "php-mock/php-mock-integration",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-mock/php-mock-integration.git",
+                "reference": "003d585841e435958a02e9b986953907b8b7609b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-mock/php-mock-integration/zipball/003d585841e435958a02e9b986953907b8b7609b",
+                "reference": "003d585841e435958a02e9b986953907b8b7609b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "php-mock/php-mock": "^2.2",
+                "phpunit/php-text-template": "^1 || ^2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7.27 || ^6 || ^7 || ^8 || ^9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "phpmock\\integration\\": "classes/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "WTFPL"
+            ],
+            "authors": [
+                {
+                    "name": "Markus Malkusch",
+                    "email": "markus@malkusch.de",
+                    "homepage": "http://markus.malkusch.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Integration package for PHP-Mock",
+            "homepage": "https://github.com/php-mock/php-mock-integration",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "function",
+                "mock",
+                "stub",
+                "test",
+                "test double"
+            ],
+            "time": "2020-02-08T14:40:25+00:00"
+        },
+        {
+            "name": "php-mock/php-mock-phpunit",
+            "version": "2.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-mock/php-mock-phpunit.git",
+                "reference": "2877a0e58f12e91b64bf36ccd080a209dcbf6c30"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-mock/php-mock-phpunit/zipball/2877a0e58f12e91b64bf36ccd080a209dcbf6c30",
+                "reference": "2877a0e58f12e91b64bf36ccd080a209dcbf6c30",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7",
+                "php-mock/php-mock-integration": "^2.1",
+                "phpunit/phpunit": "^6 || ^7 || ^8 || ^9"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "autoload.php"
+                ],
+                "psr-4": {
+                    "phpmock\\phpunit\\": "classes/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "WTFPL"
+            ],
+            "authors": [
+                {
+                    "name": "Markus Malkusch",
+                    "email": "markus@malkusch.de",
+                    "homepage": "http://markus.malkusch.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Mock built-in PHP functions (e.g. time()) with PHPUnit. This package relies on PHP's namespace fallback policy. No further extension is needed.",
+            "homepage": "https://github.com/php-mock/php-mock-phpunit",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "function",
+                "mock",
+                "phpunit",
+                "stub",
+                "test",
+                "test double"
+            ],
+            "time": "2020-02-08T15:44:47+00:00"
+        },
+        {
             "name": "phpdocumentor/reflection-common",
             "version": "2.1.0",
             "source": {
@@ -3577,6 +4025,7 @@
             "keywords": [
                 "tokenizer"
             ],
+            "abandoned": true,
             "time": "2019-09-17T06:23:10+00:00"
         },
         {
@@ -4412,12 +4861,12 @@
             "version": "1.8.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
+                "url": "https://github.com/webmozarts/assert.git",
                 "reference": "ab2cb0b3b559010b75981b1bdce728da3ee90ad6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/ab2cb0b3b559010b75981b1bdce728da3ee90ad6",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/ab2cb0b3b559010b75981b1bdce728da3ee90ad6",
                 "reference": "ab2cb0b3b559010b75981b1bdce728da3ee90ad6",
                 "shasum": ""
             },
@@ -4502,10 +4951,10 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.1"
+        "php": ">=7.3"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.1"
+        "php": "7.3"
     }
 }

--- a/inc/log/class-cloudwatchprovider.php
+++ b/inc/log/class-cloudwatchprovider.php
@@ -4,6 +4,7 @@ namespace Pressbooks\Log;
 
 use Aws\CloudWatchLogs\CloudWatchLogsClient;
 use Aws\Credentials\CredentialProvider;
+use Isbn\Exception;
 use function Pressbooks\Utility\debug_error_log;
 use Maxbanton\Cwh\Handler\CloudWatch;
 use Monolog\Formatter\JsonFormatter;
@@ -113,17 +114,13 @@ class CloudWatchProvider implements StorageProvider {
 		return false;
 	}
 
-	public function setFilePath( string $file_path ) {
-		$this->file_path = $file_path;
-	}
-
 	public function store( array $data, string $file_header = null ) {
 		if ( $this->create() ) {
+			$data = $this->getDataFormat( $data );
 			try {
-				$data = $this->getDataFormat( $data );
 				$this->logger->debug( 'SAML Log', $data );
 				return true;
-			} catch ( AwsException $e ) {
+			} catch ( \Exception $e ) {
 				debug_error_log( 'Error saving logs in CloudWatch: ' . $e->getMessage() );
 			}
 		}

--- a/inc/log/class-cloudwatchprovider.php
+++ b/inc/log/class-cloudwatchprovider.php
@@ -2,12 +2,12 @@
 
 namespace Pressbooks\Log;
 
-use function Pressbooks\Utility\debug_error_log;
 use Aws\Credentials\CredentialProvider;
 use Aws\CloudWatchLogs\CloudWatchLogsClient;
+use function Pressbooks\Utility\debug_error_log;
 use Maxbanton\Cwh\Handler\CloudWatch;
-use Monolog\Logger;
 use Monolog\Formatter\JsonFormatter;
+use Monolog\Logger;
 
 class CloudWatchProvider implements StorageProvider {
 
@@ -62,8 +62,6 @@ class CloudWatchProvider implements StorageProvider {
 			$this->version = env( 'AWS_S3_VERSION' );
 			$this->access_key_id = env( 'AWS_ACCESS_KEY_ID' );
 			$this->secret_key = env( 'AWS_SECRET_ACCESS_KEY' );
-			$environment = env( 'WP_ENV' ) ? env( 'WP_ENV' ) : 'production';
-			$scheme = is_ssl() ? 'https' : 'http';
 			if ( is_null( $this->client ) ) {
 				$this->client = new CloudWatchLogsClient( [
 					'region' => $this->region,

--- a/inc/log/class-cloudwatchprovider.php
+++ b/inc/log/class-cloudwatchprovider.php
@@ -5,9 +5,9 @@ namespace Pressbooks\Log;
 use Aws\Credentials\CredentialProvider;
 use Aws\CloudWatchLogs\CloudWatchLogsClient;
 use function Pressbooks\Utility\debug_error_log;
-use Maxbanton\Cwh\Handler\CloudWatch;
 use Monolog\Formatter\JsonFormatter;
 use Monolog\Logger;
+use Maxbanton\Cwh\Handler\CloudWatch;
 
 class CloudWatchProvider implements StorageProvider {
 
@@ -128,7 +128,7 @@ class CloudWatchProvider implements StorageProvider {
 		return false;
 	}
 
-	public function getDataFormat($data ) {
+	public function getDataFormat( $data ) {
 		$scheme = is_ssl() ? 'https' : 'http';
 		$data['Environment'] = env( 'WP_ENV' ) ? env( 'WP_ENV' ) : 'production';
 		$data['Network'] = [

--- a/inc/log/class-cloudwatchprovider.php
+++ b/inc/log/class-cloudwatchprovider.php
@@ -4,7 +4,6 @@ namespace Pressbooks\Log;
 
 use Aws\CloudWatchLogs\CloudWatchLogsClient;
 use Aws\Credentials\CredentialProvider;
-use Isbn\Exception;
 use function Pressbooks\Utility\debug_error_log;
 use Maxbanton\Cwh\Handler\CloudWatch;
 use Monolog\Formatter\JsonFormatter;

--- a/inc/log/class-cloudwatchprovider.php
+++ b/inc/log/class-cloudwatchprovider.php
@@ -2,12 +2,12 @@
 
 namespace Pressbooks\Log;
 
-use Aws\Credentials\CredentialProvider;
 use Aws\CloudWatchLogs\CloudWatchLogsClient;
+use Aws\Credentials\CredentialProvider;
 use function Pressbooks\Utility\debug_error_log;
+use Maxbanton\Cwh\Handler\CloudWatch;
 use Monolog\Formatter\JsonFormatter;
 use Monolog\Logger;
-use Maxbanton\Cwh\Handler\CloudWatch;
 
 class CloudWatchProvider implements StorageProvider {
 
@@ -63,11 +63,13 @@ class CloudWatchProvider implements StorageProvider {
 			$this->access_key_id = env( 'AWS_ACCESS_KEY_ID' );
 			$this->secret_key = env( 'AWS_SECRET_ACCESS_KEY' );
 			if ( is_null( $this->client ) ) {
-				$this->client = new CloudWatchLogsClient( [
-					'region' => $this->region,
-					'version' => $this->version,
-					'credentials' => CredentialProvider::env(),
-				] );
+				$this->client = new CloudWatchLogsClient(
+					[
+						'region' => $this->region,
+						'version' => $this->version,
+						'credentials' => CredentialProvider::env(),
+					]
+				);
 				$this->handler = new CloudWatch(
 					$this->client,
 					self::GROUP,

--- a/inc/log/class-cloudwatchprovider.php
+++ b/inc/log/class-cloudwatchprovider.php
@@ -47,15 +47,34 @@ class CloudWatchProvider implements StorageProvider {
 	 */
 	private $logger;
 
-	const RETENTION_DAYS = 90;
+	/**
+	 * @var integer
+	 */
+	private $retention_days;
 
-	const GROUP = 'pressbooks-logs';
+	/**
+	 * @var string
+	 */
+	private $group;
 
-	const STREAM = 'pressbooks-plugin';
+	/**
+	 * @var string
+	 */
+	private $stream;
+
+	/**
+	 * @var string
+	 */
+	private $channel;
 
 	const AWS_CONFIG_FILENAME = 'does_not_exist.ini';
 
-	const CHANNEL = 'saml-logs';
+	public function __construct( int $retention_days, string $group, string $stream, string $channel ) {
+		$this->retention_days = $retention_days;
+		$this->group = $group;
+		$this->stream = $stream;
+		$this->channel = $channel;
+	}
 
 	private function create() {
 		if ( self::areEnvironmentVariablesPresent() && is_null( $this->client ) ) {
@@ -74,14 +93,14 @@ class CloudWatchProvider implements StorageProvider {
 					);
 					$this->handler = new CloudWatch(
 						$this->client,
-						self::GROUP,
-						self::STREAM,
-						self::RETENTION_DAYS,
+						$this->group,
+						$this->stream,
+						$this->retention_days,
 						10000,
 						[], // TODO: Implement tags
 					);
 					$this->handler->setFormatter( new JsonFormatter() );
-					$this->logger = new Logger( self::CHANNEL );
+					$this->logger = new Logger( $this->channel );
 					$this->logger->pushHandler( $this->handler );
 				} catch ( UnresolvedApiException $e ) {
 					debug_error_log( 'Error initializing Cloudwatch Storage Provider: ' . $e->getMessage() );

--- a/inc/log/class-cloudwatchprovider.php
+++ b/inc/log/class-cloudwatchprovider.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Pressbooks\Log;
+
+use function Pressbooks\Utility\debug_error_log;
+use Aws\Credentials\CredentialProvider;
+use Aws\CloudWatchLogs\CloudWatchLogsClient;
+use Maxbanton\Cwh\Handler\CloudWatch;
+use Monolog\Logger;
+use Monolog\Formatter\JsonFormatter;
+
+class CloudWatchProvider implements StorageProvider {
+
+	/**
+	 * @var string
+	 */
+	private $secret_key;
+
+	/**
+	 * @var string
+	 */
+	private $access_key_id;
+
+	/**
+	 * @var string
+	 */
+	private $version;
+
+	/**
+	 * @var string
+	 */
+	private $region;
+
+	/**
+	 * @var CloudWatchLogsClient
+	 */
+	private $client;
+
+	/**
+	 * @var CloudWatch
+	 */
+	private $handler;
+
+	/**
+	 * @var Logger
+	 */
+	private $logger;
+
+	const RETENTION_DAYS = 90;
+
+	const GROUP = 'pressbooks-logs';
+
+	const STREAM = 'pressbooks-plugin';
+
+	const AWS_CONFIG_FILENAME = 'does_not_exist.ini';
+
+	const CHANNEL = 'saml-logs';
+
+	private function create() {
+		if ( self::areEnvironmentVariablesPresent() && is_null( $this->client ) ) {
+			$this->region = env( 'AWS_S3_REGION' );
+			$this->version = env( 'AWS_S3_VERSION' );
+			$this->access_key_id = env( 'AWS_ACCESS_KEY_ID' );
+			$this->secret_key = env( 'AWS_SECRET_ACCESS_KEY' );
+			$environment = env( 'WP_ENV' ) ? env( 'WP_ENV' ) : 'production';
+			$scheme = is_ssl() ? 'https' : 'http';
+			if ( is_null( $this->client ) ) {
+				$this->client = new CloudWatchLogsClient( [
+					'region' => $this->region,
+					'version' => $this->version,
+					'credentials' => CredentialProvider::env(),
+				] );
+				$this->handler = new CloudWatch(
+					$this->client,
+					self::GROUP,
+					self::STREAM,
+					self::RETENTION_DAYS,
+					10000,
+					[], // TODO: Implement tags
+				);
+				$this->handler->setFormatter( new JsonFormatter() );
+				$this->logger = new Logger( self::CHANNEL );
+				$this->logger->pushHandler( $this->handler );
+			}
+			return true;
+		} else {
+			debug_error_log( 'Error initializing S3 Storage Provider: Some environment variables are not present.' );
+		}
+		return ! is_null( $this->client ) && ! is_null( $this->handler );
+	}
+
+	/**
+	 * NOTE: We will use the same environment variables for OIDC plugin temporary.
+	 *
+	 * @return bool
+	 */
+	public static function areEnvironmentVariablesPresent() {
+		if (
+			! is_null( env( 'LOG_LOGIN_ATTEMPTS' ) ) &&
+			! is_null( env( 'AWS_SECRET_ACCESS_KEY' ) ) &&
+			! is_null( env( 'AWS_ACCESS_KEY_ID' ) ) &&
+			! is_null( env( 'AWS_S3_VERSION' ) ) &&
+			! is_null( env( 'AWS_S3_REGION' ) )
+		) {
+			if ( is_null( env( 'AWS_CONFIG_FILE' ) ) ) {
+				// this is an env variable needed for AWS SDK
+				putenv( 'AWS_CONFIG_FILE=' . __DIR__ . '/' . self::AWS_CONFIG_FILENAME );
+			}
+			return true;
+		} else {
+			debug_error_log( 'Error initializing S3 Storage Provider: Some environment variables are not present.' );
+		}
+		return false;
+	}
+
+	public function setFilePath( string $file_path ) {
+		$this->file_path = $file_path;
+	}
+
+	public function store( array $data, string $file_header = null ) {
+		if ( $this->create() ) {
+			try {
+				$data = $this->getDataFormat( $data );
+				$this->logger->debug( 'SAML Log', $data );
+				return true;
+			} catch ( AwsException $e ) {
+				debug_error_log( 'Error saving logs in CloudWatch: ' . $e->getMessage() );
+			}
+		}
+		return false;
+	}
+
+	public function getDataFormat($data ) {
+		$scheme = is_ssl() ? 'https' : 'http';
+		$data['Environment'] = env( 'WP_ENV' ) ? env( 'WP_ENV' ) : 'production';
+		$data['Network'] = [
+			'Name' => get_site_option( 'site_name' ),
+			'URL' => network_home_url( '', $scheme ),
+		];
+		return $data;
+	}
+
+	public function setLogger( Logger $logger ) {
+		$this->logger = $logger;
+	}
+
+	public function setClient( $client ) {
+		$this->client = $client;
+	}
+
+	public function setHandler( CloudWatch $handler ) {
+		$this->handler = $handler;
+	}
+}

--- a/inc/log/class-log.php
+++ b/inc/log/class-log.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Pressbooks\Log;
+
+class Log {
+
+	/**
+	 * @var array
+	 */
+	private $data;
+
+	/**
+	 * @var StorageProvider
+	 */
+	private $store_provider;
+
+	/**
+	 * @var string
+	 */
+	private $file_header;
+
+	const CSV_COLUMNS = [ 'Date', 'Key', 'Value' ];
+
+	public function __construct( StorageProvider $store_provider ) {
+		$this->store_provider = $store_provider;
+		$this->data = [];
+		$this->file_header = implode( ',', self::CSV_COLUMNS ) . "\n";
+	}
+
+	public function addRowToData( string $key, array $value ) {
+		$this->data[ $key ] = $value;
+	}
+
+	public function store() {
+		return $this->store_provider->store( $this->data, $this->file_header );
+	}
+
+}

--- a/inc/log/class-s3storageprovider.php
+++ b/inc/log/class-s3storageprovider.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Pressbooks\Log;
+
+use Aws\Credentials\CredentialProvider;
+use Aws\Exception\AwsException as AwsException;
+use Aws\S3\S3Client as S3Client;
+use function Pressbooks\Utility\debug_error_log;
+
+class S3StorageProvider implements StorageProvider {
+
+	/**
+	 * @var string
+	 */
+	private $bucket_name;
+
+	/**
+	 * @var string
+	 */
+	private $secret_key;
+
+	/**
+	 * @var string
+	 */
+	private $access_key_id;
+
+	/**
+	 * @var string
+	 */
+	private $version;
+
+	/**
+	 * @var string
+	 */
+	private $region;
+
+	/**
+	 * @var S3Client
+	 */
+	private $client;
+
+	/**
+	 * @var string
+	 */
+	private $file_path;
+
+	const FILENAME_FORMAT = '-saml_logs.csv';
+
+	const AWS_CONFIG_FILENAME = 'does_not_exist.ini';
+
+	const AWS_MAIN_LOG_FOLDER = 'saml_logs';
+
+	private function create() {
+		if ( self::areEnvironmentVariablesPresent() && is_null( $this->client ) ) {
+			$this->region = env( 'AWS_S3_REGION' );
+			$this->version = env( 'AWS_S3_VERSION' );
+			$this->bucket_name = env( 'AWS_S3_OIDC_BUCKET' );
+			$this->access_key_id = env( 'AWS_ACCESS_KEY_ID' );
+			$this->secret_key = env( 'AWS_SECRET_ACCESS_KEY' );
+			$environment = env( 'WP_ENV' ) ? env( 'WP_ENV' ) : 'production';
+			$scheme = is_ssl() ? 'https' : 'http';
+			if ( is_null( $this->file_path ) ) {
+				$this->file_path = 's3://' . $this->bucket_name . '/' . self::AWS_MAIN_LOG_FOLDER . '/' . $environment .
+					'/' . wp_hash( network_home_url( '', $scheme ) ) . '/' . current_time( 'Y-m' ) . self::FILENAME_FORMAT;
+			}
+			if ( is_null( $this->client ) ) {
+				$this->client = new S3Client( [
+					'region' => $this->region,
+					'version' => $this->version,
+					'credentials' => CredentialProvider::env(),
+				] );
+			}
+			return true;
+		} else {
+			debug_error_log( 'Error initializing S3 Storage Provider: Some environment variables are not present.' );
+		}
+		return ! is_null( $this->client );
+	}
+
+	/**
+	 * NOTE: We will use the same environment variables for OIDC plugin temporary.
+	 *
+	 * @return bool
+	 */
+	public static function areEnvironmentVariablesPresent() {
+		if (
+			! is_null( env( 'LOG_LOGIN_ATTEMPTS' ) ) &&
+			! is_null( env( 'AWS_S3_OIDC_BUCKET' ) ) &&
+			! is_null( env( 'AWS_SECRET_ACCESS_KEY' ) ) &&
+			! is_null( env( 'AWS_ACCESS_KEY_ID' ) ) &&
+			! is_null( env( 'AWS_S3_VERSION' ) ) &&
+			! is_null( env( 'AWS_S3_REGION' ) )
+		) {
+			if ( is_null( env( 'AWS_CONFIG_FILE' ) ) ) {
+				// this is an env variable needed for AWS SDK
+				putenv( 'AWS_CONFIG_FILE=' . __DIR__ . '/' . self::AWS_CONFIG_FILENAME );
+			}
+			return true;
+		} else {
+			debug_error_log( 'Error initializing S3 Storage Provider: Some environment variables are not present.' );
+		}
+		return false;
+	}
+
+	public function setFilePath( string $file_path ) {
+		$this->file_path = $file_path;
+	}
+
+	public function store( array $data, string $file_header = null ) {
+		if ( $this->create() ) {
+			try {
+				$this->client->registerStreamWrapper();
+				$stream = fopen( $this->file_path, 'a' );
+				$data = $this->getDataFormat( $data );
+				if ( ! is_null( $file_header ) && ! file_exists( $this->file_path ) ) {
+					$data = $file_header . $data;
+				}
+				fwrite( $stream, $data );
+				fclose( $stream );
+				return true;
+			} catch ( AwsException $e ) {
+				debug_error_log( 'Error saving logs in S3: ' . $e->getMessage() );
+			}
+		}
+		return false;
+	}
+
+	public function getDataFormat( array $data ) {
+		$data_csv_format = '';
+		$current_date = current_time( 'mysql' );
+		foreach ( $data as $key => $value ) {
+			$data_csv_format .= $current_date . ',' . $key . ',"' . print_r( $value, true ) . '"' . "\n"; // @codingStandardsIgnoreLine
+		}
+		return $data_csv_format;
+	}
+
+	public function setClient( $client ) {
+		$this->client = $client;
+	}
+}

--- a/inc/log/class-s3storageprovider.php
+++ b/inc/log/class-s3storageprovider.php
@@ -64,11 +64,13 @@ class S3StorageProvider implements StorageProvider {
 					'/' . wp_hash( network_home_url( '', $scheme ) ) . '/' . current_time( 'Y-m' ) . self::FILENAME_FORMAT;
 			}
 			if ( is_null( $this->client ) ) {
-				$this->client = new S3Client( [
-					'region' => $this->region,
-					'version' => $this->version,
-					'credentials' => CredentialProvider::env(),
-				] );
+				$this->client = new S3Client(
+					[
+						'region' => $this->region,
+						'version' => $this->version,
+						'credentials' => CredentialProvider::env(),
+					]
+				);
 			}
 			return true;
 		} else {

--- a/inc/log/class-storageprovider.php
+++ b/inc/log/class-storageprovider.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Pressbooks\Log;
+
+interface StorageProvider {
+	function store( array $data, string $file_header );
+	function getDataFormat( array $data );
+	function setClient( $client );
+}

--- a/tests/test-log.php
+++ b/tests/test-log.php
@@ -49,7 +49,7 @@ class LogTest extends \WP_UnitTestCase {
 				'registerStreamWrapper',
 			])
 			->getMock();
-		$this->s3_provider_mock = new Log\S3StorageProvider();
+		$this->s3_provider_mock = new Log\S3StorageProvider( 'tests/data', 'log.csv' );
 		$this->s3_provider_mock->setClient( $s3_client_mock );
 		$this->s3_provider_mock->setFilePath( self::TEST_FILE_PATH );
 		$this->log = new Log\Log( $this->s3_provider_mock );
@@ -84,7 +84,7 @@ class LogTest extends \WP_UnitTestCase {
 		$handler->expects( $this->any() )
 			->method( 'setFormatter' )
 			->will( $this->onConsecutiveCalls( true ) );
-		$this->cloudwatch_provider_mock = new Log\CloudWatchProvider();
+		$this->cloudwatch_provider_mock = new Log\CloudWatchProvider( 90, 'pressbooks-logs', 'pressbooks-plugin', 'saml-logs' );
 		$this->cloudwatch_provider_mock->setLogger( $logger_mock );
 		$this->cloudwatch_provider_mock->setHandler( $handler );
 		$this->cloudwatch_provider_mock->setClient( $cloudwatch_logs_mock );
@@ -140,7 +140,7 @@ class LogTest extends \WP_UnitTestCase {
 	 * @group log
 	 */
 	public function test_s3_invalid_store_action_because_fake_env_variables() {
-		$s3_provider = new Log\S3StorageProvider();
+		$s3_provider = new Log\S3StorageProvider( 'tests/data', 'log.csv' );
 		$this->log = new Log\Log( $s3_provider );
 		$this->log->addRowToData( 'Test key 1', ['Test value'] );
 		$this->log->addRowToData( 'Test key 2', [
@@ -154,7 +154,7 @@ class LogTest extends \WP_UnitTestCase {
 	 * @group log
 	 */
 	public function test_s3_create_action() {
-		$s3_provider = new Log\S3StorageProvider();
+		$s3_provider = new Log\S3StorageProvider( 'tests/data', 'log.csv' );
 		$this->assertFalse( $this->callMethodForReflection( $s3_provider, 'create' ) );
 	}
 
@@ -175,7 +175,7 @@ class LogTest extends \WP_UnitTestCase {
 	 * @group log
 	 */
 	public function test_cloudwatch_invalid_store_action_because_fake_env_variables() {
-		$cloudwatch_provider = new Log\CloudWatchProvider();
+		$cloudwatch_provider = new Log\CloudWatchProvider( 90, 'pressbooks-logs', 'pressbooks-plugin', 'saml-logs' );
 		$this->log = new Log\Log( $cloudwatch_provider );
 		$this->log->addRowToData( 'Test key 1', ['Test value'] );
 		$this->log->addRowToData( 'Test key 2', [

--- a/tests/test-log.php
+++ b/tests/test-log.php
@@ -1,0 +1,127 @@
+<?php
+
+use Aws\CloudWatchLogs\CloudWatchLogsClient;
+use Aws\S3\S3Client as S3Client;
+use Maxbanton\Cwh\Handler\CloudWatch;
+use Monolog\Logger;
+use Pressbooks\Log;
+
+class LogTest extends \WP_UnitTestCase {
+
+	/**
+	 * @var Log\S3StorageProvider
+	 */
+	private $s3_provider_mock;
+
+	/**
+	 * @var Log\CloudWatchProvider
+	 */
+	private $cloudwatch_provider_mock;
+
+	/**
+	 * @var Log\Log
+	 */
+	private $log;
+
+	const TEST_FILE_PATH = 'tests/data/log.csv';
+
+	/**
+	 * Test setup
+	 */
+	public function setUp() {
+		$this->setEnvironmentVariables();
+	}
+
+	private function setEnvironmentVariables() {
+		putenv( 'AWS_S3_OIDC_BUCKET=fakeBucket' );
+		putenv( 'AWS_SECRET_ACCESS_KEY=fakeAccessKey' );
+		putenv( 'AWS_ACCESS_KEY_ID=fakeKeyId' );
+		putenv( 'AWS_S3_VERSION=fakeVersion' );
+		putenv( 'AWS_S3_REGION=fakeRegion' );
+	}
+
+	private function setS3ClientMock() {
+		$s3_client_mock = $this
+			->getMockBuilder( S3Client::class )
+			->disableOriginalConstructor()
+			->setMethods([
+				'registerStreamWrapper',
+			])
+			->getMock();
+		$this->s3_provider_mock = new Log\S3StorageProvider();
+		$this->s3_provider_mock->setClient( $s3_client_mock );
+		$this->s3_provider_mock->setFilePath( self::TEST_FILE_PATH );
+		$this->log = new Log\Log( $this->s3_provider_mock );
+	}
+
+	private function setLoggerMock() {
+		$logger_mock = $this
+			->getMockBuilder( Logger::class )
+			->disableOriginalConstructor()
+			->setMethods([
+				'debug',
+				'pushHandler',
+			])
+			->getMock();
+		$logger_mock->expects( $this->any() )
+			->method( 'debug' )
+			->will( $this->onConsecutiveCalls( true ) );
+		$logger_mock->expects( $this->any() )
+			->method( 'pushHandler' )
+			->will( $this->onConsecutiveCalls( true ) );
+		$cloudwatch_logs_mock = $this
+			->getMockBuilder( CloudWatchLogsClient::class )
+			->disableOriginalConstructor()
+			->getMock();
+		$handler = $this
+			->getMockBuilder( CloudWatch::class )
+			->disableOriginalConstructor()
+			->setMethods([
+				'setFormatter',
+			])
+			->getMock();
+		$handler->expects( $this->any() )
+			->method( 'setFormatter' )
+			->will( $this->onConsecutiveCalls( true ) );
+		$this->cloudwatch_provider_mock = new Log\CloudWatchProvider();
+		$this->cloudwatch_provider_mock->setLogger( $logger_mock );
+		$this->cloudwatch_provider_mock->setHandler( $handler );
+		$this->cloudwatch_provider_mock->setClient( $cloudwatch_logs_mock );
+		$this->log = new Log\Log( $this->cloudwatch_provider_mock );
+	}
+
+	/**
+	 * @group log
+	 */
+	public function test_s3_store() {
+		$this->setS3ClientMock();
+		$this->log->addRowToData( 'Test key 1', ['Test value'] );
+		$this->log->addRowToData( 'Test key 2', [
+			'Test a' => 'Test b',
+			'Test c' => 'Test d',
+		] );
+		$this->assertTrue( $this->log->store() );
+		$file_content = str_getcsv( file_get_contents( self::TEST_FILE_PATH ) );
+		unlink( self::TEST_FILE_PATH );
+		$this->assertEquals( 'Test key 1', $file_content[1] );
+		$this->assertContains( 'Test value', $file_content[2] );
+		$this->assertEquals( 'Test key 2', $file_content[3] );
+		$this->assertContains( 'Test b', $file_content[4] );
+		$this->assertContains( 'Test d', $file_content[4] );
+		$this->assertContains( '[Test a] =>', $file_content[4] );
+		$this->assertContains( '[Test c] =>', $file_content[4] );
+	}
+
+	/**
+	 * @group log
+	 */
+	public function test_cloudwatch_store() {
+		$this->setLoggerMock();
+		$this->log->addRowToData( 'Test key 1', ['Test value'] );
+		$this->log->addRowToData( 'Test key 2', [
+			'Test a' => 'Test b',
+			'Test c' => 'Test d',
+		] );
+		$this->assertTrue( $this->log->store() );
+	}
+}

--- a/tests/test-log.php
+++ b/tests/test-log.php
@@ -115,6 +115,20 @@ class LogTest extends \WP_UnitTestCase {
 	/**
 	 * @group log
 	 */
+	public function test_s3_invalid_store_action_because_fake_env_variables() {
+		$s3_provider = new Log\S3StorageProvider();
+		$this->log = new Log\Log( $s3_provider );
+		$this->log->addRowToData( 'Test key 1', ['Test value'] );
+		$this->log->addRowToData( 'Test key 2', [
+			'Test a' => 'Test b',
+			'Test c' => 'Test d',
+		] );
+		$this->assertFalse( $this->log->store() );
+	}
+
+	/**
+	 * @group log
+	 */
 	public function test_cloudwatch_store() {
 		$this->setLoggerMock();
 		$this->log->addRowToData( 'Test key 1', ['Test value'] );
@@ -123,5 +137,19 @@ class LogTest extends \WP_UnitTestCase {
 			'Test c' => 'Test d',
 		] );
 		$this->assertTrue( $this->log->store() );
+	}
+
+	/**
+	 * @group log
+	 */
+	public function test_cloudwatch_invalid_store_action_because_fake_env_variables() {
+		$cloudwatch_provider = new Log\CloudWatchProvider();
+		$this->log = new Log\Log( $cloudwatch_provider );
+		$this->log->addRowToData( 'Test key 1', ['Test value'] );
+		$this->log->addRowToData( 'Test key 2', [
+			'Test a' => 'Test b',
+			'Test c' => 'Test d',
+		] );
+		$this->assertFalse( $this->log->store() );
 	}
 }


### PR DESCRIPTION
Related issue: https://github.com/pressbooks/private/issues/452

This change implements a Log module for log different information on demand to different providers. Providers available in this change are:
- S3: Env variables needed are:
 ```
  LOG_LOGIN_ATTEMPTS (setting this value to true will enable this feature at the infrastructure level)
  AWS_ACCESS_KEY_ID
  AWS_SECRET_ACCESS_KEY
  AWS_S3_OIDC_BUCKET
  AWS_S3_REGION
  AWS_S3_VERSION
```
The same we use for OIDC plugin.
After these variables have been properly defined, basic information about SAML login attempts will be logged to your S3 bucket. A new CSV file will be created each month so that the logs remain readable. Log storage will take place in a folder structure that looks like this `S3 Bucket > saml_logs > {ENVIRONMENT} > {Network URL hashed though wp_hash function} > {YYYY-MM} > saml_logs.log`.
- CloudWatch Logs: Env variables needed are:
 ```
  LOG_LOGIN_ATTEMPTS (setting this value to true will enable this feature at the infrastructure level)
  AWS_ACCESS_KEY_ID
  AWS_SECRET_ACCESS_KEY
  AWS_S3_REGION
  AWS_S3_VERSION
```
After these variables have been properly defined, basic information about SAML login attempts will be logged in your AWS CloudWatch Logs service in JSON format

At the moment we are not logging any information in PB Plugin, but we are planning to do for SAML information in pressbooks-saml plugin, PR Related: https://github.com/pressbooks/pressbooks-saml-sso/pull/62