### PR TITLE
fix: remove schema.org reference for styles and theme API endpoints

### DIFF
--- a/inc/api/endpoints/controller/class-styles.php
+++ b/inc/api/endpoints/controller/class-styles.php
@@ -54,29 +54,9 @@ class Styles extends \WP_REST_Controller {
 	 */
 	public function get_item_schema() : array {
 		return $this->add_additional_fields_schema( [
-			'$schema' => 'http://json-schema.org/schema#',
 			'title' => 'styles',
 			'type' => 'object',
 			'properties' => [
-				'@context' => [
-					'type' => 'string',
-					'format' => 'uri',
-					'enum' => [
-						'http://schema.org',
-					],
-					'description' => __( 'The JSON-LD context.' ),
-					'context' => [ 'view' ],
-					'readonly' => true,
-				],
-				'@type' => [
-					'type' => 'string',
-					'enum' => [
-						'Styles',
-					],
-					'description' => __( 'The type of the thing.' ),
-					'context' => [ 'view' ],
-					'readonly' => true,
-				],
 				'web' => [
 					'type' => 'string',
 					'description' => __( 'The styles for the web format of the book' ),
@@ -114,13 +94,7 @@ class Styles extends \WP_REST_Controller {
 	 * @return \WP_REST_Response
 	 */
 	public function get_item( $request ) : \WP_REST_Response {
-		$response = rest_ensure_response( array_merge(
-			[
-				'@context' => 'http://schema.org',
-				'@type' => 'Styles',
-			],
-			\Pressbooks\Styles::getAllPostContent()
-		) );
+		$response = rest_ensure_response( \Pressbooks\Styles::getAllPostContent() );
 		$this->linkCollector['self'] = [
 			'href' => rest_url( sprintf( '%s/%s', $this->namespace, $this->rest_base ) ),
 		];

--- a/inc/api/endpoints/controller/class-theme.php
+++ b/inc/api/endpoints/controller/class-theme.php
@@ -56,29 +56,9 @@ class Theme extends \WP_REST_Controller {
 	 */
 	public function get_item_schema() : array {
 		return $this->add_additional_fields_schema( [
-			'$schema' => 'http://json-schema.org/schema#',
 			'title' => 'Theme',
 			'type' => 'object',
 			'properties' => [
-				'@context' => [
-					'type' => 'string',
-					'format' => 'uri',
-					'enum' => [
-						'http://schema.org',
-					],
-					'description' => __( 'The JSON-LD context.' ),
-					'context' => [ 'view' ],
-					'readonly' => true,
-				],
-				'@type' => [
-					'type' => 'string',
-					'enum' => [
-						'Theme',
-					],
-					'description' => __( 'The type of the theme.' ),
-					'context' => [ 'view' ],
-					'readonly' => true,
-				],
 				'name' => [
 					'type' => 'string',
 					'description' => __( 'The theme\'s name' ),
@@ -157,8 +137,6 @@ class Theme extends \WP_REST_Controller {
 	public function get_item( $request ) : \WP_REST_Response {
 		$theme = wp_get_theme();
 		$response = rest_ensure_response( [
-			'@context' => 'http://schema.org',
-			'@type' => 'Theme',
 			'name' => $theme->get( 'Name' ),
 			'version' => $theme->get( 'Version' ),
 			'stylesheet' => $theme->get_stylesheet(),


### PR DESCRIPTION
Reference: https://github.com/pressbooks/pressbooks/issues/2575#issuecomment-1020616411

This PR removes any references about schema.org for styles & theme API endpoints, since those are not a schema.org types.