### PR TITLE
Fix GNU Free font display bug

### DIFF
--- a/inc/class-styles.php
+++ b/inc/class-styles.php
@@ -643,7 +643,7 @@ class Styles {
 			'Alegreya' => __( 'Alegreya', 'pressbooks' ),
 			'Cormorant Garamond' => __( 'Cormorant Garamond', 'pressbooks' ),
 			'Crimson Text' => __( 'Crimson Text', 'pressbooks' ),
-			'FreeFont Serif' => __( 'GNU FreeFont Serif', 'pressbooks' ),
+			'FreeSerif' => __( 'GNU FreeFont Serif', 'pressbooks' ),
 			'New Athena Unicode' => __( 'New Athena Unicode', 'pressbooks' ),
 			'Noto Serif' => __( 'Noto Serif', 'pressbooks' ),
 			'Sorts Mill Goudy' => __( 'Sorts Mill Goudy', 'pressbooks' ),
@@ -652,7 +652,7 @@ class Styles {
 
 		$sans_serif = [
 			'Barlow' => __( 'Barlow', 'pressbooks' ),
-			'FreeFont Sans' => __( 'GNU FreeFont Sans', 'pressbooks' ),
+			'FreeSans' => __( 'GNU FreeFont Sans', 'pressbooks' ),
 			'K2D' => __( 'K2D', 'pressbooks' ),
 			'Lato' => __( 'Lato', 'pressbooks' ),
 			'Libre Franklin' => __( 'Libre Franklin', 'pressbooks' ),


### PR DESCRIPTION
We accidentally broke this feature which displays GNU Free Sans and GNU Free Serif fonts using 'shapeshifter' with a previous commit: https://github.com/pressbooks/pressbooks/pull/2020/files. This PR restores the correct names for GNU Free fonts.

**To test:**
1. Open a book and apply the McLuhan or Malala themes
2. Go to appearance->theme options->web options and choose GNU Free Font Serif and GNU Free Font Sans for header and body fonts
![Screenshot from 2021-06-10 08-08-22](https://user-images.githubusercontent.com/13485451/121549823-0be08000-c9c3-11eb-89f0-0b7f8666091c.png)
3. Open the webbook and check to see that Pressbooks correctly load network resources corresponding to the desired fonts
![Screenshot from 2021-06-10 08-11-53](https://user-images.githubusercontent.com/13485451/121550370-87423180-c9c3-11eb-9bf2-e48b861d4ed7.png)
![Screenshot from 2021-06-10 08-11-43](https://user-images.githubusercontent.com/13485451/121550373-87dac800-c9c3-11eb-9f29-bde2da410e85.png)
