### PR TITLE
feat: add api items permissions filter and source clonable check filter

### DIFF
--- a/inc/api/endpoints/controller/class-customtype.php
+++ b/inc/api/endpoints/controller/class-customtype.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Pressbooks\Api\Endpoints\Controller;
+
+class CustomType extends \WP_REST_Posts_Controller {
+
+	public function __construct( string $post_type ) {
+		$this->post_type = $post_type;
+		$this->namespace = 'pressbooks/v2';
+		$this->rest_base = $post_type;
+		$this->meta = new \WP_REST_Post_Meta_Fields( $post_type );
+	}
+
+	/**
+	 * Retrieves the post's schema, conforming to JSON Schema.
+	 *
+	 * @since 4.7.0
+	 *
+	 * @return array Item schema data.
+	 */
+	public function get_item_schema(): array {
+		$schema = parent::get_item_schema();
+		$schema['properties']['content'] = [
+			'description' => __( 'The content for the post.' ),
+			'type'        => 'object',
+			'context'     => [ 'view', 'edit' ],
+			'arg_options' => [
+				'sanitize_callback' => null, // Note: sanitization implemented in self::prepare_item_for_database().
+				'validate_callback' => null, // Note: validation implemented in self::prepare_item_for_database().
+			],
+			'properties'  => [
+				'raw'           => [
+					'description' => __( 'Content for the post, as it exists in the database.' ),
+					'type'        => 'string',
+					'context'     => [ 'edit', 'view' ],
+				],
+				'rendered'      => [
+					'description' => __( 'HTML content for the post, transformed for display.' ),
+					'type'        => 'string',
+					'context'     => [ 'view', 'edit' ],
+					'readonly'    => true,
+				],
+				'block_version' => [
+					'description' => __( 'Version of the content block format used by the post.' ),
+					'type'        => 'integer',
+					'context'     => [ 'edit', 'view' ],
+					'readonly'    => true,
+				],
+				'protected'     => [
+					'description' => __( 'Whether the content is protected with a password.' ),
+					'type'        => 'boolean',
+					'context'     => [ 'view', 'edit', 'embed' ],
+					'readonly'    => true,
+				],
+			],
+		];
+		$schema['properties']['title'] = [
+			'description' => __( 'The title for the post.' ),
+			'type'        => 'object',
+			'context'     => [ 'view', 'edit', 'embed' ],
+			'arg_options' => [
+				'sanitize_callback' => null, // Note: sanitization implemented in self::prepare_item_for_database().
+				'validate_callback' => null, // Note: validation implemented in self::prepare_item_for_database().
+			],
+			'properties'  => [
+				'raw'      => [
+					'description' => __( 'Title for the post, as it exists in the database.' ),
+					'type'        => 'string',
+					'context'     => [ 'edit', 'view' ],
+				],
+				'rendered' => [
+					'description' => __( 'HTML title for the post, transformed for display.' ),
+					'type'        => 'string',
+					'context'     => [ 'view', 'edit', 'embed' ],
+					'readonly'    => true,
+				],
+			],
+		];
+		return $schema;
+	}
+
+	/**
+	 * @param  \WP_REST_Request $request Full details about the request.
+	 *
+	 * @return bool True if the request has read access, WP_Error object otherwise.
+	 */
+	public function get_items_permissions_check( $request ): bool {
+		if ( has_filter( 'pb_set_api_items_permission' ) && apply_filters( 'pb_set_api_items_permission', $this->rest_base ) ) {
+			return true;
+		}
+		return current_user_can( 'edit_posts' ) || get_option( 'blog_public' );
+	}
+
+	/**
+	 * Checks if a post can be read.
+	 *
+	 * Correctly handles posts with the inherit status.
+	 *
+	 * @since 4.7.0
+	 *
+	 * @param \WP_Post $post Post object.
+	 * @return bool Whether the post can be read.
+	 */
+	public function check_read_permission( $post ): bool {
+		if ( $this->post_type === 'glossary' ) {
+			// display glossary with any status
+			return true;
+		}
+		return parent::check_read_permission( $post );
+	}
+
+}

