### PR TITLE
Ensure that contributor is created when subscriber receives more powerful role

### DIFF
--- a/inc/class-taxonomy.php
+++ b/inc/class-taxonomy.php
@@ -58,6 +58,7 @@ class Taxonomy {
 			add_action( 'user_register', [ $obj->contributors, 'addBlogUser' ] );
 			add_action( 'add_user_to_blog', [ $obj, 'registerTaxonomies' ] ); // This is a workaround because newbloguser does not fire init action.
 			add_action( 'add_user_to_blog', [ $obj->contributors, 'addBlogUser' ] );
+			add_action( 'set_user_role', [ $obj->contributors, 'addBlogUser' ] );
 			add_action( 'profile_update', [ $obj->contributors, 'updateBlogUser' ], 10, 2 );
 			add_action( 'added_post_meta', [ $obj, 'upgradeToContributorTaxonomy' ], 10, 4 );
 			add_action( 'updated_postmeta', [ $obj, 'upgradeToContributorTaxonomy' ], 10, 4 );


### PR DESCRIPTION
Issue #2312 

This PR adds the possibility to create the contributor taxonomy whenever the user role is updated.
It will only create a contributor if the assigned role is contributor or greater.

### How to test

1. Create a new user on the network level and fill basic information (urls, institution, bio, etc.)
2. Switch to a book and select to add a new user
3. Add an existing user to the book with the subscriber role (use the newly created user)
4. Make sure that no contributor taxonomy was created on this book
5. Go to the list of users and change the user role to a more powerful role (e.g contributor)
6. Make sure that a contributor taxonomy was created and basic information was carried over

ps: On step 3 it's possible to create a new user instead of using an existing one, and repeat steps 4, 5, and 6.