### PR TITLE
feat: add default theme option to network settings

### DIFF
--- a/hooks-admin.php
+++ b/hooks-admin.php
@@ -114,6 +114,9 @@ if ( ! is_network_admin() ) {
 	add_action( 'admin_init', '\Pressbooks\Admin\Laf\privacy_settings_init' );
 }
 
+// Network settings
+add_action( 'network_admin_menu', [ '\Pressbooks\Admin\Network\NetworkSettings', 'init' ] );
+
 // Replaces 'WordPress' with 'Pressbooks' in titles of admin pages.
 add_filter( 'admin_title', '\Pressbooks\Admin\Branding\admin_title' );
 

--- a/inc/admin/network/class-networksettings.php
+++ b/inc/admin/network/class-networksettings.php
@@ -61,11 +61,12 @@ class NetworkSettings {
 		echo '<tr><th scope="row">' . __( 'Default Theme', 'pressbooks' ) . '</th><td>';
 		$options = '';
 		$themes = $GLOBALS['pressbooks']->allowedBookThemes( \WP_Theme::get_allowed_on_network() );
+		$default_theme = get_site_option( $this->customOptions['default_theme'], self::getDefaultTheme() );
 		foreach ( $themes as $theme => $_ ) {
 			$options .= sprintf(
 				'<option value="%1$s"%2$s>%3$s</option>',
 				$theme,
-				selected( get_site_option( $this->customOptions['default_theme'], self::DEFAULT_THEME ), $theme, false ),
+				selected( $default_theme, $theme, false ),
 				wp_get_theme( $theme )->get( 'Name' )
 			);
 		}
@@ -91,5 +92,16 @@ class NetworkSettings {
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Get default theme defined by default if available, otherwise it returns 'pressbooks-book'
+	 *
+	 * @return string
+	 */
+	public static function getDefaultTheme() {
+		$themes = $GLOBALS['pressbooks']->allowedBookThemes( \WP_Theme::get_allowed_on_network() );
+		return array_key_exists( self::DEFAULT_THEME, $themes ) ?
+			self::DEFAULT_THEME : 'pressbooks-book';
 	}
 }

--- a/inc/admin/network/class-networksettings.php
+++ b/inc/admin/network/class-networksettings.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * @author  Pressbooks <code@pressbooks.com>
+ * @license GPLv3 (or any later version)
+ */
+// @phpcs:disable Pressbooks.Security.EscapeOutput.OutputNotEscaped
+// @phpcs:disable Pressbooks.Security.NonceVerification.Missing
+// @phpcs:disable Pressbooks.Security.ValidatedSanitizedInput.MissingUnslash
+
+namespace Pressbooks\Admin\Network;
+
+class NetworkSettings {
+
+	const DEFAULT_THEME_OPTION = 'pressbooks_default_book_theme';
+
+	const DEFAULT_THEME = 'pressbooks-malala';
+
+	/**
+	 * @var array
+	 */
+	private $customOptions = [];
+
+	/**
+	 * @var NetworkSettings
+	 */
+	private static $instance = null;
+
+	public function __construct() {
+		$this->customOptions = [
+			'default_theme' => self::DEFAULT_THEME_OPTION,
+		];
+	}
+
+	/**
+	 * @return NetworkSettings
+	 */
+	public static function init() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+			self::hooks( self::$instance );
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * @param NetworkSettings $obj
+	 */
+	public static function hooks( NetworkSettings $obj ) {
+		add_filter( 'wpmu_options', [ $obj, 'renderCustomOptions' ] );
+		add_action( 'update_wpmu_options', [ $obj, 'saveNetworkSettings' ] );
+	}
+
+	/**
+	 * Render custom network settings options
+	 *
+	 * @return void
+	 */
+	public function renderCustomOptions() : void {
+		echo '<h3>' . __( 'Theme Settings', 'pressbooks' ) . '</h3>';
+		echo ' <table id="menu" class="form-table" role="presentation"><tbody>';
+		echo '<tr><th scope="row">' . __( 'Default Theme', 'pressbooks' ) . '</th><td>';
+		$options = '';
+		$themes = $GLOBALS['pressbooks']->allowedBookThemes( \WP_Theme::get_allowed_on_network() );
+		foreach ( $themes as $theme => $_ ) {
+			$options .= sprintf(
+				'<option value="%1$s"%2$s>%3$s</option>',
+				$theme,
+				selected( get_site_option( $this->customOptions['default_theme'], self::DEFAULT_THEME ), $theme, false ),
+				wp_get_theme( $theme )->get( 'Name' )
+			);
+		}
+		printf(
+			'<select id="%1$s" name="%1$s">%2$s</select></td></tr></tbody></table>',
+			$this->customOptions['default_theme'],
+			$options
+		);
+	}
+
+	/**
+	 * Save network setting options
+	 *
+	 * @return bool
+	 */
+	public function saveNetworkSettings() : bool {
+		if ( isset( $_POST[ $this->customOptions['default_theme'] ] ) ) {
+			$default_theme = sanitize_text_field( $_POST[ $this->customOptions['default_theme'] ] );
+			$themes = $GLOBALS['pressbooks']->allowedBookThemes( \WP_Theme::get_allowed_on_network() );
+			if ( array_key_exists( $default_theme, $themes ) ) {
+				update_site_option( $this->customOptions['default_theme'], $default_theme );
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/tests/test-networksettings.php
+++ b/tests/test-networksettings.php
@@ -40,4 +40,8 @@ class NetworkSettingsTest extends \WP_UnitTestCase {
 		$this->assertFalse( $this->networkSettings->saveNetworkSettings() );
 	}
 
+	public function test_getDefaultTheme() {
+		$this->assertEquals( 'pressbooks-book', \Pressbooks\Admin\Network\NetworkSettings::getDefaultTheme() );
+	}
+
 }

--- a/tests/test-networksettings.php
+++ b/tests/test-networksettings.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @group networksettings
+ */
+class NetworkSettingsTest extends \WP_UnitTestCase {
+
+	use utilsTrait;
+
+	/**
+	 * @var \Pressbooks\Admin\Network\NetworkSettings
+	 */
+	private $networkSettings;
+
+	public function setUp() {
+		parent::setUp();
+		$this->networkSettings = new \Pressbooks\Admin\Network\NetworkSettings();
+	}
+
+	public function test_hook() {
+		$this->networkSettings->hooks( $this->networkSettings );
+		$this->assertEquals( 10, has_filter( 'wpmu_options', [ $this->networkSettings, 'renderCustomOptions' ] ) );
+		$this->assertEquals( 10, has_filter( 'update_wpmu_options', [ $this->networkSettings, 'saveNetworkSettings' ] ) );
+	}
+
+	public function test_renderCustomOptions() {
+		ob_start();
+		$this->networkSettings->renderCustomOptions();
+		$buffer = ob_get_clean();
+		$this->assertStringContainsString( '<h3>' . __( 'Theme Settings', 'pressbooks' ) . '</h3>', $buffer );
+		$option = \Pressbooks\Admin\Network\NetworkSettings::DEFAULT_THEME_OPTION;
+		$this->assertStringContainsString( "<select id=\"$option\" name=\"$option\"", $buffer );
+	}
+
+	public function test_saveNetworkSettings() {
+		$this->_book();
+		$option = \Pressbooks\Admin\Network\NetworkSettings::DEFAULT_THEME_OPTION;
+		update_site_option( $option, 'pressbooks-book' );
+		$_POST[ $option ] = 'invalid-theme';
+		$this->assertFalse( $this->networkSettings->saveNetworkSettings() );
+	}
+
+}


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks-network-analytics/issues/185

This change adds the Default theme option to Network Settings page.

### Test case sample
- Go to Network Admin > Settings > Network Settings section
- Make sure a new Theme Settings / Default theme option is defined in the form. A select with available themes must be rendered.
- Change the Default Theme and save it
- Create a new book and make sure the theme applied by default is the same you defined in the previous step.