### PR TITLE
Update kindlegen creation within /tmp folder to avoid efs effects of …

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -27,6 +27,7 @@ jobs:
 
     - name: Install OS dependencies
       run: |
+        sudo apt update
         sudo apt-get install libxml2-utils ghostscript poppler-utils imagemagick
         sudo systemctl start mysql.service
         wget https://github.com/w3c/epubcheck/releases/download/v${{ matrix.epubcheck }}/epubcheck-${{ matrix.epubcheck }}.zip

--- a/inc/modules/export/mobi/class-kindlegen.php
+++ b/inc/modules/export/mobi/class-kindlegen.php
@@ -2,7 +2,6 @@
 /**
  * @author  Pressbooks <code@pressbooks.com>
  * @license GPLv3 (or any later version)
- *
  */
 
 namespace Pressbooks\Modules\Export\Mobi;
@@ -88,17 +87,16 @@ class Kindlegen extends Export {
 		$filename = $this->timestampedFileName( '.mobi' );
 		$this->outputPath = $filename;
 
-		// Move epub to tmp folder, convert and move to export folder
-		$tmp_input_path = $this->tmpDir . DIRECTORY_SEPARATOR . escapeshellcmd( basename( $input_path ) );
-
-		copy( escapeshellcmd( $input_path ), $tmp_input_path );
+		// Copy epub to tmp folder, convert and copy mobi to export folder
+		$tmp_input_path = $this->tmpDir . DIRECTORY_SEPARATOR . basename( $input_path );
+		copy( $input_path, $tmp_input_path );
 
 		$command = PB_KINDLEGEN_COMMAND . ' ' . escapeshellcmd( $tmp_input_path ) . ' -locale en -o ' . escapeshellcmd( basename( $this->outputPath ) ) . ' 2>&1';
 
 		$output = [];
 		$return_var = 0;
 		exec( $command, $output, $return_var );
-		copy( $this->tmpDir . DIRECTORY_SEPARATOR . basename( $this->outputPath ), dirname( $this->outputPath ) . DIRECTORY_SEPARATOR . basename( $this->outputPath ) );
+		copy( $this->tmpDir . DIRECTORY_SEPARATOR . basename( $this->outputPath ), $this->outputPath );
 
 		// Check build results
 

--- a/inc/modules/export/mobi/class-kindlegen.php
+++ b/inc/modules/export/mobi/class-kindlegen.php
@@ -2,6 +2,7 @@
 /**
  * @author  Pressbooks <code@pressbooks.com>
  * @license GPLv3 (or any later version)
+ *
  */
 
 namespace Pressbooks\Modules\Export\Mobi;
@@ -56,6 +57,7 @@ class Kindlegen extends Export {
 	 * Create $this->outputPath
 	 *
 	 * @return bool
+	 * @codeCoverageIgnore
 	 */
 	function convert() {
 		if ( empty( $this->tmpDir ) || ! is_dir( $this->tmpDir ) ) {
@@ -153,7 +155,7 @@ class Kindlegen extends Export {
 	/**
 	 * Delete temporary directory
 	 */
-	protected function deleteTmpDir() {
+	public function deleteTmpDir() {
 
 		// Cleanup temporary directory, if any
 		if ( ! empty( $this->tmpDir ) ) {

--- a/inc/modules/export/mobi/class-kindlegen.php
+++ b/inc/modules/export/mobi/class-kindlegen.php
@@ -87,7 +87,7 @@ class Kindlegen extends Export {
 		$this->outputPath = $filename;
 
 		// Move epub to tmp folder, convert and move to export folder
-		$tmp_input_path = $this->tmpDir . DIRECTORY_SEPARATOR . escapeshellcmd( basename( $input_path) );
+		$tmp_input_path = $this->tmpDir . DIRECTORY_SEPARATOR . escapeshellcmd( basename( $input_path ) );
 
 		copy( escapeshellcmd( $input_path ), $tmp_input_path );
 

--- a/tests/test-modules-export-mobi.php
+++ b/tests/test-modules-export-mobi.php
@@ -4,9 +4,7 @@ class Modules_Export_MobiTest extends \WP_UnitTestCase {
 
 	use utilsTrait;
 
-	/**
-	 *
-	 */
+
 	public function setUp() {
 		parent::setUp();
 		$this->kindlegen = new Pressbooks\Modules\Export\Mobi\Kindlegen( [] );

--- a/tests/test-modules-export-mobi.php
+++ b/tests/test-modules-export-mobi.php
@@ -4,7 +4,6 @@ class Modules_Export_MobiTest extends \WP_UnitTestCase {
 
 	use utilsTrait;
 
-
 	public function setUp() {
 		parent::setUp();
 		$this->kindlegen = new Pressbooks\Modules\Export\Mobi\Kindlegen( [] );

--- a/tests/test-modules-export-mobi.php
+++ b/tests/test-modules-export-mobi.php
@@ -1,0 +1,21 @@
+<?php
+
+class Modules_Export_MobiTest extends \WP_UnitTestCase {
+
+	use utilsTrait;
+
+	/**
+	 *
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->kindlegen = new Pressbooks\Modules\Export\Mobi\Kindlegen( [] );
+	}
+
+	public function test_deleteTmpDir() {
+		$this->assertTrue( file_exists( $this->kindlegen->getTmpDir() ) );
+		$this->kindlegen->deleteTmpDir();
+		$this->assertFalse( file_exists( $this->kindlegen->getTmpDir() ) );
+	}
+
+}


### PR DESCRIPTION
Description
This PR updates the mobi export creation process within the server's /tmp folder, to avoid side effects of AWS EFS which creates mobi and mobi8 files, assuming the /tmp folder is not using EFS. This process can work with infrastructure with or without EFS. For more details see: https://github.com/pressbooks/ca-central-1-infrastructure/issues/36

Test:
1. Visit qa.dev-infra.pressbooks.com 
2. Export a book in mobi format
3. Observe that a single mobi file is created without validation error
Sample screenshot
![image](https://user-images.githubusercontent.com/21694293/122858239-f7b45100-d2e7-11eb-9b7a-d7d280b9e19a.png)
