### PR TITLE
Remove unneeded JavaScript & test

### DIFF
--- a/hooks.php
+++ b/hooks.php
@@ -308,7 +308,6 @@ add_action( 'activated_plugin', '\Pressbooks\Admin\Plugins\quicklatex_svg_warnin
 add_filter( 'gettext', '\Pressbooks\Registration\custom_signup_text', 20, 3 );
 add_action( 'signup_extra_fields', '\Pressbooks\Registration\add_password_field', 9 );
 add_filter( 'wpmu_validate_user_signup', '\Pressbooks\Registration\validate_passwords' );
-add_action( 'wp_footer', '\Pressbooks\Registration\add_a11y' );
 add_filter( 'add_signup_meta', '\Pressbooks\Registration\add_temporary_password', 99 );
 add_action( 'signup_blogform', '\Pressbooks\Registration\add_hidden_password_field' );
 add_filter( 'random_password', '\Pressbooks\Registration\override_password_generation' );

--- a/inc/registration/namespace.php
+++ b/inc/registration/namespace.php
@@ -351,22 +351,6 @@ function check_for_strong_password( $pwd ) {
 }
 
 /**
- * Add accessbility on create book page
- */
-function add_a11y() {
-
-	echo '<script type="text/javascript">
-		jQuery( document ).ready( function( $ ) {
-
-			//https://core.trac.wordpress.org/ticket/48657
-			$(".mu_register.wp-signup-container").attr("role","main");
-
-		} );
-	</script>';
-
-}
-
-/**
  * Remove unwanted and unnecessary Bedrock's prefix in Lost Url link
  * only if the book name is not wp
  */

--- a/tests/test-registration.php
+++ b/tests/test-registration.php
@@ -162,17 +162,4 @@ class Registration extends \WP_UnitTestCase {
 		$this->assertTrue( is_string( $errors ) );
 		$this->assertEmpty( $errors );
 	}
-
-	/**
-	 * @group registration
-	 */
-	public function test_add_a11y() {
-		$expected = '$(".mu_register.wp-signup-container").attr("role","main");';
-
-		ob_start();
-		\Pressbooks\Registration\add_a11y();
-		$buffer = ob_get_clean();
-		$this->assertContains( $expected, $buffer );
-	}
-
 }


### PR DESCRIPTION
This PR fixes https://github.com/pressbooks/pressbooks/issues/2152 by removing the main landmark we added to the wp-signup page while waiting for WordPress to release an upstream fix. 

To test:
1. visit `https://YOURNETWORK.URL/wp-signup.php` and visually inspect the page to ensure that you see `<div class="mu_register wp-signup-container" role="main">` with role="main" applied as expected