### PR TITLE
Remove root network from the count

### DIFF
--- a/inc/datacollector/class-book.php
+++ b/inc/datacollector/class-book.php
@@ -455,7 +455,10 @@ class Book {
 	 */
 	public function getTotalBooks() {
 		global $wpdb;
-		$total = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(DISTINCT blog_id) FROM {$wpdb->blogmeta} WHERE meta_key = %s ", self::TIMESTAMP ) );
+		$root_id = 1; // root network id should not be considered
+
+		$total = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(DISTINCT blog_id) FROM {$wpdb->blogmeta} WHERE blog_id <> %d AND meta_key = %s ", $root_id,self::TIMESTAMP ) );
+
 		return (int) $total;
 	}
 

--- a/inc/datacollector/class-book.php
+++ b/inc/datacollector/class-book.php
@@ -457,7 +457,7 @@ class Book {
 		global $wpdb;
 		$root_id = 1; // root network id should not be considered
 
-		$total = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(DISTINCT blog_id) FROM {$wpdb->blogmeta} WHERE blog_id <> %d AND meta_key = %s ", $root_id,self::TIMESTAMP ) );
+		$total = $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(DISTINCT blog_id) FROM {$wpdb->blogmeta} WHERE blog_id <> %d AND meta_key = %s ", $root_id, self::TIMESTAMP ) );
 
 		return (int) $total;
 	}

--- a/tests/test-datacollector-book.php
+++ b/tests/test-datacollector-book.php
@@ -201,10 +201,15 @@ class DataCollector_BookTest extends \WP_UnitTestCase {
 	 * @group datacollector
 	 */
 	public function test_getTotalBooks() {
+		add_action( 'wp_update_site', [ $this->bookDataCollector, 'updateSite' ], 999, 2 );
+
 		$this->_book();
 		$x = $this->bookDataCollector->getTotalBooks();
+
 		$this->assertIsInt( $x );
-		$this->assertTrue( $x > 0 );
+		$this->assertEquals( 1, $x );
+
+		remove_action( 'wp_update_site', [ $this->bookDataCollector, 'updateSite' ], 999 );
 	}
 
 


### PR DESCRIPTION
This is a partial fix for pressbooks/pressbooks-network-analytics#149. Accompanies fixes in pressbooks/pressbooks-network-analytics#151

This PR changes `getTotalBooks` to ignore counting root network.

### How to test

This impacts the book list header in [pressbooks/pressbooks-network-analytics](https://github.com/pressbooks/pressbooks-network-analytics)

1. Enable Network Analytics Plugin
2. Go to the Book List
3. `There are BOOKS books on this network.` should match the amount of books in that network.
4. If you go to All Books it should show the amount of books + 1 because of the root network.