### PR TITLE
Display title in EPUB

### DIFF
--- a/inc/image/namespace.php
+++ b/inc/image/namespace.php
@@ -130,7 +130,7 @@ function is_valid_image( $file, $filename, $is_stream = false ) {
 		$file = $tmpfile_meta['uri'];
 	}
 
-	$type = @exif_imagetype( $file ); // @codingStandardsIgnoreLine
+	$type = IMAGETYPE_JPEG; // @codingStandardsIgnoreLine
 	if ( IMAGETYPE_JPEG === $type || IMAGETYPE_GIF === $type || IMAGETYPE_PNG === $type ) {
 		return true;
 	} else {

--- a/inc/image/namespace.php
+++ b/inc/image/namespace.php
@@ -130,7 +130,7 @@ function is_valid_image( $file, $filename, $is_stream = false ) {
 		$file = $tmpfile_meta['uri'];
 	}
 
-	$type = IMAGETYPE_JPEG; // @codingStandardsIgnoreLine
+	$type = @exif_imagetype( $file ); // @codingStandardsIgnoreLine
 	if ( IMAGETYPE_JPEG === $type || IMAGETYPE_GIF === $type || IMAGETYPE_PNG === $type ) {
 		return true;
 	} else {

--- a/inc/modules/export/class-exporthelpers.php
+++ b/inc/modules/export/class-exporthelpers.php
@@ -41,7 +41,6 @@ trait ExportHelpers {
 		$endnotes = $options['endnotes'] ?? false;
 		$footnotes = $options['footnotes'] ?? false;
 		$slug_as_href = $options['slug_as_href'] ?? false;
-		$remove_hidden_title_span = $options['remove_hidden_title_span'] ?? false;
 
 		$data = [
 			'id' => $post_data['ID'],
@@ -49,10 +48,7 @@ trait ExportHelpers {
 		$data['post_type_class'] = str_replace( '_', '-', $post_type_identifier ); // This class is used to map with the SCSS class in buckram Ex: front-matter
 		$data['subclass'] = $this->getPostSubClass( $post_type_identifier, $post_data['ID'] );
 		$data['slug'] = $slug_as_href ? $post_data['post_name'] : "{$data['post_type_class']}-{$post_data['post_name']}";
-		$data['title'] = $post_data['post_title'];
-		if ( ! get_post_meta( $post_data['ID'], 'pb_show_title', true ) ) {
-			$data['title'] = $remove_hidden_title_span ? '' : '<span class="display-none">' . $post_data['post_title'] . '</span>';
-		}
+		$data['title'] = get_post_meta( $post_data['ID'], 'pb_show_title', true ) ? $post_data['post_title'] : '';
 		$data['content'] = $post_data['post_content'];
 		$data['append_post_content'] = apply_filters( "pb_append_{$post_type_identifier}_content", '', $post_data['ID'] );
 		$data['short_title'] = trim( get_post_meta( $post_data['ID'], 'pb_short_title', true ) );

--- a/inc/modules/export/epub/class-epub.php
+++ b/inc/modules/export/epub/class-epub.php
@@ -1828,10 +1828,9 @@ class Epub extends ExportGenerator {
 				'type' => 'back_matter',
 				'needs_tidy_html' => true,
 				'slug_as_href' => true, // we want the slugs to be proper anchors in the EPUB export
-				'remove_hidden_title_span' => true,
 			] );
 
-			$vars['post_title'] = Sanitize\decode( $data['title'] );
+			$vars['post_title'] = Sanitize\decode( $back_matter['post_title'] );
 			$vars['post_content'] = $this->blade->render( 'export/generic-post-type', $data );
 
 			$file_id = 'back-matter-' . sprintf( '%03s', $index );

--- a/tests/test-exporthelpers.php
+++ b/tests/test-exporthelpers.php
@@ -55,7 +55,7 @@ class ExportHelpersTest extends \WP_UnitTestCase {
 			]
 		);
 		$this->assertEquals( 'introduction', $front_matter_mapped['subclass'] );
-		$this->assertEquals( '<span class="display-none">Introduction</span>', $front_matter_mapped['title'] );
+		$this->assertEmpty( $front_matter_mapped['title'] );
 		$this->assertEquals( 'front-matter-introduction', $front_matter_mapped['slug'] );
 		$this->assertEquals( 'This is where you can write your introduction.', $front_matter_mapped['content'] );
 		$this->assertEquals( 'front-matter', $front_matter_mapped['post_type_class'] );
@@ -83,7 +83,7 @@ class ExportHelpersTest extends \WP_UnitTestCase {
 		);
 
 		$this->assertEquals( 'appendix', $back_matter_mapped['subclass'] );
-		$this->assertEquals( '<span class="display-none">Appendix</span>', $back_matter_mapped['title'] );
+		$this->assertEmpty( $back_matter_mapped['title'] );
 		$this->assertEquals( 'back-matter-appendix', $back_matter_mapped['slug'] );
 		$this->assertEquals( 'This is where you can add appendices or other back matter.', $back_matter_mapped['content'] );
 		$this->assertEquals( 'back-matter', $back_matter_mapped['post_type_class'] );


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks/issues/2490 

This change avoid an empty title in the EPUB exported file in the `<head>` section for back matters, when `pb_show_title = false`.

Note: the `<span class="display-none">` wrap is for PDF and it is already specified in multiple places when needed, like: https://github.com/pressbooks/pressbooks/blob/dev/inc/modules/export/xhtml/class-xhtml11.php#L1335

### Testing
- Select a book a in the organize section disable `Show title` column for one or more back matters available.
- Export the book to EPUB
- Inspect the EPUB back matter exported and make sure the title is present in `<head>` section, but it is not in the content.
- Import the book exporter (Tools > Import > EPUB) and make sure the back matter title is displayed properly in the first step of the import routine.
- Make sure the `show title` settings also works for front matters and chapters.
- Combine: import / export from/to integrations to make sure there are compatibility regarding to the show title configuration.