### PR TITLE
Fix translation action

### DIFF
--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -18,11 +18,11 @@ jobs:
     - name: Setup PHP with tools
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.3'
+        php-version: '7.4'
         tools: composer, wp-cli
     - name: Install dependencies
       run: |
-        wp package install wp-cli/i18n-command:2.2.8
+        wp package install wp-cli/i18n-command
         cd /home/runner/.wp-cli/packages/
         composer config repositories.wp-cli '{"type": "composer","url": "https://wp-cli.org/package-index/","canonical": false}'
         cd ./
@@ -30,8 +30,13 @@ jobs:
         composer require jenssegers/blade:1.1.0
     - name: Update POT file
       run: wp pb make-pot . languages/pressbooks.pot --domain=pressbooks --slug=pressbooks --package-name="Pressbooks" --headers="{\"Report-Msgid-Bugs-To\":\"https://github.com/pressbooks/pressbooks/issues\"}"
-    - name: Commit updated POT file
-      uses: stefanzweifel/git-auto-commit-action@v4.13.1
+      # Remove the next four lines and uncomment the last five lines once the process has been confirmed to work as desired.
+    - uses: actions/upload-artifact@v2
       with:
-        commit_message: 'chore(l10n): update languages/pressbooks.pot'
-        file_pattern: '*.pot'
+        name: pressbooks.pot
+        path: languages/pressbooks.pot
+    # - name: Commit updated POT file
+    #  uses: stefanzweifel/git-auto-commit-action@v4.13.1
+    #  with:
+    #    commit_message: 'chore(l10n): update languages/pressbooks.pot'
+    #    file_pattern: '*.pot'

--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -1,12 +1,15 @@
 name: Update POT file
 
-on:
-  push:
-    branches:
-    - dev
-    paths:
-    - '**.php'
-    - '**.js'
+# Temporarily give this manual trigger. Remove this line and uncomment lines below once working as desired.
+on: workflow_dispatch
+
+# on:
+#  push:
+#    branches:
+#    - dev
+#    paths:
+#    - '**.php'
+#    - '**.js'
 
 jobs:
   update-pot:

--- a/languages/pressbooks.pot
+++ b/languages/pressbooks.pot
@@ -3,15 +3,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Pressbooks 5.33.0\n"
-"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks/issues\n"
+"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks/\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2022-03-08T17:00:31+00:00\n"
+"POT-Creation-Date: 2022-02-22T21:34:21+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.6.0\n"
+"X-Generator: WP-CLI 2.5.0\n"
 "X-Domain: pressbooks\n"
 
 #. Plugin Name of the plugin
@@ -31,455 +31,694 @@ msgstr ""
 msgid "Pressbooks (Book Oven Inc.)"
 msgstr ""
 
+#: compatibility.php:105
+#: inc/class-activation.php:326
 msgid "Simple Book Publishing"
 msgstr ""
 
+#: compatibility.php:150
 msgid "Pressbooks could not create the mu-plugins folder. Please create the following directory: %s"
 msgstr ""
 
+#: compatibility.php:157
 msgid "Pressbooks could not copy the autoloader from %1$s to %2$s. Please copy the file manually."
 msgstr ""
 
+#: compatibility.php:172
 msgid "Pressbooks will not work with your version of PHP. Pressbooks requires PHP version %s or greater. Please upgrade PHP if you would like to use Pressbooks."
 msgstr ""
 
+#: compatibility.php:185
 msgid "Pressbooks will not work with your version of WordPress. Pressbooks requires a dedicated install of WordPress Multisite, version %s or greater. Please upgrade WordPress if you would like to use Pressbooks."
 msgstr ""
 
+#: compatibility.php:196
 msgid "The Pressbooks plugin is inactive, but you have active plugins that require Pressbooks. This is causing errors. Please go to the Plugins page, and activate Pressbooks."
 msgstr ""
 
+#: inc/admin/analytics/namespace.php:16
+#: inc/admin/analytics/namespace.php:17
+#: inc/admin/analytics/namespace.php:26
+#: inc/admin/analytics/namespace.php:27
+#: inc/admin/analytics/namespace.php:170
+#: inc/admin/analytics/namespace.php:210
 msgid "Google Analytics"
 msgstr ""
 
+#: inc/admin/analytics/namespace.php:50
+#: inc/admin/analytics/namespace.php:107
 msgid "Google Analytics ID"
 msgstr ""
 
+#: inc/admin/analytics/namespace.php:55
 msgid "The Google Analytics ID for your network, e.g. &lsquo;UA-01234567-8&rsquo;."
 msgstr ""
 
+#: inc/admin/analytics/namespace.php:73
 msgid "Site-Specific Tracking"
 msgstr ""
 
+#: inc/admin/analytics/namespace.php:78
 msgid "If enabled, the Google Analytics settings page will be visible to book administrators, allowing them to use their own Google Analytics accounts to track statistics at the book level."
 msgstr ""
 
+#: inc/admin/analytics/namespace.php:112
 msgid "The Google Analytics ID for your book, e.g. &lsquo;UA-01234567-8&rsquo;."
 msgstr ""
 
+#: inc/admin/analytics/namespace.php:129
 msgid "Google Analytics settings."
 msgstr ""
 
+#: inc/admin/analytics/namespace.php:188
+#: inc/admin/network/class-sharingandprivacyoptions.php:188
 msgid "Settings saved."
 msgstr ""
 
+#: inc/admin/attachments/namespace.php:39
 msgid "ATTRIBUTIONS"
 msgstr ""
 
+#: inc/admin/attachments/namespace.php:46
 msgid "Source URL"
 msgstr ""
 
+#: inc/admin/attachments/namespace.php:54
+#: inc/admin/class-catalog-list-table.php:232
+#: inc/admin/covergenerator/namespace.php:108
 msgid "Author"
 msgstr ""
 
+#: inc/admin/attachments/namespace.php:60
 msgid "Author URL"
 msgstr ""
 
+#: inc/admin/attachments/namespace.php:68
 msgid "License"
 msgstr ""
 
+#: inc/admin/attachments/namespace.php:75
 msgid "Adapted by"
 msgstr ""
 
+#: inc/admin/attachments/namespace.php:81
 msgid "Adapted by URL"
 msgstr ""
 
+#: inc/admin/branding/namespace.php:182
 msgid "Log In"
 msgstr ""
 
+#: inc/admin/branding/namespace.php:183
 msgid "Lost Password"
 msgstr ""
 
+#: inc/admin/branding/namespace.php:184
 msgid "Reset Password"
 msgstr ""
 
+#: inc/admin/branding/namespace.php:185
 msgid "Password Reset"
 msgstr ""
 
+#: inc/admin/class-catalog-list-table.php:76
 msgid "Visit Admin"
 msgstr ""
 
+#: inc/admin/class-catalog-list-table.php:106
+#: inc/admin/class-catalog-list-table.php:271
+#: inc/admin/class-catalog-list-table.php:533
 msgid "Hide in Catalog"
 msgstr ""
 
+#: inc/admin/class-catalog-list-table.php:111
+#: inc/admin/class-catalog-list-table.php:270
+#: inc/admin/class-catalog-list-table.php:531
 msgid "Show in Catalog"
 msgstr ""
 
+#: inc/admin/class-catalog-list-table.php:228
 msgid "Catalog Status"
 msgstr ""
 
+#: inc/admin/class-catalog-list-table.php:229
 msgid "Privacy Status"
 msgstr ""
 
+#: inc/admin/class-catalog-list-table.php:230
+#: inc/class-activation.php:237
+#: inc/modules/export/epub/class-epub.php:1211
+#: tests/test-cloner.php:58
 msgid "Cover"
 msgstr ""
 
+#: inc/admin/class-catalog-list-table.php:231
+#: inc/admin/covergenerator/namespace.php:75
+#: inc/admin/metaboxes/namespace.php:204
+#: templates/admin/import.php:90
 msgid "Title"
 msgstr ""
 
+#: inc/admin/class-catalog-list-table.php:236
+#: templates/pb-catalog.php:228
 msgid "Tag"
 msgstr ""
 
+#: inc/admin/class-catalog-list-table.php:239
+#: templates/admin/catalog.php:36
 msgid "Featured"
 msgstr ""
 
+#: inc/admin/class-catalog-list-table.php:240
 msgid "Pub Date"
 msgstr ""
 
+#: inc/admin/class-catalog-list-table.php:396
 msgid "Edit Tags"
 msgstr ""
 
+#: inc/admin/class-catalog-list-table.php:435
+#: templates/admin/organize.php:44
+#: templates/admin/organize.php:55
 msgid "Private"
 msgstr ""
 
+#: inc/admin/class-catalog-list-table.php:435
+#: templates/admin/organize.php:42
+#: templates/admin/organize.php:47
 msgid "Public"
 msgstr ""
 
+#: inc/admin/class-catalog-list-table.php:507
+#: inc/admin/laf/namespace.php:429
+#: inc/admin/laf/namespace.php:610
+#: inc/admin/laf/namespace.php:882
 msgid "My Catalog"
 msgstr ""
 
+#: inc/admin/class-catalog-list-table.php:508
 msgid "Edit Profile"
 msgstr ""
 
+#: inc/admin/class-catalog-list-table.php:509
 msgid "Visit Catalog"
 msgstr ""
 
 #. translators: %s: search keywords
+#: inc/admin/class-catalog-list-table.php:515
 msgid "Search results for &#8220;%s&#8221; returned no items"
 msgstr ""
 
 #. translators: %s: search keywords
+#: inc/admin/class-catalog-list-table.php:518
 msgid "Search results for &#8220;%s&#8221; returned 1 item"
 msgstr ""
 
 #. translators: %s: search keywords, %d: total items found
+#: inc/admin/class-catalog-list-table.php:521
 msgid "Search results for &#8220;%1$s&#8221; returned %2$d items"
 msgstr ""
 
+#: inc/admin/class-catalog-list-table.php:529
 msgid "Organize your public Catalog page."
 msgstr ""
 
+#: inc/admin/class-catalog-list-table.php:530
 msgid "Show/Hide books"
 msgstr ""
 
+#: inc/admin/class-catalog-list-table.php:531
 msgid "To display a book in your catalog choose \"%s\" under Catalog Status. "
 msgstr ""
 
+#: inc/admin/class-catalog-list-table.php:533
 msgid "To hide a book in your catalog choose \"%s\" under Catalog Status."
 msgstr ""
 
+#: inc/admin/class-catalog-list-table.php:536
 msgid "Catalog sorting"
 msgstr ""
 
+#: inc/admin/class-catalog-list-table.php:537
 msgid "To add sorting ability, add your Tag names to your <a href=\"%s\">Catalog Profile</a> page (ex: Authors, Book Genre), then add the appropriate tags to each individual book."
 msgstr ""
 
+#: inc/admin/class-catalog-list-table.php:539
 msgid "Share your catalog"
 msgstr ""
 
+#: inc/admin/class-catalog-list-table.php:540
 msgid "The public link to your catalog page"
 msgstr ""
 
+#: inc/admin/class-catalog-list-table.php:553
 msgid "Add By URL"
 msgstr ""
 
+#: inc/admin/class-catalog-list-table.php:564
+#: templates/admin/search.php:81
 msgid "Search"
 msgstr ""
 
+#: inc/admin/class-exportoptions.php:68
 msgid "Email Validation Logs"
 msgstr ""
 
+#: inc/admin/class-exportoptions.php:73
 msgid "No. Ignore validation errors."
 msgstr ""
 
+#: inc/admin/class-exportoptions.php:74
 msgid "Yes."
 msgstr ""
 
+#: inc/admin/class-exportoptions.php:74
 msgid "Email me validation error logs on export."
 msgstr ""
 
+#: inc/admin/class-exportoptions.php:81
 msgid "Lock Theme"
 msgstr ""
 
+#: inc/admin/class-exportoptions.php:86
 msgid "Lock your theme at its current version."
 msgstr ""
 
+#: inc/admin/class-exportoptions.php:102
 msgid "Export settings."
 msgstr ""
 
+#: inc/admin/class-exportoptions.php:168
 msgid "This will prevent any changes to your book&rsquo;s appearance and page count when themes are updated."
 msgstr ""
 
+#: inc/admin/class-exportoptions.php:188
+#: inc/admin/laf/namespace.php:394
 msgid "Export Settings"
 msgstr ""
 
+#: inc/admin/class-network-managers-list-table.php:79
+#: inc/admin/class-network-managers-list-table.php:83
 msgid "Restrict Access"
 msgstr ""
 
+#: inc/admin/class-network-managers-list-table.php:79
+#: inc/admin/class-network-managers-list-table.php:83
 msgid "Unrestrict Access"
 msgstr ""
 
+#: inc/admin/class-publishoptions.php:68
 msgid "Amazon URL"
 msgstr ""
 
+#: inc/admin/class-publishoptions.php:77
 msgid "O'Reilly URL"
 msgstr ""
 
+#: inc/admin/class-publishoptions.php:86
 msgid "Barnes and Noble URL"
 msgstr ""
 
+#: inc/admin/class-publishoptions.php:95
 msgid "Kobo URL"
 msgstr ""
 
+#: inc/admin/class-publishoptions.php:104
 msgid "Apple Books URL"
 msgstr ""
 
+#: inc/admin/class-publishoptions.php:113
 msgid "Other Service URL"
 msgstr ""
 
+#: inc/admin/class-publishoptions.php:132
 msgid "Add BUY Links to Your Pressbooks Webbook"
 msgstr ""
 
+#: inc/admin/class-publishoptions.php:133
 msgid "Enter the URLs for locations where your book can be purchased below. <a href=\"https://guide.pressbooks.com/chapter/publish/\">Our guide</a> provides additional information about selling and distributing your book."
 msgstr ""
 
+#: inc/admin/class-publishoptions.php:293
+#: inc/admin/laf/namespace.php:378
 msgid "Publish"
 msgstr ""
 
+#: inc/admin/class-sitemap.php:58
+#: inc/admin/class-sitemap.php:59
 msgid "Sitemap"
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:17
+#: templates/admin/covergenerator.php:63
 msgid "Cover Generator"
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:45
+#: inc/admin/laf/namespace.php:358
 msgid "Saving settings"
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:48
 msgid "Cover generation is not done. Leaving this page, now, will cause problems. Are you sure?"
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:49
+#: inc/admin/laf/namespace.php:334
+#: inc/admin/laf/namespace.php:357
+#: inc/admin/laf/namespace.php:418
+#: inc/admin/laf/namespace.php:630
 msgid "Reload"
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:68
 msgid "Text"
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:86
 msgid "Title (Spine)"
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:97
+#: inc/admin/metaboxes/namespace.php:225
 msgid "Subtitle"
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:119
 msgid "Author (Spine)"
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:130
+#: inc/admin/laf/namespace.php:93
+#: inc/class-activation.php:247
+#: templates/admin/catalog.php:98
 msgid "About"
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:141
 msgid "ISBN"
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:146
 msgid "If you have an ISBN, this will generate a barcode on the back of your print cover. If you do not have an ISBN, you should leave this field blank."
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:153
 msgid "or SKU"
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:158
 msgid "If you have a 13-digit identifier that is not an ISBN, entering it in this field will generate a barcode with that number on the back of your print cover. If you do not have a non-ISBN identifier, you should leave this field blank."
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:165
 msgid "Design"
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:172
 msgid "Front Cover Background Image"
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:180
 msgid "Book Title Case"
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:193
 msgid "Spine Size"
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:200
 msgid "Page Count"
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:211
 msgid "Paper Type"
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:225
 msgid "Custom PPI"
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:236
 msgid "Text and Background Colors"
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:243
 msgid "Front Cover Text"
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:254
 msgid "Front Cover Background"
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:265
 msgid "Spine Text"
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:276
 msgid "Spine Background"
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:287
 msgid "Back Cover Text"
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:298
 msgid "Back Cover Background"
 msgstr ""
 
 #. translators: %s: URL to Book Information page
+#: inc/admin/covergenerator/namespace.php:329
 msgid "The text below is pulled from your <a href=\"%s\">Book Information</a> page, and is used to generate your cover(s). You can reformat the text below as needed. (<strong>IMPORTANT NOTE:</strong> Changes you make here will <strong>NOT</strong> be reflected on the Book Information page.)"
 msgstr ""
 
 #. translators: %s: URL to Appearance menu
+#: inc/admin/covergenerator/namespace.php:442
 msgid "Below you can make small adjustments to the design of your cover. The look and feel of the cover will echo the theme you have chosen for your book. You can change your book theme in the <a href=\"%s\">Appearance</a> menu."
 msgstr ""
 
 #. translators: 1: pdf page width, 2: pdf page height, 3: URL to Theme Options page
+#: inc/admin/covergenerator/namespace.php:449
 msgid "Your PDF page size is set to %1$s &times; %2$s, and your PDF cover will be generated with the same dimensions. You can change the PDF page size in the <a href=\"%3$s\">Theme Options</a> menu."
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:458
+#: templates/admin/export.blade.php:57
 msgid "Change Theme"
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:459
 msgid "Options"
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:462
 msgid "You can upload a background image here."
 msgstr ""
 
 #. translators: 1: minimum width, 2: minimum height, 3: aspect ratio width, 4: aspect ratio height
