### PR TITLE
Fix breaklines for contributors template

### DIFF
--- a/inc/modules/export/epub/class-epub.php
+++ b/inc/modules/export/epub/class-epub.php
@@ -595,7 +595,6 @@ class Epub extends ExportGenerator {
 		}
 		$content = apply_filters( 'the_export_content', $content );
 		$content = str_ireplace( [ '<b></b>', '<i></i>', '<strong></strong>', '<em></em>' ], '', $content );
-		$content = $this->fixAnnoyingCharacters( $content );
 		$content = $this->tidy( $content );
 		return $content;
 	}
@@ -652,27 +651,6 @@ class Epub extends ExportGenerator {
 
 		yield 90 => $this->generatorPrefix . __( 'Validation successful', 'pressbooks' );
 		yield 100 => $this->generatorPrefix . __( 'Finishing up', 'pressbooks' );
-	}
-
-	/**
-	 * Fix annoying characters that the user probably didn't do on purpose
-	 *
-	 * @param string $html
-	 *
-	 * @return string
-	 */
-	function fixAnnoyingCharacters( $html ) {
-
-		// Do parent first
-		$html = parent::fixAnnoyingCharacters( $html );
-
-		// EPUB specific
-
-		// Adobe Digital Editions has problems with exotic dashes, that is to say if this were 1999...
-		// TODO: Some users want this, others do not want this, make up your mind...
-		// $html = str_replace( array( '–', '&#8211;', '—', '&#8212;', '‑' ), '-', $html ); @codingStandardsIgnoreLine
-
-		return $html;
 	}
 
 	/**

--- a/templates/posttypes/contributor.blade.php
+++ b/templates/posttypes/contributor.blade.php
@@ -23,8 +23,8 @@
 					@if ( !isset( $exporting ) )
 						<span class="screen-reader-text">website: </span>
 					@endif
-					<a href="{{ $contributor['contributor_user_url'] }}"
-							target="_blank">{{ $contributor['contributor_user_url'] }}
+					<a href="{{ $contributor['contributor_user_url'] }}" target="_blank">
+						{{ $contributor['contributor_user_url'] }}
 					</a>
 				</p>
 			@endif

--- a/templates/posttypes/contributor.blade.php
+++ b/templates/posttypes/contributor.blade.php
@@ -23,9 +23,7 @@
 					@if ( !isset( $exporting ) )
 						<span class="screen-reader-text">website: </span>
 					@endif
-					<a href="{{ $contributor['contributor_user_url'] }}" target="_blank">
-						{{ $contributor['contributor_user_url'] }}
-					</a>
+					<a href="{{ $contributor['contributor_user_url'] }}" target="_blank">{{ $contributor['contributor_user_url'] }}</a>
 				</p>
 			@endif
 			@if ( $contributor['contributor_twitter'] || $contributor['contributor_linkedin'] || $contributor['contributor_github'])
@@ -33,9 +31,7 @@
 					@if ( $contributor['contributor_twitter'] )
 						@if ( isset( $exporting ) )
 							<p class="contributor__link">
-								<a href="{{$contributor['contributor_twitter']}}" target="_blank">
-									{{$contributor['contributor_twitter']}}
-								</a>
+								<a href="{{$contributor['contributor_twitter']}}" target="_blank">{{$contributor['contributor_twitter']}}</a>
 							</p>
 						@else
 							<a href="{{$contributor['contributor_twitter']}}" target="_blank">
@@ -49,9 +45,7 @@
 					@if ( $contributor['contributor_linkedin'] )
 						@if ( isset( $exporting ) )
 							<p class="contributor__link">
-								<a href="{{$contributor['contributor_linkedin']}}" target="_blank">
-									{{$contributor['contributor_linkedin']}}
-								</a>
+								<a href="{{$contributor['contributor_linkedin']}}" target="_blank">{{$contributor['contributor_linkedin']}}</a>
 							</p>
 						@else
 							<a href="{{$contributor['contributor_linkedin']}}" target="_blank">
@@ -65,9 +59,7 @@
 					@if ( $contributor['contributor_github'] )
 						@if ( isset( $exporting ) )
 							<p class="contributor__link">
-								<a href="{{$contributor['contributor_github']}}" target="_blank">
-									{{$contributor['contributor_github']}}
-								</a>
+								<a href="{{$contributor['contributor_github']}}" target="_blank">{{$contributor['contributor_github']}}</a>
 							</p>
 						@else
 							<a href="{{$contributor['contributor_github']}}" target="_blank">


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks/issues/2401

This change fixes the breaklines displayed in the epub exported in the "About the authors" section at the end of the chapter.
The reason of this is the [wpautop filter](https://codex.wordpress.org/Plugin_API/Filter_Reference). Basically each new breakline in the template is translated as a `<br />` html tag in the blade template.
We could disabled the wpautop filter by `remove_filter('the_content', 'wpautop');`, but instead increment impact risks I just remove the breaklines in the template, which keeps the template still the same.

### For testing
- Choose a book with contributors.
- Make sure those contains Website URL, Twitter and other fields to be displayed in the EPUB.
- Turn on the "Display about the author" theme option to display the info at the end of each chapter. 
- Export the book to EPUB.
- Make sure the about the author information does not contain extra breaklines.
- Inspect the EPUB exported to make sure any extra `<br />` were added.