### PR TITLE
Fix WP version for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ branches:
 php:
 - 7.3
 env:
-- WP_VERSION=latest WP_MULTISITE=1 TRAVIS_NODE_VERSION="10"
+- WP_VERSION="5.6.2" WP_MULTISITE=1 TRAVIS_NODE_VERSION="10"
 matrix:
   fast_finish: true
   allow_failures:

--- a/inc/covergenerator/class-isbn.php
+++ b/inc/covergenerator/class-isbn.php
@@ -242,7 +242,7 @@ class Isbn {
 	 */
 	public function crop( $path_to_png, $border = '20x20' ) {
 
-	    $border = escapeshellarg($border);
+		$border = escapeshellarg( $border );
 		$command = PB_CONVERT_COMMAND . ' ' . escapeshellarg( $path_to_png ) . " -trim +repage -bordercolor white -border {$border} " . escapeshellarg( $path_to_png );
 
 		// Execute command


### PR DESCRIPTION
Wordpress 5.7 has some breaking changes in your test suite, we fixed the version to 5.6.2

> We've determined that the test failures are related to the WordPress 5.7 release -- we will fix temporarily by changing travis file to use WP 5.6.2 for test suite (the version of WordPress we use in production). Later we will seek to understand why tests break with WP 5.7 and address.