### PR TITLE
Pb 2354 xml import fix

### DIFF
--- a/inc/modules/import/wordpress/class-wxr.php
+++ b/inc/modules/import/wordpress/class-wxr.php
@@ -223,7 +223,7 @@ class Wxr extends Import {
 	public function findExistentTerm( $term ) {
 
 			$args = [
-				'taxonomy' => 'contributor',
+				'taxonomy' => Contributors::TAXONOMY,
 				'hide_empty' => false,
 				'meta_query' => [], // phpcs:ignore
 			];
@@ -312,12 +312,12 @@ class Wxr extends Import {
 
 		// and import them if they don't already exist.
 		foreach ( $terms as $t ) {
-			if ( $t['term_taxonomy'] === 'contributor' ) {
+			if ( $t['term_taxonomy'] === Contributors::TAXONOMY ) {
 				// Find an equal contributor if exist get the slug and avoid dupes
 				$existent_term = $this->findExistentTerm( $t );
 				if ( ! $existent_term ) {
 					$term = $this->insertTerm( $t );
-					$new_term = get_term( $term['term_id'], 'contributor' );
+					$new_term = get_term( $term['term_id'], Contributors::TAXONOMY );
 				}
 				$this->contributorsSlugsToFix[ $t['slug'] ] = $existent_term ? $existent_term->slug : $new_term->slug;
 			}

--- a/inc/modules/import/wordpress/class-wxr.php
+++ b/inc/modules/import/wordpress/class-wxr.php
@@ -319,7 +319,7 @@ class Wxr extends Import {
 			if ( $t['term_taxonomy'] === 'contributor' ) {
 				// Find an equal contributor if exist get the slug and avoid dupes
 				$existent_term = $this->findExistentTerm( $t );
-				if ( ! $existent_term ) {
+				if ( ! $existent_term && ! is_a( $existent_term, \WP_Error::class ) ) {
 					$term = $this->insertTerm( $t );
 					$new_term = get_term( $term['term_id'], 'contributor' );
 				}

--- a/inc/modules/import/wordpress/class-wxr.php
+++ b/inc/modules/import/wordpress/class-wxr.php
@@ -17,9 +17,6 @@ use Pressbooks\Licensing;
 use Pressbooks\Metadata;
 use Pressbooks\Modules\Import\Import;
 
-/**
- *
- */
 class Wxr extends Import {
 
 	const TYPE_OF = 'wxr';
@@ -111,6 +108,13 @@ class Wxr extends Import {
 	 */
 	public function getSourceBookUrl() {
 		return $this->sourceBookUrl;
+	}
+
+	/**
+	 * @param $sourceBookUrl
+	 */
+	public function setSourceBookUrl( $source ) {
+		$this->sourceBookUrl = $source;
 	}
 
 	/**
@@ -221,7 +225,7 @@ class Wxr extends Import {
 			$args = [
 				'taxonomy' => 'contributor',
 				'hide_empty' => false,
-				'meta_query' => [],
+				'meta_query' => [], // phpcs:ignore
 			];
 
 			$fields_to_compare = [ 'contributor_first_name', 'contributor_last_name', 'contributor_prefix', 'contributor_suffix' ];

--- a/inc/modules/import/wordpress/class-wxr.php
+++ b/inc/modules/import/wordpress/class-wxr.php
@@ -730,7 +730,7 @@ class Wxr extends Import {
 	 * @param array $postmeta
 	 * @return array
 	 */
-	protected function searchMultipleContributorValues( $meta_key, array $postmeta = [] ) {
+	public function searchMultipleContributorValues( $meta_key, array $postmeta = [] ) {
 
 		$values = [];
 

--- a/inc/modules/import/wordpress/class-wxr.php
+++ b/inc/modules/import/wordpress/class-wxr.php
@@ -312,18 +312,18 @@ class Wxr extends Import {
 
 		// and import them if they don't already exist.
 		foreach ( $terms as $t ) {
-			$term = term_exists( $t['term_name'], $t['term_taxonomy'] );
-			if ( ( null === $term || 0 === $term ) ) {
-				$this->insertTerm( $t );
-			}
 			if ( $t['term_taxonomy'] === 'contributor' ) {
 				// Find an equal contributor if exist get the slug and avoid dupes
 				$existent_term = $this->findExistentTerm( $t );
-				if ( ! $existent_term && ! is_a( $existent_term, \WP_Error::class ) ) {
+				if ( ! $existent_term ) {
 					$term = $this->insertTerm( $t );
 					$new_term = get_term( $term['term_id'], 'contributor' );
 				}
 				$this->contributorsSlugsToFix[ $t['slug'] ] = $existent_term ? $existent_term->slug : $new_term->slug;
+			}
+			$term = term_exists( $t['term_name'], $t['term_taxonomy'] );
+			if ( ( null === $term || 0 === $term ) ) {
+				$this->insertTerm( $t );
 			}
 		}
 

--- a/inc/modules/import/wordpress/class-wxr.php
+++ b/inc/modules/import/wordpress/class-wxr.php
@@ -230,19 +230,21 @@ class Wxr extends Import {
 
 			$fields_to_compare = [ 'contributor_first_name', 'contributor_last_name', 'contributor_prefix', 'contributor_suffix' ];
 
-			foreach ( $term['termmeta'] as $field ) {
-				if ( in_array( $field['key'], $fields_to_compare, true ) ) {
-					$args['meta_query'][] = [
-						'key' => $field['key'],
-						'value' => $field['value'],
-					];
+			if ( ! empty( $term['termmeta'] ) ) {
+				foreach ( $term['termmeta'] as $field ) {
+					if ( in_array( $field['key'], $fields_to_compare, true ) ) {
+						$args['meta_query'][] = [
+							'key' => $field['key'],
+							'value' => $field['value'],
+						];
+					}
 				}
-			}
 
-			$term_query = get_terms( $args );
+				$term_query = get_terms( $args );
 
-			if ( count( $term_query ) > 0 ) {
-				return $term_query[0];
+				if ( count( $term_query ) > 0 ) {
+					return $term_query[0];
+				}
 			}
 
 			return false;

--- a/tests/test-modules-import.php
+++ b/tests/test-modules-import.php
@@ -2,6 +2,7 @@
 
 
 use Pressbooks\Modules\Import\WordPress\Downloads;
+use Pressbooks\Modules\Import\WordPress\Wxr;
 
 class ImportMock extends \Pressbooks\Modules\Import\Import {
 	/**
@@ -93,6 +94,65 @@ class Modules_ImportTest extends \WP_UnitTestCase {
 		$images = $result['dom']->getElementsByTagName( 'img' );
 		$this->assertContains( '#fixme', $images[0]->getAttribute( 'src' ) );
 		$this->assertNotContains( '#fixme', $images[1]->getAttribute( 'src' ) );
+
+	}
+
+	/**
+	 * @group import
+	 */
+	public function test_wxrInsertAndFindTerm() {
+		$wxr = new Wxr();
+		$wxr->setSourceBookUrl( 'https://pressbooks.com/' );
+
+		$imported_term = [
+			'term_name' => 'Jane Doe',
+			'term_taxonomy' => 'contributor',
+			'term_description' => 'Some description',
+			'slug' => 'jane-doe',
+			'termmeta' => [
+				[
+					'key' => 'contributor_first_name',
+					'value' => 'Jane',
+				],
+				[
+					'key' => 'contributor_last_name',
+					'value' => 'Doe',
+				],
+				[
+					'key' => 'contributor_prefix',
+					'value' => 'Dr.',
+				],
+				[
+					'key' => 'contributor_suffix',
+					'value' => 'VI',
+				],
+				[
+					'key' => 'contributor_picture',
+					'value' => 'https://pressbooks.com/app/uploads/sites/109504/2018/08/4tatoos.jpg',
+				],
+			],
+		];
+
+		$term = $wxr->insertTerm( $imported_term );
+
+		$this->assertEquals( 3, $term['term_id'] );
+
+		$meta = get_term_meta( $term['term_id'] );
+		$term = get_term( $term['term_id'] );
+
+		$this->assertEquals( 'contributor', $term->taxonomy );
+		$this->assertEquals( 'Jane Doe', $term->name );
+		$this->assertEquals( 'http://example.org/wp-content/uploads/2021/09/4tatoos.jpg', $meta['contributor_picture'][0] );
+
+		// Clean attachments after test
+		array_map( 'unlink', array_filter( (array) glob( '/tmp/wordpress/wp-content/uploads/2021/09/*' ) ) );
+
+		$existent = $wxr->findExistentTerm( $imported_term );
+
+		$this->assertEquals( 3, $existent->term_id );
+		$this->assertEquals( 'jane-doe', $existent->slug );
+
+		$this->assertFalse( $wxr->findExistentTerm( [ 'termmeta' => [] ] ) );
 
 	}
 

--- a/tests/test-modules-import.php
+++ b/tests/test-modules-import.php
@@ -165,4 +165,40 @@ class Modules_ImportTest extends \WP_UnitTestCase {
 
 	}
 
+	public function test_searchMultipleContributorValues() {
+		$contributors = new \Pressbooks\Contributors();
+		$contributors->insert( 'Leo Schopenhauer', 1 );
+		$contributors->insert( 'Leo Simon', 1 );
+		$contributors->insert( 'Mary User', 1, 'pb_editors' );
+
+		$post_meta = [
+			[
+				'key' => 'pb_authors',
+				'value' => 'Leo',
+			],
+			[
+				'key' => 'pb_editors',
+				'value' => 'Leo',
+			],
+			[
+				'key' => 'pb_editors',
+				'value' => 'Os',
+			],
+			[
+				'key' => 'pb_editors',
+				'value' => 'Sarah',
+			],
+		];
+
+		$import = new Wxr();
+		$values = $import->searchMultipleContributorValues( 'pb_authors', $post_meta );
+		$this->assertCount(1, $values);
+
+		$values = $import->searchMultipleContributorValues( 'pb_editors', $post_meta );
+		$this->assertCount(3, $values);
+
+		$values = $import->searchMultipleContributorValues( 'pb_fail', $post_meta );
+		$this->assertCount(0, $values);
+	}
+
 }

--- a/tests/test-modules-import.php
+++ b/tests/test-modules-import.php
@@ -135,7 +135,16 @@ class Modules_ImportTest extends \WP_UnitTestCase {
 
 		$term = $wxr->insertTerm( $imported_term );
 
-		$this->assertEquals( 3, $term['term_id'] );
+		$last_term = get_terms(
+			[
+				'taxonomy' => 'contributor',
+				'hide_empty'    => false,
+				'orderby' => 'id',
+				'order' => 'DESC',
+			]
+		);
+
+		$this->assertEquals( $last_term[0]->term_id, $term['term_id'] );
 
 		$meta = get_term_meta( $term['term_id'] );
 		$term = get_term( $term['term_id'] );
@@ -149,7 +158,7 @@ class Modules_ImportTest extends \WP_UnitTestCase {
 
 		$existent = $wxr->findExistentTerm( $imported_term );
 
-		$this->assertEquals( 3, $existent->term_id );
+		$this->assertEquals( $last_term[0]->term_id, $existent->term_id );
 		$this->assertEquals( 'jane-doe', $existent->slug );
 
 		$this->assertFalse( $wxr->findExistentTerm( [ 'termmeta' => [] ] ) );


### PR DESCRIPTION
This PR solves #2354 

I added an extra check to be sure we don't duplicate contributors when import and also will create new slugs and match those slugs with the created ones.

### How to test

1. Checkout this branch
2. Register a Contributor in the target book and create another contributor in the source book with the same slug to prove that contributor will not be overriden and a new one would be created with another slug.
2. Export any book that contains one of more contributors added to chapters and also could be a great idea to use some contributors with suffix and prefix information, profile picture, etc...
3. Chapters should be imported as expected with the right contributors added, also profile pictures should be copied to the target book
4. Try to import again the file and the contributors should not be duplicated