### PR TITLE
chore(docs): update links to user and developer guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ Pressbooks works with PHP 7.4 and WordPress 5.9.3. Lower versions are not suppor
 
 Pressbooks is not for use on an existing blog. Instead it should be used with a fresh, [multisite WordPress installation](https://wordpress.org/support/article/glossary/#multisite).
 
-To install Pressbooks on your site, download the [latest release](https://github.com/pressbooks/pressbooks/releases/latest) and follow our [installation instructions](https://docs.pressbooks.org/installation). 
+To install Pressbooks on your site, download the [latest release](https://github.com/pressbooks/pressbooks/releases/latest) and follow our [installation instructions](https://pressbooks.org/user-docs/installation/). 
 
 You may want to try [Pressbooks.com](https://pressbooks.com/self-publishers/) before deciding whether or not you wish to host and maintain your own instance of Pressbooks. We can also [host and maintain an instance of Pressbooks for you](https://pressbooks.com/for-educational-institutions/).
 
 ## Contributor guidelines
 
-Developers who are interested in contributing to our project should consult our ["Contributing"](.github/CONTRIBUTING.md) guidelines and the developer guides published on our [documentation website](https://docs.pressbooks.org).
+Developers who are interested in contributing to our project should consult our ["Contributing"](.github/CONTRIBUTING.md) guidelines and the developer guides published on our [documentation website](https://pressbooks.org/dev-docs/).
 
 ## Disclaimers
 

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
 	"support": {
 		"email": "code@pressbooks.com",
 		"issues": "https://github.com/pressbooks/pressbooks/issues/",
-		"forum": "https://discourse.pressbooks.org",
-		"docs": "https://docs.pressbooks.org/",
+		"forum": "https://pressbooks.community",
+		"docs": "https://pressbooks.org/user-docs/",
 		"source": "https://github.com/pressbooks/pressbooks/"
 	},
 	"config": {

--- a/inc/modules/export/namespace.php
+++ b/inc/modules/export/namespace.php
@@ -83,7 +83,7 @@ function dependency_errors_msg() {
 		sprintf(
 			__( 'Some dependencies for %1$s exports could not be found. Please verify that you have completed the <a href="%2$s">installation instructions</a>.', 'pressbooks' ),
 			( $pos ) ? substr_replace( $formats, ', ' . __( 'and', 'pressbooks' ) . ' ', $pos, strlen( ', ' ) ) : $formats,
-			'http://docs.pressbooks.org/installation'
+			'https://pressbooks.org/user-docs/installation/'
 		)
 	);
 	return $dependency_errors_msg;

--- a/templates/admin/covergenerator.php
+++ b/templates/admin/covergenerator.php
@@ -51,7 +51,7 @@ if ( $dependency_errors ) {
 			sprintf(
 				__( 'Some dependencies for %1$s exports could not be found. Please verify that you have completed the <a href="%2$s">installation instructions</a>.', 'pressbooks' ),
 				( $pos = strrpos( $formats, ', ' ) ) ? substr_replace( $formats, ', ' . __( 'and', 'pressbooks' ) . ' ', $pos, strlen( ', ' ) ) : $formats,
-				'http://docs.pressbooks.org/installation'
+				'https://pressbooks.org/user-docs/installation/'
 			)
 		);
 	}


### PR DESCRIPTION
I noticed that the links to documentation are all broken since docs.pressbooks.org was merged into pressbooks.org. I've updated them all.