### PR TITLE
Add About the Author checkbox in global options

### DIFF
--- a/inc/modules/themeoptions/class-globaloptions.php
+++ b/inc/modules/themeoptions/class-globaloptions.php
@@ -123,6 +123,17 @@ class GlobalOptions extends \Pressbooks\Options {
 		);
 
 		add_settings_field(
+			'about_the_author',
+			__( 'About the Author', 'pressbooks' ),
+			[ $this, 'renderAuthorInformation' ],
+			$_page,
+			$_section,
+			[
+				__( 'Display information about authors at the end of each chapter', 'pressbooks' ),
+			]
+		);
+
+		add_settings_field(
 			'attachment_attributions',
 			__( 'Media Attributions', 'pressbooks' ),
 			[ $this, 'renderAttachmentAttributionsField' ],
@@ -339,6 +350,24 @@ class GlobalOptions extends \Pressbooks\Options {
 	}
 
 	/**
+	 * Render the about_the_author checkbox.
+	 *
+	 * @param array $args
+	 */
+	function renderAuthorInformation( $args ) {
+		unset( $args['label_for'], $args['class'] );
+		$this->renderCheckbox(
+			[
+				'id' => 'about_the_author',
+				'name' => 'pressbooks_theme_options_' . $this->getSlug(),
+				'option' => 'about_the_author',
+				'value' => ( isset( $this->options['about_the_author'] ) ) ? $this->options['about_the_author'] : '',
+				'label' => $args[0],
+			]
+		);
+	}
+
+	/**
 	 * Render the attachment_attributions checkbox.
 	 *
 	 * @since 5.5.0
@@ -531,6 +560,7 @@ class GlobalOptions extends \Pressbooks\Options {
 				'parse_subsections' => 0,
 				'part_label' => __( 'Part', 'pressbooks' ),
 				'chapter_label' => __( 'Chapter', 'pressbooks' ),
+				'about_the_author' => 0,
 				'attachment_attributions' => 0,
 				'copyright_license' => 0,
 				'edu_textbox_examples_header_color' => '#fff',
@@ -625,6 +655,7 @@ class GlobalOptions extends \Pressbooks\Options {
 				'chapter_numbers',
 				'parse_subsections',
 				'attachment_attributions',
+				'about_the_author',
 			]
 		);
 	}

--- a/tests/test-options.php
+++ b/tests/test-options.php
@@ -461,4 +461,17 @@ class OptionsTest extends \WP_UnitTestCase {
 		$this->assertContains( '</optgroup>', $buffer );
 		$this->assertContains( '<select name="pressbooks_theme_options_web[webbook_header_font]"', $buffer );
 	}
+
+	/**
+	 * @group options
+	 */
+	public function test_renderAboutTheAuthorField() {
+		$options = new \Pressbooks\Modules\ThemeOptions\GlobalOptions( [] );
+		ob_start();
+		$options->renderAuthorInformation( [ __( 'Display information about authors at the end of each chapter', 'pressbooks' ) ] );
+		$buffer = ob_get_clean();
+		$this->assertContains( '<input ', $buffer );
+		$this->assertContains( 'type="checkbox" ', $buffer );
+		$this->assertContains( 'name="pressbooks_theme_options_global[about_the_author]"', $buffer );
+	}
 }


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks-book/issues/832
Related PR: https://github.com/pressbooks/pressbooks-book/pull/841

This PR add a new checkbox that allows to book admins to display or hide the _About the authors_ at the bottomof each chapter.

### Test
**Note: despite this PR is not dependent of  https://github.com/pressbooks/pressbooks-book/pull/841, in order to enable and test it, you need to make sure you have the changes in https://github.com/pressbooks/pressbooks-book/pull/841 in your environment.**
- For a particular book go to Appearance > Theme options > Global options
- Make sure a new **About the Author** checkbox option is present. It should be unchecked by default
- Open any chapter (or back matter, front matter, etc) and add a one or more contributors if there are any. You can do it at the bottom of the editing page, in "Chapter Metadata" section.
- Visit the chapter in the web, you should not be able to see the "About the authors" section.
- Now, enable the global option in Appearance > Theme options > Global options by checking the **About the author** checkbox and saving the new setting.
- Visit the chapter again and now you should be able to see the **About the authors** section.