### PR TITLE
Only display 3 most recent posts in dashboard RSS feeds

### DIFF
--- a/inc/admin/dashboard/namespace.php
+++ b/inc/admin/dashboard/namespace.php
@@ -368,7 +368,7 @@ function display_pressbooks_blog() {
 		wp_widget_rss_output(
 			[
 				'url' => $options['url'],
-				'items' => 5,
+				'items' => 3,
 				'show_summary' => 1,
 				'show_author' => 0,
 				'show_date' => 0,


### PR DESCRIPTION
Only display 3 most recent posts in dashboard RSS feeds (previously displayed 5 posts). Accompanies https://github.com/pressbooks/pressbooks-plugins-config/pull/28

May need to clear cache to see changes locally.