### PR TITLE
feat: Improve digital PDF a11y

### DIFF
--- a/inc/modules/export/class-exporthelpers.php
+++ b/inc/modules/export/class-exporthelpers.php
@@ -49,6 +49,11 @@ trait ExportHelpers {
 		$data['subclass'] = $this->getPostSubClass( $post_type_identifier, $post_data['ID'] );
 		$data['slug'] = $is_epub ? $post_data['post_name'] : "{$data['post_type_class']}-{$post_data['post_name']}";
 		$data['title'] = get_post_meta( $post_data['ID'], 'pb_show_title', true ) ? $post_data['post_title'] : '';
+
+		if ( ! $is_epub ) {
+			$data['title'] = empty( $data['title'] ) ? '<span class="display-none">' . $post_data['post_title'] . '</span>' : $data['title'];
+		}
+
 		$data['content'] = $post_data['post_content'];
 		$data['append_post_content'] = apply_filters( "pb_append_{$post_type_identifier}_content", '', $post_data['ID'] );
 		$data['short_title'] = trim( get_post_meta( $post_data['ID'], 'pb_short_title', true ) );

--- a/inc/modules/export/class-exporthelpers.php
+++ b/inc/modules/export/class-exporthelpers.php
@@ -82,6 +82,7 @@ trait ExportHelpers {
 		}
 
 		if ( ( Export::shouldParseSubsections() === true ) && Book::getSubsections( $post_data['ID'] ) !== false ) {
+			$data['subsection_class'] = 'with-subsections';
 			$data['content'] = $this->html5ToXhtml( Book::tagSubsections( $data['content'], $post_data['ID'] ) );
 		}
 

--- a/inc/modules/export/xhtml/class-xhtml11.php
+++ b/inc/modules/export/xhtml/class-xhtml11.php
@@ -1415,23 +1415,27 @@ class Xhtml11 extends ExportGenerator {
 			}
 
 			if ( $invisible ) {
-				echo $rendered_chapters;
+				$this->renderPart( $part_slug, $rendered_chapters );
 
 				continue;
 			}
 
 			if ( $parts_amount === 1 ) {
-				echo $part_content
+				$content = $part_content
 					? $rendered_part . $rendered_chapters
 					: $rendered_chapters;
+
+				$this->renderPart( $part_slug, $content );
 			} else {
 				if ( ! $rendered_chapters ) {
-					echo $part_content ? $rendered_part : '';
+					if ( $part_content ) {
+						$this->renderPart( $part_slug, $rendered_part );
+					}
 
 					continue;
 				}
 
-				echo $rendered_part . $rendered_chapters;
+				$this->renderPart( $part_slug, $rendered_part . $rendered_chapters );
 			}
 
 			++$part_index;
@@ -1468,6 +1472,23 @@ class Xhtml11 extends ExportGenerator {
 			++$i;
 		}
 
+	}
+
+	/**
+	 * Renders the complete part wrapper
+	 *
+	 * @param string $id
+	 * @param string $content
+	 * @return void
+	 */
+	protected function renderPart( string $id, string $content ): void {
+		echo $this->blade->render(
+			'export/part-wrapper',
+			[
+				'id' => $id,
+				'content' => $content,
+			]
+		);
 	}
 
 	/**

--- a/inc/modules/export/xhtml/class-xhtml11.php
+++ b/inc/modules/export/xhtml/class-xhtml11.php
@@ -460,7 +460,7 @@ class Xhtml11 extends ExportGenerator {
 
 			// Back-matter
 			yield 70 => $this->generatorPrefix . __( 'Exporting back matter', 'pressbooks' );
-			yield from $this->echoBackMatterGenerator( $book_contents, $metadata );
+			yield from $this->renderBackMatterGenerator( $book_contents, $metadata );
 
 			$buffer_inner_html = ob_get_clean();
 
@@ -1443,7 +1443,7 @@ class Xhtml11 extends ExportGenerator {
 	 * @param array $metadata
 	 * @return \Generator
 	 */
