### PR TITLE
Prefix and suffix added

### DIFF
--- a/inc/admin/metaboxes/namespace.php
+++ b/inc/admin/metaboxes/namespace.php
@@ -1235,6 +1235,9 @@ function contributor_add_form() {
 		<div class="form-field <?php echo $meta_tags['tag']; ?>-wrap">
 			<label for="<?php echo $meta_tags['tag']; ?>"><?php echo $meta_tags['label']; ?></label>
 			<input type="<?php echo $meta_tags['input_type'] ?>" name="<?php echo $term; ?>" id="<?php echo $meta_tags['tag']; ?>" value="" class="<?php echo $meta_tags['tag']; ?>" />
+			<?php if ( ! empty( $meta_tags['description'] ) ) : ?>
+				<p><?php echo $meta_tags['description']; ?></p>
+			<?php endif; ?>
 		</div>
 		<?php
 	}
@@ -1269,6 +1272,9 @@ function contributor_edit_form( $term ) {
 			<td>
 				<?php wp_nonce_field( 'contributor-meta', 'contributor_meta_nonce' ); ?>
 				<input type="<?php echo $meta_tags['input_type'] ?>" name="<?php echo $term; ?>" id="<?php echo $meta_tags['tag']; ?>" value="<?php echo esc_attr( $value ); ?>" class="<?php echo $meta_tags['tag']; ?>-field"  />
+				<?php if ( ! empty( $meta_tags['description'] ) ) : ?>
+					<p><?php echo $meta_tags['description']; ?></p>
+				<?php endif; ?>
 			</td>
 		</tr>
 		<?php

--- a/inc/class-contributors.php
+++ b/inc/class-contributors.php
@@ -426,7 +426,8 @@ class Contributors {
 			$last_name = get_term_meta( $term->term_id, 'contributor_last_name', true );
 			if ( ! empty( $first_name ) && ! empty( $last_name ) ) {
 				$name = $prefix ? "{$prefix} {$first_name} {$last_name}" : "{$first_name} {$last_name}";
-				$name = $suffix ? "${name} $suffix" : $name;
+				$suffix = ! empty( $suffix ) ? ( preg_match( '/^[MDCLXVI]+$/', $suffix ) ? " $suffix" : ", $suffix" ) : '';
+				$name = $suffix ? "${name}${suffix}" : $name;
 			} elseif ( ! empty( $term->name ) ) {
 				$name = $term->name;
 			}

--- a/inc/class-contributors.php
+++ b/inc/class-contributors.php
@@ -253,6 +253,13 @@ class Contributors {
 	 */
 	public static function getContributorFields( $field = '' ) {
 		$allowed_fields = [
+			self::TAXONOMY . '_prefix' => [
+				'label' => __( 'Prefix', 'pressbooks' ),
+				'tag' => self::TAXONOMY . '-prefix',
+				'input_type' => 'text',
+				'description' => 'An optional prefix or title to be displayed before the person\'s first name, e.g. Dr., Prof., Ms., Rev., Capt.',
+				'sanitization_method' => 'sanitize_text_field',
+			],
 			self::TAXONOMY . '_first_name' => [
 				'label' => __( 'First Name', 'pressbooks' ),
 				'tag' => self::TAXONOMY . '-first-name',
@@ -263,6 +270,13 @@ class Contributors {
 				'label' => __( 'Last Name', 'pressbooks' ),
 				'tag' => self::TAXONOMY . '-last-name',
 				'input_type' => 'text',
+				'sanitization_method' => 'sanitize_text_field',
+			],
+			self::TAXONOMY . '_suffix' => [
+				'label' => __( 'Suffix', 'pressbooks' ),
+				'tag' => self::TAXONOMY . '-suffix',
+				'input_type' => 'text',
+				'description' => 'An optional suffix to be displayed after the person\'s last name, e.g. Jr., Sr., IV, PhD, MD, USN (Ret.)',
 				'sanitization_method' => 'sanitize_text_field',
 			],
 			self::TAXONOMY . '_description' => [
@@ -406,10 +420,13 @@ class Contributors {
 		$name = '';
 		$term = get_term_by( 'slug', $slug, self::TAXONOMY );
 		if ( $term ) {
+			$prefix = get_term_meta( $term->term_id, 'contributor_prefix', true );
+			$suffix = get_term_meta( $term->term_id, 'contributor_suffix', true );
 			$first_name = get_term_meta( $term->term_id, 'contributor_first_name', true );
 			$last_name = get_term_meta( $term->term_id, 'contributor_last_name', true );
 			if ( ! empty( $first_name ) && ! empty( $last_name ) ) {
-				$name = "{$first_name} {$last_name}";
+				$name = $prefix ? "{$prefix} {$first_name} {$last_name}" : "{$first_name} {$last_name}";
+				$name = $suffix ? "${name} $suffix" : $name;
 			} elseif ( ! empty( $term->name ) ) {
 				$name = $term->name;
 			}

--- a/tests/test-contributors.php
+++ b/tests/test-contributors.php
@@ -247,7 +247,52 @@ class ContributorsTest extends \WP_UnitTestCase {
 
 		$contributors = $this->contributor->getFullContributors( $post_id, 'fake_reviewer' );
 
-		$this->assertCount( 0 , $contributors);
+		$this->assertCount( 0, $contributors );
+
+	}
+
+	public function test_personalName() {
+
+		$this->taxonomy->registerTaxonomies();
+		$post_id = $this->_createChapter();
+
+		$person1 = $this->contributor->insert( 'Steel Wagstaff', $post_id, 'contributors' );
+		$person2 = $this->contributor->insert( 'Apurva Ashook', $post_id, 'contributors' );
+		$person3 = $this->contributor->insert( 'Mario Bros', $post_id, 'contributors' );
+		$person4 = $this->contributor->insert( 'Isaac Asimov', $post_id, 'contributors' );
+
+		$term1 = get_term_by( 'term_id', $person1['term_id'], 'contributor' );
+		$term2 = get_term_by( 'term_id', $person2['term_id'], 'contributor' );
+		$term3 = get_term_by( 'term_id', $person3['term_id'], 'contributor' );
+		$term4 = get_term_by( 'term_id', $person4['term_id'], 'contributor' );
+
+		add_term_meta( $term1->term_id, 'contributor_first_name', 'Steel' );
+		add_term_meta( $term1->term_id, 'contributor_last_name', 'Wagstaff' );
+		add_term_meta( $term1->term_id, 'contributor_prefix', 'Dr.' );
+		add_term_meta( $term1->term_id, 'contributor_suffix', 'PhD' );
+
+
+		add_term_meta( $term2->term_id, 'contributor_first_name', 'Apurva' );
+		add_term_meta( $term2->term_id, 'contributor_last_name', 'Ashook' );
+		add_term_meta( $term2->term_id, 'contributor_prefix', 'Prof.' );
+		add_term_meta( $term2->term_id, 'contributor_suffix', 'IV' );
+
+		add_term_meta( $term3->term_id, 'contributor_first_name', 'Mario' );
+		add_term_meta( $term3->term_id, 'contributor_last_name', 'Bros' );
+
+		add_term_meta( $term4->term_id, 'contributor_first_name', 'Isaac' );
+		add_term_meta( $term4->term_id, 'contributor_last_name', 'Asimov' );
+		add_term_meta( $term4->term_id, 'contributor_prefix', 'Sir.' );
+
+		$name1 = $this->contributor->personalName( $term1->slug );
+		$name2 = $this->contributor->personalName( $term2->slug );
+		$name3 = $this->contributor->personalName( $term3->slug );
+		$name4 = $this->contributor->personalName( $term4->slug );
+
+		$this->assertEquals( 'Dr. Steel Wagstaff, PhD', $name1 );
+		$this->assertEquals( 'Prof. Apurva Ashook IV', $name2 );
+		$this->assertEquals( 'Mario Bros', $name3 );
+		$this->assertEquals( 'Sir. Isaac Asimov', $name4 );
 
 	}
 


### PR DESCRIPTION
This PR solves https://github.com/pressbooks/pressbooks-book/issues/833

We added two new fields into the contributors form to be able to append a prefix and a suffix for contributors, this will be shown on every place the contributor is printed.

### How to test

1. Create a new contributor and append the prefix and suffix or only one of them
2. Review if the prefix or suffix are being added
3. Review if those are optional