### PR TITLE
Improve cloning page instructions

### DIFF
--- a/inc/admin/dashboard/namespace.php
+++ b/inc/admin/dashboard/namespace.php
@@ -6,6 +6,7 @@
 
 namespace Pressbooks\Admin\Dashboard;
 
+use function Pressbooks\Admin\Laf\network_admin_menu;
 use function Pressbooks\Sanitize\safer_unserialize;
 
 /**
@@ -176,9 +177,11 @@ function lowly_user_callback() {
 		}
 		echo '</p>';
 	} else {
-		$href = network_home_url( 'wp-signup.php' );
-		$text = __( 'Create A New Book', 'pressbooks' );
-		echo "<p><a class='button button-hero button-primary' href='{$href}'>{$text}</a></p>";
+		$href_create = network_home_url( 'wp-signup.php' );
+		$text_create = __( 'Create a Book', 'pressbooks' );
+		$href_clone = admin_url( 'admin.php?page=pb_cloner' );
+		$text_clone = __( 'Clone a Book', 'pressbooks' );
+		echo "<p><a class='button button-hero button-primary' href='{$href_create}'>{$text_create}</a></p><p><a class='button button-hero button-primary' href='{$href_clone}'>{$text_clone}</a></p>";
 	}
 	if ( ! $user_has_books ) {
 		echo '<p>';

--- a/inc/admin/dashboard/namespace.php
+++ b/inc/admin/dashboard/namespace.php
@@ -6,7 +6,6 @@
 
 namespace Pressbooks\Admin\Dashboard;
 
-use function Pressbooks\Admin\Laf\network_admin_menu;
 use function Pressbooks\Sanitize\safer_unserialize;
 
 /**

--- a/inc/admin/metaboxes/namespace.php
+++ b/inc/admin/metaboxes/namespace.php
@@ -617,7 +617,7 @@ function add_meta_boxes() {
 					'group' => 'additional-catalog-information',
 					'label' => __( 'BISAC Subject(s)', 'pressbooks' ),
 					'multiple' => true,
-					'description' => sprintf( __( 'BISAC Subject Headings help libraries and (e)book stores properly classify your book. To select the appropriate subject heading for your book, consult %s', 'pressbooks' ), sprintf( '<a href="https://bisg.org/page/BISACEdition">%s</a>', __( 'the BISAC Subject Headings list', 'pressbooks' ) ) ),
+					'description' => sprintf( __( 'BISAC Subject Headings help libraries and bookstores properly classify your book. To select the appropriate subject heading for your book, consult %s.', 'pressbooks' ), sprintf( '<a href="https://bisg.org/page/BISACEdition">%s</a>', __( 'the BISAC Subject Headings list', 'pressbooks' ) ) ),
 				]
 			)
 		);
@@ -632,7 +632,7 @@ function add_meta_boxes() {
 				'pb_bisac_regional_theme_field_args', [
 					'group' => 'additional-catalog-information',
 					'label' => __( 'BISAC Regional Theme', 'pressbooks' ),
-					'description' => __( 'BISAC Regional Themes help libraries and (e)book stores properly classify your book.', 'pressbooks' ),
+					'description' => __( 'BISAC Regional Themes help libraries and bookstores properly classify your book.', 'pressbooks' ),
 				]
 			)
 		);

--- a/templates/admin/cloner.php
+++ b/templates/admin/cloner.php
@@ -10,14 +10,17 @@ if ( is_subdomain_install() ) {
 
 ?>
 <div class="wrap">
-	<h1><?php _e( 'Clone', 'pressbooks' ); ?></h1>
-	<p><?php _e( 'Enter the URL to a Pressbooks book to clone it.', 'pressbooks' ); ?><p>
+	<h1><?php _e( 'Clone a Book', 'pressbooks' ); ?></h1>
+	<p><?php printf( __( 'This tool allows you to %1$s from one Pressbooks network to another. Search the thousands of books in the %2$s for material you would like to clone.', 'pressbooks' ), sprintf( '<a href="https://guide.pressbooks.com/chapter/book-cloning/" target="_blank">%s</a>', __('clone openly licensed books', 'pressbooks' ) ), sprintf( '<a href="https://pressbooks.directory/" target="_blank">%s</a>', __( 'Pressbooks Directory', 'pressbooks' ) ) ); ?></p>
 	<form id="pb-cloner-form" action="" method="post">
 		<?php wp_nonce_field( 'pb-cloner' ); ?>
 		<table class="form-table" role="none">
 			<tr>
 				<th scope=row><label for="source_book_url"><?php _e( 'Source Book URL', 'pressbooks' ); ?></label></th>
-				<td><input class="regular-text code" id="source_book_url" name="source_book_url" type="url" required /></td>
+				<td>
+					<input class="regular-text code" id="source_book_url" name="source_book_url" type="url" required />
+					<p class="description" id="source_book_url_description"><?php _e( 'Enter the URL to a Pressbooks book with an open license which permits cloning.', 'pressbooks' ); ?></p>
+				</td>
 			</tr>
 			<tr>
 				<th scope=row><label for="target_book_url"><?php _e( 'Target Book URL', 'pressbooks' ); ?></label></th>
@@ -28,6 +31,7 @@ if ( is_subdomain_install() ) {
 						'<input class="regular-text code" id="target_book_url" name="target_book_url" type="text" required />'
 					);
 					?>
+					<p class="description" id="target_book_url_description"><?php _e( 'Enter an available URL where you want this book to be cloned.', 'pressbooks' ); ?></p>
 				</td>
 			</tr>
 			<tr>
@@ -38,7 +42,7 @@ if ( is_subdomain_install() ) {
 				</td>
 			</tr>
 		</table>
-		<p><input id="pb-cloner-button" class="button button-primary" type="submit" value="<?php _e( 'Clone It!', 'pressbooks' ); ?>" /></p>
+		<p><input id="pb-cloner-button" class="button button-primary" type="submit" value="<?php _e( 'Clone This Book', 'pressbooks' ); ?>" /></p>
 		<progress id="pb-sse-progressbar" max="100"></progress>
 		<p><b><span id="pb-sse-minutes"></span><span id="pb-sse-seconds"></span></b> <span id="pb-sse-info" aria-live="polite"></span></p>
 	</form>


### PR DESCRIPTION
Partial fix for https://github.com/pressbooks/pressbooks/issues/2285. This PR changes the instructions provided on the cloning page and adds a link to the Pressbooks Directory. It also adds a 'Clone a Book' button the lowly user dashboard and fixes some instructions on the Book Info page.

**To test:**
1. Switch to this branch and visit the book cloner page. Observe the changed text:
![Screenshot from 2021-07-30 06-51-27](https://user-images.githubusercontent.com/13485451/127663051-ce1d228c-8291-49f2-bd76-8f641d98c4e7.png)
1. Enter values for each of the fields and clone a book. Observe no change to the cloning routine's functionality
1. Visit the lowly user's dashboard. Observe the added 'Clone a Book' button:
![Screenshot from 2021-07-30 06-52-19](https://user-images.githubusercontent.com/13485451/127663175-d1f09f05-25fb-4124-bab6-b1f54c1a46ca.png)
1. Click this button to access the cloning routine.
1. Visit the book info page of an existing book and show all metadata. Observe the changed text for BISAC description fields
![Screenshot from 2021-07-30 06-54-01](https://user-images.githubusercontent.com/13485451/127663418-57d8a9fa-ca15-402c-ad73-83d504011dae.png)
1. Make a change and save your book info. Observe no change to the save Book Info functionality