### PR TITLE
Fix Cannot modify header warning

### DIFF
--- a/inc/redirect/namespace.php
+++ b/inc/redirect/namespace.php
@@ -201,6 +201,7 @@ function rewrite_rules_for_open() {
 	add_filter( 'template_redirect', function () {
 		do_open( function ( $filepath ) {
 			force_download( $filepath );
+			exit;
 		} );
 	}, 0 );
 }


### PR DESCRIPTION
Fix for #2233 

This PR removes the "Cannot modify header" warning when downloading books.

### How to test

1. Perform any book download
1. The file `/srv/www/pressbooks.test/logs/error.log` shouldn't have "Cannot modify header information" warnings.