### PR TITLE
Increase dependabot check frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     directory: "/"
     # Check for updates monthly
     schedule:
-      interval: "monthly"
+      interval: "daily"
     allow:
       # Allow direct updates only (for packages named in package.json)
       - dependency-type: "direct"
@@ -19,7 +19,7 @@ updates:
     directory: "/"
     # Check for updates monthly
     schedule:
-      interval: "monthly"
+      interval: "daily"
     allow:
       # Allow direct updates only (for packages named in composer.json)
       - dependency-type: "direct"


### PR DESCRIPTION
This PR changes the frequency that dependabot checks for top-level dependency updates from monthly to daily.