### PR TITLE
fix: clean up RSS cache when saving RSS settings

### DIFF
--- a/templates/admin/dashboard.php
+++ b/templates/admin/dashboard.php
@@ -24,6 +24,7 @@ if ( ! empty( $_POST ) ) {
 			$options['title'] = $_REQUEST['pressbooks_dashboard_feed']['title'];
 		}
 
+		delete_site_transient( 'pb_rss_widget' ); // Clean up old cache
 		update_site_option( 'pressbooks_dashboard_feed', $options ); ?>
 		<div id="message" role="status" class="updated notice is-dismissible"><p><strong><?php _e( 'Settings saved.', 'pressbooks-oauth' ); ?></strong></div>
 		<?php }


### PR DESCRIPTION
Partial fix for pressbooks/pressbooks-network-analytics#180. Accompanies pressbooks/pressbooks-network-analytics#188.

This PR instructs the app to clear the RSS settings cache whenever the user updates the RSS settings.

#### How to test

1. Go to the Network Dashboard page and update the feed title and url.
1. Without clearing the cache go to the dashboard page and validate the new feed is displayed properly. 