### PR TITLE
fix: unescape title and subtitle

### DIFF
--- a/templates/export/half-title.blade.php
+++ b/templates/export/half-title.blade.php
@@ -1,1 +1,1 @@
-<div id="half-title-page"><h1 class="title">{{ $title }}</h1></div>
+<div id="half-title-page"><h1 class="title">{!! $title !!}</h1></div>

--- a/templates/export/title.blade.php
+++ b/templates/export/title.blade.php
@@ -2,8 +2,8 @@
 	@if( isset( $content ) )
 		{!! $content !!}
 	@else
-		<h1 class="title">{{ $title }}</h1>
-		<h2 class="subtitle">{{ $subtitle }}</h2>
+		<h1 class="title">{!! $title !!}</h1>
+		<h2 class="subtitle">{!! $subtitle !!}</h2>
 		@if( $authors )
 			<p class="author">{{ $authors }}</p>
 		@endif


### PR DESCRIPTION
Issue pressbooks/private#1020

This PR attempts to fix apostrophe not being properly rendered on PDFs.

### How to test

1. Checkout to this branch
2. Update the book title or subtitle to add apostrophes
3. Export a new PDF version of the book
4. Apostrophes should be rendered properly.

>**Note**
This should not break EPUBs but would be good to test them as well.
Also, file names are being generated as the following right now `Jc039s-test-book-1665686454.pdf` instead of `Jcs-test-book-1665686454.pdf`. I don't remember them having the `039` for past releases.