### PR TITLE
Pb 2263 trim book info

### DIFF
--- a/inc/admin/metaboxes/namespace.php
+++ b/inc/admin/metaboxes/namespace.php
@@ -190,6 +190,9 @@ function add_meta_boxes() {
 		'pb_title', 'metadata', [
 			'group' => 'general-book-information',
 			'label' => __( 'Title', 'pressbooks' ),
+			'sanitize_callback' => function ( ...$args ) {
+				return sanitize_text_field( $args[ METADATA_CALLBACK_INDEX ] );
+			},
 		]
 	);
 
@@ -198,6 +201,9 @@ function add_meta_boxes() {
 			'group' => 'general-book-information',
 			'label' => __( 'Short Title', 'pressbooks' ),
 			'description' => __( 'In case of long titles that might be truncated in running heads in the PDF export.', 'pressbooks' ),
+			'sanitize_callback' => function ( ...$args ) {
+				return sanitize_text_field( $args[ METADATA_CALLBACK_INDEX ] );
+			},
 		]
 	);
 
@@ -205,6 +211,9 @@ function add_meta_boxes() {
 		'pb_subtitle', 'metadata', [
 			'group' => 'general-book-information',
 			'label' => __( 'Subtitle', 'pressbooks' ),
+			'sanitize_callback' => function ( ...$args ) {
+				return sanitize_text_field( $args[ METADATA_CALLBACK_INDEX ] );
+			},
 		]
 	);
 
@@ -285,6 +294,9 @@ function add_meta_boxes() {
 			'group' => 'general-book-information',
 			'label' => __( 'Publisher', 'pressbooks' ),
 			'description' => __( 'This text appears on the title page of your book.', 'pressbooks' ),
+			'sanitize_callback' => function ( ...$args ) {
+				return sanitize_text_field( $args[ METADATA_CALLBACK_INDEX ] );
+			},
 		]
 	);
 
@@ -293,6 +305,9 @@ function add_meta_boxes() {
 			'group' => 'general-book-information',
 			'label' => __( 'Publisher City', 'pressbooks' ),
 			'description' => __( 'This text appears on the title page of your book.', 'pressbooks' ),
+			'sanitize_callback' => function ( ...$args ) {
+				return sanitize_text_field( $args[ METADATA_CALLBACK_INDEX ] );
+			},
 		]
 	);
 
@@ -321,6 +336,9 @@ function add_meta_boxes() {
 			'group' => 'general-book-information',
 			'label' => __( 'Ebook ISBN', 'pressbooks' ),
 			'description' => __( 'ISBN is the International Standard Book Number, and you\'ll need one if you want to sell your book in some online ebook stores. This is added to the metadata in your ebook.', 'pressbooks' ),
+			'sanitize_callback' => function ( ...$args ) {
+				return sanitize_text_field( $args[ METADATA_CALLBACK_INDEX ] );
+			},
 		]
 	);
 
@@ -329,6 +347,9 @@ function add_meta_boxes() {
 			'group' => 'general-book-information',
 			'label' => __( 'Print ISBN', 'pressbooks' ),
 			'description' => __( 'ISBN is the International Standard Book Number, and you\'ll need one if you want to sell your book in online and physical book stores.', 'pressbooks' ),
+			'sanitize_callback' => function ( ...$args ) {
+				return sanitize_text_field( $args[ METADATA_CALLBACK_INDEX ] );
+			},
 		]
 	);
 
@@ -336,6 +357,9 @@ function add_meta_boxes() {
 		'pb_book_doi', 'metadata', [
 			'group' => 'general-book-information',
 			'label' => __( 'Digital Object Identifier (DOI)', 'pressbooks' ),
+			'sanitize_callback' => function ( ...$args ) {
+				return sanitize_text_field( $args[ METADATA_CALLBACK_INDEX ] );
+			},
 		]
 	);
 
@@ -388,6 +412,9 @@ function add_meta_boxes() {
 			'group' => 'copyright',
 			'label' => __( 'Copyright Holder', 'pressbooks' ),
 			'description' => __( 'Name of the copyright holder.', 'pressbooks' ),
+			'sanitize_callback' => function ( ...$args ) {
+				return sanitize_text_field( $args[ METADATA_CALLBACK_INDEX ] );
+			},
 		]
 	);
 
