### PR TITLE
Remove post metadata while deleting contributors

### DIFF
--- a/inc/class-contributors.php
+++ b/inc/class-contributors.php
@@ -293,10 +293,12 @@ class Contributors implements BackMatter, Transferable {
 	public function deleteContributor( $term, $tt_id, $deleted_term ) {
 		global $wpdb;
 
+		$placeholder = implode( ', ', array_fill( 0, count( $this->valid ), '%s' ) );
+
 		$wpdb->query( $wpdb->prepare(
-			"DELETE FROM $wpdb->postmeta WHERE meta_key IN ( %s ) AND meta_value = %s",
-			implode( "', '", $this->valid ),
-			$deleted_term->slug
+			//phpcs:disable WordPress.WP.PreparedSQL.NotPrepared
+			"DELETE FROM $wpdb->postmeta WHERE meta_key IN ( $placeholder ) AND meta_value = %s",
+			array_merge( $this->valid, [ $deleted_term->slug ] )
 		) );
 	}
 

--- a/inc/class-contributors.php
+++ b/inc/class-contributors.php
@@ -75,6 +75,8 @@ class Contributors implements BackMatter, Transferable {
 	 * @param Contributors $obj
 	 */
 	public static function hooks( Contributors $obj ) {
+		add_action( 'delete_' . self::TAXONOMY, [ $obj, 'deleteContributor' ], 10, 3 );
+
 		add_filter( 'the_content', [ $obj, 'overrideDisplay' ], 13 ); // Run after wpautop to avoid unwanted breaklines.
 
 		$obj->bootExportable( $obj );
@@ -280,6 +282,23 @@ class Contributors implements BackMatter, Transferable {
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Remove deleted contributor's post meta references
+	 * @param int $term
+	 * @param int $tt_id
+	 * @param \WP_Term $deleted_term
+	 */
+	public function deleteContributor( $term, $tt_id, $deleted_term ) {
+		global $wpdb;
+
+		$table = $wpdb->prefix . 'postmeta';
+
+		$wpdb->delete( $table, [
+			'meta_key' => 'pb_authors',
+			'meta_value' => $deleted_term->slug,
+		] );
 	}
 
 	/**

--- a/inc/class-contributors.php
+++ b/inc/class-contributors.php
@@ -293,12 +293,11 @@ class Contributors implements BackMatter, Transferable {
 	public function deleteContributor( $term, $tt_id, $deleted_term ) {
 		global $wpdb;
 
-		$table = $wpdb->prefix . 'postmeta';
-
-		$wpdb->delete( $table, [
-			'meta_key' => 'pb_authors',
-			'meta_value' => $deleted_term->slug,
-		] );
+		$wpdb->query( $wpdb->prepare(
+			"DELETE FROM $wpdb->postmeta WHERE meta_key IN ( %s ) AND meta_value = %s",
+			implode( "', '", $this->valid ),
+			$deleted_term->slug
+		) );
 	}
 
 	/**

--- a/tests/test-contributors.php
+++ b/tests/test-contributors.php
@@ -741,12 +741,14 @@ class ContributorsTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'monsieurfake', $authors[1]->meta_value );
 
 		wp_delete_term( $monsieur_fake->term_id, 'contributor' );
-		$this->contributor->deleteContributor( null, null, $monsieur_fake );
+		$prepare = $this->contributor->deleteContributor( null, null, $monsieur_fake );
 
-		$authors = $wpdb->get_results( "SELECT meta_value FROM {$wpdb->prefix}postmeta WHERE post_id = $post_id and meta_key = 'pb_authors'" );
+		print_r($prepare);
 
-		$this->assertNull( get_term( $result[ 'term_id'], 'contributor' ) );
-		$this->assertCount( 1, $authors );
-		$this->assertNotEquals( 'monsieurfake', $authors[0]->meta_value );
+//		$authors = $wpdb->get_results( "SELECT meta_value FROM {$wpdb->prefix}postmeta WHERE post_id = $post_id and meta_key = 'pb_authors'" );
+//
+//		$this->assertNull( get_term( $result[ 'term_id'], 'contributor' ) );
+//		$this->assertCount( 1, $authors );
+//		$this->assertNotEquals( 'monsieurfake', $authors[0]->meta_value );
 	}
 }

--- a/tests/test-contributors.php
+++ b/tests/test-contributors.php
@@ -741,14 +741,12 @@ class ContributorsTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'monsieurfake', $authors[1]->meta_value );
 
 		wp_delete_term( $monsieur_fake->term_id, 'contributor' );
-		$prepare = $this->contributor->deleteContributor( null, null, $monsieur_fake );
+		$this->contributor->deleteContributor( null, null, $monsieur_fake );
 
-		print_r($prepare);
+		$authors = $wpdb->get_results( "SELECT meta_value FROM {$wpdb->prefix}postmeta WHERE post_id = $post_id and meta_key = 'pb_authors'" );
 
-//		$authors = $wpdb->get_results( "SELECT meta_value FROM {$wpdb->prefix}postmeta WHERE post_id = $post_id and meta_key = 'pb_authors'" );
-//
-//		$this->assertNull( get_term( $result[ 'term_id'], 'contributor' ) );
-//		$this->assertCount( 1, $authors );
-//		$this->assertNotEquals( 'monsieurfake', $authors[0]->meta_value );
+		$this->assertNull( get_term( $result[ 'term_id'], 'contributor' ) );
+		$this->assertCount( 1, $authors );
+		$this->assertNotEquals( 'monsieurfake', $authors[0]->meta_value );
 	}
 }


### PR DESCRIPTION
Issue #2385 

This PR cleans up post metadata related to a contributor that has been deleted.

### How to test

1. Create some contributors and associate them as authors in chapters and book info, or as editors, illustrators, etc. in book info.
2. Make sure they appear in postmeta table `SELECT * FROM wp_<blog_id>_postmeta WHERE meta_key IN ('pb_editors', 'pb_authors', 'pb_contributors', 'pb_translators', 'pb_reviewers', 'pb_illustrators')`
3. Delete a contributor from the contributors' list
4. Make sure they are gone in book info, chapter
5. Make sure they don't appear in post meta table `SELECT * FROM wp_<blog_id>_postmeta WHERE meta_key IN ('pb_editors', 'pb_authors', 'pb_contributors', 'pb_translators', 'pb_reviewers', 'pb_illustrators')`

ps.: after deleting a contributor there's still a chance that it will be displayed in book home page. It appears to be the same cache problem as in #2359 