### PR TITLE
fix: keep private content private after cloning

### DIFF
--- a/inc/api/endpoints/controller/class-customtype.php
+++ b/inc/api/endpoints/controller/class-customtype.php
@@ -65,6 +65,11 @@ class CustomType extends \WP_REST_Posts_Controller {
 				],
 			],
 		];
+		$schema['properties']['status'] = [
+			'description' => __( 'The status for the post.' ),
+			'type'        => 'string',
+			'context' => [ 'view', 'edit', 'embed' ],
+		];
 		$schema['properties']['meta'] = $this->meta->get_field_schema();
 		return $schema;
 	}

--- a/inc/cloner/class-cloner.php
+++ b/inc/cloner/class-cloner.php
@@ -1552,7 +1552,7 @@ class Cloner {
 
 		// Private and public glossaries can be cloned
 		if ( $post_type !== 'glossary' ) {
-			$section['status'] = 'publish';
+			$section['status'] = $section['status'] ?? 'publish';
 		}
 
 		// Download media (images, videos, `select * from wp_posts where post_type = 'attachment'` ... )
@@ -1561,7 +1561,7 @@ class Cloner {
 		$content = $this->retrieveH5P( $content );
 
 		// Set title and content
-		$section['title'] = $section['title']['rendered'];
+		$section['title'] = $section['title']['raw'] ?? $section['title']['rendered'];
 		$section['content'] = $content;
 
 		// Set part

--- a/pressbooks.php
+++ b/pressbooks.php
@@ -5,7 +5,7 @@ Plugin URI:         https://pressbooks.org
 GitHub Plugin URI:  pressbooks/pressbooks
 Release Asset:      true
 Description:        Simple Book Production
-Version:            5.36.0
+Version:            5.36.1
 Requires at least:  5.9.3
 Requires PHP:       7.4
 Author:             Pressbooks (Book Oven Inc.)

--- a/readme.txt
+++ b/readme.txt
@@ -18,9 +18,9 @@ For installation instructions, visit [https://pressbooks.org/user-docs/installat
 
 == Changelog ==
 
-= 5.36.0 =
+= 5.36.1 =
 
-* See: https://github.com/pressbooks/pressbooks/releases/tag/5.36.0
+* See: https://github.com/pressbooks/pressbooks/releases/tag/5.36.1
 * Full release history available at: https://github.com/pressbooks/pressbooks/releases
 
 == Upgrade Notice ==


### PR DESCRIPTION
Issue: #2877 

This PR attempts to keep all private content as private after the clone routine completes. This is important because front-matters, chapters, or back-matters that are private in the source book should remain private after cloned.

### Current behaviour

At the moment we clone them as public and add the "Private: {CHAPTER NAME}" as the title.

### New behaviour

Private content will no longer have the  preceding "Private: " before the title, and should remain as private chapters on the target book.


### How to test

1. Create a book with private front-matter, chapters, and back-matters
1. Make the book clonable
1. Clone the book and check the output
1. All book content should be cloned with the right content, and private chapters should not be marked as show in web
1. It's important to check if other parts of the book are cloned as well -- glossary, custom styles, theme, etc.