### PR TITLE
feat: Expose custom licenses

### DIFF
--- a/inc/class-licensing.php
+++ b/inc/class-licensing.php
@@ -140,6 +140,13 @@ class Licensing {
 			],
 		];
 
+		// Merge custom licenses to the supported ones if we have any
+		$extended = apply_filters( 'extend_custom_licenses', [] );
+
+		$supported = is_array( $extended )
+			? array_merge( $supported, $extended )
+			: $supported;
+
 		// Custom
 		if ( ! $disable_custom && ! has_filter( 'extend_custom_licenses' ) ) {
 			$custom = get_terms(
@@ -148,6 +155,7 @@ class Licensing {
 					'hide_empty' => false,
 				]
 			);
+
 			if ( is_array( $custom ) ) {
 				foreach ( $custom as $custom_term ) {
 					if ( ! isset( $supported[ $custom_term->slug ] ) ) {

--- a/inc/cloner/class-cloner.php
+++ b/inc/cloner/class-cloner.php
@@ -1007,6 +1007,12 @@ class Cloner {
 			'https://choosealicense.com/no-license/',
 		];
 
+		$extended_restrictive_licenses = apply_filters( 'extend_restrictive_licenses', [] );
+
+		$restrictive_licenses = is_array( $extended_restrictive_licenses )
+			? array_merge( $restrictive_licenses, $extended_restrictive_licenses )
+			: $restrictive_licenses;
+
 		if ( is_array( $metadata_license ) ) {
 			$license_url = $metadata_license['url'];
 		} else { // Backwards compatibility.


### PR DESCRIPTION
Part of pressbooks/pressbooks-network-catalog#67. Accompanies pressbooks/pressbooks-ecampus-ontario#21.

This PR adds custom licenses to the supported license list when using the `extend_custom_licenses` hook. This should properly display custom licenses on `pressbooks/pressbooks-network-catalog` and also `pressbooks/pressbooks-network-analytics`.

It also makes use of a new hook (`extend_restrictive_licenses`) to extend the restrictive licenses when cloning books.