### PR TITLE
Escape special characters for alt image attribute

### DIFF
--- a/inc/modules/export/xhtml/class-xhtml11.php
+++ b/inc/modules/export/xhtml/class-xhtml11.php
@@ -645,7 +645,7 @@ class Xhtml11 extends ExportGenerator {
 		$content = str_ireplace( [ '<b></b>', '<i></i>', '<strong></strong>', '<em></em>' ], '', $content );
 		$content = $this->fixInternalLinks( $content, $id );
 		$content = $this->switchLaTexFormat( $content );
-		$content = $this->fixAltAttributesImages( $content );
+		$content = $this->fixImageAttributes( $content );
 		if ( ! empty( $_GET['optimize-for-print'] ) ) {
 			$content = $this->fixImages( $content );
 		}
@@ -654,7 +654,7 @@ class Xhtml11 extends ExportGenerator {
 		return $content;
 	}
 
-	protected function fixAltAttributesImages( $content ) {
+	protected function fixImageAttributes( $content ) {
 		$html5 = new HtmlParser();
 		$dom = $html5->loadHTML( $content );
 		$images = $dom->getElementsByTagName( 'img' );

--- a/inc/modules/export/xhtml/class-xhtml11.php
+++ b/inc/modules/export/xhtml/class-xhtml11.php
@@ -662,6 +662,9 @@ class Xhtml11 extends ExportGenerator {
 			$alt = $image->getAttribute( 'alt' );
 			$alt = htmlspecialchars( $alt );
 			$image->setAttribute( 'alt', $alt );
+			$title = $image->getAttribute( 'title' );
+			$title = htmlspecialchars( $title );
+			$image->setAttribute( 'title', $title );
 		}
 		$content = $html5->saveHTML( $dom );
 		return $content;

--- a/inc/modules/export/xhtml/class-xhtml11.php
+++ b/inc/modules/export/xhtml/class-xhtml11.php
@@ -645,11 +645,25 @@ class Xhtml11 extends ExportGenerator {
 		$content = str_ireplace( [ '<b></b>', '<i></i>', '<strong></strong>', '<em></em>' ], '', $content );
 		$content = $this->fixInternalLinks( $content, $id );
 		$content = $this->switchLaTexFormat( $content );
+		$content = $this->fixAltAttributesImages( $content );
 		if ( ! empty( $_GET['optimize-for-print'] ) ) {
 			$content = $this->fixImages( $content );
 		}
 		$content = $this->tidy( $content );
 
+		return $content;
+	}
+
+	protected function fixAltAttributesImages( $content ) {
+		$html5 = new HtmlParser();
+		$dom = $html5->loadHTML( $content );
+		$images = $dom->getElementsByTagName( 'img' );
+		foreach ( $images as $image ) {
+			$alt = $image->getAttribute( 'alt' );
+			$alt = htmlspecialchars( $alt );
+			$image->setAttribute( 'alt', $alt );
+		}
+		$content = $html5->saveHTML( $dom );
 		return $content;
 	}
 


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks/issues/1918

When an image is upload to a chapter, part or other taxonomies with alternative text containing unsupported html characters, it breaks the XHTML export formats affecting PDF export formats.

This change checks the `alt` and `title` attributes for images and applies the `htmlspecialchars` PHP function to convert those special characters.

### Test notes
- Add an image to a chapter, and add a unsupported character as alternative text for that image, for example: `I am > an alternative text`.
- Export the book to PDF and confirm the book looks as expected