### PR TITLE
fix: Improve TOC rendering for parts with no chapters

### DIFF
--- a/inc/modules/export/epub/class-epub.php
+++ b/inc/modules/export/epub/class-epub.php
@@ -2655,6 +2655,7 @@ class Epub extends ExportGenerator {
 		$vars = [
 			'author' => sanitize_xml_attribute( $authors ),
 			'manifest' => $this->manifest,
+			'manifest_keys' => array_keys( $this->manifest ),
 			'dtd_uid' => ! empty( $metadata['pb_ebook_isbn'] ) ? sanitize_xml_attribute( $metadata['pb_ebook_isbn'] ) : sanitize_xml_attribute( get_bloginfo( 'url' ) ),
 			'enable_external_identifier' => false,
 			'lang' => $this->lang,

--- a/templates/export/epub/toc.blade.php
+++ b/templates/export/epub/toc.blade.php
@@ -12,8 +12,11 @@
 			<h1 class="title">{{ __( 'Table of Contents', 'pressbooks' ) }}</h1>
 			<ol epub:type="list">
 			@php( $part_open = false )
-			@foreach( $manifest as $key => $value )
-				@if( $part_open && 0 !== strpos( $key, 'chapter-') )
+			@foreach( $manifest_keys as $key )
+				@php( $value = $manifest[ $key ] )
+				@php( $next_key = next( $manifest_keys ) )
+
+				@if( $part_open && 0 !== strpos( $key, 'chapter-' ) )
 					@php( $part_open = false )
 					</ol></li>
 				@endif
@@ -22,16 +25,14 @@
 					@php( $text = wp_strip_all_tags( \Pressbooks\Sanitize\decode( $value['post_title'] ) ) ?? ' ' )
 
 					@if( 0 === strpos( $key, 'part-' ) )
-						<li><a href="{{ $value['filename'] }}">{{ $text }}</a>
+						@if( $next_key && 0 === strpos( $next_key, 'chapter-' ) )
+							@php( $part_open = true )
+							<li><a href="{{ $value['filename'] }}">{{ $text }}</a><ol>
+						@else
+							<li><a href="{{ $value['filename'] }}">{{ $text }}</a></li>
+						@endif
 					@else
-						<li>
-							<a href="{{ $value['filename'] }}">{{ $text }}</a>
-						</li>
-					@endif
-
-					@if( 0 === strpos($key, 'part-') )
-						@php( $part_open = true )
-						<ol>
+						<li><a href="{{ $value['filename'] }}">{{ $text }}</a></li>
 					@endif
 				@endif
 			@endforeach


### PR DESCRIPTION
Closes #2567 

This PR fixes TOC rendering empty `<ol>` when parts have no chapters or invisible ones. However issue with chapters which have empty titles (see https://github.com/pressbooks/pressbooks/issues/2567#issuecomment-1008301831) will continue to happen because anchor tags must have a text.

### How to test

Create parts which have content and no chapters or which have only invisible chapters. The EPUB export should not return errors about empty `<ol>` tags.