### PR TITLE
fix: decode generic post type title for xtml and epub

### DIFF
--- a/inc/modules/export/class-exporthelpers.php
+++ b/inc/modules/export/class-exporthelpers.php
@@ -48,7 +48,7 @@ trait ExportHelpers {
 		$data['post_type_class'] = str_replace( '_', '-', $post_type_identifier ); // This class is used to map with the SCSS class in buckram Ex: front-matter
 		$data['subclass'] = $this->getPostSubClass( $post_type_identifier, $post_data['ID'] );
 		$data['slug'] = $is_epub ? $post_data['post_name'] : "{$data['post_type_class']}-{$post_data['post_name']}";
-		$data['title'] = get_post_meta( $post_data['ID'], 'pb_show_title', true ) ? $post_data['post_title'] : '';
+		$data['title'] = get_post_meta( $post_data['ID'], 'pb_show_title', true ) ? Sanitize\decode( $post_data['post_title'] ) : '';
 
 		if ( ! $is_epub ) {
 			$data['title'] = empty( $data['title'] ) ? '<span class="display-none">' . $post_data['post_title'] . '</span>' : $data['title'];

--- a/inc/utility/namespace.php
+++ b/inc/utility/namespace.php
@@ -700,7 +700,7 @@ function format_bytes( $bytes, $precision = 2 ) {
  */
 function debug_error_log( $message, $message_type = null ) {
 	if ( defined( 'WP_TESTS_MULTISITE' ) === false && WP_DEBUG ) {
-		\trigger_error( $message, $message_type ); // @codingStandardsIgnoreLine
+		\trigger_error( $message, $message_type ?? E_USER_NOTICE ); // @codingStandardsIgnoreLine
 	}
 }
 


### PR DESCRIPTION
Issue: https://github.com/pressbooks/private/issues/895

This change decode the post title string for generic post type exported in PDF and EPUB.

### Test case sample
- Add html tags to one or more of front matters or back matters titles in any book.
- Make sure "Show title" are true in the Organize page for these posts
- Export the book to PDF and EPUB
- Titles in TOC and in the post itself must not contain the html tags explicitly but its renderization instead.