-	protected function echoBackMatterGenerator( $book_contents, $metadata ) : \Generator {
+	protected function renderBackMatterGenerator( $book_contents, $metadata ) : \Generator {
 
 		$y = new PercentageYield( 70, 80, count( $book_contents['back-matter'] ) );
 

--- a/inc/modules/export/xhtml/class-xhtml11.php
+++ b/inc/modules/export/xhtml/class-xhtml11.php
@@ -1312,6 +1312,7 @@ class Xhtml11 extends ExportGenerator {
 		$part_index = 1;
 		$chapter_index = 1;
 		$parts_amount = count( $book_contents['part'] );
+		$parse_subsections = \Pressbooks\Modules\Export\Export::shouldParseSubsections();
 
 		foreach ( $book_contents['part'] as $part ) {
 			yield from $yield->tick( $this->generatorPrefix . __( 'Exporting parts and chapters', 'pressbooks' ) );
@@ -1370,7 +1371,7 @@ class Xhtml11 extends ExportGenerator {
 				$chapter_subtitle = trim( get_post_meta( $chapter_id, 'pb_subtitle', true ) );
 				$chapter_author = $this->contributors->get( $chapter_id, 'pb_authors' );
 
-				if ( \Pressbooks\Modules\Export\Export::shouldParseSubsections() && \Pressbooks\Book::getSubsections( $chapter_id ) !== false ) {
+				if ( $parse_subsections && \Pressbooks\Book::getSubsections( $chapter_id ) !== false ) {
 					$chapter_content = \Pressbooks\Book::tagSubsections( $chapter_content, $chapter_id );
 				}
 
@@ -1404,6 +1405,7 @@ class Xhtml11 extends ExportGenerator {
 						'append_content' => $append_chapter_content,
 						'endnotes' => $this->doEndnotes( $chapter_id ),
 						'footnotes' => $this->doFootnotes( $chapter_id ),
+						'subsection_class' => $parse_subsections ? 'has-subsections' : '',
 					]
 				);
 

--- a/inc/modules/export/xhtml/class-xhtml11.php
+++ b/inc/modules/export/xhtml/class-xhtml11.php
@@ -1106,7 +1106,9 @@ class Xhtml11 extends ExportGenerator {
 	 */
 	protected function renderDedicationAndEpigraph( $book_contents ) {
 
-		$i = $this->frontMatterPos;
+		$index = $this->frontMatterPos;
+		$parse_subsections = \Pressbooks\Modules\Export\Export::shouldParseSubsections();
+
 		foreach ( [ 'dedication', 'epigraph' ] as $compare ) {
 			foreach ( $book_contents['front-matter'] as $front_matter ) {
 
@@ -1130,18 +1132,19 @@ class Xhtml11 extends ExportGenerator {
 					[
 						'subclass' => $subclass,
 						'slug' => $slug,
-						'front_matter_number' => $i,
+						'front_matter_number' => $index,
 						'title' => Sanitize\decode( $title ),
 						'content' => $content,
 						'endnotes' => $this->doEndnotes( $front_matter_id ),
 						'footnotes' => $this->doFootnotes( $front_matter_id ),
+						'subsection_class' => $parse_subsections ? 'with-subsections' : '',
 					]
 				);
 				echo "\n";
-				++$i;
+				++$index;
 			}
 		}
-		$this->frontMatterPos = $i;
+		$this->frontMatterPos = $index;
 	}
 
 	/**
@@ -1405,7 +1408,7 @@ class Xhtml11 extends ExportGenerator {
 						'append_content' => $append_chapter_content,
 						'endnotes' => $this->doEndnotes( $chapter_id ),
 						'footnotes' => $this->doFootnotes( $chapter_id ),
-						'subsection_class' => $parse_subsections ? 'has-subsections' : '',
+						'subsection_class' => $parse_subsections ? 'with-subsections' : '',
 					]
 				);
 

--- a/templates/export/chapter.blade.php
+++ b/templates/export/chapter.blade.php
@@ -1,4 +1,4 @@
-<div class="chapter {{ $subclass }}" id="{{ $slug }}" title="{{ $sanitized_title }}">
+<div class="chapter {{ $subclass }} {{ $subsection_class }}" id="{{ $slug }}" title="{{ $sanitized_title }}">
 	<div class="chapter-title-wrap">
 		<p class="chapter-number">{{ $number }}</p>
 		<h1 class="chapter-title">{!! $title !!}</h1>

--- a/templates/export/chapter.blade.php
+++ b/templates/export/chapter.blade.php
@@ -1,7 +1,7 @@
 <div class="chapter {{ $subclass }}" id="{{ $slug }}" title="{{ $sanitized_title }}">
 	<div class="chapter-title-wrap">
 		<p class="chapter-number">{{ $number }}</p>
-		<h2 class="chapter-title">{!! $title !!}</h2>
+		<h1 class="chapter-title">{!! $title !!}</h1>
 		@if(  isset( $is_new_buckram ) && $is_new_buckram )
 			@include('export/sub-author-partial')
 		@endif

--- a/templates/export/chapter.blade.php
+++ b/templates/export/chapter.blade.php
@@ -1,4 +1,4 @@
-<div class="chapter {{ $subclass }} {{ $subsection_class }}" id="{{ $slug }}" title="{{ $sanitized_title }}">
+<div class="chapter {{ $subclass }} {{ $subsection_class ?? '' }}" id="{{ $slug }}" title="{{ $sanitized_title }}">
 	<div class="chapter-title-wrap">
 		<p class="chapter-number">{{ $number }}</p>
 		<h1 class="chapter-title">{!! $title !!}</h1>

--- a/templates/export/dedication-epigraph.blade.php
+++ b/templates/export/dedication-epigraph.blade.php
@@ -1,4 +1,4 @@
-<div class="front-matter {{ $subclass }}" id="{{ $slug }}">
+<div class="front-matter {{ $subclass }} {{ $subsection_class ?? '' }}" id="{{ $slug }}">
 	<div class="front-matter-title-wrap">
 		<p class="front-matter-number">{{ $front_matter_number }}</p>
 		<h1 class="front-matter-title">{!! $title !!}</h1>

--- a/templates/export/generic-post-type.blade.php
+++ b/templates/export/generic-post-type.blade.php
@@ -1,7 +1,7 @@
 @if( isset( $short_title ) )
-	<div class="{{$post_type_class}} {{ $subclass }}" id="{{ $slug }}" title="{{ $short_title }}">
+	<div class="{{$post_type_class}} {{ $subclass }} {{ $subsection_class ?? '' }}" id="{{ $slug }}" title="{{ $short_title }}">
 @else
-	<div class="{{$post_type_class}} {{ $subclass }}" id="{{ $slug }}">
+	<div class="{{$post_type_class}} {{ $subclass }} {{ $subsection_class ?? '' }}" id="{{ $slug }}">
 @endif
 	<div class="{{$post_type_class}}-title-wrap">
 		<p class="{{$post_type_class}}-number">{{ $post_number }}</p>

--- a/templates/export/part-wrapper.blade.php
+++ b/templates/export/part-wrapper.blade.php
@@ -1,0 +1,3 @@
+<div class="part-wrapper" id="{{ $id  }}-wrapper">
+    {!! $content !!}
+</div>

--- a/tests/test-exporthelpers.php
+++ b/tests/test-exporthelpers.php
@@ -55,7 +55,7 @@ class ExportHelpersTest extends \WP_UnitTestCase {
 			]
 		);
 		$this->assertEquals( 'introduction', $front_matter_mapped['subclass'] );
-		$this->assertEmpty( $front_matter_mapped['title'] );
+		$this->assertStringContainsString( '<span class="display-none">Introduction</span>', $front_matter_mapped['title'] );
 		$this->assertEquals( 'front-matter-introduction', $front_matter_mapped['slug'] );
 		$this->assertEquals( 'This is where you can write your introduction.', $front_matter_mapped['content'] );
 		$this->assertEquals( 'front-matter', $front_matter_mapped['post_type_class'] );
@@ -83,7 +83,7 @@ class ExportHelpersTest extends \WP_UnitTestCase {
 		);
 
 		$this->assertEquals( 'appendix', $back_matter_mapped['subclass'] );
-		$this->assertEmpty( $back_matter_mapped['title'] );
+		$this->assertStringContainsString( '<span class="display-none">Appendix</span>', $back_matter_mapped['title'] );
 		$this->assertEquals( 'back-matter-appendix', $back_matter_mapped['slug'] );
 		$this->assertEquals( 'This is where you can add appendices or other back matter.', $back_matter_mapped['content'] );
 		$this->assertEquals( 'back-matter', $back_matter_mapped['post_type_class'] );

--- a/tests/test-templates-export.php
+++ b/tests/test-templates-export.php
@@ -36,7 +36,7 @@ class TemplateExportTest extends \WP_UnitTestCase {
 		);
 
 		$this->assertStringContainsString(
-			"<div class=\"front-matter front-matter-subclass\" id=\"front-intro-01\" title=\"$short_title\">",
+			"<div class=\"front-matter front-matter-subclass \" id=\"front-intro-01\" title=\"$short_title\">",
 			$generic_post_rendered
 		);
 		$this->assertStringContainsString( '<p class="front-matter-number">2</p>', $generic_post_rendered );
@@ -168,7 +168,7 @@ class TemplateExportTest extends \WP_UnitTestCase {
 			]
 		);
 
-		$this->assertStringContainsString( '<div class="front-matter epigraph-subclass" id="epigraph-1">', $epigraph_rendered );
+		$this->assertStringContainsString( '<div class="front-matter epigraph-subclass " id="epigraph-1">', $epigraph_rendered );
 		$this->assertStringContainsString( '<p class="front-matter-number">2</p>', $epigraph_rendered );
 		$this->assertStringContainsString( '<h1 class="front-matter-title">Thank you</h1>', $epigraph_rendered );
 		$this->assertStringContainsString( 'Dedicated to Carl J', $epigraph_rendered );

--- a/tests/test-templates-export.php
+++ b/tests/test-templates-export.php
@@ -81,11 +81,11 @@ class TemplateExportTest extends \WP_UnitTestCase {
 		);
 
 		$this->assertStringContainsString(
-			"<div class=\"chapter chapter-subclass\" id=\"chapter-001\" title=\"$sanitized_title\">",
+			"<div class=\"chapter chapter-subclass \" id=\"chapter-001\" title=\"$sanitized_title\">",
 			$chapter_rendered
 		);
 		$this->assertStringContainsString( '<p class="chapter-number">1</p>', $chapter_rendered );
-		$this->assertStringContainsString( "<h2 class=\"chapter-title\">$title</h2>", $chapter_rendered );
+		$this->assertStringContainsString( "<h1 class=\"chapter-title\">$title</h1>", $chapter_rendered );
 		$this->assertStringContainsString( "<p class=\"short-title\">$short_title</p>", $chapter_rendered );
 		$this->assertStringContainsString( "<p class=\"chapter-subtitle\">$subtitle</p>", $chapter_rendered );
 		$this->assertStringContainsString( "<p class=\"chapter-author\">$author</p>", $chapter_rendered );


### PR DESCRIPTION
Fixes pressbooks/pressbooks#2300 and pressbooks/pressbooks#2485. Accompanies pressbooks/pressbooks-book#904.

This PR does a couple of things:
1. It adds back the invisible `span` on PDFs because without them the Digital PDF version has empty bookmark if Show Title is set to `false`.
2. It adds a new `has-subsections` class to identify when 2-level TOC is enabled.
3. It creates a `part-wrapper` div around the whole part + chapters

#### How to test

See pressbooks/pressbooks#2485 for a clear understanding and make sure of the following:

- Half title page and title page are not visible in digital pdf bookmarks
- Table fo contents is a level 1 bookmark
- Each front/back matter is displayed as a level 1 bookmark
- If a book has more than 1 visible part, ensure that the title of each part is displayed as a level 1 bookmark
- Display the title of each chapter within a visible part as level 2 bookmark
- Display the title of each chapter within an invisible part as a level 1 bookmark
- If the two-level ToC enabled, all H1s inside of chapters within a visible part should be displayed with the corresponding bookmark level. Level 2 when chapter is a level 1, and level 3 when chapter is a level 2.

As a sanity check, make sure EPUB exports are working as well and also check different themes.