### PR TITLE
Expose new post metadata for parts

### DIFF
--- a/inc/api/endpoints/controller/class-posts.php
+++ b/inc/api/endpoints/controller/class-posts.php
@@ -94,6 +94,11 @@ class Posts extends \WP_REST_Posts_Controller {
 			}
 		}
 
+		if ( $post->post_type === 'part' ) {
+			$response->data['meta']['pb_part_invisible_string'] = is_null( $response->data['meta']['pb_part_invisible'] ) ?
+				'on' : '';
+		}
+
 		return $response;
 	}
 

--- a/inc/cloner/class-cloner.php
+++ b/inc/cloner/class-cloner.php
@@ -1452,14 +1452,8 @@ class Cloner {
 		// Remove items handled by cloneSectionMetadata()
 		unset( $section['meta']['pb_authors'], $section['meta']['pb_section_license'] );
 
-		if ( isset( $section['meta']['pb_part_invisible_string'] ) ) {
-			// pb_part_invisible metadata compatibility with previous boolean type (false | null)
-			if ( is_bool( $section['meta']['pb_part_invisible_string'] ) && $section['meta']['pb_part_invisible_string'] === false ) {
-				$section['meta']['pb_part_invisible_string'] = '';
-			}
-			if ( is_null( $section['meta']['pb_part_invisible_string'] ) ) {
-				$section['meta']['pb_part_invisible_string'] = 'on';
-			}
+		if ( array_key_exists( 'pb_part_invisible', $section['meta'] ) ) {
+			unset( $section['meta']['pb_part_invisible'] );
 		}
 
 		// POST internal request
@@ -1475,6 +1469,9 @@ class Cloner {
 
 		// Set pb_is_based_on property
 		update_post_meta( $response['id'], 'pb_is_based_on', $permalink );
+		if ( isset( $section['meta']['pb_part_invisible_string'] ) && $section['meta']['pb_part_invisible_string'] === 'on' ) {
+			update_post_meta( $response['id'], 'pb_part_invisible', 'on' );
+		}
 
 		// Clone associated content
 		if ( $post_type !== 'part' ) {

--- a/inc/cloner/class-cloner.php
+++ b/inc/cloner/class-cloner.php
@@ -1452,13 +1452,13 @@ class Cloner {
 		// Remove items handled by cloneSectionMetadata()
 		unset( $section['meta']['pb_authors'], $section['meta']['pb_section_license'] );
 
-		if ( isset( $section['meta']['pb_part_invisible'] ) ) {
+		if ( isset( $section['meta']['pb_part_invisible_string'] ) ) {
 			// pb_part_invisible metadata compatibility with previous boolean type (false | null)
-			if ( is_bool( $section['meta']['pb_part_invisible'] ) && $section['meta']['pb_part_invisible'] === false ) {
-				$section['meta']['pb_part_invisible'] = '';
+			if ( is_bool( $section['meta']['pb_part_invisible_string'] ) && $section['meta']['pb_part_invisible_string'] === false ) {
+				$section['meta']['pb_part_invisible_string'] = '';
 			}
-			if ( is_null( $section['meta']['pb_part_invisible'] ) ) {
-				$section['meta']['pb_part_invisible'] = 'on';
+			if ( is_null( $section['meta']['pb_part_invisible_string'] ) ) {
+				$section['meta']['pb_part_invisible_string'] = 'on';
 			}
 		}
 

--- a/inc/posttype/namespace.php
+++ b/inc/posttype/namespace.php
@@ -378,18 +378,6 @@ function register_meta() {
 	);
 
 	\register_meta(
-		'post', 'pb_part_invisible_string', array_merge(
-			$defaults, [
-				'object_subtype' => 'part',
-				'description' => __( 'Whether or not the part is shown in the table of contents in string format', 'pressbooks' ),
-				'sanitize_callback' => function( $v ) {
-					return ( $v ? 'on' : null );
-				},
-			]
-		)
-	);
-
-	\register_meta(
 		'post', 'pb_media_attribution_title_url', array_merge(
 			$defaults, [
 				'object_subtype' => 'attachment',

--- a/inc/posttype/namespace.php
+++ b/inc/posttype/namespace.php
@@ -372,6 +372,16 @@ function register_meta() {
 			$defaults, [
 				'object_subtype' => 'part',
 				'description' => __( 'Whether or not the part is shown in the table of contents', 'pressbooks' ),
+				'type' => 'boolean',
+			]
+		)
+	);
+
+	\register_meta(
+		'post', 'pb_part_invisible_string', array_merge(
+			$defaults, [
+				'object_subtype' => 'part',
+				'description' => __( 'Whether or not the part is shown in the table of contents in string format', 'pressbooks' ),
 				'sanitize_callback' => function( $v ) {
 					return ( $v ? 'on' : null );
 				},

--- a/symbionts/custom-metadata/custom_metadata.php
+++ b/symbionts/custom-metadata/custom_metadata.php
@@ -740,12 +740,22 @@ class custom_metadata_manager {
 			$value = $this->_sanitize_field_value( $field_slug, $field, $object_type, $object_id, $_POST[$field_slug] );
 			$this->_save_field_value( $field_slug, $field, $object_type, $object_id, $value );
 
+			if ( $field_slug === 'pb_part_invisible' ) {
+				// Save the string format to expose to the metadata API TOC endpoint
+				$this->_save_field_value( 'pb_part_invisible_string', $field, $object_type, $object_id, $value );
+			}
+
 
 			// save the attachment ID of the upload field as well
 			if ( $field->field_type == 'upload' && isset( $_POST[$field_slug . '_attachment_id'] ) )
 				$this->_save_field_value( $field_slug . '_attachment_id', $field, $object_type, $object_id, absint( $_POST[$field_slug . '_attachment_id'] ) );
 		} else {
 			$this->_delete_field_value( $field_slug, $field, $object_type, $object_id );
+
+			if ( $field_slug === 'pb_part_invisible' ) {
+				// Delete the string format to expose to the metadata API TOC endpoint
+				$this->_delete_field_value( 'pb_part_invisible_string', $field, $object_type, $object_id );
+			}
 
 			// delete the attachment ID of the upload field as well
 			if ( $field->field_type == 'upload' && isset( $_POST[$field_slug . '_attachment_id'] ) )

--- a/symbionts/custom-metadata/custom_metadata.php
+++ b/symbionts/custom-metadata/custom_metadata.php
@@ -740,22 +740,12 @@ class custom_metadata_manager {
 			$value = $this->_sanitize_field_value( $field_slug, $field, $object_type, $object_id, $_POST[$field_slug] );
 			$this->_save_field_value( $field_slug, $field, $object_type, $object_id, $value );
 
-			if ( $field_slug === 'pb_part_invisible' ) {
-				// Save the string format to expose to the metadata API TOC endpoint
-				$this->_save_field_value( 'pb_part_invisible_string', $field, $object_type, $object_id, $value );
-			}
-
 
 			// save the attachment ID of the upload field as well
 			if ( $field->field_type == 'upload' && isset( $_POST[$field_slug . '_attachment_id'] ) )
 				$this->_save_field_value( $field_slug . '_attachment_id', $field, $object_type, $object_id, absint( $_POST[$field_slug . '_attachment_id'] ) );
 		} else {
 			$this->_delete_field_value( $field_slug, $field, $object_type, $object_id );
-
-			if ( $field_slug === 'pb_part_invisible' ) {
-				// Delete the string format to expose to the metadata API TOC endpoint
-				$this->_delete_field_value( 'pb_part_invisible_string', $field, $object_type, $object_id );
-			}
 
 			// delete the attachment ID of the upload field as well
 			if ( $field->field_type == 'upload' && isset( $_POST[$field_slug . '_attachment_id'] ) )


### PR DESCRIPTION
This PR exposes the `pb_part_invisible` metadata part as `pb_part_invisible_string` to address this issue: https://github.com/pressbooks/pressbooks/pull/2366 but keep compatibility with previous API versions.