### PR TITLE
Change permissions check for cloner page

### DIFF
--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -404,7 +404,7 @@ function replace_book_admin_menu() {
 
 	// Clone a Book
 	if ( Cloner::isEnabled() && ( can_create_new_books() || is_super_admin() ) ) {
-		$cloner_page = add_submenu_page( 'admin.php', __( 'Clone a Book', 'pressbooks' ), __( 'Clone a Book', 'pressbooks' ), 'edit_posts', 'pb_cloner', __NAMESPACE__ . '\display_cloner' );
+		$cloner_page = add_submenu_page( 'admin.php', __( 'Clone a Book', 'pressbooks' ), __( 'Clone a Book', 'pressbooks' ), 'read', 'pb_cloner', __NAMESPACE__ . '\display_cloner' );
 		add_action(
 			'admin_enqueue_scripts', function ( $hook ) use ( $cloner_page ) {
 				if ( $hook === $cloner_page ) {


### PR DESCRIPTION
This PR fixes #2549 by changing the capability needed to view the cloner a book page in individual books from 'edit_posts' (which contributors do not have) to 'read' (which they do have): https://wordpress.org/support/article/roles-and-capabilities/#read. 

To Test:
1. checkout this branch
2. add a user to a book as a contributor
3. visit that book's dashboard and then click 'My Books -> Clone a Book' 
4. confirm that you can access the cloning routine and successfully clone a new book