### PR TITLE
feat: properly associate field descriptions with fields in Options class

### DIFF
--- a/inc/admin/metaboxes/namespace.php
+++ b/inc/admin/metaboxes/namespace.php
@@ -1310,9 +1310,9 @@ function contributor_add_form() {
 				<img style="display: none" src="" id="<?php echo $meta_tags['tag']; ?>-thumbnail" width="120" /> <br />
 				<div class="form-field <?php echo $meta_tags['tag']; ?>-wrap">
 					<label for="<?php echo $meta_tags['tag']; ?>"><?php echo $meta_tags['label']; ?></label>
-					<button name="dispatch-media-picture" id="btn-media">Upload Picture</button>
+					<button name="dispatch-media-picture" id="btn-media" aria-describedby="picture-description">Upload Picture</button>
 					<input type="hidden" name="<?php echo $term; ?>" id="<?php echo $meta_tags['tag']; ?>">
-					<p>
+					<p id="picture-description">
 						<?php echo __( 'Images should be square (400px x 400px). You will be allowed to crop images after upload.', 'pressbooks' ); ?>
 					</p>
 				</div>
@@ -1367,8 +1367,8 @@ function contributor_edit_form( $term ) {
 								<img style="display: none" id="<?php echo $meta_tags['tag']; ?>-thumbnail" width="120" />
 							<?php endif; ?>
 							<br />
-							<button name="dispatch-media-picture" id="btn-media">Upload Picture</button>
-							<p class="description">
+							<button name="dispatch-media-picture" id="btn-media" aria-describedby="picture-description">Upload Picture</button>
+							<p class="description" id="picture-description">
 								<?php echo __( 'Images should be square (400px x 400px). You will be allowed to crop images after upload.', 'pressbooks' ); ?>
 							</p>
 							<input

--- a/inc/class-options.php
+++ b/inc/class-options.php
@@ -203,21 +203,23 @@ abstract class Options {
 		$args = wp_parse_args( $args, $defaults );
 
 		printf(
-			'<input id="%s" class="%s" name="%s[%s]" type="%s" value="%s" %s/>',
+			'<input id="%s" class="%s" name="%s[%s]" type="%s" value="%s" %s%s/>',
 			$args['id'],
 			$args['class'],
 			$args['name'],
 			$args['option'],
 			$args['type'],
 			$args['value'],
-			( ! empty( $args['disabled'] ) ) ? ' disabled' : ''
+			( ! empty( $args['disabled'] ) ) ? ' disabled' : '',
+			( isset( $args['description'] ) ) ? ' aria-describedby="'.$args['id'].'-description"' : ''
 		);
 		if ( isset( $args['append'] ) ) {
 			echo ' ' . $args['append'];
 		}
 		if ( isset( $args['description'] ) ) {
 			printf(
-				'<p class="description">%s</p>',
+				'<p class="description" id="%s-description">%s</p>',
+				$args['id'],
 				$args['description']
 			);
 		}
@@ -256,13 +258,14 @@ abstract class Options {
 		$args = wp_parse_args( $args, $defaults );
 
 		printf(
-			'<textarea id="%s" class="%s" name="%s[%s]" rows="%s" %s>%s</textarea>',
+			'<textarea id="%s" class="%s" name="%s[%s]" rows="%s" %s%s>%s</textarea>',
 			$args['id'],
 			$args['class'],
 			$args['name'],
 			$args['option'],
 			$args['rows'],
 			( ! empty( $args['disabled'] ) ) ? ' disabled' : '',
+			( isset( $args['description'] ) ) ? ' aria-describedby="'.$args['id'].'-description"' : '',
 			esc_textarea( $args['value'] )
 		);
 		if ( isset( $args['append'] ) ) {
@@ -270,7 +273,8 @@ abstract class Options {
 		}
 		if ( isset( $args['description'] ) ) {
 			printf(
-				'<p class="description">%s</p>',
+				'<p class="description" id="%s-description">%s</p>',
+				$args['id'],
 				$args['description']
 			);
 		}
@@ -340,18 +344,20 @@ abstract class Options {
 		$args = wp_parse_args( $args, $defaults );
 
 		printf(
-			'<input id="%s" name="%s[%s]" type="checkbox" value="1" %s%s/><label for="%s">%s</label>',
+			'<input id="%s" name="%s[%s]" type="checkbox" value="1" %s%s%s/><label for="%s">%s</label>',
 			$args['id'],
 			$args['name'],
 			$args['option'],
 			checked( 1, $args['value'], false ),
 			( ! empty( $args['disabled'] ) ) ? ' disabled' : '',
+			( isset( $args['description'] ) ) ? ' aria-describedby="'.$args['id'].'-description"' : '',
 			$args['id'],
 			$args['label']
 		);
 		if ( isset( $args['description'] ) ) {
 			printf(
-				'<p class="description">%s</p>',
+				'<p class="description" id="%s-description">%s</p>',
+				$args['id'],
 				$args['description']
 			);
 		}
@@ -425,17 +431,19 @@ abstract class Options {
 			);
 		}
 		printf(
-			'<select name="%s[%s]" id="%s" %s%s>%s</select>',
+			'<select name="%s[%s]" id="%s" %s%s%s>%s</select>',
 			$args['name'],
 			$args['option'],
 			$args['id'],
 			( $args['multiple'] ) ? ' multiple' : '',
 			( ! empty( $args['disabled'] ) ) ? ' disabled' : '',
+			( isset( $args['description'] ) ) ? ' aria-describedby="'.$args['id'].'-description"' : '',
 			$options
 		);
 		if ( isset( $args['description'] ) ) {
 			printf(
-				'<p class="description">%s</p>',
+				'<p class="description" id="%s-description">%s</p>',
+				$args['id'],
 				$args['description']
 			);
 		}
@@ -483,17 +491,19 @@ abstract class Options {
 			}
 		}
 		printf(
-			'<select name="%s[%s]" id="%s" %s%s>%s</select>',
+			'<select name="%s[%s]" id="%s" %s%s%s>%s</select>',
 			$args['name'],
 			$args['option'],
 			$args['id'],
 			( $args['multiple'] ) ? ' multiple' : '',
 			( ! empty( $args['disabled'] ) ) ? ' disabled' : '',
+			( isset( $args['description'] ) ) ? ' aria-describedby="'.$args['id'].'-description"' : '',
 			$options
 		);
 		if ( isset( $args['description'] ) ) {
 			printf(
-				'<p class="description">%s</p>',
+				'<p class="description" id="%s-description">%s</p>',
+				$args['id'],
 				$args['description']
 			);
 		}

--- a/inc/class-options.php
+++ b/inc/class-options.php
@@ -211,7 +211,7 @@ abstract class Options {
 			$args['type'],
 			$args['value'],
 			( ! empty( $args['disabled'] ) ) ? ' disabled' : '',
-			( isset( $args['description'] ) ) ? ' aria-describedby="'.$args['id'].'-description"' : ''
+			( isset( $args['description'] ) ) ? ' aria-describedby="' . $args['id'] . '-description"' : ''
 		);
 		if ( isset( $args['append'] ) ) {
 			echo ' ' . $args['append'];
@@ -265,7 +265,7 @@ abstract class Options {
 			$args['option'],
 			$args['rows'],
 			( ! empty( $args['disabled'] ) ) ? ' disabled' : '',
-			( isset( $args['description'] ) ) ? ' aria-describedby="'.$args['id'].'-description"' : '',
+			( isset( $args['description'] ) ) ? ' aria-describedby="' . $args['id'] . '-description"' : '',
 			esc_textarea( $args['value'] )
 		);
 		if ( isset( $args['append'] ) ) {
@@ -350,7 +350,7 @@ abstract class Options {
 			$args['option'],
 			checked( 1, $args['value'], false ),
 			( ! empty( $args['disabled'] ) ) ? ' disabled' : '',
-			( isset( $args['description'] ) ) ? ' aria-describedby="'.$args['id'].'-description"' : '',
+			( isset( $args['description'] ) ) ? ' aria-describedby="' . $args['id'] . '-description"' : '',
 			$args['id'],
 			$args['label']
 		);
@@ -437,7 +437,7 @@ abstract class Options {
 			$args['id'],
 			( $args['multiple'] ) ? ' multiple' : '',
 			( ! empty( $args['disabled'] ) ) ? ' disabled' : '',
-			( isset( $args['description'] ) ) ? ' aria-describedby="'.$args['id'].'-description"' : '',
+			( isset( $args['description'] ) ) ? ' aria-describedby="' . $args['id'] . '-description"' : '',
 			$options
 		);
 		if ( isset( $args['description'] ) ) {
@@ -497,7 +497,7 @@ abstract class Options {
 			$args['id'],
 			( $args['multiple'] ) ? ' multiple' : '',
 			( ! empty( $args['disabled'] ) ) ? ' disabled' : '',
-			( isset( $args['description'] ) ) ? ' aria-describedby="'.$args['id'].'-description"' : '',
+			( isset( $args['description'] ) ) ? ' aria-describedby="' . $args['id'] . '-description"' : '',
 			$options
 		);
 		if ( isset( $args['description'] ) ) {

--- a/tests/test-contributors.php
+++ b/tests/test-contributors.php
@@ -244,7 +244,7 @@ class ContributorsTest extends \WP_UnitTestCase {
 		\Pressbooks\Admin\Metaboxes\contributor_edit_form( $term );
 		$buffer = ob_get_clean();
 
-		$this->assertStringContainsString( '<button name="dispatch-media-picture" id="btn-media" aria-labelledby="picture-description">Upload Picture</button>', $buffer );
+		$this->assertStringContainsString( '<button name="dispatch-media-picture" id="btn-media" aria-describedby="picture-description">Upload Picture</button>', $buffer );
 	}
 
 	/**

--- a/tests/test-contributors.php
+++ b/tests/test-contributors.php
@@ -244,7 +244,7 @@ class ContributorsTest extends \WP_UnitTestCase {
 		\Pressbooks\Admin\Metaboxes\contributor_edit_form( $term );
 		$buffer = ob_get_clean();
 
-		$this->assertStringContainsString( '<button name="dispatch-media-picture" id="btn-media">Upload Picture</button>', $buffer );
+		$this->assertStringContainsString( '<button name="dispatch-media-picture" id="btn-media" aria-labelledby="picture-description">Upload Picture</button>', $buffer );
 	}
 
 	/**


### PR DESCRIPTION
This PR adds `aria-describedby` attributes to form fields and related `id` attributes to input descriptions when provided. See: https://github.com/pressbooks/pressbooks/issues/2434#issuecomment-1264131813