### PR TITLE
Remove unused contact fields and add new ones to user profile page

### DIFF
--- a/hooks-admin.php
+++ b/hooks-admin.php
@@ -359,3 +359,6 @@ add_action( 'admin_init', '\Pressbooks\Theme\check_upgraded_customcss' );
 // Bulk add users
 add_action( 'init', [ '\Pressbooks\Admin\Users\UserBulk', 'init' ] );
 
+// Add & sanitize additional contact methods to user profile
+add_filter( 'user_contactmethods', '\Pressbooks\Admin\Laf\modify_user_contact_fields', 11 );
+add_action( 'user_profile_update_errors', '\Pressbooks\Admin\Laf\sanitize_user_profile', 10, 3 );

--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -8,6 +8,8 @@
 
 namespace Pressbooks\Admin\Laf;
 
+use stdClass;
+use WP_Error;
 use function Pressbooks\Admin\NetworkManagers\is_restricted;
 use function Pressbooks\PostType\get_post_type_label;
 use function Pressbooks\Utility\str_starts_with;
@@ -1626,11 +1628,11 @@ function modify_user_contact_fields( $methods ) {
 /**
  *
  * $since 5.27.0
- * @param array $errors
+ * @param WP_Error $errors
  * @param bool $update
- * @param \stdClass $user
+ * @param stdClass $user
  */
-function sanitize_user_profile( $errors, $update, $user ) {
+function sanitize_user_profile( WP_Error $errors, $update, $user ) {
 
 	$additional_urls_to_check = [ 'url' => 'Website' ];
 

--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -8,8 +8,6 @@
 
 namespace Pressbooks\Admin\Laf;
 
-use stdClass;
-use WP_Error;
 use function Pressbooks\Admin\NetworkManagers\is_restricted;
 use function Pressbooks\PostType\get_post_type_label;
 use function Pressbooks\Utility\str_starts_with;
@@ -22,6 +20,7 @@ use Pressbooks\BookDirectory;
 use Pressbooks\Cloner\Cloner;
 use Pressbooks\DataCollector\Book as DataCollector;
 use Pressbooks\Metadata;
+use WP_Error;
 
 /**
  * @return bool

--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -1635,8 +1635,9 @@ function sanitize_user_profile( $errors, $update, $user ) {
 	$additional_urls_to_check = [ 'url' => 'Website' ];
 
 	foreach ( array_merge( get_user_contact_fields(), $additional_urls_to_check ) as $key => $value ) {
-		if ( ! empty( $_POST[ $key ] ) ) {
-			if ( ! filter_var( $_POST[ $key ], FILTER_VALIDATE_URL ) ) {
+		$field = wp_kses( $_POST[ $key ], false );
+		if ( ! empty( $field ) ) {
+			if ( ! filter_var( $field, FILTER_VALIDATE_URL ) ) {
 				$errors->add( $key, "The $value field is not a valid URL." );
 			}
 		}

--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -1592,3 +1592,53 @@ function edit_screen_navigation( $post ) {
 		echo '</nav>';
 	}
 }
+
+/**
+ *
+ * $since 5.27.0
+ * @return array
+ */
+function get_user_contact_fields() {
+	$methods = [];
+	$methods['twitter'] = __( 'Twitter URL', 'pressbooks' );
+	$methods['linkedin'] = __( 'LinkedIn URL', 'pressbooks' );
+	$methods['github'] = __( 'GitHub URL', 'pressbooks' );
+	return $methods;
+}
+
+/**
+ *
+ * $since 5.27.0
+ * @param array $methods
+ * @return array
+ */
+function modify_user_contact_fields( $methods ) {
+
+	// Remove unwanted user contact methods
+	unset( $methods['aim'] );
+	unset( $methods['yim'] );
+	unset( $methods['jabber'] );
+
+	// Add desired user contact methods
+	return array_merge( $methods, get_user_contact_fields() );
+}
+
+/**
+ *
+ * $since 5.27.0
+ * @param array $errors
+ * @param bool $update
+ * @param \stdClass $user
+ */
+function sanitize_user_profile( $errors, $update, $user ) {
+
+	$additional_urls_to_check = [ 'url' => 'Website' ];
+
+	foreach ( array_merge( get_user_contact_fields(), $additional_urls_to_check ) as $key => $value ) {
+		if ( ! empty( $_POST[ $key ] ) ) {
+			if ( ! filter_var( $_POST[ $key ], FILTER_VALIDATE_URL ) ) {
+				$errors->add( $key, "The $value field is not a valid URL." );
+			}
+		}
+	}
+}

--- a/tests/test-admin-laf.php
+++ b/tests/test-admin-laf.php
@@ -35,13 +35,17 @@ class Admin_LafTest extends \WP_UnitTestCase {
 		$this->assertContains( 'Powered by', $buffer );
 		$this->assertContains( 'Pressbooks', $buffer );
 
-		add_filter( 'pb_help_link', function() {
-			return 'https://pressbooks.community/';
-		} );
+		add_filter(
+			'pb_help_link', function() {
+				return 'https://pressbooks.community/';
+			}
+		);
 
-		add_filter( 'pb_contact_link', function() {
-			return 'https://pressbooks.org/contact';
-		} );
+		add_filter(
+			'pb_contact_link', function() {
+				return 'https://pressbooks.org/contact';
+			}
+		);
 
 		ob_start();
 		\Pressbooks\Admin\Laf\add_footer_link();
@@ -93,7 +97,7 @@ class Admin_LafTest extends \WP_UnitTestCase {
 		$this->assertContains( 'pb-post-visibility', $wp_scripts->queue );
 
 		$new_post['post_type'] = 'back-matter';
-		$GLOBALS['post'] =  get_post( $this->factory()->post->create_object( $new_post ) );
+		$GLOBALS['post'] = get_post( $this->factory()->post->create_object( $new_post ) );
 		$GLOBALS['current_screen'] = WP_Screen::get( 'back-matter' );
 		do_action( 'admin_enqueue_scripts', 'post.php' );
 		$this->assertContains( 'pb-post-back-matter', $wp_scripts->queue );
@@ -104,7 +108,7 @@ class Admin_LafTest extends \WP_UnitTestCase {
 		$this->assertContains( 'pb-metadata', $wp_scripts->queue );
 
 		$new_post['post_type'] = 'post';
-		$GLOBALS['post'] =  get_post( $this->factory()->post->create_object( $new_post ) );
+		$GLOBALS['post'] = get_post( $this->factory()->post->create_object( $new_post ) );
 		$GLOBALS['current_screen'] = WP_Screen::get( 'post' );
 		do_action( 'admin_enqueue_scripts', 'toplevel_page_pb_organize' );
 		$this->assertContains( 'pb-organize', $wp_scripts->queue );
@@ -154,7 +158,7 @@ class Admin_LafTest extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( '', $submenu );
 		$this->assertContains( 'Clone a Book', $submenu[''][0] );
 		$new_post['post_type'] = 'post';
-		$GLOBALS['post'] =  get_post( $this->factory()->post->create_object( $new_post ) );
+		$GLOBALS['post'] = get_post( $this->factory()->post->create_object( $new_post ) );
 		$GLOBALS['current_screen'] = WP_Screen::get( 'post' );
 		\Pressbooks\Admin\Laf\init_css_js();
 		do_action( 'admin_enqueue_scripts' );
@@ -314,6 +318,51 @@ class Admin_LafTest extends \WP_UnitTestCase {
 		$node = $wp_admin_bar->get_node( 'contact' );
 		$this->assertTrue( is_object( $node ) );
 		$this->assertContains( 'pressbooks.org', $node->href );
+	}
+
+	/**
+	 * @group branding
+	 */
+	function test_user_contact_fields() {
+
+		$fields = \Pressbooks\Admin\Laf\get_user_contact_fields();
+
+		$this->assertCount( 3, $fields );
+
+		$this->assertEquals( 'Twitter URL', $fields['twitter'] );
+
+	}
+
+	/**
+	 * @group branding
+	 */
+	function test_modify_user_fields() {
+
+		$methods = [ 'aim', 'yim', 'jabber' ];
+
+		$fields = \Pressbooks\Admin\Laf\modify_user_contact_fields( $methods );
+
+		$this->assertCount( 3, $fields );
+
+	}
+	/**
+	 * @group branding
+	 */
+	function test_sanitize_user_profile() {
+
+		$_POST['twitter'] = 'https://twitter.com/pb';
+		$_POST['linkedin'] = 'htd';
+		$_POST['github'] = 'https://github.com/pressbooks';
+		$_POST['url'] = 'https://pressbooks.org';
+
+		$error_handler = new WP_Error();
+
+		$fields = \Pressbooks\Admin\Laf\sanitize_user_profile( $error_handler, true, new stdClass() );
+
+		$this->assertTrue( $error_handler->has_errors() );
+
+		$this->assertEquals( 'The LinkedIn URL field is not a valid URL.', $error_handler->get_error_message( 'linkedin' ) );
+
 	}
 
 }

--- a/tests/test-admin-laf.php
+++ b/tests/test-admin-laf.php
@@ -338,7 +338,11 @@ class Admin_LafTest extends \WP_UnitTestCase {
 	 */
 	function test_modify_user_fields() {
 
-		$methods = [ 'aim', 'yim', 'jabber' ];
+		$methods = [
+			'aim' => '',
+			'yim' => '',
+			'jabber' => '',
+		];
 
 		$fields = \Pressbooks\Admin\Laf\modify_user_contact_fields( $methods );
 


### PR DESCRIPTION
This PR removes unwanted contact info fields from the user profile page (AIM, Yahoo IM, Jabber / Google Talk) and adds three new contact fields: Twitter URL, LinkedIn URL, and GitHub URL. It also checks to ensure that the values entered for these fields and the existing website field are valid URLs. If not, the page throws an error and does not save any changes.

Partial fix for https://github.com/pressbooks/pressbooks/issues/2096

**To Test:**
1. Checkout this branch and attempt to edit your user page
2. Observe that the previous contact fields are no longer visible and the three new fields are visible
3. Enter invalid text in the website field and save. Observe an error message and unchanged values
4. Enter a valid URL in the website field and save. Observe success!
5. Repeat 3 & 4 for each of the other new fields.
6. Login as an admin user and repeat steps 1-5 while editing the user profile for a user that is not you.