+#: inc/admin/covergenerator/namespace.php:496
 msgid "Your image must be at least %1$s pixels in width by %2$s pixels in height, with an aspect ratio of %3$s to %4$s."
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:499
 msgid "Delete Background Image"
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:521
 msgid "Spine size is calculated based on the number of pages in your book, and the weight of the paper used in printing."
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:527
 msgid "You haven't exported any PDF copies of your book, so you will need to enter a page count below."
 msgstr ""
 
 #. translators: %s: number of pages in pdf
+#: inc/admin/covergenerator/namespace.php:530
 msgid "The last PDF you exported has %s pages (you can edit this below if you like)."
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:534
 msgid "We can calculate the spine size based on CreateSpace and Ingram specifications, or you can enter your own custom pages per inch (PPI) defined by your printer."
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:567
+#: inc/modules/themeoptions/class-pdfoptions.php:159
+#: inc/modules/themeoptions/class-pdfoptions.php:380
+#: inc/modules/themeoptions/class-pdfoptions.php:399
+#: inc/modules/themeoptions/class-pdfoptions.php:418
+#: inc/modules/themeoptions/class-pdfoptions.php:437
+#: inc/modules/themeoptions/class-pdfoptions.php:455
+#: inc/modules/themeoptions/class-pdfoptions.php:473
+#: inc/modules/themeoptions/class-pdfoptions.php:494
+#: inc/modules/themeoptions/class-pdfoptions.php:515
+#: inc/modules/themeoptions/class-pdfoptions.php:534
+#: inc/modules/themeoptions/class-pdfoptions.php:553
 msgid "Custom&hellip;"
 msgstr ""
 
+#: inc/admin/covergenerator/namespace.php:585
 msgid "Choose text color and background colors below."
 msgstr ""
 
 #. translators: 1: minimum width, 2: minimum height, 3: image width 4: image height
+#: inc/admin/covergenerator/namespace.php:750
 msgid "Your image is too small. The image must be %1$d by %2$d pixels. Your image is %3$d by %4$d pixels."
 msgstr ""
 
 #. translators: 1: pdf page width, 2: pdf page height
+#: inc/admin/covergenerator/namespace.php:760
 msgid "Your image is the wrong aspect ratio. The image must have an aspect ratio of %1$s to %2$s."
 msgstr ""
 
+#: inc/admin/dashboard/namespace.php:22
 msgid "Pressbooks News"
 msgstr ""
 
+#: inc/admin/dashboard/namespace.php:94
+#: inc/admin/dashboard/namespace.php:177
 msgid "Book Permissions"
 msgstr ""
 
+#: inc/admin/dashboard/namespace.php:134
 msgid "My Book"
 msgstr ""
 
+#: inc/admin/dashboard/namespace.php:135
+#: inc/admin/laf/namespace.php:795
 msgid "Users"
 msgstr ""
 
+#: inc/admin/dashboard/namespace.php:193
 msgid "Book Invitations"
 msgstr ""
 
+#: inc/admin/dashboard/namespace.php:219
 msgid "You have been invited to join <a href=\"%1$s\">%2$s</a> as %3$s %4$s"
 msgstr ""
 
+#: inc/admin/dashboard/namespace.php:229
 msgid "Accept"
 msgstr ""
 
+#: inc/admin/dashboard/namespace.php:242
 msgid "Welcome to Pressbooks!"
 msgstr ""
 
+#: inc/admin/dashboard/namespace.php:245
 msgid "You do not have access to any books at the moment."
 msgstr ""
 
+#: inc/admin/dashboard/namespace.php:252
 msgid "This network does not allow users to create new books. To create a new book, please contact your Pressbooks Network Manager"
 msgstr ""
 
+#: inc/admin/dashboard/namespace.php:254
+#: inc/admin/dashboard/namespace.php:270
 msgid "at"
 msgstr ""
 
+#: inc/admin/dashboard/namespace.php:261
 msgid "Create a Book"
 msgstr ""
 
+#: inc/admin/dashboard/namespace.php:263
+#: inc/admin/laf/namespace.php:409
+#: inc/admin/laf/namespace.php:616
+#: inc/admin/laf/namespace.php:617
+#: templates/admin/cloner.php:13
 msgid "Clone a Book"
 msgstr ""
 
+#: inc/admin/dashboard/namespace.php:268
 msgid "You can also request access to an existing book by contacting the book's author or the institution's Pressbooks Network Manager"
 msgstr ""
 
+#: inc/admin/dashboard/namespace.php:284
+#: inc/class-activation.php:242
+#: inc/modules/themeoptions/class-pdfoptions.php:287
+#: tests/test-cloner.php:63
+#: templates/export/epub/toc.blade.php:13
 msgid "Table of Contents"
 msgstr ""
 
+#: inc/admin/dashboard/namespace.php:286
+#: inc/admin/metaboxes/namespace.php:649
+#: inc/api/endpoints/controller/class-toc.php:192
+#: inc/posttype/namespace.php:115
+#: inc/posttype/namespace.php:116
+#: inc/posttype/namespace.php:548
+#: templates/admin/import.php:91
+#: templates/admin/organize.php:64
+#: templates/admin/organize.php:87
 msgid "Front Matter"
 msgstr ""
 
+#: inc/admin/dashboard/namespace.php:327
+#: inc/admin/metaboxes/namespace.php:651
+#: inc/api/endpoints/controller/class-toc.php:225
+#: inc/posttype/namespace.php:143
+#: inc/posttype/namespace.php:144
+#: inc/posttype/namespace.php:551
+#: templates/admin/import.php:96
+#: templates/admin/organize.php:66
+#: templates/admin/organize.php:95
 msgid "Back Matter"
 msgstr ""
 
+#: inc/admin/dashboard/namespace.php:346
+#: inc/admin/dashboard/namespace.php:434
+#: templates/admin/organize.php:272
+#: templates/admin/organize.php:429
 msgid "Add"
 msgstr ""
 
+#: inc/admin/dashboard/namespace.php:346
+#: inc/admin/dashboard/namespace.php:434
+#: inc/admin/laf/namespace.php:148
 msgid "Organize"
 msgstr ""
 
+#: inc/admin/dashboard/namespace.php:420
 msgid "%1$s total users: "
 msgstr ""
 
+#: inc/admin/dashboard/namespace.php:443
+#: inc/admin/dashboard/namespace.php:444
+#: inc/admin/laf/namespace.php:779
+#: inc/admin/laf/namespace.php:854
 msgid "Dashboard"
 msgstr ""
 
+#: inc/admin/dashboard/namespace.php:493
 msgid "Dashboard Feed"
 msgstr ""
 
+#: inc/admin/dashboard/namespace.php:500
 msgid "Display Feed"
 msgstr ""
 
+#: inc/admin/dashboard/namespace.php:505
 msgid "Display an RSS feed widget on the dashboard."
 msgstr ""
 
+#: inc/admin/dashboard/namespace.php:511
 msgid "Feed Title"
 msgstr ""
 
+#: inc/admin/dashboard/namespace.php:519
 msgid "Feed URL"
 msgstr ""
 
+#: inc/admin/dashboard/namespace.php:546
 msgid "Adjust settings for your dashboard RSS feed widget below."
 msgstr ""
 
+#: inc/admin/delete/class-book.php:52
 msgid "Delete Book"
 msgstr ""
 
 #. translators: Do not translate USERNAME, URL_DELETE, SITE_NAME: those are placeholders.
+#: inc/admin/delete/class-book.php:66
 msgid ""
 "Howdy ###USERNAME###,\n"
 "\n"
@@ -498,2807 +737,4038 @@ msgid ""
 "###SITE_NAME###"
 msgstr ""
 
+#: inc/admin/diagnostics/namespace.php:33
+#: inc/admin/diagnostics/namespace.php:34
+#: inc/admin/laf/namespace.php:108
+#: templates/admin/diagnostics.blade.php:4
 msgid "Diagnostics"
 msgstr ""
 
+#: inc/admin/diagnostics/namespace.php:199
 msgid "Stylesheet regenerated."
 msgstr ""
 
+#: inc/admin/laf/namespace.php:74
+#: inc/admin/laf/namespace.php:739
 msgid "Contact"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:83
 msgid "Powered by %s"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:103
 msgid "Guides and Tutorials"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:113
+#: templates/admin/sitemap.blade.php:2
 msgid "Site Map"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:163
 msgid "private"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:164
 msgid "public"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:166
 msgid "Updating book."
 msgstr ""
 
+#: inc/admin/laf/namespace.php:167
 msgid "Updating chapters."
 msgstr ""
 
+#: inc/admin/laf/namespace.php:168
 msgid "Updating part."
 msgstr ""
 
+#: inc/admin/laf/namespace.php:169
 msgid "Updating front matter."
 msgstr ""
 
+#: inc/admin/laf/namespace.php:170
 msgid "Updating back matter."
 msgstr ""
 
+#: inc/admin/laf/namespace.php:173
 msgid "The book has been successfully updated!"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:174
 msgid "The chapters has been successfully updated!"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:175
 msgid "The part has been successfully updated!"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:176
 msgid "The front matter has been successfully updated!"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:177
 msgid "The back matter has been successfully updated!"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:180
 msgid "Sorry, the book could not be updated.!"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:181
 msgid "Sorry, the chapters could not be updated."
 msgstr ""
 
+#: inc/admin/laf/namespace.php:182
 msgid "Sorry, the part could not be updated."
 msgstr ""
 
+#: inc/admin/laf/namespace.php:183
 msgid "Sorry, the front matter could not be updated."
 msgstr ""
 
+#: inc/admin/laf/namespace.php:184
 msgid "Sorry, the back matter could not be updated."
 msgstr ""
 
+#: inc/admin/laf/namespace.php:194
+#: inc/admin/laf/namespace.php:195
+#: templates/admin/organize.php:74
+#: templates/admin/organize.php:283
 msgid "Add Part"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:202
+#: inc/admin/laf/namespace.php:203
+#: templates/admin/organize.php:73
 msgid "Add Chapter"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:210
+#: inc/admin/laf/namespace.php:211
+#: templates/admin/organize.php:71
 msgid "Add Front Matter"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:218
+#: inc/admin/laf/namespace.php:219
+#: templates/admin/organize.php:72
 msgid "Add Back Matter"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:226
+#: inc/admin/laf/namespace.php:227
+#: inc/editor/namespace.php:146
+#: inc/posttype/namespace.php:195
 msgid "Glossary Terms"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:234
+#: inc/admin/laf/namespace.php:235
 msgid "Chapter Types"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:242
+#: inc/admin/laf/namespace.php:243
 msgid "Front Matter Types"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:250
+#: inc/admin/laf/namespace.php:251
 msgid "Back Matter Types"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:258
+#: inc/admin/laf/namespace.php:259
 msgid "Glossary Types"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:285
+#: inc/modules/import/wordpress/class-wxr.php:542
+#: inc/posttype/namespace.php:151
 msgid "Book Info"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:297
 msgid "Choose institution(s)... "
 msgstr ""
 
+#: inc/admin/laf/namespace.php:298
 msgid "Choose a subject…"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:299
 msgid "Choose some subject(s)…"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:309
+#: inc/admin/laf/namespace.php:310
 msgid "Contributors"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:316
+#: inc/admin/laf/namespace.php:394
+#: templates/admin/organize.php:70
+#: templates/admin/export.blade.php:11
 msgid "Export"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:329
 msgid "Are you sure you want to delete these export files?"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:330
 msgid "Up to 5 files can be pinned at once."
 msgstr ""
 
+#: inc/admin/laf/namespace.php:331
 msgid "Cannot pin more than 3 of the same file type."
 msgstr ""
 
+#: inc/admin/laf/namespace.php:335
 msgid "Too many pinned files. Deselect one of the pinned files before attempting to export."
 msgstr ""
 
+#: inc/admin/laf/namespace.php:336
 msgid "Exports are not done. Leaving this page, now, will cause problems. Are you sure?"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:348
+#: inc/utility/class-handlestransfers.php:88
+#: templates/admin/import.php:38
+#: templates/admin/import.php:114
 msgid "Import"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:356
 msgid "Imports are not done. Leaving this page, now, will cause problems. Are you sure?"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:381
+#: inc/admin/laf/namespace.php:577
+#: inc/admin/laf/namespace.php:1469
+#: inc/admin/network/class-sharingandprivacyoptions.php:459
 msgid "Sharing and Privacy Settings"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:381
+#: inc/admin/laf/namespace.php:577
 msgid "Sharing &amp; Privacy"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:399
+#: inc/admin/laf/namespace.php:400
 msgid "QuickLaTeX"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:417
+#: inc/admin/laf/namespace.php:629
 msgid "Cloning is not done. Leaving this page, now, will cause problems. Are you sure?"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:692
+#: inc/admin/laf/namespace.php:703
 msgid "About Pressbooks"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:714
 msgid "Pressbooks.com"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:724
 msgid "Help"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:768
 msgid "Network Admin"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:787
+#: inc/admin/laf/namespace.php:1524
+#: inc/admin/laf/namespace.php:1534
 msgid "Books"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:804
 msgid "Themes"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:812
 msgid "Plugins"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:862
 msgid "Visit Website"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:872
 msgid "My Books"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:892
 msgid "Create A New Book"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:904
 msgid "Clone A Book"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:1126
 msgid "Are you sure you want to unlock your theme? This will update your book to the most recent version of your selected theme, which may change your book&rsquo;s appearance and page count. Once you save your settings on this page, this action will NOT be reversable!"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:1189
 msgid "Book Visibility"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:1203
 msgid "Private Content"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:1216
 msgid "Disable Comments"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:1231
 msgid "Share Latest Export Files"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:1261
+#: templates/admin/cloner.php:14
 msgid "Pressbooks Directory"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:1278
 msgid "Sharing and Privacy settings"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:1293
 msgid "Public. I would like this book to be visible to everyone."
 msgstr ""
 
+#: inc/admin/laf/namespace.php:1299
 msgid "Private. I would like this book to be accessible only to people I invite."
 msgstr ""
 
+#: inc/admin/laf/namespace.php:1323
 msgid "Who can see private front matter, chapters and back matter?"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:1326
 msgid "Only logged in editors and administrators."
 msgstr ""
 
+#: inc/admin/laf/namespace.php:1328
 msgid "All logged in users including subscribers."
 msgstr ""
 
+#: inc/admin/laf/namespace.php:1349
 msgid "Yes. I want to automatically disable comments, trackbacks and pingbacks on all front matter, chapters and back matter."
 msgstr ""
 
+#: inc/admin/laf/namespace.php:1355
 msgid "No. I want to leave comments, trackbacks and pingbacks enabled on all front matter, chapters and back matter unless I disable them manually."
 msgstr ""
 
+#: inc/admin/laf/namespace.php:1371
 msgid "Yes. I would like the latest export files to be available on the homepage for free, to everyone."
 msgstr ""
 
+#: inc/admin/laf/namespace.php:1377
 msgid "No. I would like the latest export files to only be available to administrators."
 msgstr ""
 
+#: inc/admin/laf/namespace.php:1396
 msgid "Yes. I want this book to be listed in the Pressbooks directory."
 msgstr ""
 
+#: inc/admin/laf/namespace.php:1402
 msgid "No. Exclude this book from the Pressbooks directory."
 msgstr ""
 
+#: inc/admin/laf/namespace.php:1527
 msgid "All Books"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:1537
 msgid "Search Books"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:1543
 msgid "Edit Book: %s"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:1546
+#: inc/admin/laf/namespace.php:1555
 msgid "Book Address (URL)"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:1552
 msgid "Add New Book"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:1558
+#: inc/modules/themeoptions/class-pdfoptions.php:373
+#: inc/modules/themeoptions/class-pdfoptions.php:392
+#: inc/modules/themeoptions/class-pdfoptions.php:411
+#: inc/modules/themeoptions/class-pdfoptions.php:430
+#: inc/modules/themeoptions/class-pdfoptions.php:449
+#: inc/modules/themeoptions/class-pdfoptions.php:467
+#: inc/modules/themeoptions/class-pdfoptions.php:485
+#: inc/modules/themeoptions/class-pdfoptions.php:506
+#: inc/modules/themeoptions/class-pdfoptions.php:527
+#: inc/modules/themeoptions/class-pdfoptions.php:546
 msgid "Book Title"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:1561
 msgid "Book Language"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:1564
 msgid "Add Book"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:1581
 msgid "Edit previous or next item"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:1586
 msgid "Edit Previous (%s)"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:1591
 msgid "Edit Next (%s)"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:1606
 msgid "Twitter URL"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:1607
 msgid "LinkedIn URL"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:1608
 msgid "GitHub URL"
 msgstr ""
 
+#: inc/admin/laf/namespace.php:1654
 msgid "Your institutional affiliation, e.g. Rebus Foundation, Open University, Amnesty International."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:104
 msgid "Your cover image was not saved because it is too small (%1$s x %2$s). It should be at least 800px in height."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:110
 msgid "Your cover image was not saved because the aspect ratio (%s) is outside the permitted range (.66 to 1). We recommend an aspect ratio of .75."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:135
+#: inc/admin/metaboxes/namespace.php:190
+#: inc/class-metadata.php:437
 msgid "Cover Image"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:176
