### PR TITLE
Replace error_log to trigger_error for Sentry logging

### DIFF
--- a/inc/modules/import/class-import.php
+++ b/inc/modules/import/class-import.php
@@ -653,7 +653,7 @@ abstract class Import {
 	}
 
 	/**
-	 * Log something using wp_mail() and error_log(), include useful WordPress info.
+	 * Log something using wp_mail() and trigger_error(), include useful WordPress info.
 	 *
 	 * Note: This method is here temporarily. We are using it to find & fix bugs for the first iterations of import.
 	 * Do not count on this method being here in the future.

--- a/inc/utility/namespace.php
+++ b/inc/utility/namespace.php
@@ -700,7 +700,7 @@ function format_bytes( $bytes, $precision = 2 ) {
  */
 function debug_error_log( $message, $message_type = null ) {
 	if ( defined( 'WP_TESTS_MULTISITE' ) === false && WP_DEBUG ) {
-		\error_log( $message, $message_type ); // @codingStandardsIgnoreLine
+		\trigger_error( $message, $message_type ); // @codingStandardsIgnoreLine
 	}
 }
 

--- a/tests/test-utility.php
+++ b/tests/test-utility.php
@@ -294,7 +294,7 @@ class UtilityTest extends \WP_UnitTestCase {
 
 
 	//  public function test_email_error_log() {
-	//      // TODO: Testing this as-is would send emails, write to error_log... Need to refactor
+	//      // TODO: Testing this as-is would send emails, write to trigger_error... Need to refactor
 	//      $this->markTestIncomplete();
 	//  }
 


### PR DESCRIPTION
Ticket: https://github.com/pressbooks/private/issues/336

Features:

Add Sentry logging using trigger_error instead of error_log
Test: Errors using the function trigger_error will be sent to Sentry.