### PR TITLE
feat: appends missing exported formats tracking

### DIFF
--- a/inc/datacollector/class-book.php
+++ b/inc/datacollector/class-book.php
@@ -292,7 +292,7 @@ class Book {
 		$exports_by_format = '';
 		$latest_exports = \Pressbooks\Utility\latest_exports();
 		foreach ( $latest_exports as $filetype => $filename ) {
-			$filetype = str_replace( '_', '-', $filetype );
+			$filetype = ! str_contains( $filetype, 'print' ) ? str_replace( '_', '-', $filetype ) : $filetype;
 			$name = \Pressbooks\Modules\Export\get_name_from_filetype_slug( $filetype );
 			$exports_by_format .= "{$name},";
 		}

--- a/inc/modules/export/namespace.php
+++ b/inc/modules/export/namespace.php
@@ -164,6 +164,9 @@ function filetypes() {
 			'mpdf' => '._oss.pdf',
 			'odf' => '.odt',
 			'weblinks' => '._1_1_weblinks.imscc',
+			'thincc11' => '._1_1.imscc',
+			'thincc12' => '._1_2.imscc',
+			'thincc13' => '._1_3.imscc',
 		]
 	);
 	return $filetypes;
@@ -198,6 +201,9 @@ function get_name_from_filetype_slug( $filetype ) {
 			'wxr' => __( 'Pressbooks XML', 'pressbooks' ),
 			'vanillawxr' => __( 'WordPress XML', 'pressbooks' ),
 			'weblinks' => __( 'Common Cartridge (Web Links)', 'pressbooks' ),
+			'thincc11' => __( 'Common Cartridge with LTI links (1.1)', 'pressbooks' ),
+			'thincc12' => __( 'Common Cartridge with LTI links (1.2)', 'pressbooks' ),
+			'thincc13' => __( 'Common Cartridge with LTI links (1.3)', 'pressbooks' ),
 		]
 	);
 	return isset( $formats[ $filetype ] ) ? $formats[ $filetype ] : ucfirst( $filetype );

--- a/tests/test-modules-export.php
+++ b/tests/test-modules-export.php
@@ -52,6 +52,8 @@ class Modules_ExportTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'Print PDF', $type );
 		$type = \Pressbooks\Modules\Export\get_name_from_filetype_slug( 'wtfbbq' );
 		$this->assertEquals( 'Wtfbbq', $type );
+		$type = \Pressbooks\Modules\Export\get_name_from_filetype_slug( 'thincc11' );
+		$this->assertEquals( 'Common Cartridge with LTI links (1.1)', $type );
 	}
 
 	/**


### PR DESCRIPTION
See #2556 

This PR appends missing exported formats

### How to test

1. Export a book using the Common Cartridge with LTI links options
2. Run the data collector `wp eval-file bin/sync/books.php`
3. Check if `wp_blogmeta` `pb_exports_by_formats` key has the expected meta values 

Example

```
EPUB,Digital PDF,Print-pdf,HTMLBook,XHTML,Pressbooks XML,WordPress XML,OpenDocument,Common Cartridge (Web Links),Common Cartridge with LTI links (1.1),Common Cartridge with LTI links (1.2),Common Cartridge with LTI links (1.3)
```