### PR TITLE
fix: numbering handling for TOC in EPUB

### DIFF
--- a/inc/modules/export/epub/class-epub.php
+++ b/inc/modules/export/epub/class-epub.php
@@ -1929,11 +1929,9 @@ class Epub extends ExportGenerator {
 
 				$chapter_type = $this->taxonomy->getChapterType( $chapter_data['ID'] );
 
-				if ( 'numberless' !== $chapter_type ) {
+				if ( 'numberless' !== $chapter_type && $this->numbered ) {
 					$chapter_data['title'] = "${chapters_count}. ${chapter_data['title']}";
-					if ( $this->numbered ) {
-						$chapters_count++;
-					}
+					$chapters_count++;
 				}
 
 				$rendered_items[] = $this->renderTocItem( 'chapter', $chapter_data, false );


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks/issues/2666

This PR improve the numbering handling in the TOC section for EPUB exports.

### Test case sample
For a particular book with 2 or more chapters:
- Make one or more chapters are not "Numberless" chapter type.
- Uncheck Appareance > Theme options > Display part and chapter numbers option. 
- Export the book to EPUB format
- EPUB Book exported must not contain numbered chapters in the TOC at all.
- Check the Appareance > Theme options > Display part and chapter numbers option. 
- Export the book to EPUB again.
- The TOC of the EPUB file exported must be numbered properly.