### PR TITLE
fix: expose `raw` key for post titles in API

### DIFF
--- a/inc/api/endpoints/controller/class-posts.php
+++ b/inc/api/endpoints/controller/class-posts.php
@@ -102,6 +102,14 @@ class Posts extends \WP_REST_Posts_Controller {
 				'on' : '';
 		}
 
+		// Override post title to avoid \PressbooksBook\Filters\add_private_to_title filter for the_title hook.
+		if ( ! empty( $response->data['title']['rendered'] ) ) {
+			$response->data['title']['rendered'] = $post->post_title;
+		}
+		if ( ! empty( $response->data['title']['raw'] ) ) {
+			$response->data['title']['raw'] = $post->post_title;
+		}
+
 		return $response;
 	}
 

--- a/inc/api/endpoints/controller/class-posts.php
+++ b/inc/api/endpoints/controller/class-posts.php
@@ -102,14 +102,6 @@ class Posts extends \WP_REST_Posts_Controller {
 				'on' : '';
 		}
 
-		// Override post title to avoid \PressbooksBook\Filters\add_private_to_title filter for the_title hook.
-		if ( ! empty( $response->data['title']['rendered'] ) ) {
-			$response->data['title']['rendered'] = $post->post_title;
-		}
-		if ( ! empty( $response->data['title']['raw'] ) ) {
-			$response->data['title']['raw'] = $post->post_title;
-		}
-
 		return $response;
 	}
 
@@ -195,6 +187,10 @@ class Posts extends \WP_REST_Posts_Controller {
 			if ( isset( $schema['properties'][ $taxonomy ] ) ) {
 				$schema['properties'][ $taxonomy ]['context'][] = 'embed';
 			}
+		}
+
+		if ( isset( $schema['properties']['title'] ) ) {
+			array_push( $schema['properties']['title']['properties']['raw']['context'], 'view', 'embed' );
 		}
 
 		$schema['properties']['status'] = [

--- a/inc/api/namespace.php
+++ b/inc/api/namespace.php
@@ -32,8 +32,6 @@ function add_help_link( $response ) {
  * @see https://developer.wordpress.org/rest-api/extending-the-rest-api/
  */
 function init_book() {
-	// Don't add Private: to the front matter, back matter, or chapter titles in any case when exposing the TOC to the API.
-	remove_action( 'the_title', '\PressbooksBook\Filters\add_private_to_title' );
 
 	// Register TOC
 	( new Endpoints\Controller\Toc() )->register_routes();

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -451,7 +451,7 @@ class ApiTest extends \WP_UnitTestCase {
 		$data = $response->get_data();
 
 		$this->assertEquals( 3, count( $data ) );
-		$this->assertEquals( 'Private: Not done', $data[0]['title']['rendered'] );
+		$this->assertEquals( 'Not done', $data[0]['title']['rendered'] );
 		$this->assertEquals( 'Synapse', $data[1]['title']['rendered'] );
 	}
 

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -451,7 +451,8 @@ class ApiTest extends \WP_UnitTestCase {
 		$data = $response->get_data();
 
 		$this->assertEquals( 3, count( $data ) );
-		$this->assertEquals( 'Not done', $data[0]['title']['rendered'] );
+		$this->assertEquals( 'Private: Not done', $data[0]['title']['rendered'] );
+		$this->assertEquals( 'Not done', $data[0]['title']['raw'] );
 		$this->assertEquals( 'Synapse', $data[1]['title']['rendered'] );
 	}
 


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks/issues/1863

This PR exposes the raw key for post titles during the API responses to avoid the `the_title` hook for the `\PressbooksBook\Filters\add_private_to_title` callback to avoid to prepend `Private: ` to titles when exposing to the TOC API endpoint in the `rendered` key, which will avoid to add it to the target books during the cloning routine. It improves the solution proposed in https://github.com/pressbooks/pressbooks/pull/2903.

### Testing
For testing, you could try to clone books as an admin (to access to private content) with privates front matters, back matters or chapters. 
The target books must respect the same post status than the target book and it must not prepend `Private: ` string to the titles for private posts.