+#: inc/admin/metaboxes/namespace.php:706
+#: inc/admin/metaboxes/namespace.php:768
+#: inc/api/endpoints/controller/class-toc.php:202
+#: inc/class-sass.php:89
+#: inc/modules/export/epub/class-epub.php:1910
+#: inc/modules/themeoptions/class-globaloptions.php:563
+#: inc/posttype/namespace.php:87
+#: inc/posttype/namespace.php:542
+#: inc/posttype/namespace.php:580
+#: templates/admin/import.php:94
+#: tests/test-posttype.php:261
 msgid "Part"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:180
 msgid "Save Part"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:181
 msgid "Save Book Information"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:182
 msgid "Status & Visibility"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:196
 msgid "General Book Information"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:214
 msgid "Short Title"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:215
 msgid "In case of long titles that might be truncated in running heads in the PDF export."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:235
 msgid "Author(s)"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:239
+#: inc/admin/metaboxes/namespace.php:251
+#: inc/admin/metaboxes/namespace.php:263
+#: inc/admin/metaboxes/namespace.php:275
+#: inc/admin/metaboxes/namespace.php:287
+#: inc/admin/metaboxes/namespace.php:299
+#: inc/admin/metaboxes/namespace.php:680
 msgid "Create New Contributor"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:240
+#: inc/admin/metaboxes/namespace.php:681
 msgid "Choose author(s)..."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:247
 msgid "Editor(s)"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:252
 msgid "Choose editor(s)..."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:259
 msgid "Translator(s)"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:264
 msgid "Choose translator(s)..."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:271
 msgid "Reviewer(s)"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:276
 msgid "Choose reviewer(s)..."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:283
 msgid "Illustrator(s)"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:288
 msgid "Choose illustrator(s)..."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:295
 msgid "Contributor(s)"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:300
 msgid "Choose contributor(s)..."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:307
 msgid "Publisher"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:308
+#: inc/admin/metaboxes/namespace.php:319
 msgid "This text appears on the title page of your book."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:318
 msgid "Publisher City"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:330
 msgid "Publication Date"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:331
+#: inc/admin/metaboxes/namespace.php:341
 msgid "This is added to the metadata in your ebook. Please write date in YYYY-MM-DD format."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:340
 msgid "On-Sale Date"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:349
 msgid "Ebook ISBN"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:350
 msgid "ISBN is the International Standard Book Number, and you'll need one if you want to sell your book in some online ebook stores. This is added to the metadata in your ebook."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:360
 msgid "Print ISBN"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:361
 msgid "ISBN is the International Standard Book Number, and you'll need one if you want to sell your book in online and physical book stores."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:371
 msgid "Digital Object Identifier (DOI)"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:383
 msgid "Language"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:384
 msgid "This sets metadata in your ebook, making it easier to find in some stores. It also changes some system generated content for supported languages, such as the \"Contents\" header."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:384
 msgid "Help translate Pressbooks into your language!"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:391
+#: inc/class-licensing.php:321
+#: inc/modules/export/epub/class-epub.php:1401
+#: inc/modules/export/epub/class-epub.php:1423
+#: inc/modules/export/htmlbook/class-htmlbook.php:855
+#: inc/modules/export/xhtml/class-xhtml11.php:1074
 msgid "Copyright"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:404
+#: templates/admin/cloner.php:19
 msgid "Source Book URL"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:406
 msgid "This book was cloned from a pre-existing book at the above URL. This information will be displayed on the webbook homepage."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:416
 msgid "Copyright Year"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:417
 msgid "Year that the book is/was published."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:429
 msgid "Copyright Holder"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:430
 msgid "Name of the copyright holder."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:442
 msgid "Copyright License"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:443
 msgid "You can select various licenses including Creative Commons."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:451
 msgid "Copyright Notice"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:452
 msgid "Enter a custom copyright notice, with whatever information you like. This will override the auto-generated copyright notice if All Rights Reserved or no license is selected, and will be inserted after the title page. If you select a Creative Commons license, the custom notice will appear after the license text in both the webbook and your exports."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:461
 msgid "About the Book"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:469
 msgid "Book Tagline"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:470
 msgid "A very short description of your book. It should fit in a Twitter post, and encapsulate your book in the briefest sentence."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:481
 msgid "Short Description"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:482
 msgid "A short paragraph about your book, for catalogs, reviewers etc. to quote."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:493
 msgid "Long Description"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:494
 msgid "The full description of your book."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:501
 msgid "Subject(s)"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:503
+#: templates/admin/institutions.blade.php:2
 msgid "Institutions"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:508
 msgid "Additional Catalog Information"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:516
 msgid "Series Title"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:517
+#: inc/admin/metaboxes/namespace.php:528
 msgid "Add if your book is part of a series."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:527
 msgid "Series Number"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:538
 msgid "Keywords"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:540
 msgid "These are added to your webbook cover page, and in your ebook metadata. Keywords are used by online book stores and search engines."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:547
 msgid "Hashtag"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:548
 msgid "These are added to your webbook cover page. For those of you who like Twitter."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:558
 msgid "List Price (Print)"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:559
 msgid "The list price of your book in print."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:569
 msgid "List Price (PDF)"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:570
 msgid "The list price of your book in PDF format."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:580
 msgid "List Price (ebook)"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:581
 msgid "The list price of your book in Ebook formats."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:591
 msgid "List Price (Web)"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:592
 msgid "The list price of your webbook."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:604
 msgid "Choose an audience&hellip;"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:605
 msgid "Juvenile"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:606
 msgid "Young Adult"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:607
 msgid "Adult"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:609
 msgid "Audience"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:610
 msgid "The target audience for your book."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:623
 msgid "BISAC Subject(s)"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:625
 msgid "BISAC Subject Headings help libraries and bookstores properly classify your book. To select the appropriate subject heading for your book, consult %s."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:625
 msgid "the BISAC Subject Headings list"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:639
 msgid "BISAC Regional Theme"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:640
 msgid "BISAC Regional Themes help libraries and bookstores properly classify your book."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:650
+#: inc/api/endpoints/controller/class-toc.php:209
+#: inc/class-sass.php:78
+#: inc/modules/themeoptions/class-globaloptions.php:564
+#: inc/posttype/namespace.php:64
+#: inc/posttype/namespace.php:545
+#: inc/posttype/namespace.php:584
+#: templates/admin/import.php:92
+#: templates/admin/organize.php:91
 msgid "Chapter"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:655
 msgid "%s Metadata"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:662
 msgid "%s Short Title (appears in the PDF running header and webbook navigation)"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:669
 msgid "%s Subtitle (appears in the Web/ebook/PDF output)"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:676
 msgid "%s Author(s)"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:690
 msgid "%s Copyright License (overrides book license on this page)"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:697
 msgid "%s Digital Object Identifier (DOI)"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:717
 msgid "Appears on part page. Parts will not appear if a book has only one part."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:725
 msgid "Part Visibility"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:735
 msgid "Invisible"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:736
 msgid "Hide from table of contents and part numbering."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:890
 msgid "Show in Glossary Lists"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:901
 msgid "Preview"
 msgstr ""
 
 #. translators: accessibility text
+#: inc/admin/metaboxes/namespace.php:903
 msgid "(opens in a new window)"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:912
+#: templates/admin/organize.php:140
+#: templates/admin/organize.php:243
+#: templates/admin/organize.php:299
+#: templates/admin/organize.php:401
 msgid "Show in Web"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:916
 msgid "Require a Password"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:917
 msgid "Password..."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:921
+#: templates/admin/organize.php:148
+#: templates/admin/organize.php:247
+#: templates/admin/organize.php:307
+#: templates/admin/organize.php:405
 msgid "Show in Exports"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:925
+#: templates/admin/organize.php:155
+#: templates/admin/organize.php:251
+#: templates/admin/organize.php:315
+#: templates/admin/organize.php:409
 msgid "Show Title"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:1125
 msgid "Primary Subject"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:1129
 msgid "%1$s subject terms appear on the web homepage of your book and help categorize your book in your network catalog and Pressbooks Directory (if applicable). Use %2$s to determine which subject category is best for your book."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:1129
+#: inc/admin/metaboxes/namespace.php:1142
 msgid "Thema"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:1129
+#: inc/admin/metaboxes/namespace.php:1142
 msgid "the Thema subject category list"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:1132
 msgid "Additional Subject(s)"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:1142
 msgid "%1$s subject terms appear on the web homepage of your book and help categorize your book in your network catalog and Pressbooks Directory (if applicable). Use %2$s to determine which additional subject categories are appropriate for your book."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:1316
+#: inc/admin/metaboxes/namespace.php:1372
 msgid "Images should be square (400px x 400px). You will be allowed to crop images after upload."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:1481
 msgid "Name"
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:1510
 msgid "Name cannot be left blank."
 msgstr ""
 
+#: inc/admin/metaboxes/namespace.php:1544
 msgid "Owner"
 msgstr ""
 
+#: inc/admin/network/class-networksettings.php:59
+#: tests/test-networksettings.php:30
 msgid "Theme Settings"
 msgstr ""
 
+#: inc/admin/network/class-networksettings.php:61
 msgid "Default Theme"
 msgstr ""
 
+#: inc/admin/network/class-sharingandprivacyoptions.php:81
 msgid "Allow Redistribution"
 msgstr ""
 
+#: inc/admin/network/class-sharingandprivacyoptions.php:87
 msgid "Allow book administrators to enable redistribution of export files."
 msgstr ""
 
+#: inc/admin/network/class-sharingandprivacyoptions.php:93
 msgid "Enable network API"
 msgstr ""
 
+#: inc/admin/network/class-sharingandprivacyoptions.php:99
 msgid "Enable access to your network of books via the Pressbooks REST API."
 msgstr ""
 
+#: inc/admin/network/class-sharingandprivacyoptions.php:105
 msgid "Enable Cloning"
 msgstr ""
 
+#: inc/admin/network/class-sharingandprivacyoptions.php:111
 msgid "Enable book cloning via the Pressbooks REST API."
 msgstr ""
 
+#: inc/admin/network/class-sharingandprivacyoptions.php:117
 msgid "Enable CC with Weblinks"
 msgstr ""
 
+#: inc/admin/network/class-sharingandprivacyoptions.php:123
 msgid "Allow users to produce Common Cartridge exports with simple Web Links."
 msgstr ""
 
+#: inc/admin/network/class-sharingandprivacyoptions.php:129
 msgid "Book directory"
 msgstr ""
 
+#: inc/admin/network/class-sharingandprivacyoptions.php:135
 msgid "Exclude non-catalogued public books from Pressbooks Directory."
 msgstr ""
 
+#: inc/admin/network/class-sharingandprivacyoptions.php:141
 msgid "Iframe Allowlist"
 msgstr ""
 
+#: inc/admin/network/class-sharingandprivacyoptions.php:146
 msgid "To allowlist all content from a domain: <code>guide.pressbooks.com</code> To allowlist a path: <code>//guide.pressbooks.com/some/path/</code> One per line."
 msgstr ""
 
+#: inc/admin/network/class-sharingandprivacyoptions.php:162
 msgid "Sharing and Privacy settings."
 msgstr ""
 
+#: inc/admin/networkmanagers/namespace.php:21
+#: inc/admin/networkmanagers/namespace.php:22
 msgid "Network Managers"
 msgstr ""
 
+#: inc/admin/networkmanagers/namespace.php:116
 msgid "Pressbooks Network Managers"
 msgstr ""
 
+#: inc/admin/networkmanagers/namespace.php:118
 msgid "Network administrators&rsquo; access to network administration menus can be restricted to leave only sites and users visible to them."
 msgstr ""
 
+#: inc/admin/plugins/namespace.php:94
 msgid "Please be advised that any content provided via a remote third-party service, like WP QuickLaTeX, may not be trustworthy. The WP QuickLaTeX plugin also includes an advanced setting which allows users to create and display SVG files, a format that may carry a higher security risk than other image formats."
 msgstr ""
 
+#: inc/admin/users/class-userbulk.php:66
+#: inc/admin/users/class-userbulk.php:67
 msgid "Bulk Add"
 msgstr ""
 
+#: inc/admin/users/class-userbulk.php:169
 msgid "Invalid email address"
 msgstr ""
 
+#: inc/admin/users/class-userbulk.php:243
 msgid "The following user(s) could not be added."
 msgstr ""
 
+#: inc/admin/users/class-userbulk.php:246
 msgid "User(s) successfully added to this book."
 msgstr ""
 
+#: inc/admin/users/class-userbulk.php:249
 msgid "An invitation email has been sent to the user(s) below. A confirmation link must be clicked before their account is created."
 msgstr ""
 
+#: inc/api/endpoints/controller/class-books.php:127
+#: inc/api/endpoints/controller/class-toc.php:151
+#: inc/api/endpoints/controller/class-toc.php:164
+#: inc/api/endpoints/controller/class-toc.php:177
 msgid "Metadata"
 msgstr ""
 
+#: inc/api/endpoints/controller/class-books.php:153
 msgid "ID offset, overrides page."
 msgstr ""
 
+#: inc/api/endpoints/controller/class-metadata.php:549
+#: inc/api/endpoints/controller/class-sectionmetadata.php:453
 msgid "URL of a reference Web page that unambiguously indicates the item's identity."
 msgstr ""
 
+#: inc/api/endpoints/controller/class-toc.php:98
 msgid "Comment count"
 msgstr ""
 
+#: inc/api/endpoints/controller/class-toc.php:123
 msgid "Include in exports."
 msgstr ""
 
+#: inc/api/endpoints/controller/class-toc.php:129
 msgid "Has post content, the content field is not empty."
 msgstr ""
 
+#: inc/api/endpoints/controller/class-toc.php:134
 msgid "Word count."
 msgstr ""
 
+#: inc/api/namespace.php:77
 msgid "Part ID."
 msgstr ""
 
+#: inc/api/namespace.php:201
 msgid "Invalid batch parameter(s)."
 msgstr ""
 
+#: inc/api/namespace.php:356
 msgid "Part does not exist"
 msgstr ""
 
+#: inc/api/namespace.php:363
 msgid "ID is not a part"
 msgstr ""
 
+#: inc/api/namespace.php:377
 msgid "Failed to update chapter part"
 msgstr ""
 
+#: inc/class-activation.php:204
 msgid "Main Body"
 msgstr ""
 
+#: inc/class-activation.php:210
+#: tests/test-book.php:51
 msgid "Introduction"
 msgstr ""
 
+#: inc/class-activation.php:212
+#: tests/test-book.php:102
 msgid "This is where you can write your introduction."
 msgstr ""
 
+#: inc/class-activation.php:217
 msgid "Chapter 1"
 msgstr ""
 
+#: inc/class-activation.php:219
 msgid "This is the first chapter in the main body of the text. You can change the text, rename the chapter, add new chapters, and add new parts."
 msgstr ""
 
+#: inc/class-activation.php:224
 msgid "Appendix"
 msgstr ""
 
+#: inc/class-activation.php:226
 msgid "This is where you can add appendices or other back matter."
 msgstr ""
 
+#: inc/class-activation.php:232
+#: templates/admin/organize.php:129
+#: templates/admin/organize.php:216
+#: templates/admin/organize.php:290
+#: templates/admin/organize.php:375
+#: tests/test-cloner.php:53
 msgid "Authors"
 msgstr ""
 
+#: inc/class-activation.php:252
 msgid "Buy"
 msgstr ""
 
+#: inc/class-activation.php:257
 msgid "Access Denied"
 msgstr ""
 
+#: inc/class-activation.php:259
 msgid "This book is private, and accessible only to registered users. If you have an account you can login <a href=\"/wp-login.php\">here</a>. You can also set up your own Pressbooks book at: <a href=\"http://pressbooks.com\">Pressbooks.com</a>."
 msgstr ""
 
+#: inc/class-activation.php:264
+#: inc/class-customcss.php:91
 msgid "Custom CSS for Ebook"
 msgstr ""
 
+#: inc/class-activation.php:269
+#: inc/class-customcss.php:96
 msgid "Custom CSS for PDF"
 msgstr ""
 
+#: inc/class-activation.php:274
+#: inc/class-customcss.php:101
 msgid "Custom CSS for Web"
 msgstr ""
 
+#: inc/class-activation.php:280
+#: inc/posttype/namespace.php:165
+#: inc/posttype/namespace.php:166
+#: inc/posttype/namespace.php:539
+#: templates/admin/import.php:118
 msgid "Book Information"
 msgstr ""
 
+#: inc/class-activation.php:311
 msgid "Default Data"
 msgstr ""
 
+#: inc/class-catalog.php:803
 msgid "Catalog Logo"
 msgstr ""
 
+#: inc/class-catalog.php:1143
+#: inc/class-catalog.php:1197
+#: inc/class-catalog.php:1244
+#: templates/admin/catalog.php:19
 msgid "You do not have permission to do that."
 msgstr ""
 
+#: inc/class-catalog.php:1290
 msgid "Invalid URL."
 msgstr ""
 
+#: inc/class-catalog.php:1310
 msgid "No book found."
 msgstr ""
 
+#: inc/class-contributors.php:436
 msgid "Prefix"
 msgstr ""
 
+#: inc/class-contributors.php:439
 msgid "Prefix to be displayed before this contributor's name, e.g. Dr., Prof., Ms., Rev., Capt."
 msgstr ""
 
