### PR TITLE
Improve publish option page

### DIFF
--- a/inc/admin/class-publishoptions.php
+++ b/inc/admin/class-publishoptions.php
@@ -68,7 +68,8 @@ class PublishOptions extends \Pressbooks\Options {
 			__( 'Amazon URL', 'pressbooks' ),
 			[ $this, 'renderAmazonField' ],
 			$_page,
-			$_section
+			$_section,
+			[ 'label_for' => 'amazon' ]
 		);
 
 		add_settings_field(
@@ -76,7 +77,8 @@ class PublishOptions extends \Pressbooks\Options {
 			__( 'O\'Reilly URL', 'pressbooks' ),
 			[ $this, 'renderOReillyField' ],
 			$_page,
-			$_section
+			$_section,
+			[ 'label_for' => 'oreilly' ]
 		);
 
 		add_settings_field(
@@ -84,7 +86,8 @@ class PublishOptions extends \Pressbooks\Options {
 			__( 'Barnes and Noble URL', 'pressbooks' ),
 			[ $this, 'renderBarnesAndNobleField' ],
 			$_page,
-			$_section
+			$_section,
+			[ 'label_for' => 'barnesandnoble' ]
 		);
 
 		add_settings_field(
@@ -92,15 +95,17 @@ class PublishOptions extends \Pressbooks\Options {
 			__( 'Kobo URL', 'pressbooks' ),
 			[ $this, 'renderKoboField' ],
 			$_page,
-			$_section
+			$_section,
+			[ 'label_for' => 'kobo' ]
 		);
 
 		add_settings_field(
-			'ibooks',
-			__( 'iBooks URL', 'pressbooks' ),
-			[ $this, 'renderiBooksField' ],
+			'applebooks',
+			__( 'Apple Books URL', 'pressbooks' ),
+			[ $this, 'renderAppleBooksField' ],
 			$_page,
-			$_section
+			$_section,
+			[ 'label_for' => 'applebooks' ]
 		);
 
 		add_settings_field(
@@ -108,7 +113,8 @@ class PublishOptions extends \Pressbooks\Options {
 			__( 'Other Service URL', 'pressbooks' ),
 			[ $this, 'renderOtherServiceField' ],
 			$_page,
-			$_section
+			$_section,
+			[ 'label_for' => 'otherservice' ]
 		);
 
 		register_setting(
@@ -123,21 +129,8 @@ class PublishOptions extends \Pressbooks\Options {
 	 */
 	function display() {
 		ob_start(); ?>
-		<p><?php _e( 'Once your book is finished, you can download the files and submit them to ebookstores and print-on-demand providers.', 'pressbooks' ); ?></p>
-
-		<div class="postbox">
-			<div class="inside">
-				<h2><?php _e( 'Ebook Stores', 'pressbooks' ); ?></h2>
-				<p><?php printf( __( 'Once you have downloaded your files, you can either submit them to ebookstores yourself, or use a third-party distributor. Recommended self-serve ebookstores are <a href="%1$1s">Kindle</a>, <a href="%2$2s">Kobo</a>, and <a href="%3$3s">Nook</a>. Other ebook stores include Apple iBooks and Google.', 'pressbooks' ), 'https://kdp.amazon.com', 'https://www.kobo.com/writinglife', 'https://www.nookpress.com' ); ?></p>
-				<p><?php printf( __( 'If you do not wish to submit your ebooks yourself, we recommend using a third-party distribution service such as <a href="%1s">IngramSpark</a>, which can also make your books available online in print.', 'pressbooks' ), 'https://ingramspark.com' ); ?></p>
-
-				<h2><?php _e( 'Print-on-Demand', 'pressbooks' ); ?></h2>
-				<p><?php printf( __( 'If you wish to sell your printed books online, we recommend going through <a href="%1$1s">IngramSpark</a> or Amazon\'s <a href="%2$2s">CreateSpace</a>.', 'pressbooks' ), 'https://ingramspark.com', 'https://www.createspace.com' ); ?></p>
-			</div>
-		</div>
-
-		<h2><?php _e( 'Adding BUY Links to Your Pressbooks Web Book', 'pressbooks' ); ?></h2>
-		<p><?php _e( 'If you would like to add <strong>BUY</strong> links to your Pressbooks web book, add the links to your book at the different retailers below:', 'pressbooks' ); ?></p>
+		<h2><?php _e( 'Add BUY Links to Your Pressbooks Webbook', 'pressbooks' ); ?></h2>
+		<p><?php _e( 'Enter the URLs for locations where your book can be purchased below. <a href="https://guide.pressbooks.com/chapter/publish/">Our guide</a> provides additional information about selling and distributing your book.', 'pressbooks' ); ?></p>
 
 		<?php
 		$output = ob_get_contents();
@@ -251,15 +244,15 @@ class PublishOptions extends \Pressbooks\Options {
 	}
 
 	/**
-	 * Render the ibooks field.
+	 * Render the Apple Books field.
 	 */
-	function renderiBooksField() {
+	function renderAppleBooksField() {
 		$this->renderField(
 			[
-				'id' => 'ibooks',
+				'id' => 'applebooks',
 				'name' => $this->getSlug(),
-				'option' => 'ibooks',
-				'value' => ( isset( $this->options['ibooks'] ) ) ? $this->options['ibooks'] : '',
+				'option' => 'applebooks',
+				'value' => ( isset( $this->options['applebooks'] ) ) ? $this->options['applebooks'] : '',
 				'type' => 'url',
 				'class' => 'regular-text code',
 			]
@@ -267,7 +260,7 @@ class PublishOptions extends \Pressbooks\Options {
 	}
 
 	/**
-	 * Render the ibooks field.
+	 * Render the other service field.
 	 */
 	function renderOtherServiceField() {
 		$this->renderField(
@@ -327,7 +320,7 @@ class PublishOptions extends \Pressbooks\Options {
 			'oreilly',
 			'barnesandnoble',
 			'kobo',
-			'ibooks',
+			'applebooks',
 			'otherservice',
 		];
 	}


### PR DESCRIPTION
This PR addresses #2446 by adding labels to all inputs, updating the user instructions, and changing iBooks to Apple Books (https://www.theverge.com/2018/6/4/17425852/ibooks-redesign-apple-books-branding-ios-12-update-wwdc-2018). It is accompanied by https://github.com/pressbooks/pressbooks-book/pull/886

To test:
1. Check out this branch and visit the 'publish' menu for a book. 
2. Check to see that the page instructions have been changed, that 'iBooks URL' now reads 'Apple Books URL' and that all inputs now have accessible labels