@@ -425,6 +452,9 @@ function add_meta_boxes() {
 			'group' => 'about-the-book',
 			'label' => __( 'Book Tagline', 'pressbooks' ),
 			'description' => __( 'A very short description of your book. It should fit in a Twitter post, and encapsulate your book in the briefest sentence.', 'pressbooks' ),
+			'sanitize_callback' => function ( ...$args ) {
+				return sanitize_text_field( $args[ METADATA_CALLBACK_INDEX ] );
+			},
 		]
 	);
 
@@ -475,6 +505,9 @@ function add_meta_boxes() {
 				'group' => 'additional-catalog-information',
 				'label' => __( 'Series Number', 'pressbooks' ),
 				'description' => __( 'Add if your book is part of a series.', 'pressbooks' ),
+				'sanitize_callback' => function ( ...$args ) {
+					return sanitize_text_field( $args[ METADATA_CALLBACK_INDEX ] );
+				},
 			]
 		);
 
@@ -492,6 +525,9 @@ function add_meta_boxes() {
 				'group' => 'additional-catalog-information',
 				'label' => __( 'Hashtag', 'pressbooks' ),
 				'description' => __( 'These are added to your webbook cover page. For those of you who like Twitter.', 'pressbooks' ),
+				'sanitize_callback' => function ( ...$args ) {
+					return sanitize_text_field( $args[ METADATA_CALLBACK_INDEX ] );
+				},
 			]
 		);
 
@@ -500,6 +536,9 @@ function add_meta_boxes() {
 				'group' => 'additional-catalog-information',
 				'label' => __( 'List Price (Print)', 'pressbooks' ),
 				'description' => __( 'The list price of your book in print.', 'pressbooks' ),
+				'sanitize_callback' => function ( ...$args ) {
+					return sanitize_text_field( $args[ METADATA_CALLBACK_INDEX ] );
+				},
 			]
 		);
 
@@ -508,6 +547,9 @@ function add_meta_boxes() {
 				'group' => 'additional-catalog-information',
 				'label' => __( 'List Price (PDF)', 'pressbooks' ),
 				'description' => __( 'The list price of your book in PDF format.', 'pressbooks' ),
+				'sanitize_callback' => function ( ...$args ) {
+					return sanitize_text_field( $args[ METADATA_CALLBACK_INDEX ] );
+				},
 			]
 		);
 
@@ -516,6 +558,9 @@ function add_meta_boxes() {
 				'group' => 'additional-catalog-information',
 				'label' => __( 'List Price (ebook)', 'pressbooks' ),
 				'description' => __( 'The list price of your book in Ebook formats.', 'pressbooks' ),
+				'sanitize_callback' => function ( ...$args ) {
+					return sanitize_text_field( $args[ METADATA_CALLBACK_INDEX ] );
+				},
 			]
 		);
 
@@ -524,6 +569,9 @@ function add_meta_boxes() {
 				'group' => 'additional-catalog-information',
 				'label' => __( 'List Price (Web)', 'pressbooks' ),
 				'description' => __( 'The list price of your webbook.', 'pressbooks' ),
+				'sanitize_callback' => function ( ...$args ) {
+					return sanitize_text_field( $args[ METADATA_CALLBACK_INDEX ] );
+				},
 			]
 		);
 

--- a/inc/admin/metaboxes/namespace.php
+++ b/inc/admin/metaboxes/namespace.php
@@ -403,6 +403,10 @@ function add_meta_boxes() {
 				'group' => 'copyright',
 				'label' => __( 'Copyright Year', 'pressbooks' ),
 				'description' => __( 'Year that the book is/was published.', 'pressbooks' ),
+				'sanitize_callback' => function ( ...$args ) {
+					return sanitize_text_field( $args[ METADATA_CALLBACK_INDEX ] );
+				},
+
 			]
 		);
 	}
