### PR TITLE
fix: add compatibility with WordPress 6.1 (resolves #2986)

### DIFF
--- a/inc/l10n/namespace.php
+++ b/inc/l10n/namespace.php
@@ -384,6 +384,10 @@ function load_plugin_textdomain( $locale = '' ) {
  * @return mixed
  */
 function override_core_strings( $translated, $original, $domain ) {
+    if ($original === 'put your unique phrase here') {
+		return $original;
+	}
+
 	$overrides = include_core_overrides();
 
 	if ( isset( $overrides[ $original ] ) ) {

--- a/inc/l10n/namespace.php
+++ b/inc/l10n/namespace.php
@@ -384,7 +384,7 @@ function load_plugin_textdomain( $locale = '' ) {
  * @return mixed
  */
 function override_core_strings( $translated, $original, $domain ) {
-    if ($original === 'put your unique phrase here') {
+	if ( $original === 'put your unique phrase here' ) {
 		return $original;
 	}
 


### PR DESCRIPTION
Resolves https://github.com/pressbooks/pressbooks/issues/2986.

The issue is that as of WordPress 6.1, `wp_current_user` calls a sequence of methods which leads to a string being localized within `wp_salt` (see https://github.com/WordPress/WordPress/commit/06cb9d7691535b4fddc3761be7c1fe3ab6ff2f68). This leads to `Pressbooks\L10n\override_core_strings()` being called again which triggers an infinite loop.

```
14 | 0.9088 | 5002064 | Pressbooks\L10n\override_core_strings( $translated = 'Whether theme opts in to wide alignment CSS class.', $original = 'Whether theme opts in to wide alignment CSS class.', $domain = 'default' ) | .../class-wp-hook.php:308
-- | -- | -- | -- | --
15 | 0.9088 | 5002064 | Pressbooks\L10n\include_core_overrides(  ) | .../namespace.php:391
16 | 0.9088 | 5002064 | Pressbooks\L10n\get_locale(  ) | .../namespace.php:414
17 | 0.9088 | 5002064 | wp_get_current_user(  ) | .../namespace.php:330
18 | 0.9088 | 5002064 | _wp_get_current_user(  ) | .../pluggable.php:70
19 | 0.9088 | 5002096 | apply_filters( $hook_name = 'determine_current_user', $value = FALSE ) | .../user.php:3604
20 | 0.9088 | 5002504 | WP_Hook->apply_filters( $value = FALSE, $args = [0 => FALSE] ) | .../plugin.php:205
21 | 0.9088 | 5004008 | wp_validate_auth_cookie( $cookie = FALSE, $scheme = ??? ) | .../class-wp-hook.php:308
22 | 0.9104 | 5043856 | wp_hash( $data = 'admin\|7FWx\|1668787026\|DUA6dIsT6D1WKWJhjqk5Rdp7cnliLcYETaWLfcEJjkd', $scheme = 'secure_auth' ) | .../pluggable.php:761
23 | 0.9104 | 5043856 | wp_salt( $scheme = 'secure_auth' ) | .../pluggable.php:2479
24 | 0.9104 | 5044672 | __( $text = 'put your unique phrase here', $domain = ??? ) | .../pluggable.php:2413
2
```

See also: https://github.com/pressbooks/pressbooks/issues/2986#issuecomment-1303835278
