### PR TITLE
fix: expose and clone private glossary terms

### DIFF
--- a/inc/api/endpoints/controller/class-posts.php
+++ b/inc/api/endpoints/controller/class-posts.php
@@ -152,16 +152,10 @@ class Posts extends \WP_REST_Posts_Controller {
 	 * @return bool Whether the post can be read.
 	 */
 	public function check_read_permission( $post ) {
-
-		if ( parent::check_read_permission( $post ) ) {
-			return true;
-		}
-
-		if ( current_user_can( 'edit_posts' ) ) {
-			return true;
-		}
-
-		return false;
+		// Private and public glossaries can be exposed
+		return parent::check_read_permission( $post ) ||
+			current_user_can( 'edit_posts' ) ||
+			$post->post_type === 'glossary';
 	}
 
 	/**

--- a/inc/cloner/class-cloner.php
+++ b/inc/cloner/class-cloner.php
@@ -1543,8 +1543,10 @@ class Cloner {
 			unset( $section[ $bad_key ] );
 		}
 
-		// Set status
-		$section['status'] = 'publish';
+		// Private and public glossaries can be cloned
+		if ( $post_type !== 'glossary' ) {
+			$section['status'] = 'publish';
+		}
 
 		// Download media (images, videos, `select * from wp_posts where post_type = 'attachment'` ... )
 		list( $content, $attachments ) = $this->retrieveSectionContent( $section );

--- a/inc/shortcodes/glossary/class-glossary.php
+++ b/inc/shortcodes/glossary/class-glossary.php
@@ -220,10 +220,8 @@ class Glossary implements BackMatter {
 
 		// Get the glossary post object the glossary term ID belongs to
 		$glossary_term = get_post( $glossary_term_id );
-		if ( ! $glossary_term ) {
-			return $content . 'no post';
-		}
-		if ( $glossary_term->post_status === 'trash' ) {
+
+		if ( ! $glossary_term || $glossary_term->post_status === 'trash' ) {
 			return $content;
 		}
 

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -392,6 +392,13 @@ class ApiTest extends \WP_UnitTestCase {
 			'post_status'  => 'publish',
 		];
 
+		$term4 = [
+			'post_type'    => 'glossary',
+			'post_title'   => 'Moved to trash',
+			'post_content' => 'This term was moved to trash.',
+			'post_status'  => 'trash',
+		];
+
 		$this->factory()->post->create_object( $term1 );
 		$this->factory()->post->create_object( $term2 );
 		$this->factory()->post->create_object( $term3 );
@@ -400,7 +407,7 @@ class ApiTest extends \WP_UnitTestCase {
 		$response = $server->dispatch( $request );
 		$data = $response->get_data();
 
-		$this->assertEquals( 2, count( $data ) );
+		$this->assertEquals( 3, count( $data ) );
 		$this->assertEquals( 'Synapse', $data[0]['title']['rendered'] );
 		$this->assertEquals( 'ML', $data[1]['title']['rendered'] );
 	}

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -402,13 +402,14 @@ class ApiTest extends \WP_UnitTestCase {
 		$this->factory()->post->create_object( $term1 );
 		$this->factory()->post->create_object( $term2 );
 		$this->factory()->post->create_object( $term3 );
+		$this->factory()->post->create_object( $term4 );
 
 		$request = new \WP_REST_Request( 'GET', '/pressbooks/v2/glossary' );
 		$response = $server->dispatch( $request );
 		$data = $response->get_data();
 
 		$this->assertEquals( 3, count( $data ) );
-		$this->assertEquals( 'Synapse', $data[0]['title']['rendered'] );
+		$this->assertEquals( 'Private: Not done', $data[0]['title']['rendered'] );
 		$this->assertEquals( 'ML', $data[1]['title']['rendered'] );
 	}
 

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -410,7 +410,7 @@ class ApiTest extends \WP_UnitTestCase {
 
 		$this->assertEquals( 3, count( $data ) );
 		$this->assertEquals( 'Private: Not done', $data[0]['title']['rendered'] );
-		$this->assertEquals( 'ML', $data[1]['title']['rendered'] );
+		$this->assertEquals( 'Synapse', $data[1]['title']['rendered'] );
 	}
 
 }


### PR DESCRIPTION
Issue: https://github.com/pressbooks/private/issues/912

This PR exposes private glossary terms to the API and allows them to be cloned. It also avoid the `no post` string when the glossary term was moved to trash.

### Testing case
- Clone a book with private and public glossary terms. Make sure there are references to public and private glossary terms within multiple chapters.
- The target book must contain all the private and public books with the correct references to the glossary terms.
- Move to trash any glossary term referenced in 1 or more chapters.
- Make sure there's not a `no post` string in the web version of the chapter.
