### PR TITLE
feat: add built assets to Dependabot PRs

### DIFF
--- a/.github/workflows/autobuild-dependabot-assets.yml
+++ b/.github/workflows/autobuild-dependabot-assets.yml
@@ -17,11 +17,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref }}
-      - name: Cache Node modules
-        uses: actions/cache@v2
-        with:
-          path: node_modules
-          key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
       - name: Install dependencies
         run: npm ci
       - name: Build assets

--- a/.github/workflows/autobuild-dependabot-assets.yml
+++ b/.github/workflows/autobuild-dependabot-assets.yml
@@ -1,0 +1,46 @@
+name: Add built assets to Dependabot PRs
+
+on:
+  pull_request_target:
+    branches:
+      - dev
+    paths:
+      - package.json
+      - package-lock.json
+
+jobs:
+  autobuild:
+    if: startsWith(github.head_ref, 'autobuild') == false && startsWith(github.head_ref, 'dependabot') == true && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Dependabot branch
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Cache Node modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
+      - name: Install dependencies
+        run: npm ci
+      - name: Build assets
+        run: npm run build
+      - name: Create pull request with built assets
+        id: cpr
+        uses: peter-evans/create-pull-request@v4
+        with:
+          commit-message: "chore(build): build assets"
+          title: "chore(build): build assets"
+          body: This is an auto-generated PR to build assets changed by Dependabot.
+          labels: dependencies, automerge
+          branch: "autobuild/${{ github.head_ref }}"
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Merge pull request with built assets into Dependabot branch
+        if: ${{ steps.cpr.outputs.pull-request-number }}
+        uses: "pascalgn/automerge-action@v0.15.2"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_LABELS: automerge
+          MERGE_METHOD: squash
+          PULL_REQUEST: "${{ steps.cpr.outputs.pull-request-number }}"


### PR DESCRIPTION
This PR adds a new GitHub Actions workflow to facilitate testing and merging Dependabot pull requests which modify front end (CSS or JavaScript) dependencies.

## Details

Currently, when Dependabot issues a PR to update a front end dependency (CSS or JavaScript), the developer must test the PR's changes using the following steps:

1. Check out the PR branch.
2. Run `npm ci` to install the updated dependency.
3. Run `npm run build` to compile Sass and transpile JavaScript.
4. Test the changes.
5. Once the changes have been tested and the PR merged, the developer must then run the build script and commit the built assets to the `dev` branch.

This PR removes steps 2, 3, and 5 using the following approach. When a Dependabot PR is issued which modifies `package.json` and/or `package-lock.json` files, a workflow is triggered which:

1. Checks out the Dependabot PR branch.
2. Runs `npm ci` to install the updated dependency.
3. Runs `npm run build` to compile Sass and transpile JavaScript.
4. If the built assets have changed, issues a PR _against the Dependabot branch_.
6. Automatically merges the PR with built assets _into the Dependabot branch_.

This means that Dependabot PRs will now include updated CSS and JavaScript build artifacts, which means:

- [x] Developers can test Dependabot changes immediately without needing to install and build assets.
- [x] Merging a Dependabot PR also updates build artifacts.

## Other notes

- Any changes to the Dependabot PR branch (e.g. `@dependabot rebase`) will trigger a rebuild and automerge of the assets.
- This workflow can be added without modification to other repositories with front-end dependencies. It might even be a good candidate for an organization-level workflow as it does not require per-project customization (only that the primary branch is `dev`).