### PR TITLE
Fix display name for print PDF and CC with weblink exports

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -17,7 +17,7 @@ jobs:
         os: [ubuntu-18.04]
         epubcheck: [4.2.4]
         prince: [12.5-1]
-        wordpress: [5.6.2, 5.7, 5.7.1]
+        wordpress: [5.6.2, 5.7.2]
 
     name: PHPUnit - ${{ matrix.php }} - ${{ matrix.wordpress }}
 

--- a/inc/modules/export/class-table.php
+++ b/inc/modules/export/class-table.php
@@ -380,7 +380,7 @@ class Table extends \WP_List_Table {
 		} elseif ( 'epub' === $file_extension && '._3.epub' === $pre_suffix ) {
 			$file_class = 'epub3';
 		} elseif ( 'pdf' === $file_extension && '._print.pdf' === $pre_suffix ) {
-			$file_class = 'print-pdf';
+			$file_class = 'print_pdf';
 		} elseif ( 'imscc' === $file_extension && '._1_1_weblinks.imscc' === $pre_suffix ) {
 			$file_class = 'weblinks';
 		} else {

--- a/inc/modules/export/namespace.php
+++ b/inc/modules/export/namespace.php
@@ -198,7 +198,7 @@ function get_name_from_filetype_slug( $filetype ) {
 	 */
 	$formats = apply_filters(
 		'pb_export_filetype_names', [
-			'print-pdf' => __( 'Print PDF', 'pressbooks' ),
+			'print_pdf' => __( 'Print PDF', 'pressbooks' ),
 			'pdf' => __( 'Digital PDF', 'pressbooks' ),
 			'mpdf' => __( 'Digital PDF', 'pressbooks' ),
 			'htmlbook' => __( 'HTMLBook', 'pressbooks' ),
@@ -209,7 +209,7 @@ function get_name_from_filetype_slug( $filetype ) {
 			'odf' => __( 'OpenDocument', 'pressbooks' ),
 			'wxr' => __( 'Pressbooks XML', 'pressbooks' ),
 			'vanillawxr' => __( 'WordPress XML', 'pressbooks' ),
-			'weblinks' => __( 'Web Links', 'pressbooks' ), // TODO
+			'weblinks' => __( 'Common Cartridge (Web Links)', 'pressbooks' ),
 		]
 	);
 	return isset( $formats[ $filetype ] ) ? $formats[ $filetype ] : ucfirst( $filetype );
@@ -243,7 +243,7 @@ function get_name_from_module_classname( $classname ) {
 			'\Pressbooks\Modules\Export\Odt\Odt' => __( 'OpenDocument', 'pressbooks' ),
 			'\Pressbooks\Modules\Export\WordPress\Wxr' => __( 'Pressbooks XML', 'pressbooks' ),
 			'\Pressbooks\Modules\Export\WordPress\VanillaWxr' => __( 'WordPress XML', 'pressbooks' ),
-			'\Pressbooks\Modules\Export\ThinCC\WebLinks' => __( 'Web Links', 'pressbooks' ),
+			'\Pressbooks\Modules\Export\ThinCC\WebLinks' => __( 'Common Cartridge (Web Links)', 'pressbooks' ),
 		]
 	);
 	return isset( $formats[ $classname ] ) ? $formats[ $classname ] : substr( strrchr( $classname, '\\' ), 1 );

--- a/tests/test-modules-export.php
+++ b/tests/test-modules-export.php
@@ -48,7 +48,7 @@ class Modules_ExportTest extends \WP_UnitTestCase {
 	 * @group export
 	 */
 	public function test_get_name_from_filetype_slug() {
-		$type = \Pressbooks\Modules\Export\get_name_from_filetype_slug( 'print-pdf' );
+		$type = \Pressbooks\Modules\Export\get_name_from_filetype_slug( 'print_pdf' );
 		$this->assertEquals( 'Print PDF', $type );
 		$type = \Pressbooks\Modules\Export\get_name_from_filetype_slug( 'wtfbbq' );
 		$this->assertEquals( 'Wtfbbq', $type );


### PR DESCRIPTION
This PR fixes the display name for Print PDF and Common Cartridge with weblink exports as displayed on the book homepage when books are made available for download. It is a partial fix for https://github.com/pressbooks/pressbooks/issues/2162

It also adjust the test matrix to include WordPress 5.7.2 (the latest release of WordPress).

## To test:
1. checkout this branch
2. allow redistribution for books on your network at `NETWORKURL/wp-admin/network/settings.php?page=pressbooks_sharingandprivacy_options`
3. go to an individual book and turn on 'Share Latest Export Files' at `NETWORKURL/BOOKURL/wp-admin/options-general.php?page=pressbooks_sharingandprivacy_options`
4. Go to the exports menu in the book dashboard and produce file exports for PDF (for print) and Common Cartridge with Web Links  
5. Visit the book home page and confirm that you can see the updated labels and download the correct files