### PR TITLE
fix: move institutions field

### DIFF
--- a/inc/admin/metaboxes/namespace.php
+++ b/inc/admin/metaboxes/namespace.php
@@ -498,9 +498,9 @@ function add_meta_boxes() {
 		]
 	);
 
-	add_meta_box( 'institutions', __( 'Institutions', 'pressbooks' ), __NAMESPACE__ . '\institutions_metabox', 'metadata', 'normal', 'low' );
-
 	add_meta_box( 'subject', __( 'Subject(s)', 'pressbooks' ), __NAMESPACE__ . '\metadata_subject_box', 'metadata', 'normal', 'low' );
+
+	add_meta_box( 'institutions', __( 'Institutions', 'pressbooks' ), __NAMESPACE__ . '\institutions_metabox', 'metadata', 'normal', 'low' );
 
 	if ( $show_expanded_metadata ) {
 		x_add_metadata_group(


### PR DESCRIPTION
Issue: pressbooks/private#782

This PR places the institutions field between Subjects and Copyright, [see](https://github.com/pressbooks/private/issues/782#issuecomment-1043348640).

### How to test

1. Open a book info page
2. Make sure the institutions field is placed in the right position