### PR TITLE
Break line after Contact link

### DIFF
--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -70,7 +70,7 @@ function add_footer_link() {
 	}
 
 	printf(
-		'<span id="footer-thankyou">%1$s</span> &bull; %2$s &bull; %3$s &bull; %4$s &bull; %5$s %6$s',
+		'<span id="footer-thankyou">%1$s</span> &bull; %2$s &bull; %3$s &bull; %4$s &bull; %5$s %6$s <br/>',
 		sprintf(
 			__( 'Powered by %s', 'pressbooks' ),
 			sprintf(


### PR DESCRIPTION
This PR adds a line break after the Pressbooks footer text, so that it will display more cleanly when other plugins (like Koko Analytics) append additional text in this area.