+#: inc/class-contributors.php:443
 msgid "First Name"
 msgstr ""
 
+#: inc/class-contributors.php:449
 msgid "Last Name"
 msgstr ""
 
+#: inc/class-contributors.php:455
 msgid "Suffix"
 msgstr ""
 
+#: inc/class-contributors.php:458
 msgid "Suffix to be displayed after this contributors's name, e.g. Jr., Sr., IV, PhD, MD, USN (Ret.)."
 msgstr ""
 
+#: inc/class-contributors.php:462
 msgid "Picture"
 msgstr ""
 
+#: inc/class-contributors.php:468
 msgid "Biographical Info"
 msgstr ""
 
+#: inc/class-contributors.php:473
 msgid "Institution"
 msgstr ""
 
+#: inc/class-contributors.php:476
 msgid "Institution this contributor is associated with, e.g. Rebus Foundation, Open University, Amnesty International."
 msgstr ""
 
+#: inc/class-contributors.php:483
 msgid "Website for this contributor. Must be a valid URL."
 msgstr ""
 
+#: inc/class-contributors.php:487
 msgid "Twitter"
 msgstr ""
 
+#: inc/class-contributors.php:490
 msgid "Twitter profile for this contributor. Must be a valid URL."
 msgstr ""
 
+#: inc/class-contributors.php:494
 msgid "LinkedIn"
 msgstr ""
 
+#: inc/class-contributors.php:497
 msgid "LinkedIn profile for this contributor. Must be a valid URL."
 msgstr ""
 
+#: inc/class-contributors.php:501
 msgid "GitHub"
 msgstr ""
 
+#: inc/class-contributors.php:504
 msgid "GitHub profile for this contributor. Must be a valid URL."
 msgstr ""
 
+#: inc/class-contributors.php:575
 msgid "<p>Import multiple contributors at once by uploading a valid JSON file. See <a href=\"%s\" target=\"_blank\">our guide</a> for details.</p>"
 msgstr ""
 
+#: inc/class-contributors.php:578
 msgid "Import Contributors"
 msgstr ""
 
+#: inc/class-eventstreams.php:201
 msgid "Cloning succeeded! Cloned %1$s, %2$s, %3$s, %4$s, %5$s, %6$s, %7$s, and %8$s to %9$s."
 msgstr ""
 
+#: inc/class-eventstreams.php:202
 msgid "%s term"
 msgid_plural "%s terms"
 msgstr[0] ""
 msgstr[1] ""
 
+#: inc/class-eventstreams.php:203
+#: inc/modules/import/wordpress/class-wxr.php:416
 msgid "%s front matter"
 msgid_plural "%s front matter"
 msgstr[0] ""
 msgstr[1] ""
 
+#: inc/class-eventstreams.php:204
+#: inc/modules/import/wordpress/class-wxr.php:417
 msgid "%s part"
 msgid_plural "%s parts"
 msgstr[0] ""
 msgstr[1] ""
 
+#: inc/class-eventstreams.php:205
+#: inc/modules/import/wordpress/class-wxr.php:418
 msgid "%s chapter"
 msgid_plural "%s chapters"
 msgstr[0] ""
 msgstr[1] ""
 
+#: inc/class-eventstreams.php:206
+#: inc/modules/import/wordpress/class-wxr.php:419
 msgid "%s back matter"
 msgid_plural "%s back matter"
 msgstr[0] ""
 msgstr[1] ""
 
+#: inc/class-eventstreams.php:207
+#: inc/modules/import/wordpress/class-wxr.php:420
 msgid "%s media attachment"
 msgid_plural "%s media attachments"
 msgstr[0] ""
 msgstr[1] ""
 
+#: inc/class-eventstreams.php:208
 msgid "%s H5P element"
 msgid_plural "%s H5P elements"
 msgstr[0] ""
 msgstr[1] ""
 
+#: inc/class-eventstreams.php:209
+#: inc/modules/import/wordpress/class-wxr.php:421
 msgid "%s glossary term"
 msgid_plural "%s glossary terms"
 msgstr[0] ""
 msgstr[1] ""
 
+#: inc/class-eventstreams.php:216
 msgid " The source book's theme, '%1$s (%2$s)', was not available on this network and could not be applied. Contact your network manager with questions about theme availability."
 msgstr ""
 
+#: inc/class-eventstreams.php:220
 msgid "The source book's theme, theme settings, and custom styles were successfully applied."
 msgstr ""
 
+#: inc/class-eventstreams.php:242
 msgid "No export format was selected."
 msgstr ""
 
+#: inc/class-eventstreams.php:286
 msgid "No chapters were selected for import."
 msgstr ""
 
+#: inc/class-eventstreams.php:310
 msgid "You do not have sufficient permissions to access this page."
 msgstr ""
 
+#: inc/class-globaltypography.php:40
 msgid "Adlam"
 msgstr ""
 
+#: inc/class-globaltypography.php:41
 msgid "Ancient Greek"
 msgstr ""
 
+#: inc/class-globaltypography.php:42
 msgid "Armenian"
 msgstr ""
 
+#: inc/class-globaltypography.php:43
 msgid "Arabic"
 msgstr ""
 
+#: inc/class-globaltypography.php:44
 msgid "Bengali"
 msgstr ""
 
+#: inc/class-globaltypography.php:45
 msgid "Biblical Hebrew"
 msgstr ""
 
+#: inc/class-globaltypography.php:46
 msgid "Canadian Indigenous Syllabics"
 msgstr ""
 
+#: inc/class-globaltypography.php:47
 msgid "Devanagari (Hindi and Sanskrit)"
 msgstr ""
 
+#: inc/class-globaltypography.php:48
 msgid "Chinese (Simplified)"
 msgstr ""
 
+#: inc/class-globaltypography.php:49
 msgid "Chinese (Traditional)"
 msgstr ""
 
+#: inc/class-globaltypography.php:50
 msgid "Coptic"
 msgstr ""
 
+#: inc/class-globaltypography.php:51
 msgid "Gujarati"
 msgstr ""
 
+#: inc/class-globaltypography.php:52
 msgid "Punjabi (Gurmukhi)"
 msgstr ""
 
+#: inc/class-globaltypography.php:53
 msgid "Japanese"
 msgstr ""
 
+#: inc/class-globaltypography.php:54
 msgid "Kannada"
 msgstr ""
 
+#: inc/class-globaltypography.php:55
 msgid "Korean"
 msgstr ""
 
+#: inc/class-globaltypography.php:56
 msgid "Malayalam"
 msgstr ""
 
+#: inc/class-globaltypography.php:57
 msgid "Musical Notation"
 msgstr ""
 
+#: inc/class-globaltypography.php:58
 msgid "N'Ko"
 msgstr ""
 
+#: inc/class-globaltypography.php:59
 msgid "Odia"
 msgstr ""
 
+#: inc/class-globaltypography.php:60
 msgid "Syriac"
 msgstr ""
 
+#: inc/class-globaltypography.php:61
 msgid "Tamil"
 msgstr ""
 
+#: inc/class-globaltypography.php:62
 msgid "Telugu"
 msgstr ""
 
+#: inc/class-globaltypography.php:63
 msgid "Tibetan"
 msgstr ""
 
+#: inc/class-globaltypography.php:64
 msgid "Turkish"
 msgstr ""
 
+#: inc/class-globaltypography.php:445
 msgid "Your %1$s font could not be downloaded from %2$s."
 msgstr ""
 
+#: inc/class-licensing.php:57
 msgid "Public Domain"
 msgstr ""
 
+#: inc/class-licensing.php:67
 msgid "CC0 (Creative Commons Zero)"
 msgstr ""
 
+#: inc/class-licensing.php:77
 msgid "CC BY (Attribution)"
 msgstr ""
 
+#: inc/class-licensing.php:78
 msgid "Creative Commons Attribution 4.0 International License"
 msgstr ""
 
+#: inc/class-licensing.php:88
 msgid "CC BY-SA (Attribution ShareAlike)"
 msgstr ""
 
+#: inc/class-licensing.php:89
 msgid "Creative Commons Attribution-ShareAlike 4.0 International License"
 msgstr ""
 
+#: inc/class-licensing.php:99
 msgid "CC BY-ND (Attribution NoDerivatives)"
 msgstr ""
 
+#: inc/class-licensing.php:100
 msgid "Creative Commons Attribution-NoDerivatives 4.0 International License"
 msgstr ""
 
+#: inc/class-licensing.php:110
 msgid "CC BY-NC (Attribution NonCommercial)"
 msgstr ""
 
+#: inc/class-licensing.php:111
 msgid "Creative Commons Attribution-NonCommercial 4.0 International License"
 msgstr ""
 
+#: inc/class-licensing.php:121
 msgid "CC BY-NC-SA (Attribution NonCommercial ShareAlike)"
 msgstr ""
 
+#: inc/class-licensing.php:122
 msgid "Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License"
 msgstr ""
 
+#: inc/class-licensing.php:132
 msgid "CC BY-NC-ND (Attribution NonCommercial NoDerivatives)"
 msgstr ""
 
+#: inc/class-licensing.php:133
 msgid "Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International License"
 msgstr ""
 
+#: inc/class-licensing.php:139
+#: inc/class-licensing.php:326
 msgid "All Rights Reserved"
 msgstr ""
 
+#: inc/class-licensing.php:205
 msgid "$title is deprecated. Method will automatically determine title from licenses"
 msgstr ""
 
+#: inc/class-licensing.php:323
+#: inc/class-styles.php:818
+#: inc/modules/export/epub/class-epub.php:1410
+#: inc/modules/export/htmlbook/class-htmlbook.php:864
+#: inc/modules/export/xhtml/class-xhtml11.php:1083
+#: templates/export/epub/opf.blade.php:95
 msgid "by"
 msgstr ""
 
+#: inc/class-licensing.php:382
 msgid "except where otherwise noted."
 msgstr ""
 
+#: inc/class-licensing.php:409
+#: inc/class-licensing.php:433
 msgid "%1$s Copyright &copy;%2$s by %3$s. All Rights Reserved."
 msgstr ""
 
+#: inc/class-licensing.php:421
 msgid "Icon for the %s"
 msgstr ""
 
+#: inc/class-licensing.php:423
 msgid "%1$s by %2$s is licensed under a %3$s, except where otherwise noted."
 msgstr ""
 
+#: inc/class-licensing.php:442
+#: inc/class-licensing.php:452
 msgid "Icon for the %s license"
 msgstr ""
 
+#: inc/class-licensing.php:444
 msgid "This work (%1$s by %2$s) is free of known copyright restrictions."
 msgstr ""
 
+#: inc/class-mathjax.php:162
+#: inc/class-mathjax.php:163
+#: templates/admin/mathjax.blade.php:2
 msgid "MathJax"
 msgstr ""
 
+#: inc/class-mathjax.php:183
 msgid "<code>PB_MATHJAX_URL</code> is not configured."
 msgstr ""
 
+#: inc/class-sass.php:197
 msgid "There was a problem with SASS. Contact your site administrator. Error: %1$s %2$s"
 msgstr ""
 
+#: inc/class-styles.php:96
+#: templates/admin/custom-styles.php:38
 msgid "Custom Styles"
 msgstr ""
 
+#: inc/class-styles.php:118
 msgid "Custom Style for Ebook"
 msgstr ""
 
+#: inc/class-styles.php:123
 msgid "Custom Style for PDF"
 msgstr ""
 
+#: inc/class-styles.php:128
 msgid "Custom Style for Web"
 msgstr ""
 
+#: inc/class-styles.php:670
 msgid "Alegreya"
 msgstr ""
 
+#: inc/class-styles.php:671
 msgid "Cormorant Garamond"
 msgstr ""
 
+#: inc/class-styles.php:672
 msgid "Crimson Text"
 msgstr ""
 
+#: inc/class-styles.php:673
 msgid "GNU FreeFont Serif"
 msgstr ""
 
+#: inc/class-styles.php:674
 msgid "New Athena Unicode"
 msgstr ""
 
+#: inc/class-styles.php:675
 msgid "Noto Serif"
 msgstr ""
 
+#: inc/class-styles.php:676
 msgid "Sorts Mill Goudy"
 msgstr ""
 
+#: inc/class-styles.php:677
 msgid "Spectral"
 msgstr ""
 
+#: inc/class-styles.php:681
 msgid "Barlow"
 msgstr ""
 
+#: inc/class-styles.php:682
 msgid "GNU FreeFont Sans"
 msgstr ""
 
+#: inc/class-styles.php:683
 msgid "K2D"
 msgstr ""
 
+#: inc/class-styles.php:684
 msgid "Lato"
 msgstr ""
 
+#: inc/class-styles.php:685
 msgid "Libre Franklin"
 msgstr ""
 
+#: inc/class-styles.php:686
 msgid "Montserrat"
 msgstr ""
 
+#: inc/class-styles.php:687
 msgid "Noto Sans"
 msgstr ""
 
+#: inc/class-styles.php:688
 msgid "Open Sans"
 msgstr ""
 
+#: inc/class-styles.php:689
 msgid "Raleway"
 msgstr ""
 
+#: inc/class-styles.php:690
 msgid "Roboto"
 msgstr ""
 
+#: inc/class-styles.php:691
 msgid "Rubik"
 msgstr ""
 
+#: inc/class-styles.php:692
 msgid "Source Sans Pro"
 msgstr ""
 
+#: inc/class-styles.php:696
+#: tests/test-styles.php:219
 msgid "Theme default"
 msgstr ""
 
+#: inc/class-styles.php:697
+#: inc/class-styles.php:711
+#: tests/test-styles.php:220
 msgid "Serif"
 msgstr ""
 
+#: inc/class-styles.php:698
+#: tests/test-styles.php:221
 msgid "Sans serif"
 msgstr ""
 
+#: inc/class-styles.php:743
 msgid "Unexpected Error: There was a problem trying to query slug: %s - Please contact technical support."
 msgstr ""
 
+#: inc/class-styles.php:783
+#: templates/admin/custom-styles.php:16
 msgid "Web"
 msgstr ""
 
+#: inc/class-styles.php:815
 msgid "Last 10 Revisions"
 msgstr ""
 
+#: inc/cloner/class-cloner.php:435
+#: inc/modules/import/api/class-api.php:115
 msgid "Looking up the source book"
 msgstr ""
 
+#: inc/cloner/class-cloner.php:437
 msgid "Failed to setup source"
 msgstr ""
 
+#: inc/cloner/class-cloner.php:441
 msgid "Creating the target book"
 msgstr ""
 
+#: inc/cloner/class-cloner.php:452
 msgid "Cloning metadata"
 msgstr ""
 
+#: inc/cloner/class-cloner.php:459
 msgid "Cloning contributors and licenses"
 msgstr ""
 
+#: inc/cloner/class-cloner.php:470
 msgid "Cloning front matter"
 msgstr ""
 
+#: inc/cloner/class-cloner.php:485
+#: inc/cloner/class-cloner.php:491
 msgid "Cloning parts and chapters"
 msgstr ""
 
+#: inc/cloner/class-cloner.php:504
 msgid "Cloning back matter"
 msgstr ""
 
+#: inc/cloner/class-cloner.php:536
+#: inc/covergenerator/class-generator.php:298
+#: inc/modules/export/epub/class-epub.php:664
+#: inc/modules/import/class-import.php:373
 msgid "Finishing up"
 msgstr ""
 
+#: inc/cloner/class-cloner.php:552
 msgid "You can only clone from a book hosted by Pressbooks 4.1 or later. Please ensure that your source book meets these requirements."
 msgstr ""
 
+#: inc/cloner/class-cloner.php:559
 msgid "Could not retrieve metadata from %s."
 msgstr ""
 
+#: inc/cloner/class-cloner.php:567
 msgid "%s is not licensed for cloning."
 msgstr ""
 
+#: inc/cloner/class-cloner.php:576
 msgid "Could not retrieve contents and structure from %s."
 msgstr ""
 
+#: inc/cloner/class-cloner.php:584
 msgid "Could not retrieve taxonomies from %s."
 msgstr ""
 
+#: inc/cloner/class-cloner.php:592
 msgid "Could not retrieve media from %s."
 msgstr ""
 
+#: inc/cloner/class-cloner.php:767
 msgid "The source book contained H5P content that could not be cloned. Please review the cloned version of your book carefully, as missing H5P content will be indicated. You may want to remove or replace these elements."
 msgstr ""
 
+#: inc/cloner/class-cloner.php:789
 msgid "The source book&rsquo;s media could not be read."
 msgstr ""
 
+#: inc/cloner/class-cloner.php:885
 msgid "The source book&rsquo;s metadata could not be read."
 msgstr ""
 
+#: inc/cloner/class-cloner.php:916
 msgid "The source book&rsquo;s structure and contents could not be read."
 msgstr ""
 
+#: inc/cloner/class-cloner.php:958
 msgid "The source book&rsquo;s taxonomies could not be read."
 msgstr ""
 
+#: inc/cloner/class-cloner.php:2030
 msgid "Your book URL can only contain lowercase letters (a-z) and numbers."
 msgstr ""
 
+#: inc/cloner/class-cloner.php:2032
 msgid "Your book URL must contain at least some letters."
 msgstr ""
 
