### PR TITLE
feat: Add method to sync network manager ids

### DIFF
--- a/inc/admin/networkmanagers/namespace.php
+++ b/inc/admin/networkmanagers/namespace.php
@@ -91,11 +91,8 @@ function update_admin_status() {
 
 		if ( is_array( $restricted ) && ! empty( $restricted ) ) {
 			update_site_option( 'pressbooks_network_managers', $restricted );
-			// This meta option will only be used by the BI, but we want to keep that in sync.
-			update_site_option( 'pressbooks_network_managers_ids', implode( ',', $restricted ) );
 		} else {
 			delete_site_option( 'pressbooks_network_managers' );
-			delete_site_option( 'pressbooks_network_managers_ids' );
 		}
 		// Reset the cheap cache after updating the option
 		_restricted_users( true );

--- a/inc/datacollector/class-user.php
+++ b/inc/datacollector/class-user.php
@@ -6,6 +6,8 @@
 
 namespace Pressbooks\DataCollector;
 
+use function Pressbooks\Admin\NetworkManagers\_restricted_users;
+
 class User {
 
 	// Meta Key Constants:
@@ -93,6 +95,23 @@ class User {
 			update_site_option( 'pb_user_sync_cron_timestamp', gmdate( 'Y-m-d H:i:s' ) );
 			delete_transient( $in_progress_transient );
 		}
+	}
+
+	/**
+	 * Updates the network manager's site meta data
+	 *
+	 * @return void
+	 */
+	public function updateNetworkManagers(): void {
+		$users = _restricted_users( true );
+
+		if ( is_array( $users ) && ! empty( $users ) ) {
+			update_site_option( 'pressbooks_network_managers_ids', implode( ',', $users ) );
+
+			return;
+		}
+
+		delete_site_option( 'pressbooks_network_managers_ids' );
 	}
 
 	/**

--- a/tests/test-datacollector-user.php
+++ b/tests/test-datacollector-user.php
@@ -52,6 +52,28 @@ class DataCollector_UserTest extends \WP_UnitTestCase {
 	/**
 	 * @group datacollector
 	 */
+	public function test_updateNetworkManagers() {
+		$user_id = $this->factory()->user->create( [ 'role' => 'administrator' ] );
+
+		grant_super_admin( $user_id );
+		wp_set_current_user( $user_id );
+
+		$_REQUEST['_ajax_nonce'] = wp_create_nonce( 'pb-network-managers' );
+		$_POST['admin_id'] = $user_id;
+		$_POST['status'] = 1;
+
+		\Pressbooks\Admin\NetworkManagers\update_admin_status();
+
+		$this->assertEmpty( get_site_option( 'pressbooks_network_managers_ids' ) );
+
+		$this->userDataCollector->updateNetworkManagers();
+
+		$this->assertNotEmpty( get_site_option( 'pressbooks_network_managers_ids' ) );
+	}
+
+	/**
+	 * @group datacollector
+	 */
 	public function test_updateAllUsersMetadata() {
 		$user = $this->factory()->user->create_and_get( [ 'role' => 'contributor' ] );
 		$i = 0;

--- a/tests/test-datacollector-user.php
+++ b/tests/test-datacollector-user.php
@@ -69,6 +69,14 @@ class DataCollector_UserTest extends \WP_UnitTestCase {
 		$this->userDataCollector->updateNetworkManagers();
 
 		$this->assertNotEmpty( get_site_option( 'pressbooks_network_managers_ids' ) );
+
+		$_POST['status'] = 0;
+
+		\Pressbooks\Admin\NetworkManagers\update_admin_status();
+
+		$this->userDataCollector->updateNetworkManagers();
+
+		$this->assertEmpty( get_site_option( 'pressbooks_network_managers_ids' ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes pressbooks/pressbooks-network-analytics#166. Accompanies pressbooks/pressbooks-network-analytics#168

This PR adds a new `updateNetworkManagers` to the user data collector which is responsible to sync network manager ids.

#### How to test

Follow instructions at pressbooks/pressbooks-network-analytics#168