### PR TITLE
Contributor fixes

### DIFF
--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -1648,14 +1648,14 @@ function add_user_profile_fields( \WP_User $user ) {
 
 	$institution = __( 'Institution' );
 	$value = esc_attr( get_the_author_meta( 'institution', $user->ID ) );
-	$helper = __( 'Please enter your institutional affiliation (i.e. Rebus Foundation or Open University.' );
+	$helper = __( 'Your institutional affiliation, e.g. Rebus Foundation, Open University, Amnesty International.', 'pressbooks' );
 
 	$row = <<<HTML
 	<tr class="institution">
 		<th><label for="institution"> $institution </label></th>
 		<td>
 			<input type="text" name="institution" id="institution" value="$value" class="regular-text" /><br />
-			<span class="description"> $helper </span>
+			<p class="description"> $helper </p>
 		</td>
 	</tr>
 HTML;

--- a/inc/class-contributors.php
+++ b/inc/class-contributors.php
@@ -302,7 +302,7 @@ class Contributors {
 				'label' => __( 'Twitter', 'pressbooks' ),
 				'tag' => self::TAXONOMY . '-twitter',
 				'input_type' => 'text',
-				'description' => __( 'Twitter profile for this contributor. Must be valid URL.', 'pressbooks' ),
+				'description' => __( 'Twitter profile for this contributor. Must be a valid URL.', 'pressbooks' ),
 				'sanitization_method' => '\Pressbooks\Sanitize\validate_url_field',
 			],
 			self::TAXONOMY . '_linkedin' => [

--- a/inc/class-contributors.php
+++ b/inc/class-contributors.php
@@ -257,7 +257,7 @@ class Contributors {
 				'label' => __( 'Prefix', 'pressbooks' ),
 				'tag' => self::TAXONOMY . '-prefix',
 				'input_type' => 'text',
-				'description' => 'An optional prefix or title to be displayed before the person\'s first name, e.g. Dr., Prof., Ms., Rev., Capt.',
+				'description' => __( 'Prefix to be displayed before this contributor\'s name, e.g. Dr., Prof., Ms., Rev., Capt.', 'pressbooks' ),
 				'sanitization_method' => 'sanitize_text_field',
 			],
 			self::TAXONOMY . '_first_name' => [
@@ -276,7 +276,7 @@ class Contributors {
 				'label' => __( 'Suffix', 'pressbooks' ),
 				'tag' => self::TAXONOMY . '-suffix',
 				'input_type' => 'text',
-				'description' => 'An optional suffix to be displayed after the person\'s last name, e.g. Jr., Sr., IV, PhD, MD, USN (Ret.)',
+				'description' => __( 'Suffix to be displayed after this contributors\'s name, e.g. Jr., Sr., IV, PhD, MD, USN (Ret.).', 'pressbooks' ),
 				'sanitization_method' => 'sanitize_text_field',
 			],
 			self::TAXONOMY . '_description' => [
@@ -288,30 +288,35 @@ class Contributors {
 				'label' => __( 'Institution', 'pressbooks' ),
 				'tag' => self::TAXONOMY . '-institution',
 				'input_type' => 'text',
+				'description' => __( 'Institution this contributor is associated with, e.g. Rebus Foundation, Open University, Amnesty International.', 'pressbooks' ),
 				'sanitization_method' => 'sanitize_text_field',
 			],
 			self::TAXONOMY . '_user_url' => [
 				'label' => __( 'Website', 'presbooks' ),
 				'tag' => self::TAXONOMY . '-website',
 				'input_type' => 'text',
+				'description' => __( 'Website for this contributor. Must be a valid URL.', 'pressbooks' ),
 				'sanitization_method' => '\Pressbooks\Sanitize\validate_url_field',
 			],
 			self::TAXONOMY . '_twitter' => [
 				'label' => __( 'Twitter', 'pressbooks' ),
 				'tag' => self::TAXONOMY . '-twitter',
 				'input_type' => 'text',
+				'description' => __( 'Twitter profile for this contributor. Must be valid URL.', 'pressbooks' ),
 				'sanitization_method' => '\Pressbooks\Sanitize\validate_url_field',
 			],
 			self::TAXONOMY . '_linkedin' => [
 				'label' => __( 'LinkedIn', 'pressbooks' ),
 				'tag' => self::TAXONOMY . '-linkedin',
 				'input_type' => 'text',
+				'description' => __( 'LinkedIn profile for this contributor. Must be a valid URL.', 'pressbooks' ),
 				'sanitization_method' => '\Pressbooks\Sanitize\validate_url_field',
 			],
 			self::TAXONOMY . '_github' => [
 				'label' => __( 'GitHub', 'pressbooks' ),
 				'tag' => self::TAXONOMY . '-github',
 				'input_type' => 'text',
+				'description' => __( 'GitHub profile for this contributor. Must be a valid URL.', 'pressbooks' ),
 				'sanitization_method' => '\Pressbooks\Sanitize\validate_url_field',
 			],
 		];

--- a/tests/test-admin-laf.php
+++ b/tests/test-admin-laf.php
@@ -379,7 +379,7 @@ class Admin_LafTest extends \WP_UnitTestCase {
 		$buffer = ob_get_clean();
 
 		$this->assertContains( 'element.insertAdjacentHTML', $buffer );
-		$this->assertContains( 'Please enter your institutional affiliation', $buffer );
+		$this->assertContains( 'Your institutional affiliation, e.g. Rebus Foundation, Open University, Amnesty International.', $buffer );
 
 		$_REQUEST['institution'] = 'Rebus Foundation';
 


### PR DESCRIPTION
This PR includes some small fixes for the new description fields on the user profile and contributor pages. 

To test:
1. Apply this branch and visit the edit user profile page. Check to see that the institution description is wrapped in a paragraph element with class description and resembles the other item descriptions on the page
2. Visit the add contributor page. Check to see that all text entry fields have descriptions wrapped in paragraph elements with the class description