+#: inc/cloner/class-cloner.php:2034
 msgid "That book URL is not allowed."
 msgstr ""
 
+#: inc/cloner/class-cloner.php:2036
 msgid "Your book URL must be at least %s character."
 msgid_plural "Your book URL must be at least %s characters."
 msgstr[0] ""
 msgstr[1] ""
 
+#: inc/cloner/class-cloner.php:2038
 msgid "Sorry, you may not use that book URL."
 msgstr ""
 
+#: inc/cloner/class-cloner.php:2040
 msgid "Sorry, that book URL already exists!"
 msgstr ""
 
+#: inc/covergenerator/class-generator.php:201
 msgid "Calculating spine width"
 msgstr ""
 
+#: inc/covergenerator/class-generator.php:217
 msgid "Creating barcode"
 msgstr ""
 
+#: inc/covergenerator/class-generator.php:225
 msgid "Loading metadata"
 msgstr ""
 
+#: inc/covergenerator/class-generator.php:283
 msgid "Generating cover"
 msgstr ""
 
+#: inc/covergenerator/class-generator.php:363
+#: inc/modules/export/class-export.php:331
 msgid "book"
 msgstr ""
 
+#: inc/covergenerator/class-generator.php:453
+#: inc/modules/export/prince/class-docraptor.php:116
 msgid "Your PDF could not be retrieved."
 msgstr ""
 
+#: inc/covergenerator/class-isbn.php:61
 msgid "There was a problem creating the barcode: Invalid ISBN number."
 msgstr ""
 
+#: inc/covergenerator/class-sku.php:43
 msgid "There was a problem creating the barcode: Invalid characters in SKU"
 msgstr ""
 
+#: inc/editor/namespace.php:110
 msgid "Insert Footnote"
 msgstr ""
 
+#: inc/editor/namespace.php:111
 msgid "Convert MS Word Footnotes"
 msgstr ""
 
+#: inc/editor/namespace.php:118
 msgid "Insert LaTeX"
 msgstr ""
 
+#: inc/editor/namespace.php:131
+#: templates/admin/import.php:156
 msgid "Cancel"
 msgstr ""
 
+#: inc/editor/namespace.php:132
 msgid "Description"
 msgstr ""
 
+#: inc/editor/namespace.php:133
 msgid "Insert Glossary Term"
 msgstr ""
 
+#: inc/editor/namespace.php:134
 msgid "Insert"
 msgstr ""
 
+#: inc/editor/namespace.php:136
 msgctxt "JS template string"
 msgid "Glossary term <em>${templateString1}</em> not found. Please create it."
 msgstr ""
 
+#: inc/editor/namespace.php:137
 msgid "Select a Term"
 msgstr ""
 
+#: inc/editor/namespace.php:138
 msgid "Create and Insert Term"
 msgstr ""
 
+#: inc/editor/namespace.php:139
 msgid "Choose Existing Term"
 msgstr ""
 
+#: inc/editor/namespace.php:140
 msgid "Glossary term already exists."
 msgstr ""
 
+#: inc/editor/namespace.php:142
 msgid "Cannot submit empty Glossary term."
 msgstr ""
 
+#: inc/editor/namespace.php:143
 msgid "A term was not selected?"
 msgstr ""
 
+#: inc/editor/namespace.php:144
+#: inc/posttype/namespace.php:243
 msgid "To display a list of glossary terms, leave this back matter's content blank."
 msgstr ""
 
+#: inc/editor/namespace.php:145
 msgid "Term"
 msgstr ""
 
+#: inc/editor/namespace.php:203
 msgid "Indent"
 msgstr ""
 
+#: inc/editor/namespace.php:209
 msgid "Hanging indent"
 msgstr ""
 
+#: inc/editor/namespace.php:215
 msgid "No indent"
 msgstr ""
 
+#: inc/editor/namespace.php:221
 msgid "Write right to left"
 msgstr ""
 
+#: inc/editor/namespace.php:229
 msgid "Write left to right"
 msgstr ""
 
+#: inc/editor/namespace.php:237
 msgid "Tight tracking"
 msgstr ""
 
+#: inc/editor/namespace.php:243
 msgid "Very tight tracking"
 msgstr ""
 
+#: inc/editor/namespace.php:249
 msgid "Loose tracking"
 msgstr ""
 
+#: inc/editor/namespace.php:255
 msgid "Very loose tracking"
 msgstr ""
 
+#: inc/editor/namespace.php:261
 msgid "Pullquote (left)"
 msgstr ""
 
+#: inc/editor/namespace.php:267
 msgid "Pullquote (right)"
 msgstr ""
 
+#: inc/editor/namespace.php:317
+#: inc/editor/namespace.php:359
+#: inc/editor/namespace.php:373
+#: inc/modules/themeoptions/class-weboptions.php:120
+#: languages/tinymce.php:7
 msgid "Standard"
 msgstr ""
 
+#: inc/editor/namespace.php:321
 msgid "No lines"
 msgstr ""
 
+#: inc/editor/namespace.php:325
 msgid "Lines"
 msgstr ""
 
+#: inc/editor/namespace.php:329
+#: inc/editor/namespace.php:367
+#: inc/editor/namespace.php:381
+#: languages/tinymce.php:10
 msgid "Shaded"
 msgstr ""
 
+#: inc/editor/namespace.php:333
 msgid "Full Grid"
 msgstr ""
 
+#: inc/editor/namespace.php:337
 msgid "Standard Landscape*"
 msgstr ""
 
+#: inc/editor/namespace.php:341
 msgid "No lines Landscape*"
 msgstr ""
 
+#: inc/editor/namespace.php:345
 msgid "Lines Landscape*"
 msgstr ""
 
+#: inc/editor/namespace.php:349
 msgid "Shaded Landscape*"
 msgstr ""
 
+#: inc/editor/namespace.php:353
 msgid "Full Grid Landscape*"
 msgstr ""
 
+#: inc/editor/namespace.php:363
+#: inc/editor/namespace.php:377
 msgid "Border"
 msgstr ""
 
+#: inc/editor/namespace.php:494
 msgid "Internal Link"
 msgstr ""
 
+#: inc/image/namespace.php:394
 msgid "This image will be displayed on the webbook home page and used as the internal cover in ebook exports. Cover images must be at least 800px tall and have an aspect ratio between .66 and 1. Very large images will be resized upon upload. Read more in <a href=\"https://guide.pressbooks.com/chapter/how-to-design-your-book-cover/\" target=\"_blank\">our guide</a>."
 msgstr ""
 
+#: inc/image/namespace.php:432
+#: templates/admin/covergenerator.php:123
 msgid "Are you sure you want to delete this?"
 msgstr ""
 
+#: inc/image/namespace.php:464
 msgid "Delete"
 msgstr ""
 
+#: inc/interactive/class-h5p.php:174
 msgid "The original version of this chapter contained H5P content. You may want to remove or replace this element."
 msgstr ""
 
+#: inc/l10n/namespace.php:508
+#: inc/l10n/namespace.php:531
 msgid "Please contact your system administrator if you would like them to install extended %s language support for the Pressbooks interface."
 msgstr ""
 
+#: inc/metadata/namespace.php:117
 msgid "Hide Additional Book Information"
 msgstr ""
 
+#: inc/metadata/namespace.php:120
 msgid "Show Additional Book Information"
 msgstr ""
 
+#: inc/metadata/namespace.php:127
 msgid "The book information you enter here appears on your book’s cover and title pages and in the metadata of your webbook and exported files."
 msgstr ""
 
+#: inc/metadata/namespace.php:129
 msgid "If you need to enter additional information, click the button below to see all available fields."
 msgstr ""
 
+#: inc/metadata/namespace.php:1191
 msgid "The %1$s Thema subject terms requested for this book could not be downloaded from %2$s. Please report this error to your network manager."
 msgstr ""
 
+#: inc/modules/export/class-export.php:740
 msgid "%s: Initializing"
 msgstr ""
 
+#: inc/modules/export/class-export.php:742
 msgid "%s: Exporting"
 msgstr ""
 
+#: inc/modules/export/class-export.php:747
 msgid "%s: Export successful"
 msgstr ""
 
+#: inc/modules/export/class-export.php:749
 msgid "%s: Validating file"
 msgstr ""
 
+#: inc/modules/export/class-export.php:754
 msgid "%s: Validation successful"
 msgstr ""
 
+#: inc/modules/export/class-export.php:758
 msgid "%s: Finishing up"
 msgstr ""
 
+#: inc/modules/export/class-export.php:823
 msgid "The export failed. See logs for more details."
 msgstr ""
 
+#: inc/modules/export/class-export.php:832
 msgid "Warning: The export has validation errors. See logs for more details."
 msgstr ""
 
+#: inc/modules/export/class-export.php:833
 msgid "Emailed to:"
 msgstr ""
 
+#: inc/modules/export/class-table.php:81
 msgid "Are you sure you want to delete this export file?"
 msgstr ""
 
+#: inc/modules/export/class-table.php:131
 msgid "File"
 msgstr ""
 
+#: inc/modules/export/class-table.php:132
 msgid "Format"
 msgstr ""
 
+#: inc/modules/export/class-table.php:133
 msgid "Size"
 msgstr ""
 
+#: inc/modules/export/class-table.php:134
 msgid "Pin"
 msgstr ""
 
+#: inc/modules/export/class-table.php:135
 msgid "Date Exported"
 msgstr ""
 
+#: inc/modules/export/epub/class-epub.php:384
 msgid "EPUB %s: "
 msgstr ""
 
+#: inc/modules/export/epub/class-epub.php:494
+#: inc/modules/export/xhtml/class-xhtml11.php:204
 msgid "Initializing"
 msgstr ""
 
+#: inc/modules/export/epub/class-epub.php:508
 msgid "Preparing book contents"
 msgstr ""
 
+#: inc/modules/export/epub/class-epub.php:519
 msgid "Creating container"
 msgstr ""
 
+#: inc/modules/export/epub/class-epub.php:529
+#: inc/modules/export/xhtml/class-xhtml11.php:212
 msgid "Saving file to exports folder"
 msgstr ""
 
+#: inc/modules/export/epub/class-epub.php:537
+#: inc/modules/export/xhtml/class-xhtml11.php:216
 msgid "Export successful"
 msgstr ""
 
+#: inc/modules/export/epub/class-epub.php:634
+#: inc/modules/export/xhtml/class-xhtml11.php:242
 msgid "Validating file"
 msgstr ""
 
+#: inc/modules/export/epub/class-epub.php:663
+#: inc/modules/export/xhtml/class-xhtml11.php:258
 msgid "Validation successful"
 msgstr ""
 
+#: inc/modules/export/epub/class-epub.php:960
 msgid "Compiling styles"
 msgstr ""
 
+#: inc/modules/export/epub/class-epub.php:969
+#: inc/modules/export/xhtml/class-xhtml11.php:431
 msgid "Creating cover"
 msgstr ""
 
+#: inc/modules/export/epub/class-epub.php:976
+#: inc/modules/export/xhtml/class-xhtml11.php:435
 msgid "Creating title page"
 msgstr ""
 
+#: inc/modules/export/epub/class-epub.php:980
+#: inc/modules/export/xhtml/class-xhtml11.php:439
 msgid "Creating copyright page"
 msgstr ""
 
+#: inc/modules/export/epub/class-epub.php:984
 msgid "Exporting dedication and epigraph"
 msgstr ""
 
+#: inc/modules/export/epub/class-epub.php:988
+#: inc/modules/export/epub/class-epub.php:1555
+#: inc/modules/export/xhtml/class-xhtml11.php:451
+#: inc/modules/export/xhtml/class-xhtml11.php:1255
 msgid "Exporting front matter"
 msgstr ""
 
+#: inc/modules/export/epub/class-epub.php:995
+#: inc/modules/export/epub/class-epub.php:1656
+#: inc/modules/export/epub/class-epub.php:1686
+#: inc/modules/export/xhtml/class-xhtml11.php:458
+#: inc/modules/export/xhtml/class-xhtml11.php:1321
+#: inc/modules/export/xhtml/class-xhtml11.php:1361
 msgid "Exporting parts and chapters"
 msgstr ""
 
+#: inc/modules/export/epub/class-epub.php:999
+#: inc/modules/export/epub/class-epub.php:1817
+#: inc/modules/export/xhtml/class-xhtml11.php:462
+#: inc/modules/export/xhtml/class-xhtml11.php:1461
 msgid "Exporting back matter"
 msgstr ""
 
+#: inc/modules/export/epub/class-epub.php:1004
+#: inc/modules/export/xhtml/class-xhtml11.php:447
 msgid "Creating table of contents"
 msgstr ""
 
+#: inc/modules/export/epub/class-epub.php:1346
 msgid "Title Page"
 msgstr ""
 
+#: inc/modules/export/epub/class-epub.php:1611
 msgid "Make your own books using Pressbooks"
 msgstr ""
 
+#: inc/modules/export/epub/class-epub.php:1869
 msgid "Table Of Contents"
 msgstr ""
 
+#: inc/modules/export/epub/class-epub.php:1944
+#: inc/modules/export/htmlbook/class-htmlbook.php:979
+#: inc/modules/export/xhtml/class-xhtml11.php:1237
 msgid "Contents"
 msgstr ""
 
+#: inc/modules/export/htmlbook/class-htmlbook.php:190
+#: inc/modules/export/wordpress/class-wxr.php:81
+#: inc/modules/export/xhtml/class-xhtml11.php:289
 msgid "Invalid permission error"
 msgstr ""
 
+#: inc/modules/export/namespace.php:84
+#: templates/admin/covergenerator.php:52
 msgid "Some dependencies for %1$s exports could not be found. Please verify that you have completed the <a href=\"%2$s\">installation instructions</a>."
 msgstr ""
 
+#: inc/modules/export/namespace.php:85
+#: inc/modules/themeoptions/class-globaloptions.php:420
+#: inc/utility/namespace.php:1321
+#: inc/utility/namespace.php:1326
+#: inc/utility/namespace.php:1360
+#: inc/utility/namespace.php:1370
+#: inc/utility/namespace.php:1376
+#: templates/admin/covergenerator.php:53
 msgid "and"
 msgstr ""
 
+#: inc/modules/export/namespace.php:98
+#: inc/modules/export/prince/class-filters.php:74
 msgid "PDF (for print)"
 msgstr ""
 
+#: inc/modules/export/namespace.php:99
+#: inc/modules/export/prince/class-filters.php:75
 msgid "PDF (for digital distribution)"
 msgstr ""
 
+#: inc/modules/export/namespace.php:100
+#: inc/modules/export/namespace.php:193
+#: inc/modules/export/namespace.php:228
 msgid "EPUB"
 msgstr ""
 
+#: inc/modules/export/namespace.php:101
+#: inc/modules/export/namespace.php:198
+#: inc/modules/export/namespace.php:231
 msgid "Pressbooks XML"
 msgstr ""
 
+#: inc/modules/export/namespace.php:104
 msgid "XHTML"
 msgstr ""
 
+#: inc/modules/export/namespace.php:105
+#: inc/modules/export/namespace.php:192
+#: inc/modules/export/namespace.php:227
 msgid "HTMLBook"
 msgstr ""
 
+#: inc/modules/export/namespace.php:106
+#: inc/modules/export/namespace.php:197
+#: inc/modules/export/namespace.php:230
 msgid "OpenDocument"
 msgstr ""
 
+#: inc/modules/export/namespace.php:107
+#: inc/modules/export/namespace.php:199
+#: inc/modules/export/namespace.php:232
 msgid "WordPress XML"
 msgstr ""
 
+#: inc/modules/export/namespace.php:115
 msgid "Common Cartridge with Web Links"
 msgstr ""
 
+#: inc/modules/export/namespace.php:189
+#: inc/modules/export/namespace.php:223
+#: inc/modules/export/namespace.php:225
 msgid "Print PDF"
 msgstr ""
 
+#: inc/modules/export/namespace.php:190
+#: inc/modules/export/namespace.php:191
+#: inc/modules/export/namespace.php:224
+#: inc/modules/export/namespace.php:226
 msgid "Digital PDF"
 msgstr ""
 
+#: inc/modules/export/namespace.php:194
 msgid "MOBI"
 msgstr ""
 
+#: inc/modules/export/namespace.php:195
 msgid "EPUB3"
 msgstr ""
 
+#: inc/modules/export/namespace.php:200
+#: inc/modules/export/namespace.php:233
 msgid "Common Cartridge (Web Links)"
 msgstr ""
 
-msgid "Common Cartridge with LTI links (1.1)"
-msgstr ""
-
-msgid "Common Cartridge with LTI links (1.2)"
-msgstr ""
-
-msgid "Common Cartridge with LTI links (1.3)"
-msgstr ""
-
+#: inc/modules/export/namespace.php:269
 msgid "The file %1$s has been %2$s successfully."
 msgstr ""
 
+#: inc/modules/export/namespace.php:271
 msgid "pinned"
 msgstr ""
 
+#: inc/modules/export/namespace.php:271
 msgid "unpinned"
 msgstr ""
 
+#: inc/modules/export/namespace.php:290
 msgid "%s Author"
 msgid_plural "%s Authors"
 msgstr[0] ""
 msgstr[1] ""
 
