### PR TITLE
Add about the authors section inside the post content

### DIFF
--- a/inc/modules/export/xhtml/class-xhtml11.php
+++ b/inc/modules/export/xhtml/class-xhtml11.php
@@ -1387,6 +1387,8 @@ class Xhtml11 extends ExportGenerator {
 
 			$append_front_matter_content .= $this->removeAttributionLink( $this->doSectionLevelLicense( $metadata, $front_matter_id ) );
 
+			$content .= $this->displayAboutTheAuthors ? \Pressbooks\Modules\Export\get_contributors_section( $front_matter_id ) : '';
+
 			printf(
 				$front_matter_printf,
 				$subclass,
@@ -1400,10 +1402,6 @@ class Xhtml11 extends ExportGenerator {
 				$this->doEndnotes( $front_matter_id ),
 				$this->doFootnotes( $front_matter_id )
 			);
-
-			if ( $this->displayAboutTheAuthors ) {
-				echo \Pressbooks\Modules\Export\get_contributors_section( $front_matter_id );
-			}
 
 			echo "\n";
 			++$i;
@@ -1559,6 +1557,8 @@ class Xhtml11 extends ExportGenerator {
 
 				$append_chapter_content .= $this->removeAttributionLink( $this->doSectionLevelLicense( $metadata, $chapter_id ) );
 
+				$content .= $this->displayAboutTheAuthors ? \Pressbooks\Modules\Export\get_contributors_section( $chapter_id ) : '';
+
 				$my_chapter_number = ( strpos( $subclass, 'numberless' ) === false ) ? $j : '';
 				$my_chapters .= sprintf(
 					$chapter_printf,
@@ -1573,8 +1573,6 @@ class Xhtml11 extends ExportGenerator {
 					$this->doEndnotes( $chapter_id ),
 					$this->doFootnotes( $chapter_id )
 				) . "\n";
-
-				$my_chapters .= $this->displayAboutTheAuthors ? \Pressbooks\Modules\Export\get_contributors_section( $chapter_id ) : '';
 
 				if ( $my_chapter_number !== '' ) {
 					++$j;
@@ -1682,6 +1680,8 @@ class Xhtml11 extends ExportGenerator {
 
 			$append_back_matter_content .= $this->removeAttributionLink( $this->doSectionLevelLicense( $metadata, $back_matter_id ) );
 
+			$content .= $this->displayAboutTheAuthors ? \Pressbooks\Modules\Export\get_contributors_section( $back_matter_id ) : '';
+
 			printf(
 				$back_matter_printf,
 				$subclass,
@@ -1695,10 +1695,6 @@ class Xhtml11 extends ExportGenerator {
 				$this->doEndnotes( $back_matter_id ),
 				$this->doFootnotes( $back_matter_id )
 			);
-
-			if ( $this->displayAboutTheAuthors ) {
-				echo \Pressbooks\Modules\Export\get_contributors_section( $back_matter_id );
-			}
 
 			echo "\n";
 			++$i;


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks/issues/2404

This PR adds the about the authors section inside the post content in the XHTML export routine, to consider the pagination.

### Testing
For test, enable the "Display about the authors" global option and export the a book with chapter, back matter and front matters with authors assigned.