### PR TITLE
Change Ryerson name and url, fix Google fonts path & tests, update CI pipeline

### DIFF
--- a/.github/workflows/standards-and-tests.yml
+++ b/.github/workflows/standards-and-tests.yml
@@ -19,7 +19,7 @@ jobs:
         os: [ubuntu-20.04]
         epubcheck: [4.2.4]
         prince: [14.2-1]
-        wordpress: [5.9.3, latest]
+        wordpress: [6.0, latest]
         experimental: [false]
         include:
           - php: 8.0

--- a/.github/workflows/standards-and-tests.yml
+++ b/.github/workflows/standards-and-tests.yml
@@ -19,7 +19,7 @@ jobs:
         os: [ubuntu-20.04]
         epubcheck: [4.2.4]
         prince: [14.2-1]
-        wordpress: [6.0, latest]
+        wordpress: ['6.0', latest]
         experimental: [false]
         include:
           - php: 8.0

--- a/inc/class-globaltypography.php
+++ b/inc/class-globaltypography.php
@@ -295,7 +295,7 @@ class GlobalTypography {
 	function fontPacks() {
 		$fontpacks = [
 			'bn' => [
-				'baseurl' => 'https://github.com/googlefonts/noto-fonts/raw/main/unhinted/ttf/',
+				'baseurl' => 'https://github.com/notofonts/noto-fonts/raw/main/unhinted/ttf/',
 				'files' => [
 					'NotoSansBengali-Bold.ttf' => 'NotoSansBengali/NotoSansBengali-Bold.ttf',
 					'NotoSansBengali-Regular.ttf' => 'NotoSansBengali/NotoSansBengali-Regular.ttf',
@@ -304,28 +304,28 @@ class GlobalTypography {
 				],
 			],
 			'cans' => [
-				'baseurl' => 'https://github.com/googlefonts/noto-fonts/raw/main/unhinted/ttf/',
+				'baseurl' => 'https://github.com/notofonts/noto-fonts/raw/main/unhinted/ttf/',
 				'files' => [
 					'NotoSansCanadianAboriginal-Regular.ttf' => 'NotoSansCanadianAboriginal/NotoSansCanadianAboriginal-Regular.ttf',
 					'NotoSansCanadianAboriginal-Bold.ttf' => 'NotoSansCanadianAboriginal/NotoSansCanadianAboriginal-Bold.ttf',
 				],
 			],
 			'chr' => [
-				'baseurl' => 'https://github.com/googlefonts/noto-fonts/raw/main/unhinted/ttf/',
+				'baseurl' => 'https://github.com/notofonts/noto-fonts/raw/main/unhinted/ttf/',
 				'files' => [
 					'NotoSansCherokee-Regular.ttf' => 'NotoSansCherokee/NotoSansCherokee-Regular.ttf',
 					'NotoSansCherokee-Bold.ttf' => 'NotoSansCherokee/NotoSansCherokee-Bold.ttf',
 				],
 			],
 			'ff' => [
-				'baseurl' => 'https://github.com/googlefonts/noto-fonts/raw/main/unhinted/ttf/',
+				'baseurl' => 'https://github.com/notofonts/noto-fonts/raw/main/unhinted/ttf/',
 				'files' => [
 					'NotoSansAdlam-Regular.ttf' => 'NotoSansAdlam/NotoSansAdlam-Regular.ttf',
 					'NotoSansAdlam-Bold.ttf' => 'NotoSansAdlam/NotoSansAdlam-Bold.ttf',
 				],
 			],
 			'hi' => [
-				'baseurl' => 'https://github.com/googlefonts/noto-fonts/raw/main/unhinted/ttf/',
+				'baseurl' => 'https://github.com/notofonts/noto-fonts/raw/main/unhinted/ttf/',
 				'files' => [
 					'NotoSansDevanagari-Regular.ttf' => 'NotoSansDevanagari/NotoSansDevanagari-Regular.ttf',
 					'NotoSansDevanagari-Bold.ttf' => 'NotoSansDevanagari/NotoSansDevanagari-Bold.ttf',
@@ -334,7 +334,7 @@ class GlobalTypography {
 				],
 			],
 			'hy' => [
-				'baseurl' => 'https://github.com/googlefonts/noto-fonts/raw/main/unhinted/ttf/',
+				'baseurl' => 'https://github.com/notofonts/noto-fonts/raw/main/unhinted/ttf/',
 				'files' => [
 					'NotoSansArmenian-Regular.ttf' => 'NotoSansArmenian/NotoSansArmenian-Regular.ttf',
 					'NotoSansArmenian-Bold.ttf' => 'NotoSansArmenian/NotoSansArmenian-Bold.ttf',
@@ -351,7 +351,7 @@ class GlobalTypography {
 				],
 			],
 			'kn' => [
-				'baseurl' => 'https://github.com/googlefonts/noto-fonts/raw/main/unhinted/ttf/',
+				'baseurl' => 'https://github.com/notofonts/noto-fonts/raw/main/unhinted/ttf/',
 				'files' => [
 					'NotoSansKannada-Bold.ttf' => 'NotoSansKannada/NotoSansKannada-Bold.ttf',
 					'NotoSansKannada-Regular.ttf' => 'NotoSansKannada/NotoSansKannada-Regular.ttf',
@@ -367,7 +367,7 @@ class GlobalTypography {
 				],
 			],
 			'ml' => [
-				'baseurl' => 'https://github.com/googlefonts/noto-fonts/raw/main/unhinted/ttf/',
+				'baseurl' => 'https://github.com/notofonts/noto-fonts/raw/main/unhinted/ttf/',
 				'files' => [
 					'NotoSansMalayalam-Bold.ttf' => 'NotoSansMalayalam/NotoSansMalayalam-Bold.ttf',
 					'NotoSansMalayalam-Regular.ttf' => 'NotoSansMalayalam/NotoSansMalayalam-Regular.ttf',
@@ -382,20 +382,20 @@ class GlobalTypography {
 				],
 			],
 			'nqo' => [
-				'baseurl' => 'https://github.com/googlefonts/noto-fonts/raw/main/unhinted/ttf/',
+				'baseurl' => 'https://github.com/notofonts/noto-fonts/raw/main/unhinted/ttf/',
 				'files' => [
 					'NotoSansNKo-Regular.ttf' => 'NotoSansNKo/NotoSansNKo-Regular.ttf',
 				],
 			],
 			'or' => [
-				'baseurl' => 'https://github.com/googlefonts/noto-fonts/raw/main/hinted/ttf/',
+				'baseurl' => 'https://github.com/notofonts/noto-fonts/raw/main/hinted/ttf/',
 				'files' => [
 					'NotoSansOriya-Bold.ttf' => 'NotoSansOriya/NotoSansOriya-Bold.ttf',
 					'NotoSansOriya-Regular.ttf' => 'NotoSansOriya/NotoSansOriya-Regular.ttf',
 				],
 			],
 			'te' => [
-				'baseurl' => 'https://github.com/googlefonts/noto-fonts/raw/main/unhinted/ttf/',
+				'baseurl' => 'https://github.com/notofonts/noto-fonts/raw/main/unhinted/ttf/',
 				'files' => [
 					'NotoSansTelugu-Bold.ttf' => 'NotoSansTelugu/NotoSansTelugu-Bold.ttf',
 					'NotoSansTelugu-Regular.ttf' => 'NotoSansTelugu/NotoSansTelugu-Regular.ttf',

--- a/symbionts/institutions/institutions.json
+++ b/symbionts/institutions/institutions.json
@@ -929,8 +929,8 @@
           },
           {
             "code": "CA-ON-037",
-            "name": "Ryerson University",
-            "url": "https:\/\/www.ryerson.ca\/"
+            "name": "Toronto Metropolitan University",
+            "url": "https:\/\/www.torontomu.ca\/"
           },
           {
             "code": "CA-ON-038",


### PR DESCRIPTION
This PR updates the name of Ryerson Unversity to its official new name of "Toronto Metropolitan University". https://www.torontomu.ca/next-chapter/

This PR also fixes the path for several Google Fonts and updates tests accordingly, and updates the test matrix to use WordPress 6.0, which is what is running our our production servers.