### PR TITLE
Suppress mobi 8 generation for kindlegen

### DIFF
--- a/inc/modules/export/mobi/class-kindlegen.php
+++ b/inc/modules/export/mobi/class-kindlegen.php
@@ -27,6 +27,10 @@ class Kindlegen extends Export {
 			define( 'PB_KINDLEGEN_COMMAND', '/opt/kindlegen/kindlegen' );
 		}
 
+		if ( ! defined( 'PB_KINDLEGEN_SUPPRESS_MOBI8' ) ) {
+			define( 'PB_KINDLEGEN_SUPRRESS_MOBI8', false );
+		}
+
 	}
 
 
@@ -71,6 +75,12 @@ class Kindlegen extends Export {
 		$last_line = array_filter( $output );
 		$last_line = strtolower( end( $last_line ) );
 		if ( false !== strpos( $last_line, 'mobi file built successfully' ) ) {
+			if ( PB_KINDLEGEN_SUPPRESS_MOBI8 ) {
+				$mobi8_filename = $input_folder . sanitize_file_name( basename( $this->outputPath . '8' ) );
+				if ( file_exists( $mobi8_filename ) ) {
+					unlink( $mobi8_filename );
+				}
+			}
 
 			// Ok!
 			return true;


### PR DESCRIPTION
**Description**
This Pull Request suppresses the .mobi8 generation for Kindlegen in the site's export folder by removing the file after generation in Ubuntu 20.04.

To suppress the .mobi8 file generation define php constant PB_KINDLEGEN_SUPRRESS_MOBI8 to true.
By default PB_KINDLEGEN_SUPRRESS_MOBI8 is false.

**Test**
Export a book in Mobi format in an OS Ubuntu 20.04 with Pressbooks

**Result**
Only Mobi file is generated and Mobi8 does not exist.
