### PR TITLE
fix: announce search results on catalog (resolves #1778)

### DIFF
--- a/inc/admin/class-catalog-list-table.php
+++ b/inc/admin/class-catalog-list-table.php
@@ -535,7 +535,8 @@ class Catalog_List_Table extends \WP_List_Table {
 					/* translators: %s: search keywords, %d: total items found */
 					$search_results = sprintf( __( 'Search results for &#8220;%1$s&#8221; returned %2$d items', 'pressbooks' ), esc_html( wp_unslash( $_REQUEST['s'] ) ), $total_items );
 				}
-				echo '<span class="subtitle">' . $search_results . '</span>';
+				echo '<span id="search-results" class="subtitle" role="alert"></span>';
+				echo '<script>window.addEventListener("load", function(event){document.getElementById("search-results").innerHTML="' . $search_results . '";});</script>';
 			}
 			?>
 			<div class="postbox">


### PR DESCRIPTION
Resolves #1778. To test, perform a search on the catalog page while using a screen reader. Search results should be announced (screen reader behaviour is [inconsistent](https://github.com/w3c/aria/issues/1360#issuecomment-739319614), though— your mileage may vary).

See also: https://github.com/pressbooks/pressbooks/issues/1778#issuecomment-821294887