### PR TITLE
Replace DOI resolver URL

### DIFF
--- a/inc/metadata/namespace.php
+++ b/inc/metadata/namespace.php
@@ -371,11 +371,11 @@ function book_information_to_schema( array $book_information, bool $network_excl
 			'value' => $book_information['pb_book_doi'],
 		];
 		/**
-		 * Filter the DOI resolver service URL (default: https://dx.doi.org).
+		 * Filter the DOI resolver service URL (default: https://doi.org).
 		 *
 		 * @since 5.6.0
 		 */
-		$doi_resolver = apply_filters( 'pb_doi_resolver', 'https://dx.doi.org' );
+		$doi_resolver = apply_filters( 'pb_doi_resolver', 'https://doi.org' );
 		$book_schema['sameAs'] = trailingslashit( $doi_resolver ) . $book_information['pb_book_doi'];
 	}
 
@@ -550,11 +550,11 @@ function schema_to_book_information( array $book_schema ): array {
 
 	if ( isset( $book_schema['sameAs'] ) ) {
 		/**
-		 * Filter the DOI resolver service URL (default: https://dx.doi.org).
+		 * Filter the DOI resolver service URL (default: https://doi.org).
 		 *
 		 * @since 5.6.0
 		 */
-		$doi_resolver = apply_filters( 'pb_doi_resolver', 'https://dx.doi.org' );
+		$doi_resolver = apply_filters( 'pb_doi_resolver', 'https://doi.org' );
 		$book_information['pb_book_doi'] = str_replace( trailingslashit( $doi_resolver ), '', $book_schema['sameAs'] );
 	}
 
@@ -707,11 +707,11 @@ function section_information_to_schema( $section_information, $book_information 
 			'value' => $section_information['pb_section_doi'],
 		];
 		/**
-		 * Filter the DOI resolver service URL (default: https://dx.doi.org).
+		 * Filter the DOI resolver service URL (default: https://doi.org).
 		 *
 		 * @since 5.6.0
 		 */
-		$doi_resolver = apply_filters( 'pb_doi_resolver', 'https://dx.doi.org' );
+		$doi_resolver = apply_filters( 'pb_doi_resolver', 'https://doi.org' );
 		$section_schema['sameAs'] = trailingslashit( $doi_resolver ) . $section_information['pb_section_doi'];
 	}
 
@@ -795,11 +795,11 @@ function schema_to_section_information( $section_schema, $book_schema ) {
 
 	if ( isset( $section_schema['sameAs'] ) ) {
 		/**
-		 * Filter the DOI resolver service URL (default: https://dx.doi.org).
+		 * Filter the DOI resolver service URL (default: https://doi.org).
 		 *
 		 * @since 5.6.0
 		 */
-		$doi_resolver = apply_filters( 'pb_doi_resolver', 'https://dx.doi.org' );
+		$doi_resolver = apply_filters( 'pb_doi_resolver', 'https://doi.org' );
 		$section_information['pb_section_doi'] = str_replace( trailingslashit( $doi_resolver ), '', $section_schema['sameAs'] );
 	}
 

--- a/tests/test-metadata.php
+++ b/tests/test-metadata.php
@@ -130,7 +130,7 @@ class MetadataTest extends \WP_UnitTestCase {
 		self::assertArraySubset(
 			[
 				'name' => 'Moby Dick',
-				'sameAs' => 'https://dx.doi.org/my_doi',
+				'sameAs' => 'https://doi.org/my_doi',
 				'identifier' => ['value' => 'my_doi'],
 				'author' => [
 					['name' => 'Herman Melville']
@@ -162,7 +162,7 @@ class MetadataTest extends \WP_UnitTestCase {
 					'name' => 'Pat Metheny',
 				],
 			],
-			'sameAs' => 'https://dx.doi.org/my_doi',
+			'sameAs' => 'https://doi.org/my_doi',
 			'institutions' => [
 				[
 					'@type' => 'Institution',
@@ -409,7 +409,7 @@ class MetadataTest extends \WP_UnitTestCase {
 				'url' => 'https://creativecommons.org/publicdomain/zero/1.0/',
 				'name' => 'Public Domain (No Rights Reserved)',
 			],
-			'sameAs' => 'https://dx.doi.org/my_doi',
+			'sameAs' => 'https://doi.org/my_doi',
 		];
 
 		$result = \Pressbooks\Metadata\schema_to_section_information( $section_schema, $book_schema );


### PR DESCRIPTION
Partial fix for https://github.com/pressbooks/pressbooks/issues/2429. Accompanies https://github.com/pressbooks/pressbooks-book/pull/1003

To test:
1. Checkout this branch and `pb-2429-doi-fix` in pressbooks-book 
2. Enter a DOI for a book in book info (for example `10.1109/5.771073`) and save changes
3. Make sure that the resolver URL uses `https://doi.org` instead of `https://dx.doi.org` when rendered on the book homepage and in file exports
![Screenshot from 2022-04-05 14-40-06](https://user-images.githubusercontent.com/13485451/161854293-ee623121-9fad-4215-b8a3-a073ea6dc360.png)

