### PR TITLE
Remove duplicated contributor page

### DIFF
--- a/inc/cloner/class-cloner.php
+++ b/inc/cloner/class-cloner.php
@@ -1108,6 +1108,7 @@ class Cloner {
 				'main-body',
 				'chapter-1',
 				'appendix',
+				'contributors',
 			] as $post
 		) {
 			unset( $contents[ $post ] );


### PR DESCRIPTION
This Solves #2340 

This ticket removed the duplicated Contributors back matter after cloning a book.

### How to test

1. Clone a book and review you have only one Contributors Back Matter