### PR TITLE
Add redirect when user is accepting invitations

### DIFF
--- a/inc/registration/namespace.php
+++ b/inc/registration/namespace.php
@@ -401,7 +401,7 @@ function clean_invitation_data( $user_id, $result ) {
 	delete_user_meta( $user_id, 'new_user_' . $key );
 
 	// If running tests, we don't want to redirect
-	if ( ! defined( 'WP_TESTS_MULTISITE' ) ) {
+	if ( ! defined( 'WP_TESTS_MULTISITE' ) && is_user_logged_in() ) {
 		wp_redirect( network_site_url( 'wp-admin' ) );
 	}
 }


### PR DESCRIPTION
Issue #2192 

This PR improves the invitation widget so when a user accepts it, it will redirect back to the dashboard.

### How to test

Follow the steps from #2424 and after user accepts it, they should be redirected to the dashboard.