### PR TITLE
Replace intervention

### DIFF
--- a/.github/workflows/build-and-lint.yml
+++ b/.github/workflows/build-and-lint.yml
@@ -13,15 +13,15 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
-      - name: Cache node modules
+      - name: Cache Node modules
         uses: actions/cache@v2
         with:
           path: node_modules
           key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
-      - name: Install Node dependencies
-          run: |
-            node -v
-            npm install
-            npm run build
+      - name: Install Node dependencies & build assets
+        run: |
+          node -v
+          npm install
+          npm run build
       - name: Run ESLint and Stylelint
-          run: npm run lint
+        run: npm run lint

--- a/.github/workflows/build-and-lint.yml
+++ b/.github/workflows/build-and-lint.yml
@@ -1,0 +1,27 @@
+on: push
+name: Build & Lint
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [ '14' ]
+    name: Node ${{ matrix.node }}
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Cache node modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
+      - name: Install Node dependencies
+          run: |
+            node -v
+            npm install
+            npm run build
+      - name: Run ESLint and Stylelint
+          run: npm run lint

--- a/.github/workflows/standards-and-tests.yml
+++ b/.github/workflows/standards-and-tests.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Run Standards & Tests
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
     branches: [ dev ]
 
 jobs:
-  lint-and-test:
+  standards-and-tests:
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Lint and test
+name: Test
 
 on:
   push:
@@ -53,22 +53,6 @@ jobs:
         path: vendor
         key: ${{ matrix.php }}-php-${{ hashFiles('**/composer.lock') }}
 
-    - name: Cache node modules
-      uses: actions/cache@v2
-      with:
-        path: node_modules
-        key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
-      if: matrix.experimental == false
-
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ matrix.php }}
-        tools: composer:v1
-        coverage: pcov
-        extensions: imagick
-      if: matrix.experimental == false
-
     - name: Setup PHP with Composer 2
       uses: shivammathur/setup-php@v2
       with:
@@ -76,24 +60,12 @@ jobs:
         tools: composer
         coverage: pcov
         extensions: imagick
-      if: matrix.experimental == true
-
-    - name: Install Node dependencies
-      run: |
-        node -v
-        npm install
-        npm run build
-      if: matrix.experimental == false
 
     - name: Install PHP dependencies
       run: |
         export PATH="$HOME/.composer/vendor/bin:$PATH"
         composer install --no-interaction
         ulimit -n 4096
-
-    - name: Run ESLint and Stylelint
-      run: npm run lint
-      if: matrix.experimental == false
 
     - name: Run PHP CodeSniffer
       run: composer standards

