### PR TITLE
ci: set wp-cli package index to canonical = false

### DIFF
--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -21,6 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         wp package install wp-cli/i18n-command:2.2.8
+        composer config repositories.wp-cli '{"type": "composer","url": "https://wp-cli.org/package-index/","canonical": false}'
         wp package install pressbooks/pb-cli:2.1.0
         composer require jenssegers/blade:1.1.0
     - name: Update POT file


### PR DESCRIPTION
This should fix the install issues with the POT update GitHub Action.