### PR TITLE
Add correct class to contributor descriptions

### DIFF
--- a/inc/admin/metaboxes/namespace.php
+++ b/inc/admin/metaboxes/namespace.php
@@ -1236,7 +1236,7 @@ function contributor_add_form() {
 			<label for="<?php echo $meta_tags['tag']; ?>"><?php echo $meta_tags['label']; ?></label>
 			<input type="<?php echo $meta_tags['input_type'] ?>" name="<?php echo $term; ?>" id="<?php echo $meta_tags['tag']; ?>" value="" class="<?php echo $meta_tags['tag']; ?>" />
 			<?php if ( ! empty( $meta_tags['description'] ) ) : ?>
-				<p><?php echo $meta_tags['description']; ?></p>
+				<p class="description"><?php echo $meta_tags['description']; ?></p>
 			<?php endif; ?>
 		</div>
 		<?php
@@ -1273,7 +1273,7 @@ function contributor_edit_form( $term ) {
 				<?php wp_nonce_field( 'contributor-meta', 'contributor_meta_nonce' ); ?>
 				<input type="<?php echo $meta_tags['input_type'] ?>" name="<?php echo $term; ?>" id="<?php echo $meta_tags['tag']; ?>" value="<?php echo esc_attr( $value ); ?>" class="<?php echo $meta_tags['tag']; ?>-field"  />
 				<?php if ( ! empty( $meta_tags['description'] ) ) : ?>
-					<p><?php echo $meta_tags['description']; ?></p>
+					<p class="description"><?php echo $meta_tags['description']; ?></p>
 				<?php endif; ?>
 			</td>
 		</tr>


### PR DESCRIPTION
This PR adds expected 'description' class to the descriptions for new contributor fields on both the new taxonomy and edit taxonomy term pages.