### PR TITLE
fix: do not expose empty contributors keys in PB API

### DIFF
--- a/inc/metadata/namespace.php
+++ b/inc/metadata/namespace.php
@@ -274,19 +274,23 @@ function book_information_to_schema( $book_information, $network_excluded_direct
 			// Compatibility with previous version (basic strings contributors)
 			if ( is_string( $book_information[ $contributor_type ] ) ) {
 				$contributors_string = explode_remove_and( ';', $book_information[ $contributor_type ] );
-				$book_schema[ $mapped_properties[ $contributor_type ] ] = [];
-				foreach ( $contributors_string as $contributor_name ) {
-					$book_schema[ $mapped_properties[ $contributor_type ] ][] = [
-						'@type' => 'Person',
-						'name' => $contributor_name,
-					];
+				unset( $book_schema[ $mapped_properties[ $contributor_type ] ] );
+				if ( ! empty( $contributors_string ) ) {
+					$book_schema[ $mapped_properties[ $contributor_type ] ] = [];
+					foreach ( $contributors_string as $contributor_name ) {
+						$book_schema[ $mapped_properties[ $contributor_type ] ][] = [
+							'@type' => 'Person',
+							'name' => $contributor_name,
+						];
+					}
 				}
 				continue;
 			}
-			$contributors_array = $book_information[ $contributor_type ];
-			$book_schema[ $mapped_properties[ $contributor_type ] ] = [];
-			foreach ( $contributors_array as $contributor ) {
-				$book_schema[ $mapped_properties[ $contributor_type ] ][] = array_merge( [ '@type' => 'Person' ], $contributor );
+			if ( ! empty( $book_information[ $contributor_type ] ) ) {
+				$book_schema[ $mapped_properties[ $contributor_type ] ] = [];
+				foreach ( $book_information[ $contributor_type ] as $contributor ) {
+					$book_schema[ $mapped_properties[ $contributor_type ] ][] = array_merge( [ '@type' => 'Person' ], $contributor );
+				}
 			}
 		}
 	}

--- a/tests/test-metadata.php
+++ b/tests/test-metadata.php
@@ -107,6 +107,7 @@ class MetadataTest extends \WP_UnitTestCase {
 	public function test_book_information_to_schema() {
 		$book_information = [
 			'pb_authors' => 'Herman Melville',
+			'pb_editors' => 'Pat Metheny',
 			'pb_title' => 'Moby Dick',
 			'pb_book_doi' => 'my_doi',
 		];
@@ -114,6 +115,7 @@ class MetadataTest extends \WP_UnitTestCase {
 		$result = \Pressbooks\Metadata\book_information_to_schema( $book_information );
 		$this->assertEquals( $result['name'], 'Moby Dick' );
 		$this->assertEquals( $result['author'][0]['name'], 'Herman Melville' );
+		$this->assertEquals( $result['editor'][0]['name'], 'Pat Metheny' );
 		$this->assertEquals( $result['sameAs'], 'https://dx.doi.org/my_doi' );
 		$this->assertEquals( $result['identifier']['value'], 'my_doi' );
 	}


### PR DESCRIPTION
Related issue: https://github.com/pressbooks/pressbooks/issues/2467

This change avoids to expose empty contributors keys based on contributors types (illustrators, editors, reviewers, etc) in the API.

### Test
For testing you can pick a public book and go to Book Info, and then add some contributors like editors, and illustrators, and leave some of them empties, like reviewers or contributors.
Then, visit: https://<YOUR_LOCAL_URL_ENV>/wp-json/pressbooks/v2/books
The JSON exposed search for the book you picked, the JSON object must display only the keys where the contributors types are stored.