### PR TITLE
fix: clean up metadata if key is empty

### DIFF
--- a/tests/test-datacollector-book.php
+++ b/tests/test-datacollector-book.php
@@ -169,6 +169,46 @@ class DataCollector_BookTest extends \WP_UnitTestCase {
 	/**
 	 * @group datacollector
 	 */
+	public function test_check_book_meta_removed_when_empty(): void {
+		$this->_book();
+
+		$book_id = get_current_blog_id();
+
+		$metadata_post = ( new \Pressbooks\Metadata() )->getMetaPost();
+
+		add_post_meta( $metadata_post->ID, 'pb_institutions', 'CA-ON-001' );
+		add_post_meta( $metadata_post->ID, 'pb_institutions', 'CA-ON-002' );
+		add_post_meta( $metadata_post->ID, 'pb_primary_subject', 'ABA' );
+		add_post_meta( $metadata_post->ID, 'pb_additional_subjects', 'AVP, AVR, AVRQ' );
+		add_post_meta( $metadata_post->ID, 'pb_publisher', 'Publisher Name' );
+
+		\Pressbooks\Book::deleteBookObjectCache();
+
+		$this->bookDataCollector->copyBookMetaIntoSiteTable( $book_id );
+
+		$this->assertNotEmpty( get_site_meta( $book_id, BookDataCollector::INSTITUTIONS ) );
+		$this->assertNotEmpty( get_site_meta( $book_id, BookDataCollector::SUBJECTS_CODES ) );
+		$this->assertNotEmpty( get_site_meta( $book_id, BookDataCollector::PUBLISHER, true ) );
+		$this->assertNotEmpty( get_site_meta( $book_id, BookDataCollector::SUBJECT, true ) );
+
+		delete_post_meta( $metadata_post->ID, 'pb_institutions' );
+		delete_post_meta( $metadata_post->ID, 'pb_primary_subject' );
+		delete_post_meta( $metadata_post->ID, 'pb_additional_subjects' );
+		delete_post_meta( $metadata_post->ID, 'pb_publisher' );
+
+		\Pressbooks\Book::deleteBookObjectCache();
+
+		$this->bookDataCollector->copyBookMetaIntoSiteTable( $book_id );
+
+		$this->assertEmpty( get_site_meta( $book_id, BookDataCollector::INSTITUTIONS ) );
+		$this->assertEmpty( get_site_meta( $book_id, BookDataCollector::SUBJECTS_CODES ) );
+		$this->assertEmpty( get_site_meta( $book_id, BookDataCollector::PUBLISHER, true ) );
+		$this->assertEmpty( get_site_meta( $book_id, BookDataCollector::SUBJECT, true ) );
+	}
+
+	/**
+	 * @group datacollector
+	 */
 	public function test_themaSubjectsLocale() {
 		$this->assertEquals( 'en', $this->bookDataCollector->themaSubjectsLocale( 'fr' ) );
 	}


### PR DESCRIPTION
This PR attempts to fix an issue while collecting book metadata.

If one adds a metadata for a given field (e.g. Institutions, subjects, editors, publisher) and then later removes that value, the `wp_blogmeta` table would keep old values. This PR aims to clean up old metadata when running the data collector.

__How to test__

1. Add one or more values to institutions, subjects, or editors
2. Check that `wp_blogmeta` has the correct values for those fields -- __pb_institutions__, __pb_subjects__, __pb_subjects_code__, __pb_subjects_string__, __pb_editors__, __pb_publishers__
3. Remove one or more values from any of those fields
4. Check that `wp_blogmeta` has the correct values
5. Empty any of those fields
6. Check that `wp_blogmeta` has the correct values -- empty values should be removed or be set as `null`