--- a/hooks-admin.php
+++ b/hooks-admin.php
@@ -54,6 +54,7 @@ add_action( 'wp_user_dashboard_setup', '\Pressbooks\Admin\Laf\add_pb_cloner_page
 add_action( 'admin_menu', '\Pressbooks\Admin\Dashboard\add_menu', 1 );
 add_action( 'admin_menu', '\Pressbooks\Admin\Diagnostics\add_menu', 30 );
 add_action( 'init', [ '\Pressbooks\Admin\SiteMap', 'init' ] );
+add_action( 'init', [ '\Pressbooks\Admin\Laf\remove_emoji' ] );
 add_action( 'wp_user_dashboard_setup', '\Pressbooks\Admin\Dashboard\lowly_user' );
 remove_action( 'welcome_panel', 'wp_welcome_panel' );
 

--- a/hooks-admin.php
+++ b/hooks-admin.php
@@ -54,7 +54,7 @@ add_action( 'wp_user_dashboard_setup', '\Pressbooks\Admin\Laf\add_pb_cloner_page
 add_action( 'admin_menu', '\Pressbooks\Admin\Dashboard\add_menu', 1 );
 add_action( 'admin_menu', '\Pressbooks\Admin\Diagnostics\add_menu', 30 );
 add_action( 'init', [ '\Pressbooks\Admin\SiteMap', 'init' ] );
-add_action( 'init', [ '\Pressbooks\Admin\Laf\remove_emoji' ] );
+add_action( 'init', '\Pressbooks\Admin\Laf\remove_emoji' );
 add_action( 'wp_user_dashboard_setup', '\Pressbooks\Admin\Dashboard\lowly_user' );
 remove_action( 'welcome_panel', 'wp_welcome_panel' );
 

--- a/hooks-admin.php
+++ b/hooks-admin.php
@@ -40,6 +40,7 @@ add_action( 'admin_bar_menu', '\Pressbooks\Admin\Laf\replace_menu_bar_branding',
 add_action( 'admin_bar_menu', '\Pressbooks\Admin\Laf\replace_menu_bar_my_sites', 21 );
 add_action( 'admin_bar_menu', '\Pressbooks\Admin\Laf\remove_menu_bar_update', 41 );
 add_action( 'admin_bar_menu', '\Pressbooks\Admin\Laf\remove_menu_bar_new_content', 71 );
+add_filter( 'admin_bar_menu', '\Pressbooks\Admin\Laf\replace_wordpress_howdy', 25 );
 add_action( 'admin_head', '\Pressbooks\Admin\Branding\favicon' );
 
 // Add contact Info

--- a/inc/admin/dashboard/namespace.php
+++ b/inc/admin/dashboard/namespace.php
@@ -72,10 +72,11 @@ function replace_root_dashboard_widgets() {
 	// Remove unwanted dashboard widgets
 	remove_meta_box( 'dashboard_primary', 'dashboard', 'side' );
 	remove_meta_box( 'dashboard_quick_press', 'dashboard', 'side' );
+	remove_meta_box( 'dashboard_recent_drafts', 'dashboard', 'side' );
 	remove_meta_box( 'health_check_status', 'dashboard', 'normal' );
 	remove_meta_box( 'dashboard_activity', 'dashboard', 'normal' );
 	remove_meta_box( 'dashboard_site_health', 'dashboard', 'normal' );
-	remove_meta_box( 'dashboard_recent_drafts', 'dashboard', 'side' );
+
 
 	// Remove third-party widgets
 	remove_meta_box( 'dashboard_rediscache', 'dashboard', 'normal' );

--- a/inc/admin/dashboard/namespace.php
+++ b/inc/admin/dashboard/namespace.php
@@ -75,6 +75,7 @@ function replace_root_dashboard_widgets() {
 	remove_meta_box( 'health_check_status', 'dashboard', 'normal' );
 	remove_meta_box( 'dashboard_activity', 'dashboard', 'normal' );
 	remove_meta_box( 'dashboard_site_health', 'dashboard', 'normal' );
+	remove_meta_box( 'dashboard_recent_drafts', 'dashboard', 'side' );
 
 	// Remove third-party widgets
 	remove_meta_box( 'dashboard_rediscache', 'dashboard', 'normal' );

--- a/inc/admin/dashboard/namespace.php
+++ b/inc/admin/dashboard/namespace.php
@@ -77,7 +77,6 @@ function replace_root_dashboard_widgets() {
 	remove_meta_box( 'dashboard_activity', 'dashboard', 'normal' );
 	remove_meta_box( 'dashboard_site_health', 'dashboard', 'normal' );
 
-
 	// Remove third-party widgets
 	remove_meta_box( 'dashboard_rediscache', 'dashboard', 'normal' );
 	$user = wp_get_current_user();

--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -1681,3 +1681,17 @@ function update_user_profile_fields( $user_id ) {
 
 	update_user_meta( $user_id, 'institution', sanitize_string( $_REQUEST['institution'] ) );
 }
+
+/**
+ *
+ * @since 5.35.0
+ * @param object $wp_admin_bar
+ */
+function replace_wordpress_howdy( $wp_admin_bar ) {
+	$my_account = $wp_admin_bar->get_node('my-account');
+	$newtext = str_replace( 'Howdy,', 'Welcome,', $my_account->title );
+	$wp_admin_bar->add_node( array(
+			'id' => 'my-account',
+			'title' => $newtext,
+	) );
+}

--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -1689,7 +1689,7 @@ function update_user_profile_fields( $user_id ) {
  */
 function replace_wordpress_howdy( $wp_admin_bar ) {
 	$my_account = $wp_admin_bar->get_node('my-account');
-	$newtext = str_replace( 'Howdy,', 'Welcome,', $my_account->title );
+	$newtext = str_replace( 'Howdy,', 'Hello,', $my_account->title );
 	$wp_admin_bar->add_node( array(
 			'id' => 'my-account',
 			'title' => $newtext,

--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -1700,7 +1700,6 @@ function replace_wordpress_howdy( $wp_admin_bar ) {
  *
  * @since 5.35.0
  */
-
 function remove_emoji() {
 	remove_action( 'admin_print_styles', 'print_emoji_styles' );
 	remove_action( 'wp_head', 'print_emoji_detection_script', 7 );

--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -1688,10 +1688,10 @@ function update_user_profile_fields( $user_id ) {
  * @param object $wp_admin_bar
  */
 function replace_wordpress_howdy( $wp_admin_bar ) {
-	$my_account = $wp_admin_bar->get_node('my-account');
+	$my_account = $wp_admin_bar->get_node( 'my-account' );
 	$newtext = str_replace( 'Howdy,', 'Hello,', $my_account->title );
-	$wp_admin_bar->add_node( array(
-			'id' => 'my-account',
-			'title' => $newtext,
-	) );
+	$wp_admin_bar->add_node( [
+		'id' => 'my-account',
+		'title' => $newtext,
+	] );
 }

--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -1695,3 +1695,26 @@ function replace_wordpress_howdy( $wp_admin_bar ) {
 		'title' => $newtext,
 	] );
 }
+
+/**
+ *
+ * @since 5.35.0
+ */
+
+function removeEmoji() {
+	remove_action( 'admin_print_styles', 'print_emoji_styles' );
+	remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
+	remove_action( 'admin_print_scripts', 'print_emoji_detection_script' );
+	remove_action( 'wp_print_styles', 'print_emoji_styles' );
+	remove_filter( 'wp_mail', 'wp_staticize_emoji_for_email' );
+	remove_filter( 'the_content_feed', 'wp_staticize_emoji' );
+	remove_filter( 'comment_text_rss', 'wp_staticize_emoji' );
+	add_filter( 'emoji_svg_url', '__return_false' );
+	add_filter('tiny_mce_plugins', function ( $plugins ) {
+		if ( is_array( $plugins ) ) {
+			return array_diff( $plugins, [ 'wpemoji' ] );
+		} else {
+			return [];
+		}
+	});
+}

--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -1701,7 +1701,7 @@ function replace_wordpress_howdy( $wp_admin_bar ) {
  * @since 5.35.0
  */
 
-function removeEmoji() {
+function remove_emoji() {
 	remove_action( 'admin_print_styles', 'print_emoji_styles' );
 	remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
 	remove_action( 'admin_print_scripts', 'print_emoji_detection_script' );

--- a/tests/test-admin-laf.php
+++ b/tests/test-admin-laf.php
@@ -129,7 +129,6 @@ class Admin_LafTest extends \WP_UnitTestCase {
 	/**
 	 * @group branding
 	 */
-
 	function test_fix_root_admin_menu() {
 		$user_id = $this->factory()->user->create();
 		$user = get_userdata( $user_id );
@@ -146,7 +145,6 @@ class Admin_LafTest extends \WP_UnitTestCase {
 	/**
 	 * @group branding
 	 */
-
 	function test_add_pb_cloner_page() {
 		$user_id = $this->factory()->user->create();
 		$user = get_userdata( $user_id );
@@ -369,7 +367,9 @@ class Admin_LafTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'The LinkedIn URL field is not a valid URL.', $error_handler->get_error_message( 'linkedin' ) );
 
 	}
-
+	/**
+	 * @group branding
+	 */
 	function test_institution_fields_hooks() {
 
 		global $post, $pagenow;
@@ -397,6 +397,20 @@ class Admin_LafTest extends \WP_UnitTestCase {
 
 		$this->assertNull( $result );
 
+	}
+	/**
+	 * @group branding
+	 */
+	function test_remove_emoji() {
+		\Pressbooks\Admin\Laf\remove_emoji();
+
+		$this->assertFalse( has_action( 'print_emoji_detection_script', 'wp_head' ) );
+		$this->assertFalse( has_action( 'print_emoji_styles', 'wp_print_styles' ) );
+		$this->assertFalse( has_action( 'print_emoji_detection_script', 'admin_print_scripts', ) );
+		$this->assertFalse( has_action( 'admin_print_styles', 'print_emoji_styles' ) );
+		$this->assertFalse( has_filter( 'wp_mail', 'wp_staticize_emoji_for_email' ) );
+		$this->assertFalse( has_filter( 'wp_staticize_emoji', 'the_content_feed' ) );
+		$this->assertFalse( has_filter( 'wp_staticize_emoji', 'comment_text_css' ) );
 	}
 
 }


### PR DESCRIPTION
This PR moves some of the functionality previously delegated to soberwp/intervention in pressbooks-book and aldine into core Pressbooks. It accompanies https://github.com/pressbooks/pressbooks-book/pull/1010 and https://github.com/pressbooks/pressbooks-aldine/pull/326

It also separates our CI pipeline into two separate steps: one which builds and lints js/css assets and another which runs standards and tests on php files. This will make checks faster, since we won't be repeatedly running the build & lint steps in each of our test matrices.