+#: inc/modules/export/prince/class-pdf.php:278
 msgid "This book was produced with Pressbooks (https://pressbooks.com) and rendered with Prince."
 msgstr ""
 
+#: inc/modules/export/xhtml/class-xhtml11.php:178
 msgid "XHTML: "
 msgstr ""
 
+#: inc/modules/export/xhtml/class-xhtml11.php:423
 msgid "Creating before title page"
 msgstr ""
 
+#: inc/modules/export/xhtml/class-xhtml11.php:427
 msgid "Creating half title page"
 msgstr ""
 
+#: inc/modules/export/xhtml/class-xhtml11.php:443
 msgid "Creating dedication and epigraph"
 msgstr ""
 
+#: inc/modules/export/xhtml/class-xhtml11.php:553
 msgid "Notes"
 msgstr ""
 
+#: inc/modules/import/api/class-api.php:83
 msgid "No chapters in %s are licensed for cloning."
 msgstr ""
 
+#: inc/modules/import/api/class-api.php:141
 msgid "Importing front matter"
 msgstr ""
 
+#: inc/modules/import/api/class-api.php:164
 msgid "Importing parts and chapters"
 msgstr ""
 
+#: inc/modules/import/api/class-api.php:189
 msgid "Importing back matter"
 msgstr ""
 
+#: inc/modules/import/api/class-api.php:205
 msgid "Importing glossary terms"
 msgstr ""
 
+#: inc/modules/import/class-import.php:371
+#: inc/modules/import/epub/class-epub201.php:211
 msgid "Importing"
 msgstr ""
 
+#: inc/modules/import/class-import.php:503
 msgid "Your file does not appear to be a valid %s."
 msgstr ""
 
+#: inc/modules/import/class-import.php:541
 msgid "Your URL does not appear to be valid"
 msgstr ""
 
+#: inc/modules/import/class-import.php:548
+#: inc/modules/import/class-import.php:577
 msgid "The URL you are trying to import is bigger than the maximum file size."
 msgstr ""
 
+#: inc/modules/import/class-import.php:570
 msgid "The website you are attempting to reach is not returning a successful response code: "
 msgstr ""
 
+#: inc/modules/import/epub/class-epub201.php:152
 msgid "Opening EPUB file"
 msgstr ""
 
+#: inc/modules/import/epub/class-epub201.php:159
 msgid "Reading metadata"
 msgstr ""
 
+#: inc/modules/import/epub/class-epub201.php:165
 msgid "Deleting temporary files"
 msgstr ""
 
+#: inc/modules/import/epub/class-epub201.php:216
 msgid "Imported %s chapters."
 msgstr ""
 
+#: inc/modules/import/html/class-xhtml.php:45
 msgid "The HTML is larger than pcre.backtrack_limit."
 msgstr ""
 
+#: inc/modules/import/wordpress/class-parser.php:65
+#: inc/modules/import/wordpress/class-parser.php:71
 msgid "This does not appear to be a WXR file, missing/invalid WXR version number"
 msgstr ""
 
+#: inc/modules/import/wordpress/class-wxr.php:415
 msgctxt "String which tells user how many front matter, parts, chapters, back matter, media attachments, and glossary terms were imported."
 msgid "Imported %1$s, %2$s, %3$s, %4$s, %5$s, and %6$s."
 msgstr ""
 
+#: inc/modules/searchandreplace/class-search.php:140
 msgid "Invalid regular expression"
 msgstr ""
 
+#: inc/modules/searchandreplace/class-search.php:148
 msgid "No search pattern."
 msgstr ""
 
+#: inc/modules/searchandreplace/class-searchandreplace.php:66
 msgid "Once you&rsquo;ve pressed &lsquo;Replace & Save&rsquo; there is no going back! Have you checked &lsquo;Preview Replacements&rsquo; to make sure this will do what you want it to do?"
 msgstr ""
 
+#: inc/modules/searchandreplace/class-searchandreplace.php:76
+#: inc/modules/searchandreplace/class-searchandreplace.php:77
+#: templates/admin/search.php:11
 msgid "Search & Replace"
 msgstr ""
 
+#: inc/modules/searchandreplace/types/class-content.php:60
 msgid "view"
 msgstr ""
 
+#: inc/modules/searchandreplace/types/class-content.php:62
 msgid "edit"
 msgstr ""
 
+#: inc/modules/searchandreplace/types/class-content.php:72
 msgid "%1$s ID #%2$d: %3$s"
 msgstr ""
 
+#: inc/modules/searchandreplace/types/class-content.php:100
 msgid "Content Text"
 msgstr ""
 
+#: inc/modules/themeoptions/class-admin.php:94
+#: inc/modules/themeoptions/class-admin.php:95
+#: inc/modules/themeoptions/class-admin.php:149
+#: templates/admin/export.blade.php:58
 msgid "Theme Options"
 msgstr ""
 
+#: inc/modules/themeoptions/class-admin.php:152
 msgid "Theme Options Tabs"
 msgstr ""
 
+#: inc/modules/themeoptions/class-ebookoptions.php:81
+#: inc/modules/themeoptions/class-pdfoptions.php:86
+#: inc/modules/themeoptions/class-weboptions.php:85
 msgid "Header Font"
 msgstr ""
 
+#: inc/modules/themeoptions/class-ebookoptions.php:89
+#: inc/modules/themeoptions/class-pdfoptions.php:94
+#: inc/modules/themeoptions/class-weboptions.php:93
 msgid "Body Font"
 msgstr ""
 
+#: inc/modules/themeoptions/class-ebookoptions.php:99
 msgid "Ebook Start Point"
 msgstr ""
 
+#: inc/modules/themeoptions/class-ebookoptions.php:104
 msgid "Note: This designated ebook start book may be overridden by some ereader devices."
 msgstr ""
 
+#: inc/modules/themeoptions/class-ebookoptions.php:111
+#: inc/modules/themeoptions/class-pdfoptions.php:262
+#: inc/modules/themeoptions/class-weboptions.php:128
 msgid "Paragraph Separation"
 msgstr ""
 
+#: inc/modules/themeoptions/class-ebookoptions.php:116
+#: inc/modules/themeoptions/class-pdfoptions.php:267
+#: inc/modules/themeoptions/class-weboptions.php:133
 msgid "Indent paragraphs"
 msgstr ""
 
+#: inc/modules/themeoptions/class-ebookoptions.php:117
+#: inc/modules/themeoptions/class-pdfoptions.php:268
+#: inc/modules/themeoptions/class-weboptions.php:134
 msgid "Skip lines between paragraphs"
 msgstr ""
 
+#: inc/modules/themeoptions/class-ebookoptions.php:123
 msgid "Compress Images"
 msgstr ""
 
+#: inc/modules/themeoptions/class-ebookoptions.php:128
 msgid "Reduce image size and quality"
 msgstr ""
 
+#: inc/modules/themeoptions/class-ebookoptions.php:153
 msgid "These options apply to ebook exports."
 msgstr ""
 
+#: inc/modules/themeoptions/class-ebookoptions.php:354
 msgid "Ebook Options"
 msgstr ""
 
+#: inc/modules/themeoptions/class-globaloptions.php:83
 msgid "Part and Chapter Numbers"
 msgstr ""
 
+#: inc/modules/themeoptions/class-globaloptions.php:88
 msgid "Display part and chapter numbers"
 msgstr ""
 
+#: inc/modules/themeoptions/class-globaloptions.php:94
 msgid "Part Label"
 msgstr ""
 
+#: inc/modules/themeoptions/class-globaloptions.php:99
 msgid "The \"part\" label is used in the table of contents and in part titles in your webbook and exports."
 msgstr ""
 
+#: inc/modules/themeoptions/class-globaloptions.php:106
 msgid "Chapter Label"
 msgstr ""
 
+#: inc/modules/themeoptions/class-globaloptions.php:111
 msgid "The \"chapter\" label is used in the table of contents and in chapter titles in your webbook and exports."
 msgstr ""
 
+#: inc/modules/themeoptions/class-globaloptions.php:118
 msgid "Two-Level TOC"
 msgstr ""
 
+#: inc/modules/themeoptions/class-globaloptions.php:123
 msgid "Enable two-level table of contents (displays headings under chapter titles)"
 msgstr ""
 
+#: inc/modules/themeoptions/class-globaloptions.php:129
 msgid "About the Author"
 msgstr ""
 
+#: inc/modules/themeoptions/class-globaloptions.php:134
+#: tests/test-options.php:471
 msgid "Display information about authors at the end of each chapter"
 msgstr ""
 
+#: inc/modules/themeoptions/class-globaloptions.php:140
+#: inc/shortcodes/attributions/class-attachments.php:262
 msgid "Media Attributions"
 msgstr ""
 
+#: inc/modules/themeoptions/class-globaloptions.php:145
 msgid "Display attributions at the end of a chapter"
 msgstr ""
 
+#: inc/modules/themeoptions/class-globaloptions.php:153
 msgid "Language & Script Support"
 msgstr ""
 
+#: inc/modules/themeoptions/class-globaloptions.php:158
 msgid "Include fonts to support the following languages and scripts:"
 msgstr ""
 
+#: inc/modules/themeoptions/class-globaloptions.php:172
 msgid "Chapter Licenses"
 msgstr ""
 
+#: inc/modules/themeoptions/class-globaloptions.php:177
 msgid "Do not display section level copyright license"
 msgstr ""
 
+#: inc/modules/themeoptions/class-globaloptions.php:178
 msgid "Display section level license on table of contents in export formats"
 msgstr ""
 
+#: inc/modules/themeoptions/class-globaloptions.php:179
 msgid "Display section level license at end of chapter in export formats"
 msgstr ""
 
+#: inc/modules/themeoptions/class-globaloptions.php:185
+#: languages/tinymce.php:21
 msgid "Examples"
 msgstr ""
 
+#: inc/modules/themeoptions/class-globaloptions.php:186
+#: languages/tinymce.php:18
 msgid "Exercises"
 msgstr ""
 
+#: inc/modules/themeoptions/class-globaloptions.php:187
+#: languages/tinymce.php:15
 msgid "Key Takeaways"
 msgstr ""
 
+#: inc/modules/themeoptions/class-globaloptions.php:188
+#: languages/tinymce.php:12
 msgid "Learning Objectives"
 msgstr ""
 
+#: inc/modules/themeoptions/class-globaloptions.php:197
 msgid "Customize colors for %s textboxes using the fields below."
 msgstr ""
 
+#: inc/modules/themeoptions/class-globaloptions.php:203
 msgid "Header Color"
 msgstr ""
 
+#: inc/modules/themeoptions/class-globaloptions.php:209
 msgid "The header text color for a %s textbox."
 msgstr ""
 
+#: inc/modules/themeoptions/class-globaloptions.php:214
 msgid "Header Background"
 msgstr ""
 
+#: inc/modules/themeoptions/class-globaloptions.php:220
 msgid "The header background color for a %s textbox."
 msgstr ""
 
+#: inc/modules/themeoptions/class-globaloptions.php:225
 msgid "Background"
 msgstr ""
 
+#: inc/modules/themeoptions/class-globaloptions.php:231
 msgid "The background color for a %s textbox."
 msgstr ""
 
+#: inc/modules/themeoptions/class-globaloptions.php:258
 msgid "These options apply universally to webbook, PDF and ebook exports."
 msgstr ""
 
+#: inc/modules/themeoptions/class-globaloptions.php:429
 msgid "Select languages&hellip;"
 msgstr ""
 
+#: inc/modules/themeoptions/class-globaloptions.php:437
 msgid "This theme includes built-in support for %s."
 msgstr ""
 
+#: inc/modules/themeoptions/class-globaloptions.php:545
 msgid "Global Options"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:105
 msgid "Body Font Size"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:110
 msgid "Heading sizes are proportional to the body font size and will also be affected by this setting."
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:118
 msgid "Footnote Font Size"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:131
 msgid "Body Line Height"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:145
 msgid "Page Size"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:150
 msgid "Digest (5.5&quot; &times; 8.5&quot;)"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:151
 msgid "US Trade (6&quot; &times; 9&quot;)"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:152
 msgid "US Letter (8.5&quot; &times; 11&quot;)"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:153
 msgid "Custom (8.5&quot; &times; 9.25&quot;)"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:154
 msgid "Duodecimo (5&quot; &times; 7.75&quot;)"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:155
 msgid "Pocket (4.25&quot; &times; 7&quot;)"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:156
 msgid "A4 (21cm &times; 29.7cm)"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:157
 msgid "A5 (14.8cm &times; 21cm)"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:158
 msgid "5&quot; &times; 8&quot;"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:166
 msgid "Page Width"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:171
 msgid "Page width must be expressed in CSS-compatible units, e.g. &lsquo;5.5in&rsquo; or &lsquo;10cm&rsquo;."
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:178
 msgid "Page Height"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:183
 msgid "Page height must be expressed in CSS-compatible units, e.g. &lsquo;8.5in&rsquo; or &lsquo;10cm&rsquo;."
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:191
 msgid "Margins"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:196
 msgid "Customize your book&rsquo;s margins using the fields below."
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:202
+#: inc/modules/themeoptions/class-pdfoptions.php:927
 msgid "Outside Margin"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:207
+#: inc/modules/themeoptions/class-pdfoptions.php:219
+#: inc/modules/themeoptions/class-pdfoptions.php:231
+#: inc/modules/themeoptions/class-pdfoptions.php:243
 msgid "Margins must be expressed in CSS-compatible units, e.g. &lsquo;8.5in&rsquo; or &lsquo;10cm&rsquo;."
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:214
+#: inc/modules/themeoptions/class-pdfoptions.php:928
 msgid "Inside Margin"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:226
+#: inc/modules/themeoptions/class-pdfoptions.php:929
 msgid "Top Margin"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:238
+#: inc/modules/themeoptions/class-pdfoptions.php:930
 msgid "Bottom Margin"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:251
 msgid "Hyphens"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:256
 msgid "Enable hyphenation"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:274
 msgid "Section Openings"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:279
 msgid "Left or right page section opening (for print PDF)"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:280
 msgid "Right page section openings (for print PDF)"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:281
 msgid "No blank pages (for web PDF)"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:292
 msgid "Display table of contents"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:298
 msgid "Crop Marks"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:303
 msgid "Display crop marks"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:310
 msgid "Romanize Part Numbers"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:315
 msgid "Convert part numbers into Roman numerals"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:322
 msgid "Footnote Style"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:327
 msgid "Regular footnotes"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:328
 msgid "Display as chapter endnotes"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:334
 msgid "Widows"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:345
 msgid "Orphans"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:357
 msgid "Running Heads & Feet"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:362
 msgid "Running content appears in either running heads or running feet (at the top or bottom of the page) depending on your theme."
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:368
 msgid "Front Matter Left Page Running Content"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:374
+#: inc/modules/themeoptions/class-pdfoptions.php:393
+#: inc/modules/themeoptions/class-pdfoptions.php:412
+#: inc/modules/themeoptions/class-pdfoptions.php:431
+#: inc/modules/themeoptions/class-pdfoptions.php:450
+#: inc/modules/themeoptions/class-pdfoptions.php:468
+#: inc/modules/themeoptions/class-pdfoptions.php:486
+#: inc/modules/themeoptions/class-pdfoptions.php:507
+#: inc/modules/themeoptions/class-pdfoptions.php:528
+#: inc/modules/themeoptions/class-pdfoptions.php:547
 msgid "Book Subtitle"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:375
+#: inc/modules/themeoptions/class-pdfoptions.php:394
+#: inc/modules/themeoptions/class-pdfoptions.php:413
+#: inc/modules/themeoptions/class-pdfoptions.php:432
+#: inc/modules/themeoptions/class-pdfoptions.php:451
+#: inc/modules/themeoptions/class-pdfoptions.php:469
+#: inc/modules/themeoptions/class-pdfoptions.php:487
+#: inc/modules/themeoptions/class-pdfoptions.php:508
+#: inc/modules/themeoptions/class-pdfoptions.php:529
+#: inc/modules/themeoptions/class-pdfoptions.php:548
 msgid "Book Author"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:376
+#: inc/modules/themeoptions/class-pdfoptions.php:395
 msgid "Front Matter Title"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:377
+#: inc/modules/themeoptions/class-pdfoptions.php:396
 msgid "Front Matter Author"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:378
+#: inc/modules/themeoptions/class-pdfoptions.php:397
 msgid "Front Matter Subtitle"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:379
+#: inc/modules/themeoptions/class-pdfoptions.php:398
+#: inc/modules/themeoptions/class-pdfoptions.php:417
+#: inc/modules/themeoptions/class-pdfoptions.php:436
+#: inc/modules/themeoptions/class-pdfoptions.php:454
+#: inc/modules/themeoptions/class-pdfoptions.php:472
+#: inc/modules/themeoptions/class-pdfoptions.php:493
+#: inc/modules/themeoptions/class-pdfoptions.php:514
+#: inc/modules/themeoptions/class-pdfoptions.php:533
+#: inc/modules/themeoptions/class-pdfoptions.php:552
 msgid "Blank"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:387
 msgid "Front Matter Right Page Running Content"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:406
 msgid "Introduction Left Page Running Content"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:414
+#: inc/modules/themeoptions/class-pdfoptions.php:433
 msgid "Introduction Title"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:415
