### PR TITLE
Enable redirection plugin for super admins

### DIFF
--- a/hooks-admin.php
+++ b/hooks-admin.php
@@ -77,6 +77,11 @@ if ( $is_book ) {
 	add_action( 'admin_menu', '\Pressbooks\Admin\Laf\fix_root_admin_menu', 1 );
 	// TODO: Add Privacy Policy content
 	// See Pressbooks\Privacy::addPrivacyPolicyContent() for reference.
+
+	// If exists on the network enable redirection plugin only for super admins
+	add_filter( 'redirection_role', function() {
+		return 'manage_sites';
+	} );
 }
 
 if ( is_network_admin() ) {


### PR DESCRIPTION
Related Issue [#436](https://github.com/pressbooks/private/issues/436)

### Solution

I added a filter hook that enable the redirection plugin only for super admin according to [official docs](https://redirection.me/developer/permissions/).



