### PR TITLE
hotfix: fix encoding

### DIFF
--- a/templates/export/epub/html.blade.php
+++ b/templates/export/epub/html.blade.php
@@ -1,6 +1,8 @@
+{!! '<'.'?xml version="1.0" encoding="UTF-8" ?>' !!}
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="{{ $lang }}" lang="{{ $lang }}">
 	<head>
 		<title>{{ $post_title }} -- {{ get_bloginfo('name') }}</title>
+		<meta charset="utf-8"/>
 		<meta name="EPB-UUID" content="{{ $isbn }}" />
 
         @if( $stylesheet )

--- a/templates/export/epub/opf.blade.php
+++ b/templates/export/epub/opf.blade.php
@@ -1,3 +1,4 @@
+{!! '<'.'?xml version="1.0" encoding="UTF-8" ?>' !!}
 <package version="3.0" xmlns="http://www.idpf.org/2007/opf" unique-identifier="pub-identifier">
 	<metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
 		<dc:title id="pub-title">{!!  $meta['pb_title'] ?? get_bloginfo('name') !!}</dc:title>

--- a/templates/export/epub/toc.blade.php
+++ b/templates/export/epub/toc.blade.php
@@ -1,3 +1,4 @@
+{!! '<'.'?xml version="1.0" encoding="UTF-8" ?>' !!}
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops">
 	<head>
 		<meta http-equiv="default-style" content="text/html; charset=utf-8"/>


### PR DESCRIPTION
This PR solves #2548 

I added back the missing `xml` schema definition and the missing meta in HTML content

### How to test

1. Export an ePUB with accents and other encoded characters
2. Open the exported book in Kindle Preview and it should has be encoded properly
3. Open the book in Sigil to see if all the missing xml declarations were added