### PR TITLE
fix: improve parts and chapters conditional

### DIFF
--- a/inc/modules/export/class-exporthelpers.php
+++ b/inc/modules/export/class-exporthelpers.php
@@ -28,6 +28,7 @@ trait ExportHelpers {
 		$needs_tidy_html = $options['needs_tidy_html'] ?? false;
 		$endnotes = $options['endnotes'] ?? false;
 		$footnotes = $options['footnotes'] ?? false;
+		$slug_as_href = $options['slug_as_href'] ?? false;
 
 		$data = [
 			'id' => $post_data['ID'],
@@ -36,7 +37,7 @@ trait ExportHelpers {
 		$method = studly_case( $post_type_identifier );
 		$taxonomy_method = "get{$method}Type";
 		$data['subclass'] = $this->taxonomy->{$taxonomy_method}( $post_data['ID'] );
-		$data['slug'] = "{$data['post_type_class']}-{$post_data['post_name']}";
+		$data['slug'] = $slug_as_href ? $post_data['post_name'] : "{$data['post_type_class']}-{$post_data['post_name']}";
 		$data['title'] = ( get_post_meta( $post_data['ID'], 'pb_show_title', true ) ? $post_data['post_title'] : '<span class="display-none">' . $post_data['post_title'] . '</span>' ); // Preserve auto-indexing in Prince using hidden span
 		$data['content'] = $post_data['post_content'];
 		$data['append_post_content'] = apply_filters( "pb_append_{$post_type_identifier}_content", '', $post_data['ID'] );

--- a/inc/modules/export/class-exporthelpers.php
+++ b/inc/modules/export/class-exporthelpers.php
@@ -32,7 +32,7 @@ trait ExportHelpers {
 		$data = [
 			'id' => $post_data['ID'],
 		];
-		$data['post_type_class'] = str_replace( '_','-', $post_type_identifier ); // This class is used to map with the SCSS class in buckram Ex: front-matter
+		$data['post_type_class'] = str_replace( '_', '-', $post_type_identifier ); // This class is used to map with the SCSS class in buckram Ex: front-matter
 		$method = studly_case( $post_type_identifier );
 		$taxonomy_method = "get{$method}Type";
 		$data['subclass'] = $this->taxonomy->{$taxonomy_method}( $post_data['ID'] );

--- a/inc/modules/export/epub/class-epub.php
+++ b/inc/modules/export/epub/class-epub.php
@@ -1582,6 +1582,7 @@ class Epub extends ExportGenerator {
 			$data = $this->mapBookDataAndContent( $front_matter, $metadata, $i, [
 				'type' => 'front_matter',
 				'needs_tidy_html' => true,
+				'slug_as_href' => true, // we want the slugs to be proper anchors in the EPUB export
 			] );
 
 			$subclass = $data['subclass'];
@@ -1853,6 +1854,7 @@ class Epub extends ExportGenerator {
 			$data = $this->mapBookDataAndContent( $back_matter, $metadata, $i, [
 				'type' => 'back_matter',
 				'needs_tidy_html' => true,
+				'slug_as_href' => true, // we want the slugs to be proper anchors in the EPUB export
 			] );
 
 			$vars['post_title'] = $data['title'];

--- a/inc/modules/export/xhtml/class-xhtml11.php
+++ b/inc/modules/export/xhtml/class-xhtml11.php
@@ -1482,9 +1482,13 @@ class Xhtml11 extends ExportGenerator {
 					? $rendered_part . $rendered_chapters
 					: $rendered_chapters;
 			} else {
-				echo $rendered_chapters
-					? $rendered_part . $rendered_chapters
-					: $rendered_part;
+				if ( ! $rendered_chapters ) {
+					echo $part_content ? $rendered_part : '';
+
+					continue;
+				}
+
+				echo $rendered_part . $rendered_chapters;
 			}
 
 			++$part_index;
@@ -1517,7 +1521,7 @@ class Xhtml11 extends ExportGenerator {
 			] );
 
 			echo $this->blade->render( 'export/generic-post-type', $data );
-			
+
 			++$i;
 		}
 

--- a/templates/export/chapter.blade.php
+++ b/templates/export/chapter.blade.php
@@ -1,7 +1,7 @@
 <div class="chapter {{ $subclass }}" id="{{ $slug }}" title="{{ $sanitized_title }}">
 	<div class="chapter-title-wrap">
 		<p class="chapter-number">{{ $number }}</p>
-		<h1 class="chapter-title">{!! $title !!}</h1>
+		<h2 class="chapter-title">{!! $title !!}</h2>
 		@if(  isset( $is_new_buckram ) && $is_new_buckram )
 			@include('export/sub-author-partial')
 		@endif

--- a/tests/test-templates-export.php
+++ b/tests/test-templates-export.php
@@ -85,7 +85,7 @@ class TemplateExportTest extends \WP_UnitTestCase {
 			$chapter_rendered
 		);
 		$this->assertContains( '<p class="chapter-number">1</p>', $chapter_rendered );
-		$this->assertContains( "<h1 class=\"chapter-title\">$title</h1>", $chapter_rendered );
+		$this->assertContains( "<h2 class=\"chapter-title\">$title</h2>", $chapter_rendered );
 		$this->assertContains( "<p class=\"short-title\">$short_title</p>", $chapter_rendered );
 		$this->assertContains( "<p class=\"chapter-subtitle\">$subtitle</p>", $chapter_rendered );
 		$this->assertContains( "<p class=\"chapter-author\">$author</p>", $chapter_rendered );


### PR DESCRIPTION
Fix for #2471 

This PR aims to fix parts not being rendered properly when they had empty content + chapters or content and no chapters. It also changes the book title heading to `h2` instead of `h1` for now, fixing the title breaking on exports.

The PR also fixes some EPUB issues where front-matters and back-matters were not being properly referenced in the book, causing validation issues and internal links not working as expected.

### How to test

1. Clone a book from integrations
2. Make sure settings for the original one and the clone one are the same
3. Export the original one form integrations
4. Export the clone one and compare them 