### PR TITLE
Add contributors metadata info in section metadata API endpoints

### DIFF
--- a/inc/api/endpoints/controller/class-metadata.php
+++ b/inc/api/endpoints/controller/class-metadata.php
@@ -634,7 +634,7 @@ class Metadata extends \WP_REST_Controller {
 	 */
 	public function get_item( $request ) {
 
-		$meta = Book::getBookInformation( null, false );
+		$meta = Book::getBookInformation( null, false, false );
 		$meta = $this->buildMetadata( $meta );
 
 		$response = rest_ensure_response( $meta );

--- a/inc/api/endpoints/controller/class-sectionmetadata.php
+++ b/inc/api/endpoints/controller/class-sectionmetadata.php
@@ -503,7 +503,7 @@ class SectionMetadata extends \WP_REST_Controller {
 
 		$section_meta = $this->buildMetadata(
 			get_section_information( $request['parent'] ),
-			Book::getBookInformation( null, false )
+			Book::getBookInformation( null, false, false )
 		);
 
 		$response = rest_ensure_response( $section_meta );

--- a/inc/api/endpoints/controller/class-sectionmetadata.php
+++ b/inc/api/endpoints/controller/class-sectionmetadata.php
@@ -503,7 +503,7 @@ class SectionMetadata extends \WP_REST_Controller {
 
 		$section_meta = $this->buildMetadata(
 			get_section_information( $request['parent'] ),
-			Book::getBookInformation()
+			Book::getBookInformation( null, false )
 		);
 
 		$response = rest_ensure_response( $section_meta );

--- a/inc/class-book.php
+++ b/inc/class-book.php
@@ -77,6 +77,8 @@ class Book {
 	 * Returns book information in a useful, string only, format. Data is converted to HTML.
 	 *
 	 * @param int $id The book ID.
+	 * @param bool $contributors_as_string Read contributors list as a string.
+	 * @param int $read_contributors_from_cache Read contributors from cache, if book information is stored in wp cache.
 	 *
 	 * @return array
 	 */

--- a/inc/class-book.php
+++ b/inc/class-book.php
@@ -104,7 +104,7 @@ class Book {
 		// -----------------------------------------------------------------------------
 
 		$cache_id = "book-inf-$blog_id";
-		if (  static::useCache() ) {
+		if ( static::useCache() ) {
 			$cached_book_information = wp_cache_get( $cache_id, 'pb' );
 			if ( $cached_book_information ) {
 				if ( ! $read_contributors_from_cache ) {
@@ -124,10 +124,13 @@ class Book {
 		if ( $meta_post ) {
 
 			// Contributors
-			$book_information = array_merge( $book_information, $contributors->getAll(
-				$meta_post->ID,
-				$contributors_as_string,
-				true )
+			$book_information = array_merge(
+				$book_information,
+				$contributors->getAll(
+					$meta_post->ID,
+					$contributors_as_string,
+					true
+				)
 			);
 
 			// Post Meta

--- a/inc/class-book.php
+++ b/inc/class-book.php
@@ -80,25 +80,13 @@ class Book {
 	 *
 	 * @return array
 	 */
-	static function getBookInformation( $id = null, $contributors_as_string = true ) {
+	static function getBookInformation( $id = null, $contributors_as_string = true, $read_contributors_from_cache = true ) {
 
 		if ( ! empty( $id ) && is_int( $id ) ) {
 			$blog_id = $id;
 			switch_to_blog( $blog_id );
 		} else {
 			global $blog_id;
-		}
-
-		// -----------------------------------------------------------------------------
-		// Is cached?
-		// -----------------------------------------------------------------------------
-
-		$cache_id = "book-inf-$blog_id";
-		if ( static::useCache() ) {
-			$book_information = wp_cache_get( $cache_id, 'pb' );
-			if ( $book_information ) {
-				return $book_information;
-			}
 		}
 
 		// ----------------------------------------------------------------------------
@@ -109,14 +97,38 @@ class Book {
 		$meta = new Metadata();
 		$meta_post = $meta->getMetaPost();
 
+		$contributors = new Contributors();
+
+		// -----------------------------------------------------------------------------
+		// Is cached?
+		// -----------------------------------------------------------------------------
+
+		$cache_id = "book-inf-$blog_id";
+		if (  static::useCache() ) {
+			$cached_book_information = wp_cache_get( $cache_id, 'pb' );
+			if ( $cached_book_information ) {
+				if ( ! $read_contributors_from_cache ) {
+					$cached_book_information = array_merge(
+						$cached_book_information,
+						$contributors->getAll(
+							$meta_post->ID,
+							$contributors_as_string,
+							true
+						)
+					);
+				}
+				return $cached_book_information;
+			}
+		}
+
 		if ( $meta_post ) {
 
 			// Contributors
-			$contributors = new Contributors();
-			$all_contributors = $contributors->getAll( $meta_post->ID, $contributors_as_string, true );
-			foreach ( $all_contributors as $key => $val ) {
-				$book_information[ $key ] = $val;
-			};
+			$book_information = array_merge( $book_information, $contributors->getAll(
+				$meta_post->ID,
+				$contributors_as_string,
+				true )
+			);
 
 			// Post Meta
 			$expected_array = [ 'pb_keywords_tags', 'pb_additional_subjects', 'pb_bisac_subject' ];

--- a/inc/cloner/class-cloner.php
+++ b/inc/cloner/class-cloner.php
@@ -1322,7 +1322,7 @@ class Cloner {
 						$contributor_data['slug'] = sanitize_title_with_dashes( remove_accents( $contributor_data['name'] ), '', 'save' );
 					}
 					$this->contributors->insert( $contributor_data, $metadata_post_id, $key, $this->downloads, 'slug' );
-					if ( $key === 'pb_authors' && isset( $contributor_data['slug'] ) ) {
+					if ( $key === 'pb_authors' ) {
 						$authors_slug[] = $contributor_data['slug'];
 					}
 				}

--- a/inc/metadata/namespace.php
+++ b/inc/metadata/namespace.php
@@ -975,7 +975,7 @@ function add_json_ld_metadata() {
 	if ( $context === 'section' ) {
 		global $post;
 		$section_information = get_section_information( $post->ID );
-		$book_information = Book::getBookInformation( null, false );
+		$book_information = Book::getBookInformation( null, false, false );
 		$metadata = section_information_to_schema( $section_information, $book_information );
 	} else {
 		$metadata = new Metadata();
@@ -992,7 +992,7 @@ function add_json_ld_metadata() {
  */
 function add_citation_metadata() {
 	$context = is_singular( [ 'front-matter', 'part', 'chapter', 'back-matter' ] ) ? 'section' : 'book';
-	$book_information = Book::getBookInformation( null, false );
+	$book_information = Book::getBookInformation( null, false, false );
 	$tags = [];
 
 	$map = [

--- a/inc/modules/export/htmlbook/class-htmlbook.php
+++ b/inc/modules/export/htmlbook/class-htmlbook.php
@@ -205,7 +205,7 @@ class HTMLBook extends Export {
 		// ------------------------------------------------------------------------------------------------------------
 		// HTMLBook, Start!
 
-		$metadata = \Pressbooks\Book::getBookInformation( null, false );
+		$metadata = \Pressbooks\Book::getBookInformation( null, false, false );
 		$book_contents = $this->preProcessBookContents( \Pressbooks\Book::getBookContents() );
 
 		// Set two letter language code

--- a/inc/modules/export/xhtml/class-xhtml11.php
+++ b/inc/modules/export/xhtml/class-xhtml11.php
@@ -317,7 +317,7 @@ class Xhtml11 extends ExportGenerator {
 		// ------------------------------------------------------------------------------------------------------------
 		// XHTML, Start!
 
-		$metadata = \Pressbooks\Book::getBookInformation( null, false );
+		$metadata = \Pressbooks\Book::getBookInformation( null, false, false );
 		$_unused = [];
 
 		// Set two letter language code


### PR DESCRIPTION
Related issue: https://github.com/pressbooks/pressbooks/issues/2358
Related change: https://github.com/pressbooks/pressbooks/pull/2369

This PR adds contributors metadata in the API in the sections (Chapters, Back Matters, Front Matters, etc), not only for editors and other types of contributors, but also for authors.

### Testing example
_Note: Do not clone a book from integration until staging contains this version of the API. If you clone a book from staging without this new version, then the contributors information won't be exposed at the metadata section level. Instead, use a local version or use production to test compatibility with latest stable versions._

Here's a video about how to test and check the API endpoints, specially for the cloning process:

https://user-images.githubusercontent.com/13248424/134782513-104c87c7-fffb-4f34-a893-336b0ba9f5d0.mp4

**Important note: Make sure cleaned the wp cache**