### PR TITLE
Generate Cover Thumbnail & Expose its URL to Books API Endpoint

### DIFF
--- a/inc/api/endpoints/controller/class-books.php
+++ b/inc/api/endpoints/controller/class-books.php
@@ -261,7 +261,9 @@ class Books extends \WP_REST_Controller {
 			'last_updated' => strtotime( get_blog_details( $id )->last_updated ),
 		];
 
-		$metadata = array_merge( $metadata_info_array, $metadata_blog_meta, $blog_info );
+		$metadata_thumb['pb_thumbnail'] = $this->bookDataCollector->getCoverThumbnail( $id, $metadata_info_array['pb_cover_image'] );
+
+		$metadata = array_merge( $metadata_info_array, $metadata_blog_meta, $blog_info, $metadata_thumb );
 		$metadata = ( is_array( $metadata ) && ! empty( $metadata ) ) ? book_information_to_schema( $metadata, $this->networkExcludedDirectory ) : [];
 
 		$item = [

--- a/inc/api/endpoints/controller/class-metadata.php
+++ b/inc/api/endpoints/controller/class-metadata.php
@@ -164,6 +164,13 @@ class Metadata extends \WP_REST_Controller {
 					'context' => [ 'view' ],
 					'readonly' => true,
 				],
+				'thumbnailUrl' => [
+					'type' => 'string',
+					'format' => 'uri',
+					'description' => __( 'A thumbnail of the item.' ),
+					'context' => [ 'view' ],
+					'readonly' => true,
+				],
 				'position' => [
 					'type' => 'integer',
 					'description' => __( 'The position of an item in a series or sequence of items.' ),

--- a/inc/datacollector/class-book.php
+++ b/inc/datacollector/class-book.php
@@ -464,18 +464,14 @@ class Book {
 	 * It will force https in each image path
 	 * @return string
 	 */
-	public function getCoverThumbnail( $book_id, $cover_path ) {
+	public function getCoverThumbnail( $book_id, $cover_path, $attachment_id = null ) {
 
 		switch_to_blog( $book_id );
 
-		$thumbnail_size = [ 683, 1024 ];
-
-		$cover_id = attachment_id_from_url( $cover_path );
-
-		var_dump($cover_id);
+		$cover_id = $attachment_id ? $attachment_id : attachment_id_from_url( $cover_path );
 
 		if ( $cover_id ) {
-			$cover_path = wp_get_attachment_image_url( $cover_id, $thumbnail_size, false );
+			$cover_path = wp_get_attachment_image_url( $cover_id, 'large', false );
 		}
 
 		return  str_replace( 'http://', 'https://', $cover_path );

--- a/inc/datacollector/class-book.php
+++ b/inc/datacollector/class-book.php
@@ -6,6 +6,7 @@
 
 namespace Pressbooks\DataCollector;
 
+use function Pressbooks\Image\attachment_id_from_url;
 use function \Pressbooks\Metadata\get_in_catalog_option;
 
 class Book {
@@ -456,6 +457,25 @@ class Book {
 		global $wpdb;
 		$total = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(DISTINCT blog_id) FROM {$wpdb->blogmeta} WHERE meta_key = %s ", self::TIMESTAMP ) );
 		return (int) $total;
+	}
+
+	/**
+	 * Get the cover thumbnail from WordPress resized items
+	 * @return string
+	 */
+	public function getCoverThumbnail( $book_id, $cover_path ) {
+
+		switch_to_blog( $book_id );
+
+		$thumbnail_size = [ 683, 1024 ];
+
+		$cover_id = attachment_id_from_url( $cover_path );
+
+		if ( $cover_id ) {
+			return wp_get_attachment_image_url( $cover_id, $thumbnail_size, false );
+		}
+
+		return  $cover_path;
 	}
 
 

--- a/inc/datacollector/class-book.php
+++ b/inc/datacollector/class-book.php
@@ -474,7 +474,7 @@ class Book {
 			$cover_path = wp_get_attachment_image_url( $cover_id, 'large', false );
 		}
 
-		return  str_replace( 'http://', 'https://', $cover_path );
+		return  is_ssl() ? str_replace( 'http://', 'https://', $cover_path ) : $cover_path;
 	}
 
 

--- a/inc/datacollector/class-book.php
+++ b/inc/datacollector/class-book.php
@@ -472,6 +472,8 @@ class Book {
 
 		$cover_id = attachment_id_from_url( $cover_path );
 
+		var_dump($cover_id);
+
 		if ( $cover_id ) {
 			$cover_path = wp_get_attachment_image_url( $cover_id, $thumbnail_size, false );
 		}

--- a/inc/datacollector/class-book.php
+++ b/inc/datacollector/class-book.php
@@ -461,6 +461,7 @@ class Book {
 
 	/**
 	 * Get the cover thumbnail from WordPress resized items
+	 * It will force https in each image path
 	 * @return string
 	 */
 	public function getCoverThumbnail( $book_id, $cover_path ) {
@@ -472,10 +473,10 @@ class Book {
 		$cover_id = attachment_id_from_url( $cover_path );
 
 		if ( $cover_id ) {
-			return wp_get_attachment_image_url( $cover_id, $thumbnail_size, false );
+			$cover_path = wp_get_attachment_image_url( $cover_id, $thumbnail_size, false );
 		}
 
-		return  $cover_path;
+		return  str_replace( 'http://', 'https://', $cover_path );
 	}
 
 

--- a/inc/image/namespace.php
+++ b/inc/image/namespace.php
@@ -210,6 +210,10 @@ function attachment_id_from_url( $url ) {
 		)
 	);
 
+	$results = $wpdb->get_results("SELECT meta_value FROM $wpdb->postmeta WHERE meta_key = 'wp_attached_file'");
+
+	var_dump($results);
+
 	return absint( $id );
 }
 

--- a/inc/image/namespace.php
+++ b/inc/image/namespace.php
@@ -210,10 +210,6 @@ function attachment_id_from_url( $url ) {
 		)
 	);
 
-	$results = $wpdb->get_results("SELECT meta_value FROM $wpdb->postmeta WHERE meta_key = 'wp_attached_file'");
-
-	var_dump($results);
-
 	return absint( $id );
 }
 

--- a/inc/metadata/namespace.php
+++ b/inc/metadata/namespace.php
@@ -62,6 +62,7 @@ function get_microdata_elements() {
 		'description' => 'pb_about_50',
 		'editor' => 'pb_editors',
 		'image' => 'pb_cover_image',
+		'thumbnailUrl' => 'pb_thumbnail',
 		'inLanguage' => 'pb_language',
 		'keywords' => 'pb_keywords_tags',
 		'publisher' => 'pb_publisher',
@@ -210,6 +211,7 @@ function book_information_to_schema( $book_information, $network_excluded_direct
 		'pb_about_50' => 'disambiguatingDescription',
 		'pb_about_unlimited' => 'description',
 		'pb_cover_image' => 'image',
+		'pb_thumbnail' => 'thumbnailUrl',
 		'pb_series_number' => 'position',
 		'pb_is_based_on' => 'isBasedOn',
 		'pb_word_count' => 'wordCount',
@@ -463,6 +465,7 @@ function schema_to_book_information( $book_schema ) {
 		'disambiguatingDescription' => 'pb_about_50',
 		'description' => 'pb_about_unlimited',
 		'image' => 'pb_cover_image',
+		'thumbnailUrl' => 'pb_thumbnail',
 		'position' => 'pb_series_number',
 		'isBasedOn' => 'pb_is_based_on',
 	];

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -63,6 +63,7 @@ class ApiTest extends \WP_UnitTestCase {
             "pb_title" => "The onboarding process",
 			"pb_language" => "en",
 			"pb_cover_image" => "https://pressbooks.test/app/plugins/pressbooks/assets/dist/images/default-book-cover.jpg",
+			"pb_thumbnail" => "https://pressbooks.test/app/plugins/pressbooks/assets/dist/images/default-book-cover.jpg",
             "pb_primary_subject" => "YXHB",
 			"pb_additional_subjects" => "ATL, ABK",
 			"pb_subtitle" => "subtitle test",
@@ -80,6 +81,7 @@ class ApiTest extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'language', $schema );
 		$this->assertArrayHasKey( 'wordCount', $schema );
 		$this->assertArrayHasKey( 'h5pActivities', $schema );
+		$this->assertArrayHasKey( 'thumbnailUrl', $schema );
 	}
 
 	/**

--- a/tests/test-datacollector-book.php
+++ b/tests/test-datacollector-book.php
@@ -226,14 +226,14 @@ class DataCollector_BookTest extends \WP_UnitTestCase {
 		$path = $this->bookDataCollector->getCoverThumbnail( $blog_id, 'http://presssbooks.test/https-cover-image.jpg' );
 		$this->assertEquals( 'https://presssbooks.test/https-cover-image.jpg', $path );
 
-		$_SERVER['HTTPS'] = 'off';
-
 		$attachment_id = $this->factory->attachment->create_upload_object( __DIR__ . '/data/skates.jpg', $blog_id );
 		$attachment_path = wp_get_attachment_url( $attachment_id );
 
 		$path = $this->bookDataCollector->getCoverThumbnail( $blog_id, $attachment_path, $attachment_id );
 
 		$this->assertEquals( 1, preg_match( '/https:\/\/.*-768x1024\.jpg/', $path ) );
+
+		$_SERVER['HTTPS'] = 'off';
 	}
 
 

--- a/tests/test-datacollector-book.php
+++ b/tests/test-datacollector-book.php
@@ -226,6 +226,8 @@ class DataCollector_BookTest extends \WP_UnitTestCase {
 		$path = $this->bookDataCollector->getCoverThumbnail( $blog_id, 'http://presssbooks.test/https-cover-image.jpg' );
 		$this->assertEquals( 'https://presssbooks.test/https-cover-image.jpg', $path );
 
+		$_SERVER['HTTPS'] = 'off';
+
 		$attachment_id = $this->factory->attachment->create_upload_object( __DIR__ . '/data/skates.jpg', $blog_id );
 		$attachment_path = wp_get_attachment_url( $attachment_id );
 

--- a/tests/test-datacollector-book.php
+++ b/tests/test-datacollector-book.php
@@ -231,8 +231,6 @@ class DataCollector_BookTest extends \WP_UnitTestCase {
 		$attachment_id = $this->factory->attachment->create_upload_object( __DIR__ . '/data/skates.jpg', $blog_id );
 		$attachment_path = wp_get_attachment_url( $attachment_id );
 
-		update_post_meta( $blog_id, 'pb_cover_image', $attachment_path );
-
 		$path = $this->bookDataCollector->getCoverThumbnail( $blog_id, $attachment_path, $attachment_id );
 
 		$this->assertEquals( 1, preg_match( '/https:\/\/.*-768x1024\.jpg/', $path ) );

--- a/tests/test-datacollector-book.php
+++ b/tests/test-datacollector-book.php
@@ -207,4 +207,14 @@ class DataCollector_BookTest extends \WP_UnitTestCase {
 	}
 
 
+	/**
+	 * @group datacollector
+	 */
+	public function test_getCoverThumbnail() {
+		$this->_book();
+		$path = $this->bookDataCollector->getCoverThumbnail(1, 'https://presssbooks.test/cover-image.jpg');
+		$this->assertEquals('https://presssbooks.test/cover-image.jpg', $path);
+	}
+
+
 }

--- a/tests/test-datacollector-book.php
+++ b/tests/test-datacollector-book.php
@@ -212,8 +212,31 @@ class DataCollector_BookTest extends \WP_UnitTestCase {
 	 */
 	public function test_getCoverThumbnail() {
 		$this->_book();
-		$path = $this->bookDataCollector->getCoverThumbnail(1, 'https://presssbooks.test/cover-image.jpg');
-		$this->assertEquals('https://presssbooks.test/cover-image.jpg', $path);
+		$path = $this->bookDataCollector->getCoverThumbnail( 1, 'https://presssbooks.test/cover-image.jpg' );
+		$this->assertEquals( 'https://presssbooks.test/cover-image.jpg', $path );
+
+		$path = $this->bookDataCollector->getCoverThumbnail( 1, 'http://presssbooks.test/no-https-cover-image.jpg' );
+		$this->assertEquals( 'https://presssbooks.test/no-https-cover-image.jpg', $path );
+
+		$image_name = 'themetamorphosis_1200x1600.jpg';
+
+		$good_url = 'https://metamorphosiskafka.pressbooks.com/wp-content/uploads/sites/26642/2014/04/' . $image_name;
+		update_post_meta( 1, 'pb_cover_image', $good_url );
+
+		$args = [
+			'post_mime_type' => 'jpg',
+			'post_title' => __( 'Cover Image', 'pressbooks' ),
+			'post_content' => '',
+			'post_status' => 'inherit',
+			'post_name' => 'pb-cover-image',
+		];
+
+		$id = wp_insert_attachment( $args, $image_name, 1 );
+
+		wp_update_attachment_metadata( $id, wp_generate_attachment_metadata( $id, $image_name ) );
+
+		$path = $this->bookDataCollector->getCoverThumbnail( 1, $good_url );
+		$this->assertEquals( 'https://presssbooks.test/no-https-cover-image.jpg', $path );
 	}
 
 

--- a/tests/test-datacollector-book.php
+++ b/tests/test-datacollector-book.php
@@ -212,31 +212,27 @@ class DataCollector_BookTest extends \WP_UnitTestCase {
 	 */
 	public function test_getCoverThumbnail() {
 		$this->_book();
-		$path = $this->bookDataCollector->getCoverThumbnail( 1, 'https://presssbooks.test/cover-image.jpg' );
+
+		global $blog_id;
+
+		$path = $this->bookDataCollector->getCoverThumbnail( $blog_id, 'https://presssbooks.test/cover-image.jpg' );
 		$this->assertEquals( 'https://presssbooks.test/cover-image.jpg', $path );
 
-		$path = $this->bookDataCollector->getCoverThumbnail( 1, 'http://presssbooks.test/no-https-cover-image.jpg' );
+		$path = $this->bookDataCollector->getCoverThumbnail( $blog_id, 'http://presssbooks.test/no-https-cover-image.jpg' );
 		$this->assertEquals( 'https://presssbooks.test/no-https-cover-image.jpg', $path );
 
-		$image_name = 'themetamorphosis_1200x1600.jpg';
 
-		$good_url = 'https://metamorphosiskafka.pressbooks.com/wp-content/uploads/sites/26642/2014/04/' . $image_name;
-		update_post_meta( 1, 'pb_cover_image', $good_url );
+		$attachment = $this->factory->attachment->create_upload_object( __DIR__ . '/data/skates.jpg', $blog_id );
 
-		$args = [
-			'post_mime_type' => 'jpg',
-			'post_title' => __( 'Cover Image', 'pressbooks' ),
-			'post_content' => '',
-			'post_status' => 'inherit',
-			'post_name' => 'pb-cover-image',
-		];
+		$attachment_path = wp_get_attachment_url( $attachment );
 
-		$id = wp_insert_attachment( $args, $image_name, 1 );
+		$obj = get_post_meta($attachment);
 
-		wp_update_attachment_metadata( $id, wp_generate_attachment_metadata( $id, $image_name ) );
+		var_dump($obj);
+		var_dump($attachment_path);
 
-		$path = $this->bookDataCollector->getCoverThumbnail( 1, $good_url );
-		$this->assertEquals( 'https://presssbooks.test/no-https-cover-image.jpg', $path );
+		$path = $this->bookDataCollector->getCoverThumbnail( 1, $attachment_path );
+		$this->assertEquals( $attachment_path, $path );
 	}
 
 

--- a/tests/test-datacollector-book.php
+++ b/tests/test-datacollector-book.php
@@ -218,8 +218,13 @@ class DataCollector_BookTest extends \WP_UnitTestCase {
 		$path = $this->bookDataCollector->getCoverThumbnail( $blog_id, 'https://presssbooks.test/cover-image.jpg' );
 		$this->assertEquals( 'https://presssbooks.test/cover-image.jpg', $path );
 
-		$path = $this->bookDataCollector->getCoverThumbnail( $blog_id, 'http://presssbooks.test/no-https-cover-image.jpg' );
-		$this->assertEquals( 'https://presssbooks.test/no-https-cover-image.jpg', $path );
+		$path = $this->bookDataCollector->getCoverThumbnail( $blog_id, 'http://presssbooks.test/server-whitout-ssl-image.jpg' );
+		$this->assertEquals( 'http://presssbooks.test/server-whitout-ssl-image.jpg', $path );
+
+		$_SERVER['HTTPS'] = 'on';
+
+		$path = $this->bookDataCollector->getCoverThumbnail( $blog_id, 'http://presssbooks.test/https-cover-image.jpg' );
+		$this->assertEquals( 'https://presssbooks.test/https-cover-image.jpg', $path );
 
 		$attachment_id = $this->factory->attachment->create_upload_object( __DIR__ . '/data/skates.jpg', $blog_id );
 		$attachment_path = wp_get_attachment_url( $attachment_id );

--- a/tests/test-datacollector-book.php
+++ b/tests/test-datacollector-book.php
@@ -29,6 +29,7 @@ class DataCollector_BookTest extends \WP_UnitTestCase {
 		// Put the hooks back in place
 		$obj = BookDataCollector::init();
 		$obj::hooks( $obj );
+		$_SERVER['SERVER_PORT'] = '';
 	}
 
 
@@ -221,7 +222,7 @@ class DataCollector_BookTest extends \WP_UnitTestCase {
 		$path = $this->bookDataCollector->getCoverThumbnail( $blog_id, 'http://presssbooks.test/server-whitout-ssl-image.jpg' );
 		$this->assertEquals( 'http://presssbooks.test/server-whitout-ssl-image.jpg', $path );
 
-		$_SERVER['HTTPS'] = 'on';
+		$_SERVER['SERVER_PORT'] = '443';
 
 		$path = $this->bookDataCollector->getCoverThumbnail( $blog_id, 'http://presssbooks.test/https-cover-image.jpg' );
 		$this->assertEquals( 'https://presssbooks.test/https-cover-image.jpg', $path );
@@ -232,8 +233,6 @@ class DataCollector_BookTest extends \WP_UnitTestCase {
 		$path = $this->bookDataCollector->getCoverThumbnail( $blog_id, $attachment_path, $attachment_id );
 
 		$this->assertEquals( 1, preg_match( '/https:\/\/.*-768x1024\.jpg/', $path ) );
-
-		$_SERVER['HTTPS'] = 'off';
 	}
 
 

--- a/tests/test-datacollector-book.php
+++ b/tests/test-datacollector-book.php
@@ -221,18 +221,14 @@ class DataCollector_BookTest extends \WP_UnitTestCase {
 		$path = $this->bookDataCollector->getCoverThumbnail( $blog_id, 'http://presssbooks.test/no-https-cover-image.jpg' );
 		$this->assertEquals( 'https://presssbooks.test/no-https-cover-image.jpg', $path );
 
+		$attachment_id = $this->factory->attachment->create_upload_object( __DIR__ . '/data/skates.jpg', $blog_id );
+		$attachment_path = wp_get_attachment_url( $attachment_id );
 
-		$attachment = $this->factory->attachment->create_upload_object( __DIR__ . '/data/skates.jpg', $blog_id );
+		update_post_meta( $blog_id, 'pb_cover_image', $attachment_path );
 
-		$attachment_path = wp_get_attachment_url( $attachment );
+		$path = $this->bookDataCollector->getCoverThumbnail( $blog_id, $attachment_path, $attachment_id );
 
-		$obj = get_post_meta($attachment);
-
-		var_dump($obj);
-		var_dump($attachment_path);
-
-		$path = $this->bookDataCollector->getCoverThumbnail( 1, $attachment_path );
-		$this->assertEquals( $attachment_path, $path );
+		$this->assertEquals( 1, preg_match( '/https:\/\/.*-768x1024\.jpg/', $path ) );
 	}
 
 


### PR DESCRIPTION
This PR is part of https://github.com/pressbooks/pressbooks-book-directory-fe/issues/269

This PR creates a new getCoverThumbnail function in `datacollector/class-book.php` which checks to see if a book has replaced the default cover image. If so, it returns the path for 'large' size thumbnail (max height/width of 1024px) of that image.

The URL of the cover image thumbnail is then exposed as part of the books API endpoint using the `thumbnailUrl` attribute 
recommended by Schema.org (https://schema.org/thumbnailUrl).

### How to test

1. Review the API endpoint has the new thumbnailUrl attr
2. Upload a new cover image and check to see if the thumbnail version is returned
3. Review if images with no cover images return the same default cover as the `image` attribute