### PR TITLE
feat: remove Private: prepend to draft posts when exposing to the API

### DIFF
--- a/inc/api/endpoints/controller/class-posts.php
+++ b/inc/api/endpoints/controller/class-posts.php
@@ -189,6 +189,12 @@ class Posts extends \WP_REST_Posts_Controller {
 			}
 		}
 
+		$schema['properties']['status'] = [
+			'description' => __( 'The status for the post.', 'pressbooks' ),
+			'type'        => 'string',
+			'context' => [ 'view', 'edit', 'embed' ],
+		];
+
 		return $schema;
 	}
 

--- a/inc/api/endpoints/controller/class-toc.php
+++ b/inc/api/endpoints/controller/class-toc.php
@@ -259,12 +259,16 @@ class Toc extends \WP_REST_Controller {
 		// Register missing routes
 		$this->registerRouteDependencies();
 
+		// Don't add Private: to the front matter, back matter, or chapter titles in any case when exposing the TOC to the API.
+		remove_action( 'the_title', '\PressbooksBook\Filters\add_private_to_title' );
+
 		$struct = Book::getBookStructure();
 		unset( $struct['__order'] );
 		$has_permission = current_user_can( 'edit_posts' );
 		if ( has_filter( 'pb_set_api_items_permission' ) && apply_filters( 'pb_set_api_items_permission', false ) ) {
 			$has_permission = true;
 		}
+
 		$struct = $this->fixBookStructure( $struct, $has_permission );
 
 		$response = rest_ensure_response( $struct );

--- a/inc/api/endpoints/controller/class-toc.php
+++ b/inc/api/endpoints/controller/class-toc.php
@@ -259,9 +259,6 @@ class Toc extends \WP_REST_Controller {
 		// Register missing routes
 		$this->registerRouteDependencies();
 
-		// Don't add Private: to the front matter, back matter, or chapter titles in any case when exposing the TOC to the API.
-		remove_action( 'the_title', '\PressbooksBook\Filters\add_private_to_title' );
-
 		$struct = Book::getBookStructure();
 		unset( $struct['__order'] );
 		$has_permission = current_user_can( 'edit_posts' );

--- a/inc/api/namespace.php
+++ b/inc/api/namespace.php
@@ -32,6 +32,8 @@ function add_help_link( $response ) {
  * @see https://developer.wordpress.org/rest-api/extending-the-rest-api/
  */
 function init_book() {
+	// Don't add Private: to the front matter, back matter, or chapter titles in any case when exposing the TOC to the API.
+	remove_action( 'the_title', '\PressbooksBook\Filters\add_private_to_title' );
 
 	// Register TOC
 	( new Endpoints\Controller\Toc() )->register_routes();

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -451,7 +451,7 @@ class ApiTest extends \WP_UnitTestCase {
 		$data = $response->get_data();
 
 		$this->assertEquals( 3, count( $data ) );
-		$this->assertEquals( 'Private: Not done', $data[0]['title']['rendered'] );
+		$this->assertEquals( 'Not done', $data[0]['title']['rendered'] );
 		$this->assertEquals( 'Synapse', $data[1]['title']['rendered'] );
 	}
 

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -451,7 +451,7 @@ class ApiTest extends \WP_UnitTestCase {
 		$data = $response->get_data();
 
 		$this->assertEquals( 3, count( $data ) );
-		$this->assertEquals( 'Not done', $data[0]['title']['rendered'] );
+		$this->assertEquals( 'Private: Not done', $data[0]['title']['rendered'] );
 		$this->assertEquals( 'Synapse', $data[1]['title']['rendered'] );
 	}
 
@@ -472,7 +472,7 @@ class ApiTest extends \WP_UnitTestCase {
 			'post_type'    => 'front-matter',
 			'post_title'   => 'Front matter title II',
 			'post_content' => 'This is a front matter content II',
-			'post_status'  => 'publish',
+			'post_status'  => 'private',
 		];
 		$this->factory()->post->create_object( $post1 );
 		$this->factory()->post->create_object( $post2 );


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks/issues/1863

This PR removed the `the_title` hook for the `\PressbooksBook\Filters\add_private_to_title` callback to avoid to prepend `Private: ` to titles when exposing to the TOC API endpoint, which will avoid to add it to the target books during the cloning routine.

It also exposes the `status` property for posts to keep the same status for the target books during cloning routine.

### Testing
For testing, you could try to clone books as an admin (to access to private content) with privates front matters, back matters or chapters. 
The target books must respect the same post status than the target book and it must not prepend `Private: ` string to the titles for private posts.