### PR TITLE
ci: remove unnecessary conditional

### DIFF
--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -11,7 +11,6 @@ on:
 jobs:
   update-pot:
     runs-on: ubuntu-latest
-    if: github.repository == "pressbooks/pressbooks" # Don't run on forks.
     steps:
     - uses: actions/checkout@v2
     - name: Setup PHP with tools


### PR DESCRIPTION
This PR removes an invalid and unnecessary conditional check from the localization GitHub Action.

Follow-up to #2140.