### PR TITLE
feat: add function to retrieve short file name for export icons

### DIFF
--- a/inc/modules/export/class-table.php
+++ b/inc/modules/export/class-table.php
@@ -423,7 +423,7 @@ class Table extends \WP_List_Table {
 	protected function getIcon( $file, $size = 'large' ) {
 		$file_class = $this->getCssClass( $file );
 
-		$file_type = \Pressbooks\Modules\Export\get_name_from_filetype_slug( $file_class, true );
+		$file_type = \Pressbooks\Modules\Export\get_shortname_from_filetype_slug( $file_class );
 
 		$html = "<div class='export-file-icon {$size} {$file_class}'>" . Container::get( 'Blade' )->render( 'admin.icon', [ 'file_type' => $file_type ] ) . '</div>';
 		return $html;

--- a/inc/modules/export/namespace.php
+++ b/inc/modules/export/namespace.php
@@ -179,11 +179,9 @@ function filetypes() {
  *
  * @param string $filetype The filetype slug.
  *
- * @param bool $short Whether the method should return a long name or a short name, suitable for an icon badge.
- *
  * @return string A human-readable filetype.
  */
-function get_name_from_filetype_slug( $filetype, $short = false ) {
+function get_name_from_filetype_slug( $filetype ) {
 	/**
 	 * Add custom export file type slugs to the array of file type slugs and corresponding human-readable filetypes.
 	 *
@@ -192,20 +190,57 @@ function get_name_from_filetype_slug( $filetype, $short = false ) {
 	$formats = apply_filters(
 		'pb_export_filetype_names', [
 			'print_pdf' => __( 'Print PDF', 'pressbooks' ),
-			'pdf' => $short ? __( 'PDF', 'pressbooks' ) : __( 'Digital PDF', 'pressbooks' ),
-			'mpdf' => $short ? __( 'PDF', 'pressbooks' ) : __( 'Digital PDF', 'pressbooks' ),
-			'htmlbook' => $short ? __( 'HTML5', 'pressbooks' ) : __( 'HTMLBook', 'pressbooks' ),
+			'pdf' => __( 'Digital PDF', 'pressbooks' ),
+			'mpdf' => __( 'Digital PDF', 'pressbooks' ),
+			'htmlbook' => __( 'HTMLBook', 'pressbooks' ),
 			'epub' => __( 'EPUB', 'pressbooks' ),
 			'mobi' => __( 'MOBI', 'pressbooks' ),
 			'epub3' => __( 'EPUB3', 'pressbooks' ),
 			'xhtml' => __( 'XHTML', 'presbooks' ),
-			'odf' => $short ? __( 'ODT', 'pressbooks' ) : __( 'OpenDocument', 'pressbooks' ),
-			'wxr' => $short ? __( 'WXR', 'pressbooks' ) : __( 'Pressbooks XML', 'pressbooks' ),
-			'vanillawxr' => $short ? __( 'WXR', 'pressbooks' ) : __( 'WordPress XML', 'pressbooks' ),
-			'weblinks' => $short ? __( 'IMSCC', 'pressbooks' ) : __( 'Common Cartridge (Web Links)', 'pressbooks' ),
-			'thincc11' => $short ? __( 'IMSCC', 'pressbooks' ) : __( 'Common Cartridge with LTI links (1.1)', 'pressbooks' ),
-			'thincc12' => $short ? __( 'IMSCC', 'pressbooks' ) : __( 'Common Cartridge with LTI links (1.2)', 'pressbooks' ),
-			'thincc13' => $short ? __( 'IMSCC', 'pressbooks' ) : __( 'Common Cartridge with LTI links (1.3)', 'pressbooks' ),
+			'odf' => __( 'OpenDocument', 'pressbooks' ),
+			'wxr' => __( 'Pressbooks XML', 'pressbooks' ),
+			'vanillawxr' => __( 'WordPress XML', 'pressbooks' ),
+			'weblinks' => __( 'Common Cartridge (Web Links)', 'pressbooks' ),
+			'thincc11' => __( 'Common Cartridge (LTI Links)', 'pressbooks' ),
+			'thincc12' => __( 'Common Cartridge (LTI Links)', 'pressbooks' ),
+			'thincc13' => __( 'Common Cartridge (LTI Links)', 'pressbooks' ),
+		]
+	);
+	return isset( $formats[ $filetype ] ) ? $formats[ $filetype ] : ucfirst( $filetype );
+}
+
+/**
+ * Return a human-readable short filetype for a given filetype slug. Used on icon badges.
+ *
+ * @since 6.1.0
+ *
+ * @param string $filetype The filetype slug.
+ *
+ * @return string A human-readable short filetype.
+ */
+function get_shortname_from_filetype_slug( $filetype ) {
+	/**
+	 * Add custom export file type slugs to the array of file type slugs and corresponding human-readable short filetypes.
+	 *
+	 * @since 6.1.0
+	 */
+	$formats = apply_filters(
+		'pb_export_filetype_shortnames', [
+			'print_pdf' => __( 'Print PDF', 'pressbooks' ),
+			'pdf' => __( 'PDF', 'pressbooks' ),
+			'mpdf' => __( 'PDF', 'pressbooks' ),
+			'htmlbook' => __( 'HTML5', 'pressbooks' ),
+			'epub' => __( 'EPUB', 'pressbooks' ),
+			'mobi' => __( 'MOBI', 'pressbooks' ),
+			'epub3' => __( 'EPUB3', 'pressbooks' ),
+			'xhtml' => __( 'XHTML', 'presbooks' ),
+			'odf' => __( 'ODT', 'pressbooks' ),
+			'wxr' => __( 'WXR', 'pressbooks' ),
+			'vanillawxr' => __( 'WXR', 'pressbooks' ),
+			'weblinks' => __( 'IMSCC', 'pressbooks' ),
+			'thincc11' => __( 'IMSCC', 'pressbooks' ),
+			'thincc12' => __( 'IMSCC', 'pressbooks' ),
+			'thincc13' => __( 'IMSCC', 'pressbooks' ),
 		]
 	);
 	return isset( $formats[ $filetype ] ) ? $formats[ $filetype ] : ucfirst( $filetype );

--- a/tests/test-modules-export.php
+++ b/tests/test-modules-export.php
@@ -52,7 +52,19 @@ class Modules_ExportTest extends \WP_UnitTestCase {
 		$type = \Pressbooks\Modules\Export\get_name_from_filetype_slug( 'wtfbbq' );
 		$this->assertEquals( 'Wtfbbq', $type );
 		$type = \Pressbooks\Modules\Export\get_name_from_filetype_slug( 'thincc11' );
-		$this->assertEquals( 'Common Cartridge with LTI links (1.1)', $type );
+		$this->assertEquals( 'Common Cartridge (LTI Links)', $type );
+	}
+
+	/**
+	 * @group export
+	 */
+	public function test_get_shortname_from_filetype_slug() {
+		$type = \Pressbooks\Modules\Export\get_shortname_from_filetype_slug( 'print_pdf' );
+		$this->assertEquals( 'Print PDF', $type );
+		$type = \Pressbooks\Modules\Export\get_shortname_from_filetype_slug( 'wtfbbq' );
+		$this->assertEquals( 'Wtfbbq', $type );
+		$type = \Pressbooks\Modules\Export\get_shortname_from_filetype_slug( 'thincc11' );
+		$this->assertEquals( 'IMSCC', $type );
 	}
 
 	/**


### PR DESCRIPTION
In #2926 I added support for SVG export icons. In order to retrieve the file type which would be displayed on the export icon badge, I added an optional `$short` parameter to the Export namespace's `get_name_from_filetype_slug()` function. However, this resulted in a situation where custom formats could not be properly added via a filter as the values being filtered were no longer simple strings but ternary operations. This PR improves this behaviour by adding a new function, `get_shortname_from_filetype_slug()`, which returns short file types for SVG export icon badges. The array of values can be filtered using a new filter hook, `pb_export_filetype_shortnames`.