### PR TITLE
chore: add support to use external licenses

### DIFF
--- a/inc/class-licensing.php
+++ b/inc/class-licensing.php
@@ -140,27 +140,6 @@ class Licensing {
 			],
 		];
 
-		// Custom
-		if ( ! $disable_custom ) {
-			$custom = get_terms(
-				[
-					'taxonomy' => self::TAXONOMY,
-					'hide_empty' => false,
-				]
-			);
-			if ( is_array( $custom ) ) {
-				foreach ( $custom as $custom_term ) {
-					if ( ! isset( $supported[ $custom_term->slug ] ) ) {
-						$supported[ $custom_term->slug ] = [
-							'api' => [], // Not supported
-							'url' => "https://choosealicense.com/no-license/#{$custom_term->slug}",
-							'desc' => $custom_term->name,
-						];
-					}
-				}
-			}
-		}
-
 		if ( $disable_translation ) {
 			remove_filter( 'gettext', [ $this, 'disableTranslation' ], 999 );
 		}
@@ -225,10 +204,6 @@ class Licensing {
 		} else {
 			$license = 'all-rights-reserved';
 		}
-		if ( ! $this->isSupportedType( $license ) ) {
-			// License not supported, bail
-			return '';
-		}
 
 		// Unless section is licensed differently, it should display the book license statement
 		if ( $section_license === $book_license && empty( $section_author ) || empty( $section_license ) ) {
@@ -268,6 +243,15 @@ class Licensing {
 			$copyright_year = strftime( '%Y', absint( $metadata['pb_publication_date'] ) );
 		} else {
 			$copyright_year = 0;
+		}
+
+		if ( ! $this->isSupportedType( $license ) ) {
+			// License not supported, bail but allow a custom fallback printer
+			return apply_filters( 'print_custom_license', '', array_merge( $metadata, [
+				'link' => $link,
+				'title' => $title,
+				'copyright_holder' => $copyright_holder,
+			] ) );
 		}
 
 		$html = $this->getLicense( $license, $copyright_holder, $link, $title, $copyright_year );

--- a/inc/class-licensing.php
+++ b/inc/class-licensing.php
@@ -140,6 +140,27 @@ class Licensing {
 			],
 		];
 
+		// Custom
+		if ( ! $disable_custom ) {
+			$custom = get_terms(
+				[
+					'taxonomy' => self::TAXONOMY,
+					'hide_empty' => false,
+				]
+			);
+			if ( is_array( $custom ) ) {
+				foreach ( $custom as $custom_term ) {
+					if ( ! isset( $supported[ $custom_term->slug ] ) ) {
+						$supported[ $custom_term->slug ] = [
+							'api' => [], // Not supported
+							'url' => "https://choosealicense.com/no-license/#{$custom_term->slug}",
+							'desc' => $custom_term->name,
+						];
+					}
+				}
+			}
+		}
+
 		if ( $disable_translation ) {
 			remove_filter( 'gettext', [ $this, 'disableTranslation' ], 999 );
 		}

--- a/inc/class-licensing.php
+++ b/inc/class-licensing.php
@@ -141,7 +141,7 @@ class Licensing {
 		];
 
 		// Custom
-		if ( ! $disable_custom ) {
+		if ( ! $disable_custom && ! has_filter( 'extend_custom_licenses' ) ) {
 			$custom = get_terms(
 				[
 					'taxonomy' => self::TAXONOMY,

--- a/inc/class-taxonomy.php
+++ b/inc/class-taxonomy.php
@@ -453,12 +453,18 @@ class Taxonomy {
 			]
 		);
 
-		foreach ( $this->licensing->getSupportedTypes( true, true ) as $key => $val ) {
-			wp_insert_term(
-				$val['desc'], Licensing::TAXONOMY, [
-					'slug' => $key,
-				]
-			);
+		$this->insertLicenseTerms();
+	}
+
+	public function insertLicenseTerms() {
+		$extended = apply_filters( 'extend_custom_licenses', [] ); // override inserted license terms only if this hook is called
+		$licenses = ( count( $extended ) > 0 ) ? $extended : $this->licensing->getSupportedTypes( true, true );
+		foreach ( $licenses as $key => $val ) {
+				wp_insert_term(
+					$val['desc'], Licensing::TAXONOMY, [
+						'slug' => $key,
+					]
+				);
 		}
 	}
 

--- a/inc/class-taxonomy.php
+++ b/inc/class-taxonomy.php
@@ -458,7 +458,8 @@ class Taxonomy {
 
 	public function insertLicenseTerms() {
 		$extended = apply_filters( 'extend_custom_licenses', [] ); // override inserted license terms only if this hook is called
-		$licenses = ( count( $extended ) > 0 ) ? $extended : $this->licensing->getSupportedTypes( true, true );
+		$supported_licenses = $this->licensing->getSupportedTypes( true, true );
+		$licenses = ( count( $extended ) > 0 ) ? array_merge( $supported_licenses, $extended ) : $supported_licenses;
 		foreach ( $licenses as $key => $val ) {
 				wp_insert_term(
 					$val['desc'], Licensing::TAXONOMY, [


### PR DESCRIPTION
This PR adds support to override copyright licenses through custom hooks. Partial fix for https://github.com/pressbooks/private/issues/661, linked to https://github.com/pressbooks/pressbooks-book/pull/917 and https://github.com/pressbooks/pressbooks-plugins-config/pull/15