### PR TITLE
Add anchors to interactive elements in export routines

### DIFF
--- a/inc/interactive/class-content.php
+++ b/inc/interactive/class-content.php
@@ -310,20 +310,21 @@ class Content {
 		$html5 = new HtmlParser();
 		$dom = $html5->loadHTML( $html );
 		foreach ( $tags as $tag ) {
-			// Load blade template based on $tag
-			$html = $this->blade->render(
-				"interactive.{$tag}", [
-					'title' => $this->getTitle( $id ),
-					'url' => wp_get_shortlink( $id ),
-				]
-			);
-			$fragment = $html5->parser->loadHTMLFragment( $html );
-
 			// Replace
 			$elements = $dom->getElementsByTagName( $tag );
-			for ( $i = $elements->length; --$i >= 0; ) {  // If you're deleting elements from within a loop, you need to loop backwards
-				$iframe = $elements->item( $i );
-				$iframe->parentNode->replaceChild( $dom->importNode( $fragment, true ), $iframe );
+			$element_number = $elements->length;
+			for ( $i = $elements->length; --$i >= 0; ) {
+				$element = $elements->item( $i );
+				$template = $this->blade->render(
+					"interactive.{$tag}", [
+						'title' => $this->getTitle( $id ),
+						'url' => wp_get_shortlink( $id ),
+						'id' => "$tag-$id-$element_number",
+					]
+				);
+				$fragment = $html5->parser->loadHTMLFragment( $template );
+				$element->parentNode->replaceChild( $dom->importNode( $fragment, true ), $element );
+				$element_number --;
 			}
 		}
 

--- a/templates/interactive/audio.blade.php
+++ b/templates/interactive/audio.blade.php
@@ -1,6 +1,6 @@
 <div class="textbox interactive-content interactive-content--audio">
     <span class="interactive-content__icon"></span>
 	<p>{{ __( 'An audio element has been excluded from this version of the text. You can listen to it online here:', 'pressbooks' ) }}
-	<a href="{{ $url }}{{ \Pressbooks\Interactive\Content::ANCHOR }}" title="{{ $title }}">{{ $url }}</a>
+		<a href="{{ $url }}#{{ $id }}" title="{{ $title }}">{{ $url }}#{{ $id }}</a>
     </p>
 </div>

--- a/templates/interactive/video.blade.php
+++ b/templates/interactive/video.blade.php
@@ -1,6 +1,6 @@
 <div class="textbox interactive-content interactive-content--video">
     <span class="interactive-content__icon"></span>
     <p>{{ __( 'A video element has been excluded from this version of the text. You can watch it online here:', 'pressbooks' ) }}
-		<a href="{{ $url }}{{ \Pressbooks\Interactive\Content::ANCHOR }}" title="{{ $title }}">{{ $url }}</a>
+		<a href="{{ $url }}#{{ $id }}" title="{{ $title }}">{{ $url }}#{{ $id }}</a>
     </p>
 </div>

--- a/tests/test-interactive-content.php
+++ b/tests/test-interactive-content.php
@@ -106,6 +106,8 @@ class Interactive_ContentTest extends \WP_UnitTestCase {
 	 * @group interactivecontent
 	 */
 	public function test_replaceInteractiveTags() {
+		global $id;
+		$id = 2;
 
 		$html = '
 			<audio controls="controls">
@@ -118,6 +120,8 @@ class Interactive_ContentTest extends \WP_UnitTestCase {
 		$this->assertNotContains( '<audio', $result );
 		$this->assertContains( '<div ', $result );
 		$this->assertContains( 'excluded from this version of the text', $result );
+		$this->assertContains( 'href="#audio-2-1"', $result );
+		$this->assertContains( '>#audio-2-1</a>', $result );
 	}
 
 	/**


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks/issues/2287 - Items 3.

This change adds the link to the interactive elements (audio & videos) in the chapter. Currently we don't specify with anchors the specific link to the interactive elements in PDF, XHTML and HTMLBook exports.

### Test
- Pick a book and in a chapter ready to export, add multiple audios and/or videos.
- Export the book to PDF, XHTML and HTMLBook formats.
- Make sure the templates for audios and videos are rendered accordingly with the link to the interactive element.

Examples about what to expect in terms of output:
![Screenshot from 2021-11-11 08-40-43](https://user-images.githubusercontent.com/13248424/141308093-72429914-b2b1-48e5-b1ed-4059c7097c6c.png)
![Screenshot from 2021-11-11 08-40-38](https://user-images.githubusercontent.com/13248424/141308096-85c97ea5-cf79-48f8-8412-12208b7d354a.png)
