### PR TITLE
fix: register glossary shortcode for replacement through transitions

### DIFF
--- a/inc/cloner/class-cloner.php
+++ b/inc/cloner/class-cloner.php
@@ -321,9 +321,8 @@ class Cloner {
 		$this->h5p = $h5p ? $h5p : \Pressbooks\Interactive\Content::init()->getH5P();
 		$this->downloads = $downloads ? $downloads : new Downloads( $this, $this->h5p );
 		$this->contributors = $contributors ? $contributors : new \Pressbooks\Contributors();
-		// Register glossary and Attachments shortcodes if not already registered.
+		// Register glossary shortcode if not already registered.
 		Glossary::init();
-		Attachments::init();
 	}
 
 	/**

--- a/inc/cloner/class-cloner.php
+++ b/inc/cloner/class-cloner.php
@@ -8,9 +8,6 @@
 
 namespace Pressbooks\Cloner;
 
-use Pressbooks\Interactive\H5P;
-use Pressbooks\Shortcodes\Attributions\Attachments;
-use Pressbooks\Shortcodes\Glossary\Glossary;
 use function Pressbooks\Image\default_cover_url;
 use function Pressbooks\Image\strip_baseurl as image_strip_baseurl;
 use function Pressbooks\Media\strip_baseurl as media_strip_baseurl;
@@ -22,6 +19,7 @@ use function Pressbooks\Utility\str_remove_prefix;
 use function Pressbooks\Utility\str_starts_with;
 use Pressbooks\Admin\Network\SharingAndPrivacyOptions;
 use Pressbooks\Container;
+use Pressbooks\Shortcodes\Glossary\Glossary;
 use Pressbooks\Utility\PercentageYield;
 
 class Cloner {

--- a/inc/cloner/class-cloner.php
+++ b/inc/cloner/class-cloner.php
@@ -8,6 +8,9 @@
 
 namespace Pressbooks\Cloner;
 
+use Pressbooks\Interactive\H5P;
+use Pressbooks\Shortcodes\Attributions\Attachments;
+use Pressbooks\Shortcodes\Glossary\Glossary;
 use function Pressbooks\Image\default_cover_url;
 use function Pressbooks\Image\strip_baseurl as image_strip_baseurl;
 use function Pressbooks\Media\strip_baseurl as media_strip_baseurl;
@@ -318,6 +321,9 @@ class Cloner {
 		$this->h5p = $h5p ? $h5p : \Pressbooks\Interactive\Content::init()->getH5P();
 		$this->downloads = $downloads ? $downloads : new Downloads( $this, $this->h5p );
 		$this->contributors = $contributors ? $contributors : new \Pressbooks\Contributors();
+		// Register glossary and Attachments shortcodes if not already registered.
+		Glossary::init();
+		Attachments::init();
 	}
 
 	/**


### PR DESCRIPTION
Issue: https://github.com/pressbooks/private/issues/912

This PR initialize Glossary class to register the short codes during the cloning process. 
Context:
When checking shortcodes in the content for each chapter, `pb_glossary` short code is not identified as a existing shortcode for WP because it was not registered at that point:
https://github.com/pressbooks/pressbooks/blob/b4797bd7eb9ea622ac21d5eb788151c723bb76f7/inc/cloner/class-cloner.php#L1249-L1251

We need to make sure Glossary shortcode is registered before the cloning process to be able to identify the custom PB shortcode.