### PR TITLE
Change label for LTI weblink export

### DIFF
--- a/inc/modules/export/namespace.php
+++ b/inc/modules/export/namespace.php
@@ -124,7 +124,7 @@ function formats() {
 
 	$enable_thincc_weblinks = \Pressbooks\Admin\Network\SharingAndPrivacyOptions::getOption( 'enable_thincc_weblinks' );
 	if ( $enable_thincc_weblinks ) {
-		$formats['exotic']['weblinks'] = __( 'Common Cartridge with weblinks', 'pressbooks' );
+		$formats['exotic']['weblinks'] = __( 'Common Cartridge with Web Links', 'pressbooks' );
 	}
 
 	/**

--- a/inc/modules/export/namespace.php
+++ b/inc/modules/export/namespace.php
@@ -124,7 +124,7 @@ function formats() {
 
 	$enable_thincc_weblinks = \Pressbooks\Admin\Network\SharingAndPrivacyOptions::getOption( 'enable_thincc_weblinks' );
 	if ( $enable_thincc_weblinks ) {
-		$formats['exotic']['weblinks'] = __( 'Common Cartridge 1.1 (Web Links)', 'pressbooks' );
+		$formats['exotic']['weblinks'] = __( 'Common Cartridge with weblinks', 'pressbooks' );
 	}
 
 	/**


### PR DESCRIPTION
Change the label for CC LTI weblink export to a more user friendly name. Partial fix for https://github.com/pressbooks/pressbooks-lti-provider-1p3/issues/143