### PR TITLE
feat: Upgrade Docraptor / PrinceXML

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 		"aws/aws-sdk-php": "^3.173",
 		"composer/installers": "~1.0",
 		"davidgorges/human-name-parser": "^1.0",
-		"docraptor/docraptor": "1.3",
+		"docraptor/docraptor": "^3.0",
 		"fale/isbn": "^3.0",
 		"gridonic/princexml-php": "^1.2",
 		"illuminate/container": "5.4.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f73c94ec5324774b3d1fb61758cb1ab9",
+    "content-hash": "c0a2163d0f42cae2fd2e6c0f132ef4a8",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -331,29 +331,29 @@
         },
         {
             "name": "docraptor/docraptor",
-            "version": "1.3.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/DocRaptor/docraptor-php.git",
-                "reference": "7739bbf5be46aa5a0d8b636ce8dc9300500fbbab"
+                "reference": "61247608c8dfc27d66bc5473498697d09ede5419"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/DocRaptor/docraptor-php/zipball/7739bbf5be46aa5a0d8b636ce8dc9300500fbbab",
-                "reference": "7739bbf5be46aa5a0d8b636ce8dc9300500fbbab",
+                "url": "https://api.github.com/repos/DocRaptor/docraptor-php/zipball/61247608c8dfc27d66bc5473498697d09ede5419",
+                "reference": "61247608c8dfc27d66bc5473498697d09ede5419",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
                 "ext-json": "*",
                 "ext-mbstring": "*",
-                "php": ">=5.4"
+                "guzzlehttp/guzzle": "^7.3",
+                "guzzlehttp/psr7": "^2.0",
+                "php": "^7.3 || ^8.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "~1.12",
-                "phpunit/phpunit": "~4.8",
-                "satooshi/php-coveralls": "~1.0",
-                "squizlabs/php_codesniffer": "~2.6"
+                "friendsofphp/php-cs-fixer": "^2.12",
+                "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "type": "library",
             "autoload": {
@@ -371,7 +371,7 @@
                     "homepage": "https://github.com/expectedbehavior"
                 }
             ],
-            "description": "A wrapper for the DocRaptor HTML to PDF/XLS service.",
+            "description": "A native client library for the DocRaptor HTML to PDF/XLS service.",
             "homepage": "https://github.com/docraptor/docraptor-php",
             "keywords": [
                 "api",
@@ -381,7 +381,7 @@
                 "xls",
                 "xlsx"
             ],
-            "time": "2017-11-21T19:33:20+00:00"
+            "time": "2021-11-30T20:04:26+00:00"
         },
         {
             "name": "doctrine/inflector",

--- a/inc/covergenerator/class-generator.php
+++ b/inc/covergenerator/class-generator.php
@@ -415,12 +415,9 @@ abstract class Generator {
 	 * @return bool
 	 */
 	public function generateWithDocraptor( $pdf_profile, $document_content, $output_path ) {
-		// Configure service
-		$configuration = \DocRaptor\Configuration::getDefaultConfiguration();
-		$configuration->setUsername( DOCRAPTOR_API_KEY );
-
 		// Save PDF as file in exports folder
 		$docraptor = new \DocRaptor\DocApi();
+		$docraptor->getConfig()->setUsername( DOCRAPTOR_API_KEY );
 		$prince_options = new \DocRaptor\PrinceOptions();
 		$prince_options->setHttpTimeout( max( ini_get( 'max_execution_time' ), 30 ) );
 		$prince_options->setProfile( $pdf_profile );

--- a/inc/covergenerator/class-generator.php
+++ b/inc/covergenerator/class-generator.php
@@ -437,7 +437,7 @@ abstract class Generator {
 			$doc->setDocumentContent( $document_content );
 			$doc->setName( get_bloginfo( 'name' ) . ' Cover' );
 			$doc->setPrinceOptions( $prince_options );
-			$doc->setPipeline( 7 ); // Prince 12, see: https://docraptor.com/documentation/api#api_pipeline
+			$doc->setPipeline( 9 ); // Prince 14, see: https://docraptor.com/documentation/api#api_pipeline
 
 			$create_response = $docraptor->createAsyncDoc( $doc );
 			$done = false;

--- a/inc/modules/export/prince/class-docraptor.php
+++ b/inc/modules/export/prince/class-docraptor.php
@@ -58,10 +58,9 @@ class Docraptor extends Pdf {
 		// --------------------------------------------------------------------
 		// Save PDF as file in exports folder
 
-		$configuration = \DocRaptor\Configuration::getDefaultConfiguration();
-		$configuration->setUsername( DOCRAPTOR_API_KEY );
-
 		$docraptor = new \DocRaptor\DocApi();
+		$docraptor->getConfig()->setUsername( DOCRAPTOR_API_KEY );
+
 		$prince_options = new \DocRaptor\PrinceOptions();
 		$prince_options->setNoCompress( false );
 		$prince_options->setHttpTimeout( max( ini_get( 'max_execution_time' ), 30 ) );

--- a/inc/modules/export/prince/class-docraptor.php
+++ b/inc/modules/export/prince/class-docraptor.php
@@ -100,7 +100,7 @@ class Docraptor extends Pdf {
 			}
 			$doc->setName( get_bloginfo( 'name' ) );
 			$doc->setPrinceOptions( $prince_options );
-			$doc->setPipeline( 7 ); // Prince 12, see: https://docraptor.com/documentation/api#api_pipeline
+			$doc->setPipeline( 9 ); // Prince 14, see: https://docraptor.com/documentation/api#api_pipeline
 
 			$create_response = $docraptor->createAsyncDoc( $doc );
 			$done = false;


### PR DESCRIPTION
Issue #2228 

This PR upgrades [docraptor/docraptor](https://github.com/DocRaptor/docraptor-php) to v3 and changes the pipeline to use the latest version of PrinceXML.

#### How to test

1. Generate a book export and a book cover export using the dev branch.
1. Switch to this branch and `composer install` to update dependencies.
1. Generate new book and cover exports.
1. Both export versions should be equal.