+#: inc/modules/themeoptions/class-pdfoptions.php:434
 msgid "Introduction Author"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:416
+#: inc/modules/themeoptions/class-pdfoptions.php:435
 msgid "Introduction Subtitle"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:425
 msgid "Introduction Right Page Running Content"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:444
 msgid "Part Left Page Running Content"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:452
+#: inc/modules/themeoptions/class-pdfoptions.php:470
+#: inc/modules/themeoptions/class-pdfoptions.php:488
+#: inc/modules/themeoptions/class-pdfoptions.php:509
 msgid "Part Number"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:453
+#: inc/modules/themeoptions/class-pdfoptions.php:471
+#: inc/modules/themeoptions/class-pdfoptions.php:489
+#: inc/modules/themeoptions/class-pdfoptions.php:510
 msgid "Part Title"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:462
 msgid "Part Right Page Running Content"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:480
 msgid "Chapter Left Page Running Content"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:490
+#: inc/modules/themeoptions/class-pdfoptions.php:511
 msgid "Chapter Title"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:491
+#: inc/modules/themeoptions/class-pdfoptions.php:512
 msgid "Chapter Author"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:492
+#: inc/modules/themeoptions/class-pdfoptions.php:513
 msgid "Chapter Subtitle"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:501
 msgid "Chapter Right Page Running Content"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:522
 msgid "Back Matter Left Page Running Content"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:530
+#: inc/modules/themeoptions/class-pdfoptions.php:549
 msgid "Back Matter Title"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:531
+#: inc/modules/themeoptions/class-pdfoptions.php:550
 msgid "Back Matter Author"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:532
+#: inc/modules/themeoptions/class-pdfoptions.php:551
 msgid "Back Matter Subtitle"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:541
 msgid "Back Matter Right Page Running Content"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:562
 msgid "Increase Font Size"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:567
 msgid "Increases font size and line height for greater accessibility"
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:593
 msgid "These options apply to PDF exports."
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:935
 msgid "IMPORTANT: If you plan to use a print-on-demand service, margins under 2cm on any side can cause your file to be rejected."
 msgstr ""
 
+#: inc/modules/themeoptions/class-pdfoptions.php:1499
 msgid "PDF Options"
 msgstr ""
 
+#: inc/modules/themeoptions/class-weboptions.php:103
 msgid "Enable Social Media"
 msgstr ""
 
+#: inc/modules/themeoptions/class-weboptions.php:108
 msgid "Adds a button to cover page and each chapter which allows readers to share links to your book through Twitter"
 msgstr ""
 
+#: inc/modules/themeoptions/class-weboptions.php:114
 msgid "Webbook Width"
 msgstr ""
 
+#: inc/modules/themeoptions/class-weboptions.php:119
 msgid "Narrow"
 msgstr ""
 
+#: inc/modules/themeoptions/class-weboptions.php:121
 msgid "Wide"
 msgstr ""
 
+#: inc/modules/themeoptions/class-weboptions.php:140
 msgid "Display Part Title"
 msgstr ""
 
+#: inc/modules/themeoptions/class-weboptions.php:145
 msgid "Display the Part title on each chapter"
 msgstr ""
 
+#: inc/modules/themeoptions/class-weboptions.php:152
 msgid "Collapse Sections"
 msgstr ""
 
+#: inc/modules/themeoptions/class-weboptions.php:157
 msgid "Collapse sections within front matter, chapters, and back matter"
 msgstr ""
 
+#: inc/modules/themeoptions/class-weboptions.php:165
 msgid "Enable Source Comparison"
 msgstr ""
 
+#: inc/modules/themeoptions/class-weboptions.php:170
 msgid "Add comparison tool to the end of each front matter, part, chapter, and back matter"
 msgstr ""
 
+#: inc/modules/themeoptions/class-weboptions.php:171
 msgid "Allows readers to compare content with the original book from which it was cloned."
 msgstr ""
 
+#: inc/modules/themeoptions/class-weboptions.php:197
 msgid "These options apply to the webbook."
 msgstr ""
 
+#: inc/modules/themeoptions/class-weboptions.php:397
 msgid "Web Options"
 msgstr ""
 
+#: inc/posttype/namespace.php:65
+#: templates/admin/organize.php:65
 msgid "Chapters"
 msgstr ""
 
+#: inc/posttype/namespace.php:88
+#: templates/admin/organize.php:67
 msgid "Parts"
 msgstr ""
 
+#: inc/posttype/namespace.php:194
 msgid "Glossary Term"
 msgstr ""
 
+#: inc/posttype/namespace.php:233
 msgid "Links, bold text and italic text are supported in glossary terms. Other elements will be removed."
 msgstr ""
 
+#: inc/posttype/namespace.php:248
 msgid "To display a list of contributors, leave this back matter's content blank."
 msgstr ""
 
+#: inc/posttype/namespace.php:287
 msgid "Unlisted"
 msgstr ""
 
+#: inc/posttype/namespace.php:324
 msgid "Show title in exports"
 msgstr ""
 
+#: inc/posttype/namespace.php:336
 msgid "Chapter Short Title (appears in the PDF running header)"
 msgstr ""
 
+#: inc/posttype/namespace.php:345
 msgid "Chapter Subtitle (appears in the Web/ebook/PDF output)"
 msgstr ""
 
+#: inc/posttype/namespace.php:355
 msgid "Chapter Author (appears in Web/ebook/PDF output)"
 msgstr ""
 
+#: inc/posttype/namespace.php:364
 msgid "Chapter Copyright License (overrides book license on this page)"
 msgstr ""
 
+#: inc/posttype/namespace.php:374
 msgid "Whether or not the part is shown in the table of contents"
 msgstr ""
 
+#: inc/posttype/namespace.php:384
 msgid "Media attribution source url"
 msgstr ""
 
+#: inc/posttype/namespace.php:393
 msgid "Media attribution author"
 msgstr ""
 
+#: inc/posttype/namespace.php:402
 msgid "Media attribution author url"
 msgstr ""
 
+#: inc/posttype/namespace.php:411
 msgid "Media attribution adapted by"
 msgstr ""
 
+#: inc/posttype/namespace.php:420
 msgid "Media attribution adapted by url"
 msgstr ""
 
+#: inc/posttype/namespace.php:429
 msgid "Media attribution license"
 msgstr ""
 
+#: inc/posttype/namespace.php:441
 msgctxt "post status"
 msgid "Web Only"
 msgstr ""
 
+#: inc/posttype/namespace.php:487
 msgid "parts"
 msgstr ""
 
+#: inc/posttype/namespace.php:488
 msgid "chapters"
 msgstr ""
 
+#: inc/posttype/namespace.php:489
 msgid "front matter"
 msgstr ""
 
+#: inc/posttype/namespace.php:490
 msgid "back matter"
 msgstr ""
 
+#: inc/posttype/namespace.php:491
 msgid "glossary"
 msgstr ""
 
+#: inc/posttype/namespace.php:554
+#: templates/admin/import.php:97
+#: templates/admin/organize.php:68
 msgid "Glossary"
 msgstr ""
 
+#: inc/redirect/namespace.php:147
+#: inc/redirect/namespace.php:244
 msgid "Error: Unknown export format."
 msgstr ""
 
+#: inc/redirect/namespace.php:263
 msgid "File not found"
 msgstr ""
 
+#: inc/redirect/namespace.php:350
 msgid "Unsupported post type."
 msgstr ""
 
+#: inc/redirect/namespace.php:384
 msgid "Unsupported taxonomy."
 msgstr ""
 
+#: inc/redirect/namespace.php:408
 msgid "You do not have sufficient permissions to access that URL."
 msgstr ""
 
+#: inc/registration/namespace.php:36
 msgid "Register my book now"
 msgstr ""
 
+#: inc/registration/namespace.php:39
 msgid "Register my book later"
 msgstr ""
 
+#: inc/registration/namespace.php:43
 msgid "Webbook Address:"
 msgstr ""
 
+#: inc/registration/namespace.php:46
+#: inc/registration/namespace.php:78
 msgid "Your webbook address is the web address where you will access and create your book. It must be at least 4 characters, letters and numbers only. It <strong>cannot be changed</strong>, so choose carefully! We suggest using the title of your book with no spaces."
 msgstr ""
 
+#: inc/registration/namespace.php:49
 msgid "Book Title:"
 msgstr ""
 
+#: inc/registration/namespace.php:52
 msgid "Book Language:"
 msgstr ""
 
+#: inc/registration/namespace.php:55
 msgid "Would you like your webbook to be visible to the public?"
 msgstr ""
 
+#: inc/registration/namespace.php:59
 msgid "Create Book"
 msgstr ""
 
+#: inc/registration/namespace.php:62
 msgid "Register a %s account"
 msgstr ""
 
+#: inc/registration/namespace.php:65
 msgid "Create a new book"
 msgstr ""
 
+#: inc/registration/namespace.php:68
 msgid "Welcome, %s. Fill out the form below to <strong>add a new book to your account</strong>."
 msgstr ""
 
+#: inc/registration/namespace.php:72
 msgid "yourwebbookname"
 msgstr ""
 
+#: inc/registration/namespace.php:75
 msgid "Books you are already a member of:"
 msgstr ""
 
+#: inc/registration/namespace.php:81
 msgid "Congratulations! Your new book, %s, is almost ready"
 msgstr ""
 
+#: inc/registration/namespace.php:84
 msgid "But, before you can start writing your book, <strong>you must activate it</strong>."
 msgstr ""
 
+#: inc/registration/namespace.php:87
 msgid "Your account has been activated. You may now <a href=\"%1$s\">log in</a> to your book using your chosen username of &#8220;%2$s&#8221;. Please check your email inbox at %3$s for your password and login instructions. If you do not receive an email, please check your junk or spam folder. If you still do not receive an email within an hour, you can <a href=\"%4$s\">reset your password</a>."
 msgstr ""
 
+#: inc/registration/namespace.php:90
 msgid "Your book at <a href=\"%1$s\">%2$s</a> is active. You may now log in to your book using your chosen username of &#8220;%3$s&#8221;. Please check your email inbox at %4$s for your password and login instructions. If you do not receive an email, please check your junk or spam folder. If you still do not receive an email within an hour, you can <a href=\"%5$s\">reset your password</a>."
 msgstr ""
 
+#: inc/registration/namespace.php:93
 msgid "Your account is now activated. <a href=\"%1$s\">View your book</a> or <a href=\"%2$s\">Log in</a>"
 msgstr ""
 
+#: inc/registration/namespace.php:113
 msgid "Password"
 msgstr ""
 
+#: inc/registration/namespace.php:118
 msgid "Type in your password."
 msgstr ""
 
+#: inc/registration/namespace.php:119
 msgid "Confirm Password"
 msgstr ""
 
+#: inc/registration/namespace.php:121
 msgid "Type in your password again."
 msgstr ""
 
+#: inc/registration/namespace.php:122
 msgid "Password must be at least 12 characters in length, include at least one upper case letter, and have at least one number."
 msgstr ""
 
+#: inc/registration/namespace.php:136
+#: inc/registration/namespace.php:176
+#: inc/registration/namespace.php:195
+#: inc/registration/namespace.php:214
 msgid "Please try again."
 msgstr ""
 
+#: inc/registration/namespace.php:146
 msgid "You have to enter a password."
 msgstr ""
 
+#: inc/registration/namespace.php:152
 msgid "Passwords do not match."
 msgstr ""
 
+#: inc/registration/namespace.php:341
 msgid "Password must be at least 12 characters."
 msgstr ""
 
+#: inc/registration/namespace.php:345
 msgid "Password must include at least one upper case letter."
 msgstr ""
 
+#: inc/registration/namespace.php:349
 msgid "Password must include at least one lower case letter."
 msgstr ""
 
+#: inc/registration/namespace.php:353
 msgid "Password must include at least one number."
 msgstr ""
 
+#: inc/shortcodes/attributions/class-attachments.php:200
 msgid " &copy; "
 msgstr ""
 
+#: inc/shortcodes/attributions/class-attachments.php:201
 msgid " adapted by "
 msgstr ""
 
+#: inc/shortcodes/footnotes/class-footnotes.php:187
+#: tests/test-shortcodes-footnotes-footnotes.php:164
 msgid "Invalid permissions."
 msgstr ""
 
+#: inc/shortcodes/glossary/class-glossary.php:139
 msgid "Select"
 msgstr ""
 
+#: inc/theme/class-lock.php:96
 msgid "Your book&rsquo;s theme, %1$s, has been locked in its current state as of %2$s at %3$s."
 msgstr ""
 
+#: inc/theme/class-lock.php:109
 msgid "Your book&rsquo;s theme could not be locked. Please ensure that you have write access to the uploads directory."
 msgstr ""
 
+#: inc/theme/class-lock.php:203
 msgid "Your book&rsquo;s theme has been unlocked."
 msgstr ""
 
+#: inc/theme/class-lock.php:269
 msgid "Your book&rsquo;s theme, %1$s, was locked in its current state as of %2$s at %3$s. To select a new theme or change your theme options, please %4$s."
 msgstr ""
 
+#: inc/theme/namespace.php:41
 msgid "Your theme, %1$s, is not installed. Please visit %2$s for installation instructions."
 msgstr ""
 
+#: inc/theme/namespace.php:56
 msgid "The Pressbooks Book theme is not installed, but Pressbooks needs it in order to function properly. Please visit %s for installation instructions."
 msgstr ""
 
+#: inc/theme/namespace.php:84
 msgid "The Pressbooks Custom CSS theme must be upgraded. Please visit %s for installation instructions."
 msgstr ""
 
+#: inc/theme/namespace.php:138
 msgid "Luther has been replaced with McLuhan as Pressbooks’ default book theme. To continue using Luther for your book, please ensure that the standalone <a href=\"%1$s\">Luther theme</a> is installed and network activated."
 msgstr ""
 
+#: inc/utility/class-handlestransfers.php:41
 msgid "Download JSON"
 msgstr ""
 
+#: inc/utility/class-handlestransfers.php:119
 msgid "Successfully imported."
 msgstr ""
 
+#: inc/utility/class-handlestransfers.php:244
 msgid "One or more contributors could not be imported because they were missing a name or slug."
 msgstr ""
 
+#: inc/utility/class-handlestransfers.php:311
 msgid "Values for one or more of the imported contributors were altered by our validation routine. "
 msgstr ""
 
+#: inc/utility/class-percentageyield.php:90
 msgid " (%1$d of %2$d)"
 msgstr ""
 
+#: inc/utility/namespace.php:580
+#: inc/utility/namespace.php:591
+#: inc/utility/namespace.php:607
 msgid "An unexpected error occurred. Something may be wrong with the plugin recommendations server or your site&#8217;s server&#8217;s configuration."
 msgstr ""
 
+#: inc/utility/namespace.php:580
 msgid "(Pressbooks could not establish a secure connection to the plugin recommendations server. Please contact your server administrator.)"
 msgstr ""
 
+#: inc/utility/namespace.php:631
 msgid "These plugins have been created and/or recommended by the Pressbooks community."
 msgstr ""
 
+#: languages/tinymce.php:4
 msgid "Class"
 msgstr ""
 
+#: languages/tinymce.php:5
 msgid "Textboxes"
 msgstr ""
 
+#: languages/tinymce.php:6
 msgid "Custom Textbox"
 msgstr ""
 
+#: languages/tinymce.php:8
 msgid "Standard (Sidebar)"
 msgstr ""
 
+#: languages/tinymce.php:9
 msgid "Type your textbox content here."
 msgstr ""
 
+#: languages/tinymce.php:11
 msgid "Shaded (Sidebar)"
 msgstr ""
 
+#: languages/tinymce.php:13
 msgid "Learning Objectives (Sidebar)"
 msgstr ""
 
+#: languages/tinymce.php:14
 msgid "Type your learning objectives here."
 msgstr ""
 
+#: languages/tinymce.php:16
 msgid "Key Takeaways (Sidebar)"
 msgstr ""
 
+#: languages/tinymce.php:17
 msgid "Type your key takeaways here."
 msgstr ""
 
+#: languages/tinymce.php:19
 msgid "Exercises (Sidebar)"
 msgstr ""
 
+#: languages/tinymce.php:20
 msgid "Type your exercises here."
 msgstr ""
 
+#: languages/tinymce.php:22
 msgid "Examples (Sidebar)"
 msgstr ""
 
+#: languages/tinymce.php:23
 msgid "Type your examples here."
 msgstr ""
 
+#: languages/tinymce.php:24
 msgid "Custom..."
 msgstr ""
 
+#: languages/tinymce.php:25
 msgid "First"
 msgstr ""
 
+#: languages/tinymce.php:26
 msgid "Second"
 msgstr ""
 
+#: languages/tinymce.php:27
 msgid "Apply Class"
 msgstr ""
 
 #. translators: 1: URL to Composer documentation, 2: URL to Pressbooks latest releases
+#: pressbooks.php:79
 msgid "Pressbooks dependencies are missing. Please make sure that your project&rsquo;s <a href=\"%1$s\">Composer autoload file</a> is being required, or use the <a href=\"%2$s\">latest release</a> instead."
 msgstr ""
 
+#: pressbooks.php:90
 msgid "Cannot find Pressbooks install."
 msgstr ""
 
