### PR TITLE
fix: prevent user subscription to books while logging in

### DIFF
--- a/inc/datacollector/class-user.php
+++ b/inc/datacollector/class-user.php
@@ -165,9 +165,27 @@ class User {
 	}
 
 	public function setSubscriberRole( $user_login, $user ) {
+		$switched_blog = false;
+		$main_site_id = get_main_site_id();
+		$current_site_id = get_current_blog_id();
+
+		// Switch to the main site if user is logging from a different blog
+		if ( get_current_blog_id() !== $main_site_id ) {
+			$switched_blog = true;
+			$user->for_site( $main_site_id );
+			switch_to_blog( $main_site_id );
+		}
+
 		$caps = $user->get_role_caps();
+
 		if ( ! in_array( 'read', $caps, true ) ) {
 			$user->add_role( 'subscriber' );
+		}
+
+		// If needed, restore original values after adding user as subscriber to the main site
+		if ( $switched_blog ) {
+			$user->for_site( $current_site_id );
+			restore_current_blog();
 		}
 	}
 

--- a/tests/test-datacollector-user.php
+++ b/tests/test-datacollector-user.php
@@ -3,6 +3,8 @@
 use Pressbooks\DataCollector\User as UserDataCollector;
 
 class DataCollector_UserTest extends \WP_UnitTestCase {
+	use utilsTrait;
+
 	/**
 	 * @var UserDataCollector
 	 */
@@ -25,6 +27,26 @@ class DataCollector_UserTest extends \WP_UnitTestCase {
 		$last_login = get_user_meta( $user->ID, UserDataCollector::LAST_LOGIN, true );
 		$this->assertNotEmpty( $last_login );
 		$this->assertTrue( DateTime::createFromFormat( 'Y-m-d H:i:s', $last_login ) !== false );
+	}
+
+	/**
+	 * @group datacollector
+	 */
+	public function test_setSubscriberRole() {
+		global $wpdb;
+
+		$user = $this->factory()->user->create_and_get();
+		$this->_book();
+
+		$current_blog_id = get_current_blog_id();
+		$user->for_site( $current_blog_id ); // simulate user login in a book.
+
+		$this->userDataCollector->setSubscriberRole( '', $user );
+
+		$metadata = get_user_meta( $user->ID );
+
+		$this->assertArrayHasKey( "{$wpdb->base_prefix}capabilities", $metadata );
+		$this->assertArrayNotHasKey( "{$wpdb->prefix}capabilities", $metadata );
 	}
 
 	/**


### PR DESCRIPTION
Partial fix for #2375 

This PR prevents users from being subscribed to books while logging in. If users have no capabilities, they will be subscribed to the main site so they have the ability to clone books.

#### How to test

1. Add a new lowly user to the network level.
2. Login with the new user from the main page, make sure the user will be added as subscriber to the main site.
3. Logout and login again but from a book page -- could be a private one -- and make sure the user is NOT added as subscriber to that book.
4. Users should still have access to the clone routine if they don't have any book created.

[See](https://github.com/pressbooks/pressbooks/issues/2375#issuecomment-937976999) for better understanding the actual behavior.