--- a/inc/api/endpoints/controller/class-metadata.php
+++ b/inc/api/endpoints/controller/class-metadata.php
@@ -650,16 +650,10 @@ class Metadata extends \WP_REST_Controller {
 	 * @return bool True if the request has read access, WP_Error object otherwise.
 	 */
 	public function get_item_permissions_check( $request ) {
-
-		if ( current_user_can( 'edit_posts' ) ) {
+		if ( has_filter( 'pb_set_api_items_permission' ) && apply_filters( 'pb_set_api_items_permission', $this->rest_base ) ) {
 			return true;
 		}
-
-		if ( get_option( 'blog_public' ) ) {
-			return true;
-		}
-
-		return false;
+		return current_user_can( 'edit_posts' ) || get_option( 'blog_public' );
 	}
 
 	/**

--- a/inc/api/endpoints/controller/class-revisions.php
+++ b/inc/api/endpoints/controller/class-revisions.php
@@ -9,4 +9,16 @@ class Revisions extends \WP_REST_Revisions_Controller {
 		$this->namespace = 'pressbooks/v2';
 	}
 
+	/**
+	 * @param  \WP_REST_Request $request Full details about the request.
+	 *
+	 * @return bool True if the request has read access, WP_Error object otherwise.
+	 */
+	public function get_item_permissions_check( $request ): bool {
+		if ( has_filter( 'pb_set_api_items_permission' ) && apply_filters( 'pb_set_api_items_permission', $this->rest_base ) ) {
+			return true;
+		}
+		return parent::get_items_permissions_check( $request );
+	}
+
 }

--- a/inc/api/endpoints/controller/class-sectionmetadata.php
+++ b/inc/api/endpoints/controller/class-sectionmetadata.php
@@ -466,16 +466,10 @@ class SectionMetadata extends \WP_REST_Controller {
 	 * @return bool True if the request has read access, WP_Error object otherwise.
 	 */
 	public function get_item_permissions_check( $request ) {
-
-		if ( current_user_can( 'edit_posts' ) ) {
+		if ( has_filter( 'pb_set_api_items_permission' ) && apply_filters( 'pb_set_api_items_permission', $this->rest_base ) ) {
 			return true;
 		}
-
-		if ( get_option( 'blog_public' ) ) {
-			return true;
-		}
-
-		return false;
+		return current_user_can( 'edit_posts' ) || get_option( 'blog_public' );
 	}
 
 	/**

--- a/inc/api/endpoints/controller/class-styles.php
+++ b/inc/api/endpoints/controller/class-styles.php
@@ -85,6 +85,9 @@ class Styles extends \WP_REST_Controller {
 	 * @return bool True if the request has read access
 	 */
 	public function get_item_permissions_check( $request ) : bool {
+		if ( has_filter( 'pb_set_api_items_permission' ) && apply_filters( 'pb_set_api_items_permission', $this->rest_base ) ) {
+			return true;
+		}
 		return current_user_can( 'edit_posts' ) || get_option( 'blog_public' );
 	}
 

--- a/inc/api/endpoints/controller/class-terms.php
+++ b/inc/api/endpoints/controller/class-terms.php
@@ -7,4 +7,16 @@ class Terms extends \WP_REST_Terms_Controller {
 		parent::__construct( $parent_taxonomy );
 		$this->namespace = 'pressbooks/v2';
 	}
+
+	/**
+	 * @param  \WP_REST_Request $request Full details about the request.
+	 *
+	 * @return bool True if the request has read access, WP_Error object otherwise.
+	 */
+	public function get_item_permissions_check( $request ): bool {
+		if ( has_filter( 'pb_set_api_items_permission' ) && apply_filters( 'pb_set_api_items_permission', $this->rest_base ) ) {
+			return true;
+		}
+		return parent::get_items_permissions_check( $request );
+	}
 }

--- a/inc/api/endpoints/controller/class-theme.php
+++ b/inc/api/endpoints/controller/class-theme.php
@@ -14,7 +14,7 @@ class Theme extends \WP_REST_Controller {
 	/**
 	 * @var
 	 */
-	protected $rent_base;
+	protected $rest_base;
 
 	/**
 	 * Metadata
@@ -126,6 +126,9 @@ class Theme extends \WP_REST_Controller {
 	 * @return bool True if the request has read access
 	 */
 	public function get_item_permissions_check( $request ) : bool {
+		if ( has_filter( 'pb_set_api_items_permission' ) && apply_filters( 'pb_set_api_items_permission', $this->rest_base ) ) {
+			return true;
+		}
 		return current_user_can( 'edit_posts' ) || get_option( 'blog_public' );
 	}
 

--- a/inc/api/endpoints/controller/class-toc.php
+++ b/inc/api/endpoints/controller/class-toc.php
@@ -242,17 +242,11 @@ class Toc extends \WP_REST_Controller {
 	 *
 	 * @return bool True if the request has read access, WP_Error object otherwise.
 	 */
-	public function get_item_permissions_check( $request ) {
-
-		if ( current_user_can( 'edit_posts' ) ) {
+	public function get_item_permissions_check( $request ): bool {
+		if ( has_filter( 'pb_set_api_items_permission' ) && apply_filters( 'pb_set_api_items_permission', $this->rest_base ) ) {
 			return true;
 		}
-
-		if ( get_option( 'blog_public' ) ) {
-			return true;
-		}
-
-		return false;
+		return current_user_can( 'edit_posts' ) || get_option( 'blog_public' );
 	}
 
 	/**

--- a/inc/api/namespace.php
+++ b/inc/api/namespace.php
@@ -45,11 +45,10 @@ function init_book() {
 	// Register Theme Options
 	( new Endpoints\Controller\Theme() )->register_routes();
 
-	// Register Section Metadata
-	( new Endpoints\Controller\SectionMetadata( 'front-matter' ) )->register_routes();
-	( new Endpoints\Controller\SectionMetadata( 'back-matter' ) )->register_routes();
-	( new Endpoints\Controller\SectionMetadata( 'chapter' ) )->register_routes();
-	( new Endpoints\Controller\SectionMetadata( 'glossary' ) )->register_routes();
+	foreach ( [ 'front-matter', 'back-matter', 'chapter', 'glossary' ] as $post_type ) {
+		( new Endpoints\Controller\SectionMetadata( $post_type ) )->register_routes();
+		( new Endpoints\Controller\CustomType( $post_type ) )->register_routes();
+	}
 
 	foreach ( get_custom_post_types() as $post_type ) {
 		// Override Revisions routes for our custom post types

--- a/inc/cloner/class-cloner.php
+++ b/inc/cloner/class-cloner.php
@@ -996,7 +996,11 @@ class Cloner {
 	 *
 	 * @return bool Whether or not the book is public and licensed for cloning (or true if the current user is a network administrator and the book is in the current network).
 	 */
-	public function isSourceCloneable( $metadata_license ) {
+	public function isSourceCloneable( $metadata_license ): bool {
+		if ( has_filter( 'pb_set_source_clonable' ) ) {
+			return apply_filters( 'pb_set_source_clonable', [] );
+		}
+
 		$restrictive_licenses = [
 			'https://creativecommons.org/licenses/by-nd/4.0/',
 			'https://creativecommons.org/licenses/by-nc-nd/4.0/',

--- a/inc/interactive/class-h5p.php
+++ b/inc/interactive/class-h5p.php
@@ -71,7 +71,9 @@ class H5P {
 			if ( ! is_plugin_active( 'h5p/h5p.php' ) ) {
 				\H5P_Plugin::get_instance()->rest_api_init();
 			}
-			if ( get_option( 'blog_public' ) ) {
+			if ( has_filter( 'pb_set_api_items_permission' ) && apply_filters( 'pb_set_api_items_permission', 'h5p' ) ) {
+				add_filter( 'h5p_rest_api_all_permission', '__return_true' );
+			} elseif ( get_option( 'blog_public' ) ) {
 				add_filter( 'h5p_rest_api_all_permission', '__return_true' );
 			}
 		} catch ( \Throwable $e ) {

--- a/inc/interactive/class-h5p.php
+++ b/inc/interactive/class-h5p.php
@@ -71,9 +71,13 @@ class H5P {
 			if ( ! is_plugin_active( 'h5p/h5p.php' ) ) {
 				\H5P_Plugin::get_instance()->rest_api_init();
 			}
-			if ( has_filter( 'pb_set_api_items_permission' ) && apply_filters( 'pb_set_api_items_permission', 'h5p' ) ) {
-				add_filter( 'h5p_rest_api_all_permission', '__return_true' );
-			} elseif ( get_option( 'blog_public' ) ) {
+			if (
+				(
+					has_filter( 'pb_set_api_items_permission' ) &&
+					apply_filters( 'pb_set_api_items_permission', 'h5p' )
+				) ||
+				get_option( 'blog_public' )
+			) {
 				add_filter( 'h5p_rest_api_all_permission', '__return_true' );
 			}
 		} catch ( \Throwable $e ) {

--- a/tests/test-cloner.php
+++ b/tests/test-cloner.php
@@ -138,6 +138,16 @@ class ClonerTest extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @test
+	 * @group cloner
+	 */
+	public function is_source_clonable_through_pb_set_source_clonable_filter(): void {
+		add_filter( 'pb_set_source_clonable', '__return_true');
+		$this->assertTrue( $this->cloner->isSourceCloneable( [ 'url' => 'https://creativecommons.org/licenses/by-nd/4.0/' ] ) );
+		$this->assertTrue( $this->cloner->isSourceCloneable( 'https://choosealicense.com/no-license/' ) );
+	}
+
+	/**
 	 * @group cloner
 	 */
 	public function test_discoverWordPressApi(){


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks-vip/issues/177

This PR adds 2 new hooks:
-  `pb_set_api_items_permission`: which through a boolean defines if items exposed in each API endpoint can be displayed despite other permissions checking. If it returns false or the filter is not defined, then the normal permission checking flow will occur. 
- `pb_set_source_clonable`: which through a boolean defines if a book is clonable despite the licenses or the `blog_public` metadata. If the filter was not defined, the normal checking flow will occur. 

These changes also adds a new Custom Post Type API extension for back-matter, front-matter, chapter and glossary posts type. It will add a custom permission checking, instead using the default WP API behavior. 

### Testing
For testing, use the these changes in pressbooks-vip: https://github.com/pressbooks/pressbooks-vip/pull/189
And try to read private or licensed books through the API with a regular user or logged our. All the endpoints used by cloning routine must be exposed. Example: `<BOOK URL>/wp-json/h5p/v1/all` for books with H5P activities or `<BOOK_URL>/wp-json/pressbooks/v2/glossary` if the book contains glossary terms.