### PR TITLE
feature: collect last active date for users

### DIFF
--- a/hooks-admin.php
+++ b/hooks-admin.php
@@ -199,9 +199,6 @@ if ( $is_book ) {
 	add_filter( 'attachment_fields_to_edit', '\Pressbooks\Admin\Attachments\add_metadata_attachment', 10, 2 );
 	add_filter( 'attachment_fields_to_save', '\Pressbooks\Admin\Attachments\save_metadata_attachment', 10, 2 );
 	add_filter( 'edit_form_top', [ '\Pressbooks\Book', 'notifyBisacCodesRemoved' ] );
-	add_action( 'save_post', [ 'Pressbooks\DataCollector\User', 'storeLastActiveDate' ], 10 );
-	add_action( 'edit_term', [ 'Pressbooks\DataCollector\User', 'storeLastActiveDate' ], 10 );
-	add_action( 'switch_theme', [ 'Pressbooks\DataCollector\User', 'storeLastActiveDate' ], 10 );
 }
 
 // -------------------------------------------------------------------------------------------------------------------

--- a/hooks-admin.php
+++ b/hooks-admin.php
@@ -199,6 +199,9 @@ if ( $is_book ) {
 	add_filter( 'attachment_fields_to_edit', '\Pressbooks\Admin\Attachments\add_metadata_attachment', 10, 2 );
 	add_filter( 'attachment_fields_to_save', '\Pressbooks\Admin\Attachments\save_metadata_attachment', 10, 2 );
 	add_filter( 'edit_form_top', [ '\Pressbooks\Book', 'notifyBisacCodesRemoved' ] );
+	add_action( 'save_post', [ 'Pressbooks\DataCollector\User', 'storeLastActiveDate' ], 10 );
+	add_action( 'edit_term', [ 'Pressbooks\DataCollector\User', 'storeLastActiveDate' ], 10 );
+	add_action( 'switch_theme', [ 'Pressbooks\DataCollector\User', 'storeLastActiveDate' ], 10 );
 }
 
 // -------------------------------------------------------------------------------------------------------------------

--- a/inc/datacollector/class-user.php
+++ b/inc/datacollector/class-user.php
@@ -62,6 +62,10 @@ class User {
 		add_action( 'wp_login', [ $obj, 'setLastLogin' ], 0, 2 );
 		add_action( 'wp_login', [ $obj, 'setSubscriberRole' ], 0, 2 );
 		add_action( 'profile_update', [ $obj, 'updateMetaData' ] );
+		add_action( 'save_post', [ $obj, 'storeLastActiveDate' ], 10 );
+		add_action( 'saved_term', [ $obj, 'storeLastActiveDate' ], 10 );
+		add_action( 'switch_theme', [ $obj, 'storeLastActiveDate' ], 10 );
+		add_action( 'update_option', [ $obj, 'storeLastActiveDate' ], 10 );
 	}
 
 	/**

--- a/inc/datacollector/class-user.php
+++ b/inc/datacollector/class-user.php
@@ -26,6 +26,8 @@ class User {
 
 	const BOOKS_AS_SUBSCRIBER = 'pb_books_as_subscriber';
 
+	const USER_DATE_LAST_ACTIVE = 'pb_date_last_active';
+
 	/**
 	 * @var User
 	 */
@@ -236,6 +238,15 @@ class User {
 		preg_match( "~$wpdb->base_prefix(\d+)_capabilities~", $key, $matches );
 
 		return $matches[1] ?? null;
+	}
+
+	/**
+	 * Add last active date to user meta
+	 *
+	 * Hooked into: save_post
+	 */
+	public static function storeLastActiveDate() {
+		update_user_meta( get_current_user_id(), self::USER_DATE_LAST_ACTIVE, gmdate( 'Y-m-d H:i:s' ) );
 	}
 
 }

--- a/tests/test-datacollector-user.php
+++ b/tests/test-datacollector-user.php
@@ -75,4 +75,19 @@ class DataCollector_UserTest extends \WP_UnitTestCase {
 
 		$this->assertNotEmpty( get_user_meta( $user->ID, UserDataCollector::HIGHEST_ROLE ) );
 	}
+
+	/**
+	 * @group datacollector
+	 */
+	public function test_storeLastActiveDate() {
+		$user = $this->factory()->user->create_and_get( [ 'role' => 'contributor' ] );
+		wp_set_current_user( $user->ID );
+		$this->assertEmpty( get_user_meta( $user->ID, UserDataCollector::USER_DATE_LAST_ACTIVE ) );
+		$this->userDataCollector::storeLastActiveDate();
+		$date_last_active = get_user_meta( $user->ID, UserDataCollector::USER_DATE_LAST_ACTIVE );
+		$this->assertNotEmpty( $date_last_active );
+		$this->assertGreaterThanOrEqual( strtotime( $date_last_active[0] ), strtotime( gmdate( 'Y-m-d H:i:s' ) ) );
+
+
+	}
 }


### PR DESCRIPTION
Fix for https://github.com/pressbooks/pressbooks/issues/2529

This PR adds a new user metadata to store the last activate date, which means the last time the user switched themes, update a post or edit a taxonomy.

### Testing
- Check in the DB for the last active date for the last user: 
```sql 
select * from wp_usermeta where meta_key = 'pb_date_last_active' order by umeta_id desc limit 1 \G
```
It must be empty.
- Make one of the following actions: change theme, edit/add a taxonomy (like contributors), create/clone a book or edit a chapter (or other post), or edit a book info.
- After the action, make sure the user meta was updated with the UTC timezone: 
```sql 
select * from wp_usermeta where meta_key = 'pb_date_last_active' order by umeta_id desc limit 1 \G
```