@@ -435,7 +439,7 @@ function add_meta_boxes() {
 			'label' => __( 'Copyright Notice', 'pressbooks' ),
 			'description' => __( 'Enter a custom copyright notice, with whatever information you like. This will override the auto-generated copyright notice if All Rights Reserved or no license is selected, and will be inserted after the title page. If you select a Creative Commons license, the custom notice will appear after the license text in both the webbook and your exports.', 'pressbooks' ),
 			'sanitize_callback' => function ( ...$args ) {
-				return sanitize_string( $args[ METADATA_CALLBACK_INDEX ], true );
+				return trim( sanitize_string( $args[ METADATA_CALLBACK_INDEX ], true ) );
 			},
 		]
 	);
@@ -465,7 +469,7 @@ function add_meta_boxes() {
 			'label' => __( 'Short Description', 'pressbooks' ),
 			'description' => __( 'A short paragraph about your book, for catalogs, reviewers etc. to quote.', 'pressbooks' ),
 			'sanitize_callback' => function ( ...$args ) {
-				return sanitize_string( $args[ METADATA_CALLBACK_INDEX ], true );
+				return trim( sanitize_string( $args[ METADATA_CALLBACK_INDEX ], true ) );
 			},
 		]
 	);
@@ -477,7 +481,7 @@ function add_meta_boxes() {
 			'label' => __( 'Long Description', 'pressbooks' ),
 			'description' => __( 'The full description of your book.', 'pressbooks' ),
 			'sanitize_callback' => function ( ...$args ) {
-				return sanitize_string( $args[ METADATA_CALLBACK_INDEX ], true );
+				return trim( sanitize_string( $args[ METADATA_CALLBACK_INDEX ], true ) );
 			},
 		]
 	);
@@ -497,6 +501,9 @@ function add_meta_boxes() {
 				'group' => 'additional-catalog-information',
 				'label' => __( 'Series Title', 'pressbooks' ),
 				'description' => __( 'Add if your book is part of a series.', 'pressbooks' ),
+				'sanitize_callback' => function ( ...$args ) {
+					return sanitize_text_field( $args[ METADATA_CALLBACK_INDEX ] );
+				},
 			]
 		);
 

--- a/inc/redirect/namespace.php
+++ b/inc/redirect/namespace.php
@@ -198,12 +198,16 @@ function rewrite_rules_for_sitemap() {
 function rewrite_rules_for_open() {
 
 	add_rewrite_endpoint( 'open', EP_ROOT );
-	add_filter( 'template_redirect', function () {
-		do_open( function ( $filepath ) {
-			force_download( $filepath );
-			exit;
-		} );
-	}, 0 );
+	add_filter(
+		'template_redirect', function () {
+			do_open(
+				function ( $filepath ) {
+					force_download( $filepath );
+					exit;
+				}
+			);
+		}, 0
+	);
 }
 
 /**

--- a/inc/tracking/class-tracking.php
+++ b/inc/tracking/class-tracking.php
@@ -67,12 +67,14 @@ abstract class Tracking {
 
 		$date = new \DateTime( 'now', new \DateTimeZone( 'UTC' ) );
 
-		$wpdb->insert( $this->dbTable, [
-			'blog_id' => get_current_blog_id(),
-			'track_type' => $this->type,
-			'track_value' => $value,
-			'logged_in' => is_user_logged_in(),
-			'created_at' => $date->format( 'Y-m-d H:i:s' ),
-		] );
+		$wpdb->insert(
+			$this->dbTable, [
+				'blog_id' => get_current_blog_id(),
+				'track_type' => $this->type,
+				'track_value' => $value,
+				'logged_in' => is_user_logged_in(),
+				'created_at' => $date->format( 'Y-m-d H:i:s' ),
+			]
+		);
 	}
 }


### PR DESCRIPTION
This PR fixes #2263 by sanitizing the text entry fields for several of the book info metadata fields (including book title).

To test:
1. Open the book info page for a book
2. Enter values text entry fields which include superfluous spaces at the beginning or end of the string, html tags, `<` characters or other characters removed by the WP sanitize text field function: https://developer.wordpress.org/reference/functions/sanitize_text_field/
3. Add extra space at the beginning and end of the copyright notice, short and long description fields
4. Save book info and observe that extra white space at beginning and end of string has been removed on save for all fields
5. Observe that HTML tags and other characters have been sanitized or escaped upon save for all text entry fields except copyright notice, short and long description fields (which permit HTML).