### PR TITLE
fix: PDF blank pages for half-title pages

### DIFF
--- a/templates/export/half-title.blade.php
+++ b/templates/export/half-title.blade.php
@@ -1,3 +1,1 @@
-<div id="half-title-page">
-	<h1 class="title">{{ $title }}</h1>
-</div>
+<div id="half-title-page"><h1 class="title">{{ $title }}</h1></div>


### PR DESCRIPTION
Remove extra lines inserted by Blade template. Fix for https://github.com/pressbooks/pressbooks/issues/2507