### PR TITLE
Revert contributors automatic back-matter

### DIFF
--- a/inc/class-activation.php
+++ b/inc/class-activation.php
@@ -229,12 +229,6 @@ class Activation {
 				'post_type' => 'back-matter',
 				'menu_order' => 1,
 			],
-			'contributors' => [
-				'post_title' => __( 'Contributors', 'pressbooks' ),
-				'post_name' => 'contributors',
-				'post_type' => 'back-matter',
-				'menu_order' => 2,
-			],
 			// Pages
 			'authors' => [
 				'post_title' => __( 'Authors', 'pressbooks' ),

--- a/inc/cloner/class-cloner.php
+++ b/inc/cloner/class-cloner.php
@@ -1107,7 +1107,6 @@ class Cloner {
 				'main-body',
 				'chapter-1',
 				'appendix',
-				'contributors',
 			] as $post
 		) {
 			unset( $contents[ $post ] );

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -217,7 +217,6 @@ class ApiTest extends \WP_UnitTestCase {
 		$this->assertEquals( 200, $data[0]->get_data()['status'] );
 		$this->assertEquals( 200, $data[1]->get_data()['status'] );
 		$this->assertEquals( 'Introduction', $data[0]->get_data()['body'][0]['title']['rendered'] );
-		$this->assertEquals( 'Contributors', $data[1]->get_data()['body'][0]['title']['rendered'] );
 
 		// JSON Object Format
 


### PR DESCRIPTION
This PR reverts the automatic creation of a contributors back-matter.

### How to test

1. Create a new book the contributors back-matter should not be automatically created
2. Try to create a contributor back-matter selecting the contributor back-matter-type
3. The contributor back matter should be created and displaying the contributors list