### PR TITLE
fix: remove pb_fixme wrapper during epub export routine

### DIFF
--- a/inc/class-htmlparser.php
+++ b/inc/class-htmlparser.php
@@ -41,6 +41,7 @@ class HtmlParser {
 	 * @return \DOMDocument
 	 */
 	public function loadHTML( $html, $options = [] ) {
+		$html = '<div><!-- pb_fixme -->' . $html . '<!-- pb_fixme --></div>';
 		if ( $this->parser instanceof \DOMDocument ) {
 			libxml_use_internal_errors( true );
 			$this->parser->loadHTML( mb_convert_encoding( $html, 'HTML-ENTITIES', 'UTF-8' ), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
@@ -66,8 +67,23 @@ class HtmlParser {
 		} else {
 			$html = $this->parser->saveHTML( $dom );
 		}
-
-		return \Pressbooks\Sanitize\strip_container_tags( $html );
+		return $this->removeFixMeWrapper( \Pressbooks\Sanitize\strip_container_tags( $html ) );
 	}
+
+    /**
+     * Remove `<div><!-- pb_fixme --><!-- pb_fixme --></div>` from HTML.
+     *
+     * @param string $html
+     * @return string
+     */
+    public function removeFixMeWrapper( string $html ) {
+        return strtr(
+            \Pressbooks\Sanitize\strip_container_tags( $html ),
+            [
+                '<div><!-- pb_fixme -->' => '',
+                '<!-- pb_fixme --></div>' => '',
+            ]
+        );
+    }
 
 }

--- a/inc/class-htmlparser.php
+++ b/inc/class-htmlparser.php
@@ -70,20 +70,20 @@ class HtmlParser {
 		return $this->removeFixMeWrapper( \Pressbooks\Sanitize\strip_container_tags( $html ) );
 	}
 
-    /**
-     * Remove `<div><!-- pb_fixme --><!-- pb_fixme --></div>` from HTML.
-     *
-     * @param string $html
-     * @return string
-     */
-    public function removeFixMeWrapper( string $html ) {
-        return strtr(
-            $html,
-            [
-                '<div><!-- pb_fixme -->' => '',
-                '<!-- pb_fixme --></div>' => '',
-            ]
-        );
-    }
+	/**
+	 * Remove `<div><!-- pb_fixme --><!-- pb_fixme --></div>` from HTML.
+	 *
+	 * @param string $html
+	 * @return string
+	 */
+	public function removeFixMeWrapper( string $html ) {
+		return strtr(
+			$html,
+			[
+				'<div><!-- pb_fixme -->' => '',
+				'<!-- pb_fixme --></div>' => '',
+			]
+		);
+	}
 
 }

--- a/inc/class-htmlparser.php
+++ b/inc/class-htmlparser.php
@@ -78,7 +78,7 @@ class HtmlParser {
      */
     public function removeFixMeWrapper( string $html ) {
         return strtr(
-            \Pressbooks\Sanitize\strip_container_tags( $html ),
+            $html,
             [
                 '<div><!-- pb_fixme -->' => '',
                 '<!-- pb_fixme --></div>' => '',

--- a/inc/class-htmlparser.php
+++ b/inc/class-htmlparser.php
@@ -41,7 +41,6 @@ class HtmlParser {
 	 * @return \DOMDocument
 	 */
 	public function loadHTML( $html, $options = [] ) {
-		$html = '<div><!-- pb_fixme -->' . $html . '<!-- pb_fixme --></div>';
 		if ( $this->parser instanceof \DOMDocument ) {
 			libxml_use_internal_errors( true );
 			$this->parser->loadHTML( mb_convert_encoding( $html, 'HTML-ENTITIES', 'UTF-8' ), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
@@ -68,15 +67,7 @@ class HtmlParser {
 			$html = $this->parser->saveHTML( $dom );
 		}
 
-		$html = \Pressbooks\Sanitize\strip_container_tags( $html );
-
-		$replace_pairs = [
-			'<div><!-- pb_fixme -->' => '',
-			'<!-- pb_fixme --></div>' => '',
-		];
-		$html = strtr( $html, $replace_pairs );
-
-		return $html;
+		return \Pressbooks\Sanitize\strip_container_tags( $html );
 	}
 
 }

--- a/inc/modules/export/epub/class-epub.php
+++ b/inc/modules/export/epub/class-epub.php
@@ -2013,8 +2013,8 @@ class Epub extends ExportGenerator {
 		// Ie. It will spit out the characters converted in encoded format. Instead do the following:
 		$html = $dom->saveXML( $dom->documentElement );
 
-		// Remove auto-created <html> <body> and <!DOCTYPE> tags.
-		return \Pressbooks\Sanitize\strip_container_tags( $html );
+		// Remove pb_fixme wrapper and remove auto-created <html> <body> and <!DOCTYPE> tags.
+		return $html5->removeFixMeWrapper( \Pressbooks\Sanitize\strip_container_tags( $html ) );
 	}
 
 	/**

--- a/tests/test-htmlparser.php
+++ b/tests/test-htmlparser.php
@@ -54,4 +54,15 @@ class HtmlParserTest extends \WP_UnitTestCase {
 
 	}
 
+	/**
+	 * @group htmlparser
+	 */
+	public function test_removeFixMeWrapper() {
+		$html5 = new HtmlParser( true );
+		$html = '<div><!-- pb_fixme --><p>I am a paragraph</p><!-- pb_fixme --></div>';
+		$this->assertEquals( '<p>I am a paragraph</p>', $html5->removeFixMeWrapper( $html ) );
+		$html = '<p>I am a paragraph</p>';
+		$this->assertEquals( $html, $html5->removeFixMeWrapper( $html ) );
+	}
+
 }


### PR DESCRIPTION
Related issue: https://github.com/pressbooks/pressbooks/issues/2639

This PR removes the `<!-- pb_fixme -->` wrapper in the HTML used within the EPUB export routine.

### Testing notes
I tested it by exporting multiple books in multiple epub to make sure the wrapper is not present anymore.