-msgid "datetimepicker not supported by Pressbooks"
-msgstr ""
-
-msgid "timepicker not supported by Pressbooks"
-msgstr ""
-
+#: templates/admin/catalog.php:27
 msgid "Tags For"
 msgstr ""
 
+#: templates/admin/catalog.php:50
 msgid "Tags"
 msgstr ""
 
+#: templates/admin/catalog.php:91
 msgid "My Catalog Profile"
 msgstr ""
 
+#: templates/admin/catalog.php:102
 msgid "URL"
 msgstr ""
 
+#: templates/admin/catalog.php:106
 msgid "Tags Name"
 msgstr ""
 
+#: templates/admin/catalog.php:115
 msgid "Sidebar Color"
 msgstr ""
 
+#: templates/admin/catalog.php:118
 msgid "Logo Or Image"
 msgstr ""
 
+#: templates/admin/cloner.php:14
 msgid "This tool allows you to %1$s from one Pressbooks network to another. Search the thousands of books in the %2$s for material you would like to clone. Once a book is cloned into your network, you can edit content, add new media, and enhance with H5P interactive activities."
 msgstr ""
 
+#: templates/admin/cloner.php:14
 msgid "clone openly licensed books"
 msgstr ""
 
+#: templates/admin/cloner.php:22
 msgid "Enter the URL to a Pressbooks book with an open license which permits cloning."
 msgstr ""
 
+#: templates/admin/cloner.php:26
 msgid "Target Book URL"
 msgstr ""
 
+#: templates/admin/cloner.php:34
 msgid "Enter an available URL where you want this book to be cloned."
 msgstr ""
 
+#: templates/admin/cloner.php:38
 msgid "Target Book Title"
 msgstr ""
 
+#: templates/admin/cloner.php:41
 msgid "Optional. If you leave this blank, the title of the source book will be used."
 msgstr ""
 
+#: templates/admin/cloner.php:45
 msgid "Clone This Book"
 msgstr ""
 
+#: templates/admin/covergenerator.php:65
+#: templates/admin/covergenerator.php:85
 msgid "You are currently using the Custom CSS theme. To generate a cover, you will need to switch back to a base theme temporarily. You can then reapply your Custom CSS theme."
 msgstr ""
 
+#: templates/admin/covergenerator.php:69
 msgid "Using our cover generator, you can easily create a beautiful cover for your <strong>print</strong> book that will work with most Print on Demand services, as well as an <strong>ebook</strong> cover that will meet the specifications of Kindle, Apple and other ebook retailers."
 msgstr ""
 
+#: templates/admin/covergenerator.php:79
 msgid "Make Your Cover"
 msgstr ""
 
+#: templates/admin/covergenerator.php:92
 msgid "Make PDF Cover"
 msgstr ""
 
+#: templates/admin/covergenerator.php:98
 msgid "Make Ebook Cover"
 msgstr ""
 
+#: templates/admin/covergenerator.php:100
 msgid "Download"
 msgstr ""
 
+#: templates/admin/covergenerator.php:104
 msgid "Sorry! You have to generate some covers first."
 msgstr ""
 
 #. translators: %s date/time
+#: templates/admin/covergenerator.php:107
 msgid "Your latest covers were generated on %s. Hover to download them."
 msgstr ""
 
+#: templates/admin/covergenerator.php:139
 msgid "Are you sure you want to delete ALL your current covers?"
 msgstr ""
 
+#: templates/admin/covergenerator.php:139
 msgid "Delete All Covers"
 msgstr ""
 
+#: templates/admin/custom-styles.php:33
 msgid "Error: Something went wrong. See logs for more details."
 msgstr ""
 
+#: templates/admin/custom-styles.php:43
 msgid "You are currently editing styles for"
 msgstr ""
 
+#: templates/admin/custom-styles.php:44
 msgid "Theme %1$s Styles (%2$s)"
 msgstr ""
 
+#: templates/admin/custom-styles.php:46
 msgid "Your %s Styles"
 msgstr ""
 
+#: templates/admin/custom-styles.php:48
 msgid "Save"
 msgstr ""
 
+#: templates/admin/dashboard.php:35
 msgid "Dashboard Settings"
 msgstr ""
 
+#: templates/admin/dashboard.php:37
 msgid "Customize your Pressbooks dashboard below."
 msgstr ""
 
+#: templates/admin/import.php:18
 msgid "Web page or Pressbooks webbook (.html or URL)"
 msgstr ""
 
+#: templates/admin/import.php:18
 msgid "Web page (.html or URL)"
 msgstr ""
 
+#: templates/admin/import.php:28
 msgid "EPUB (.epub)"
 msgstr ""
 
+#: templates/admin/import.php:29
 msgid "Microsoft Word (.docx)"
 msgstr ""
 
+#: templates/admin/import.php:30
 msgid "OpenOffice (.odt)"
 msgstr ""
 
+#: templates/admin/import.php:31
 msgid "Pressbooks/WordPress XML (.wxr or .xml)"
 msgstr ""
 
+#: templates/admin/import.php:44
 msgid "Select content below for import into Pressbooks."
 msgstr ""
 
+#: templates/admin/import.php:45
 msgid "Source:"
 msgstr ""
 
+#: templates/admin/import.php:63
 msgid "Selected all sections for import"
 msgstr ""
 
+#: templates/admin/import.php:65
 msgid "Unselected all sections for import"
 msgstr ""
 
+#: templates/admin/import.php:70
 msgid "Are you sure you want to abort the import?"
 msgstr ""
 
+#: templates/admin/import.php:88
+#: templates/admin/import.php:143
 msgid "Import all"
 msgstr ""
 
+#: templates/admin/import.php:99
 msgid "Other"
 msgstr ""
 
+#: templates/admin/import.php:149
 msgid "Show imported content in web"
 msgstr ""
 
+#: templates/admin/import.php:154
 msgid "Import Selection"
 msgstr ""
 
+#: templates/admin/import.php:181
 msgid "Maximum file size:"
 msgstr ""
 
+#: templates/admin/import.php:191
 msgid "Import Type"
 msgstr ""
 
+#: templates/admin/import.php:203
 msgid "Import Source"
 msgstr ""
 
+#: templates/admin/import.php:222
 msgid "Begin Import"
 msgstr ""
 
+#: templates/admin/organize.php:42
+#: templates/admin/organize.php:44
 msgid "This book's global privacy is set to"
 msgstr ""
 
 #. translators: %s: URL to Pressbooks Directory
+#: templates/admin/organize.php:50
 msgid "Anyone with the link can see your book. Public books are eligible to be listed in <a href=\"%s\">Pressbooks Directory</a>. Individual chapters can be set to private."
 msgstr ""
 
+#: templates/admin/organize.php:56
 msgid "Only users you invite can see your book, regardless of individual chapter visibility below."
 msgstr ""
 
+#: templates/admin/organize.php:75
 msgid "Add Glossary Term"
 msgstr ""
 
+#: templates/admin/organize.php:78
 msgid "Word Count:"
 msgstr ""
 
+#: templates/admin/organize.php:78
 msgid "%s (whole book)"
 msgstr ""
 
+#: templates/admin/organize.php:79
 msgid "%s (selected for export)"
 msgstr ""
 
+#: templates/admin/organize.php:123
+#: templates/admin/organize.php:189
+#: templates/admin/organize.php:347
 msgid "Edit"
 msgstr ""
 
+#: templates/admin/organize.php:125
+#: templates/admin/organize.php:191
+#: templates/admin/organize.php:349
 msgid "Trash"
 msgstr ""
 
+#: templates/admin/organize.php:126
+#: templates/admin/organize.php:192
+#: templates/admin/organize.php:350
 msgid "View"
 msgstr ""
 
+#: templates/admin/organize.php:133
+#: templates/admin/organize.php:292
 msgid "Comments"
 msgstr ""
 
+#: templates/admin/organize.php:178
+#: templates/admin/organize.php:183
+#: templates/admin/organize.php:336
+#: templates/admin/organize.php:341
 msgid "Ebook start point"
 msgstr ""
 
+#: templates/admin/organize.php:199
+#: templates/admin/organize.php:358
 msgid "Move Up"
 msgstr ""
 
+#: templates/admin/organize.php:202
+#: templates/admin/organize.php:361
 msgid "Move Down"
 msgstr ""
 
+#: templates/admin/results.php:4
 msgid "Results"
 msgstr ""
 
+#: templates/admin/results.php:6
 msgid "%1$s result(s) found."
 msgstr ""
 
+#: templates/admin/results.php:21
 msgid "There are no results."
 msgstr ""
 
+#: templates/admin/search.php:12
 msgid "Search & Replace will find and replace ALL instances of the search pattern in your entire book. Replacements will only be saved if you click &lsquo;<strong>Replace &amp; Save</strong>&rsquo;."
 msgstr ""
 
+#: templates/admin/search.php:13
 msgid "Be careful replacing text. There is no undo button. However, you can revert your changes using the Revision History within each chapter, front matter or back matter."
 msgstr ""
 
+#: templates/admin/search.php:17
 msgid "Search Within"
 msgstr ""
 
+#: templates/admin/search.php:41
 msgid "Result Order"
 msgstr ""
 
+#: templates/admin/search.php:50
 msgid "Ascending"
 msgstr ""
 
+#: templates/admin/search.php:51
 msgid "Descending"
 msgstr ""
 
+#: templates/admin/search.php:56
 msgid "Search For"
 msgstr ""
 
+#: templates/admin/search.php:62
 msgid "Replace With"
 msgstr ""
 
+#: templates/admin/search.php:69
 msgid "Regex"
 msgstr ""
 
+#: templates/admin/search.php:73
 msgid "Enable regular expressions"
 msgstr ""
 
+#: templates/admin/search.php:84
 msgid "Preview Replacements"
 msgstr ""
 
+#: templates/admin/search.php:85
 msgid "Replace &amp; Save"
 msgstr ""
 
+#: templates/admin/trash.php:21
 msgid "Restore deleted chapters, parts, front and back matter, and glossary terms"
 msgstr ""
 
+#: templates/admin/trash.php:22
 msgid "<strong>NOTE</strong>: Items in the trash will be permanently deleted after %d days."
 msgstr ""
 
+#: templates/admin/trash.php:27
 msgid "No trash found."
 msgstr ""
 
+#: templates/admin/trash.php:37
 msgid "Last Modified"
 msgstr ""
 
+#: templates/admin/trash.php:38
 msgid "Type"
 msgstr ""
 
+#: templates/admin/trash.php:39
 msgid "Action"
 msgstr ""
 
+#: templates/pb-catalog.php:160
 msgid "'s Catalog Page"
 msgstr ""
 
+#: templates/pb-catalog.php:181
 msgid "login"
 msgstr ""
 
+#: templates/pb-catalog.php:183
 msgid "logout"
 msgstr ""
 
+#: templates/pb-catalog.php:191
 msgid "Admin"
 msgstr ""
 
+#: templates/pb-catalog.php:244
 msgid "Catalog"
 msgstr ""
 
+#: templates/pb-catalog.php:244
 msgid "filtering by"
 msgstr ""
 
+#: templates/pb-catalog.php:269
 msgid "Sorry, but no books matched your filtering criteria. Please <a class=\"clear-filters\" href=\"#\">clear your current filters</a> and try again."
 msgstr ""
 
+#: templates/pb-catalog.php:273
 msgid "Pressbooks: the CMS for Books."
 msgstr ""
 
+#: tests/test-registration.php:29
 msgid "Create Site"
 msgstr ""
 
+#: assets/src/scripts/a11y.js:35
+#: assets/src/scripts/a11y.js:36
 msgid "Gradient selector"
 msgstr ""
 
+#: assets/src/scripts/a11y.js:49
 msgid "Black"
 msgstr ""
 
+#: assets/src/scripts/a11y.js:52
 msgid "White"
 msgstr ""
 
+#: assets/src/scripts/a11y.js:55
 msgid "Red"
 msgstr ""
 
+#: assets/src/scripts/a11y.js:58
 msgid "Orange"
 msgstr ""
 
+#: assets/src/scripts/a11y.js:61
 msgid "Yellow"
 msgstr ""
 
+#: assets/src/scripts/a11y.js:64
 msgid "Green"
 msgstr ""
 
+#: assets/src/scripts/a11y.js:67
 msgid "Blue"
 msgstr ""
 
+#: assets/src/scripts/a11y.js:70
 msgid "Purple"
 msgstr ""
 
+#: templates/admin/diagnostics.blade.php:5
 msgid "Please submit this information with any bug reports."
 msgstr ""
 
+#: templates/admin/diagnostics.blade.php:6
 msgid "To copy the system info, click below then press Ctrl + C (PC) or Cmd + C (Mac)."
 msgstr ""
 
+#: templates/admin/diagnostics.blade.php:8
 msgid "View Source"
 msgstr ""
 
+#: templates/admin/diagnostics.blade.php:9
 msgid "<a href=\"%s\">View your book&rsquo;s XHTML source</a> to diagnose issues you may be encountering with your PDF exports."
 msgstr ""
 
+#: templates/admin/diagnostics.blade.php:10
 msgid "Regenerate Webbook Stylesheet"
 msgstr ""
 
+#: templates/admin/diagnostics.blade.php:11
 msgid "If your webbook stylesheet has issues, it may help to regenerate it."
 msgstr ""
 
+#: templates/admin/diagnostics.blade.php:12
 msgid "Regenerate Stylesheet"
 msgstr ""
 
+#: templates/admin/export.blade.php:12
 msgid "You can select multiple formats below. Pressbooks keeps the last 3 exports of each file format. You can pin specific files to make sure they don't get deleted."
 msgstr ""
 
+#: templates/admin/export.blade.php:15
 msgid "Toggle panel: Export Options"
 msgstr ""
 
+#: templates/admin/export.blade.php:19
 msgid "Export Options"
 msgstr ""
 
+#: templates/admin/export.blade.php:28
 msgid "Supported formats"
 msgstr ""
 
+#: templates/admin/export.blade.php:38
 msgid "Other formats"
 msgstr ""
 
+#: templates/admin/export.blade.php:56
 msgid "Your Theme"
 msgstr ""
 
+#: templates/admin/export.blade.php:76
 msgid "Export Your Book"
 msgstr ""
 
+#: templates/admin/export.blade.php:81
 msgid "Latest Exports"
 msgstr ""
 
+#: templates/admin/institutions.blade.php:9
 msgid "This optional field can be used to display the institution(s) which created this resource. If your college or university is not listed, please contact your network manager."
 msgstr ""
 
+#: templates/admin/mathjax.blade.php:5
 msgid "If you can see a big integral, then PB-MathJax is configured correctly, and all is well."
 msgstr ""
 
+#: templates/admin/mathjax.blade.php:10
 msgid "Syntax"
 msgstr ""
 
+#: templates/admin/mathjax.blade.php:13
 msgid "LaTeX"
 msgstr ""
 
+#: templates/admin/mathjax.blade.php:15
+#: templates/admin/mathjax.blade.php:26
 msgid "Shortcode syntax: %s"
 msgstr ""
 
+#: templates/admin/mathjax.blade.php:19
+#: templates/admin/mathjax.blade.php:30
 msgid "Dollar sign syntax: %s"
 msgstr ""
 
+#: templates/admin/mathjax.blade.php:24
 msgid "AsciiMath"
 msgstr ""
 
+#: templates/admin/mathjax.blade.php:35
 msgid "MathML"
 msgstr ""
 
+#: templates/admin/mathjax.blade.php:37
 msgid "Markup syntax: %s"
 msgstr ""
 
+#: templates/admin/mathjax.blade.php:44
 msgid "Text color"
 msgstr ""
 
+#: templates/admin/mathjax.blade.php:47
 msgid "A six digit hexadecimal number like <code>000000</code> or <code>ffffff</code>"
 msgstr ""
 
+#: templates/admin/mathjax.blade.php:52
 msgid "SVG/PNG Fonts"
 msgstr ""
 
+#: templates/admin/mathjax.blade.php:58
 msgid "Affects exports (PDF, EPUB, MOBI.) Webbook uses CommonHTML. CommonHTML currently only supports MathJax’s default TeX fonts."
 msgstr ""
 
+#: templates/admin/mathjax.blade.php:64
 msgid "Save Changes"
 msgstr ""
 
+#: templates/admin/sitemap.blade.php:3
 msgid "Admin Bar"
 msgstr ""
 
+#: templates/admin/sitemap.blade.php:6
 msgid "Side Menu"
 msgstr ""
 
+#: templates/export/title.blade.php:16
 msgid "Publisher Logo"
 msgstr ""
 
+#: templates/interactive/h5p.blade.php:3
 msgid "An interactive H5P element has been excluded from this version of the text. You can view it online here:"
 msgstr ""
 
+#: templates/interactive/media.blade.php:4
 msgid "One or more interactive elements has been excluded from this version of the text. You can view them online here: "
 msgstr ""


### PR DESCRIPTION
This PR attempts to fix the update-pot action by removing the specific version constraint for `wp-cli/i18n-command`. It also temporarily changes the action so that it will run on a manual trigger & produce an artifact rather than committing directly, until we can confirm that the change works as expected.

Partial fix for https://github.com/pressbooks/pressbooks/issues/2686