### PR TITLE
Update support URL

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -17,7 +17,7 @@ jobs:
         os: [ubuntu-18.04]
         epubcheck: [4.2.4]
         prince: [12.5-1]
-        wordpress: [5.7.2, latest]
+        wordpress: [5.8, latest]
 
     name: PHPUnit - ${{ matrix.php }} - ${{ matrix.wordpress }}
 

--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -91,7 +91,7 @@ function add_footer_link() {
 			 *
 			 * @since 5.6.0
 			 */
-			apply_filters( 'pb_help_link', 'https://pressbooks.com/help-and-support/' ),
+			apply_filters( 'pb_help_link', 'https://pressbooks.com/support/' ),
 			__( 'Guides and Tutorials', 'pressbooks' )
 		),
 		sprintf(


### PR DESCRIPTION
This PR changes the Guides & Tutorials URL to point to the correct URL on the Pressbooks marketing site. It also bumps the WP version in GitHub Actions.