### PR TITLE
Pb 2154 Use https when available on API books endpoint resources

### DIFF
--- a/inc/api/endpoints/controller/class-books.php
+++ b/inc/api/endpoints/controller/class-books.php
@@ -2,10 +2,10 @@
 
 namespace Pressbooks\Api\Endpoints\Controller;
 
+use function Pressbooks\Utility\apply_https_if_available;
 use function \Pressbooks\Metadata\book_information_to_schema;
 use Pressbooks\Admin\Network\SharingAndPrivacyOptions;
 use Pressbooks\DataCollector\Book as BookDataCollector;
-use function Pressbooks\Utility\apply_https_if_available;
 
 class Books extends \WP_REST_Controller {
 

--- a/inc/api/endpoints/controller/class-books.php
+++ b/inc/api/endpoints/controller/class-books.php
@@ -5,6 +5,7 @@ namespace Pressbooks\Api\Endpoints\Controller;
 use function \Pressbooks\Metadata\book_information_to_schema;
 use Pressbooks\Admin\Network\SharingAndPrivacyOptions;
 use Pressbooks\DataCollector\Book as BookDataCollector;
+use function Pressbooks\Utility\apply_https_if_available;
 
 class Books extends \WP_REST_Controller {
 
@@ -268,7 +269,7 @@ class Books extends \WP_REST_Controller {
 
 		$item = [
 			'id' => $id,
-			'link' => get_blogaddress_by_id( $id ),
+			'link' => apply_https_if_available( get_blogaddress_by_id( $id ) ),
 			'metadata' => $metadata,
 		];
 

--- a/inc/datacollector/class-book.php
+++ b/inc/datacollector/class-book.php
@@ -471,7 +471,7 @@ class Book {
 		$cover_id = $attachment_id ? $attachment_id : attachment_id_from_url( $cover_path );
 
 		if ( $cover_id ) {
-			$cover_path = wp_get_attachment_image_url( $cover_id, 'large', false );
+			$cover_path = wp_get_attachment_image_url( $cover_id, 'pb_cover_large', false );
 		}
 
 		return  is_ssl() ? str_replace( 'http://', 'https://', $cover_path ) : $cover_path;

--- a/inc/metadata/namespace.php
+++ b/inc/metadata/namespace.php
@@ -5,6 +5,7 @@ namespace Pressbooks\Metadata;
 use function \Pressbooks\L10n\get_book_language;
 use function \Pressbooks\L10n\get_locale;
 use function \Pressbooks\Sanitize\is_valid_timestamp;
+use function Pressbooks\Utility\apply_https_if_available;
 use function \Pressbooks\Utility\get_contents;
 use function \Pressbooks\Utility\is_assoc;
 use function \Pressbooks\Utility\oxford_comma;
@@ -429,6 +430,10 @@ function book_information_to_schema( $book_information, $network_excluded_direct
 			'host' => wp_parse_url( network_home_url(), PHP_URL_HOST ),
 			'name' => $book_information['site_name'],
 		];
+	}
+
+	if ( isset( $book_information['pb_cover_image'] ) ) {
+		$book_schema['image'] = apply_https_if_available( $book_schema['image'] );
 	}
 
 	// TODO: educationalAlignment, educationalUse, timeRequired, typicalAgeRange, interactivityType, learningResourceType, isBasedOnUrl

--- a/inc/metadata/namespace.php
+++ b/inc/metadata/namespace.php
@@ -2,10 +2,10 @@
 
 namespace Pressbooks\Metadata;
 
+use function Pressbooks\Utility\apply_https_if_available;
 use function \Pressbooks\L10n\get_book_language;
 use function \Pressbooks\L10n\get_locale;
 use function \Pressbooks\Sanitize\is_valid_timestamp;
-use function Pressbooks\Utility\apply_https_if_available;
 use function \Pressbooks\Utility\get_contents;
 use function \Pressbooks\Utility\is_assoc;
 use function \Pressbooks\Utility\oxford_comma;

--- a/inc/utility/namespace.php
+++ b/inc/utility/namespace.php
@@ -1500,3 +1500,13 @@ function do_shortcode_by_tags( $content, array $tags ) {
 	$shortcode_tags = $_tags;
 	return $shortcoded;
 }
+
+
+/**
+ * This function swap http to https if ssl is available
+ * @param $url
+ * @return array|mixed|string|string[]
+ */
+function apply_https_if_available( $url ) {
+	return  is_ssl() ? str_replace( 'http://', 'https://', $url ) : $url;
+}

--- a/tests/test-utility.php
+++ b/tests/test-utility.php
@@ -4,6 +4,10 @@ class UtilityTest extends \WP_UnitTestCase {
 
 	use utilsTrait;
 
+	public static function tearDownAfterClass() {
+		$_SERVER['SERVER_PORT'] = '';
+	}
+
 	/**
 	 * @group utility
 	 */
@@ -745,6 +749,16 @@ class UtilityTest extends \WP_UnitTestCase {
 
 		$expected = '<img src="http://localhost:3000/latex?latex=e%5E%7B%5Ci%20%5Cpi%7D%20%2B%201%20%3D%200&#038;fg=000000&#038;font=TeX" alt="e^{&#92;i &#92;pi} + 1 = 0" title="e^{&#92;i &#92;pi} + 1 = 0" class="latex mathjax" />';
 		$this->assertEquals( $expected, \Pressbooks\Utility\do_shortcode_by_tags( $content, [ 'latex', 'embed' ] ) );
+	}
+
+	public function test_https_swap() {
+		$_SERVER['SERVER_PORT'] = '443';
+		$url = 'http://pressbooks.test/book';
+		$this->assertEquals( \Pressbooks\Utility\apply_https_if_available( $url ), 'https://pressbooks.test/book' );
+
+		$_SERVER['SERVER_PORT'] = '';
+		$url = 'http://network-no-ssl.pressbooks.test/book';
+		$this->assertEquals( \Pressbooks\Utility\apply_https_if_available( $url ), 'http://network-no-ssl.pressbooks.test/book' );
 	}
 
 }


### PR DESCRIPTION
This PR solves #2154 

This enforces https for book urls and images exposed through the API

## How to test

Create a new book on your network, change the site_url and home_url in your wp_*_options to http://, review the book on the API and should have https on the link and image attributes.

I'm not sure about hooking the `wp_insert_site` I couldn't find any modifications inside the default multisite blog (book) creation, but if we want to proceed we could use that hook to update `site_url` and `home_url` id those values don't have https and the main has `ssl` enabled.