### PR TITLE
feat: Health check endpoint

### DIFF
--- a/inc/api/endpoints/controller/class-healthcheck.php
+++ b/inc/api/endpoints/controller/class-healthcheck.php
@@ -3,9 +3,9 @@
 namespace Pressbooks\Api\Endpoints\Controller;
 
 use Pressbooks\Health\Check;
-use Pressbooks\Health\checks\CacheCheck;
-use Pressbooks\Health\checks\DatabaseCheck;
-use Pressbooks\Health\checks\FilesystemCheck;
+use Pressbooks\Health\Checks\CacheCheck;
+use Pressbooks\Health\Checks\DatabaseCheck;
+use Pressbooks\Health\Checks\FilesystemCheck;
 use Pressbooks\Health\Checks\ObjectCacheProCheck;
 use Pressbooks\Health\Result;
 use WP_REST_Controller;

--- a/inc/api/endpoints/controller/class-healthcheck.php
+++ b/inc/api/endpoints/controller/class-healthcheck.php
@@ -58,13 +58,6 @@ class HealthCheck extends WP_REST_Controller {
 	}
 
 	public function authorize( WP_REST_Request $request ): bool {
-		$value = $request->get_param( '_token' );
-		$expected = env( 'PB_HEALTH_CHECK_TOKEN' );
-
-		if ( $value !== $expected ) {
-			return false;
-		}
-
-		return true;
+		return $request->get_param( '_token' ) === env( 'PB_HEALTH_CHECK_TOKEN' );
 	}
 }

--- a/inc/api/endpoints/controller/class-healthcheck.php
+++ b/inc/api/endpoints/controller/class-healthcheck.php
@@ -35,9 +35,9 @@ class HealthCheck extends WP_REST_Controller {
 			$check->getName() => $check->run(),
 		]);
 
-		$status = $results->filter(function( array $result ) {
-			return $result['has_issue'] ?? false;
-		})->isEmpty() ? 200 : 500;
+		$status = $results
+			->filter( fn( array $result ) => $result['has_issue'] ?? false )
+			->isEmpty() ? 200 : 500;
 
 		return rest_ensure_response(
 			new WP_REST_Response( $results, $status )

--- a/inc/api/endpoints/controller/class-healthcheck.php
+++ b/inc/api/endpoints/controller/class-healthcheck.php
@@ -61,10 +61,6 @@ class HealthCheck extends WP_REST_Controller {
 		$value = $request->get_param( '_token' );
 		$expected = env( 'PB_HEALTH_CHECK_TOKEN' );
 
-		if ( ! $value ) {
-			return false;
-		}
-
 		if ( $value !== $expected ) {
 			return false;
 		}

--- a/inc/api/endpoints/controller/class-healthcheck.php
+++ b/inc/api/endpoints/controller/class-healthcheck.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Pressbooks\Api\Endpoints\Controller;
+
+use Pressbooks\Health\Check;
+use Pressbooks\Health\checks\CacheCheck;
+use Pressbooks\Health\checks\DatabaseCheck;
+use Pressbooks\Health\checks\FilesystemCheck;
+use WP_REST_Controller;
+use WP_REST_Response;
+use WP_REST_Server;
+
+class HealthCheck extends WP_REST_Controller {
+	public function __construct() {
+		$this->namespace = 'pressbooks/v2';
+		$this->rest_base = 'health-check';
+	}
+
+	public function register_routes(): void {
+		register_rest_route($this->namespace, $this->rest_base, [
+			'methods' => WP_REST_Server::READABLE,
+			'callback' => [ $this, 'healthCheck' ],
+			'permission_callback' => '__return_true',
+		]);
+	}
+
+	public function healthCheck(): WP_REST_Response {
+		$checks = [
+			new CacheCheck,
+			new DatabaseCheck,
+			new FilesystemCheck,
+		];
+
+		$results = collect( $checks )->flatMap(fn( Check $check ) => [
+			$check->getName() => $check->run(),
+		]);
+
+		$status = $results->filter(function( array $result ) {
+			return $result['has_issue'] ?? false;
+		})->isEmpty() ? 200 : 500;
+
+		return rest_ensure_response(
+			new WP_REST_Response( $results, $status )
+		);
+	}
+}

--- a/inc/api/endpoints/controller/class-healthcheck.php
+++ b/inc/api/endpoints/controller/class-healthcheck.php
@@ -24,6 +24,13 @@ class HealthCheck extends WP_REST_Controller {
 			'methods' => WP_REST_Server::READABLE,
 			'callback' => [ $this, 'healthCheck' ],
 			'permission_callback' => [ $this, 'authorize' ],
+			'args' => [
+				'_token' => [
+					'description' => 'A token stored in your .env file as PB_HEALTH_CHECK_TOKEN and used to authorize the request.',
+					'type' => 'string',
+					'required' => true,
+				],
+			],
 		]);
 	}
 

--- a/inc/api/namespace.php
+++ b/inc/api/namespace.php
@@ -145,13 +145,14 @@ function init_root() {
 
 	( new Endpoints\Controller\HealthCheck() )->register_routes();
 
-	add_filter( 'rest_endpoints', function( $endpoints ) {
-		return array_filter(
+	add_filter(
+		'rest_endpoints',
+		fn ( $endpoints ) => array_filter(
 			$endpoints,
 			fn( $endpoint ) => ! str_contains( $endpoint, 'wp/v2/users' ),
 			ARRAY_FILTER_USE_KEY
-		);
-	});
+		)
+	);
 }
 
 /**

--- a/inc/api/namespace.php
+++ b/inc/api/namespace.php
@@ -142,6 +142,8 @@ function init_root() {
 
 	// Register Directory endpoints
 	( new Endpoints\Controller\Directory() )->register_routes();
+
+	( new Endpoints\Controller\HealthCheck() )->register_routes();
 }
 
 /**

--- a/inc/api/namespace.php
+++ b/inc/api/namespace.php
@@ -144,6 +144,14 @@ function init_root() {
 	( new Endpoints\Controller\Directory() )->register_routes();
 
 	( new Endpoints\Controller\HealthCheck() )->register_routes();
+
+	add_filter( 'rest_endpoints', function( $endpoints ) {
+		return array_filter(
+			$endpoints,
+			fn( $endpoint ) => ! str_contains( $endpoint, 'wp/v2/users' ),
+			ARRAY_FILTER_USE_KEY
+		);
+	});
 }
 
 /**

--- a/inc/api/namespace.php
+++ b/inc/api/namespace.php
@@ -146,12 +146,31 @@ function init_root() {
 	( new Endpoints\Controller\HealthCheck() )->register_routes();
 
 	add_filter(
-		'rest_endpoints',
-		fn ( $endpoints ) => array_filter(
-			$endpoints,
-			fn( $endpoint ) => ! str_contains( $endpoint, 'wp/v2/users' ),
-			ARRAY_FILTER_USE_KEY
-		)
+		'rest_endpoints', function ( $endpoints ) {
+			foreach ( $endpoints as $route => $endpoint ) {
+				if ( ! str_contains( $route, 'wp/v2/users' ) ) {
+					continue;
+				}
+
+				foreach ( $endpoint as $index => $handler ) {
+					if ( ! is_array( $handler ) ) {
+						continue;
+					}
+
+					if ( ! isset( $handler['methods'] ) ) {
+						continue;
+					}
+
+					if ( $handler['methods'] !== 'GET' ) {
+						continue;
+					}
+
+					unset( $endpoints[ $route ][ $index ] );
+				}
+			}
+
+			return $endpoints;
+		}
 	);
 }
 

--- a/inc/health/checks/class-cachecheck.php
+++ b/inc/health/checks/class-cachecheck.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Pressbooks\Health\Checks;
+
+use Pressbooks\Health\Check;
+use RedisCachePro\Diagnostics\Diagnostics;
+
+class CacheCheck extends Check {
+	public function __construct() {
+		$this->name = 'cache';
+	}
+
+	public function run(): array {
+		global $wp_object_cache;
+
+		$has_issue = false;
+
+		if ( ! is_plugin_active_for_network( 'object-cache-pro/object-cache-pro.php' ) ) {
+			// TODO: how to handle non object cache pro cache?
+			return [
+				'status' => 'Unknown',
+				'has_issue' => false,
+			];
+		}
+
+		$diagnostics = ( new Diagnostics( $wp_object_cache ) )
+			->withFilesystemAccess()
+			->toArray();
+
+		/** @var Diagnostic $status */
+		$status = $diagnostics[ Diagnostics::GENERAL ]['status'];
+
+		/** @var Diagnostic $license */
+		$license = $diagnostics[ Diagnostics::GENERAL ]['license'];
+
+		/** @var Diagnostic $filesystem */
+		$filesystem = $diagnostics[ Diagnostics::GENERAL ]['filesystem'];
+
+		$errors = $diagnostics[ Diagnostics::ERRORS ];
+
+		if ( $status->hasIssue() || $license->hasIssue() || $license->hasIssue() || ! empty( $errors ) ) {
+			$has_issue = true;
+		}
+
+		return [
+			'status' => (string) $status->withComment(),
+			'license' => (string) $license->withComment(),
+			'filesystem' => (string) $filesystem->withComment(),
+			'has_issue' => $has_issue,
+			'errors' => $errors,
+		];
+	}
+}

--- a/inc/health/checks/class-cachecheck.php
+++ b/inc/health/checks/class-cachecheck.php
@@ -7,10 +7,6 @@ use Pressbooks\Health\Check;
 use Pressbooks\Health\Result;
 
 class CacheCheck extends Check {
-	public function __construct() {
-		$this->name = 'cache';
-	}
-
 	public function run(): Result {
 		$result = Result::make();
 

--- a/inc/health/checks/class-databasecheck.php
+++ b/inc/health/checks/class-databasecheck.php
@@ -11,12 +11,16 @@ class DatabaseCheck extends Check {
 	}
 
 	public function run(): Result {
-		global $wpdb;
-
 		$result = Result::make();
 
-		return $wpdb->check_connection()
+		return $this->checkConnection()
 			? $result->ok()
-			: $result->failed( 'Could not connect to the database' );
+			: $result->failed( 'Could not connect to the database.' );
+	}
+
+	protected function checkConnection(): bool {
+		global $wpdb;
+
+		return $wpdb->check_connection();
 	}
 }

--- a/inc/health/checks/class-databasecheck.php
+++ b/inc/health/checks/class-databasecheck.php
@@ -3,25 +3,20 @@
 namespace Pressbooks\Health\Checks;
 
 use Pressbooks\Health\Check;
+use Pressbooks\Health\Result;
 
 class DatabaseCheck extends Check {
 	public function __construct() {
 		$this->name = 'database';
 	}
 
-	public function run(): array {
+	public function run(): Result {
 		global $wpdb;
 
-		$has_issue = false;
+		$result = Result::make();
 
-		if ( ! $wpdb->check_connection() ) {
-			$has_issue = true;
-		}
-
-		return [
-			'status' => $has_issue ? 'Not connected' : 'Connected',
-			'has_issue' => $has_issue,
-			'issue' => $has_issue ? 'Could not connect to the database' : null,
-		];
+		return $wpdb->check_connection()
+			? $result->ok()
+			: $result->failed( 'Could not connect to the database' );
 	}
 }

--- a/inc/health/checks/class-databasecheck.php
+++ b/inc/health/checks/class-databasecheck.php
@@ -6,10 +6,6 @@ use Pressbooks\Health\Check;
 use Pressbooks\Health\Result;
 
 class DatabaseCheck extends Check {
-	public function __construct() {
-		$this->name = 'database';
-	}
-
 	public function run(): Result {
 		$result = Result::make();
 

--- a/inc/health/checks/class-databasecheck.php
+++ b/inc/health/checks/class-databasecheck.php
@@ -21,6 +21,7 @@ class DatabaseCheck extends Check {
 		return [
 			'status' => $has_issue ? 'Not connected' : 'Connected',
 			'has_issue' => $has_issue,
+			'issue' => $has_issue ? 'Could not connect to the database' : null,
 		];
 	}
 }

--- a/inc/health/checks/class-databasecheck.php
+++ b/inc/health/checks/class-databasecheck.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Pressbooks\Health\Checks;
+
+use Pressbooks\Health\Check;
+
+class DatabaseCheck extends Check {
+	public function __construct() {
+		$this->name = 'database';
+	}
+
+	public function run(): array {
+		global $wpdb;
+
+		$has_issue = false;
+
+		if ( ! $wpdb->check_connection() ) {
+			$has_issue = true;
+		}
+
+		return [
+			'status' => $has_issue ? 'Not connected' : 'Connected',
+			'has_issue' => $has_issue,
+		];
+	}
+}

--- a/inc/health/checks/class-filesystemcheck.php
+++ b/inc/health/checks/class-filesystemcheck.php
@@ -12,19 +12,17 @@ class FilesystemCheck extends Check {
 	}
 
 	public function run(): Result {
-		global $wp_filesystem;
-
 		$result = Result::make();
 
-		if ( ! WP_Filesystem() || ! $wp_filesystem->connect() ) {
+		if ( ! $this->canConnectToFilesystem() ) {
 			return $result->failed( 'Failed to obtain filesystem write access.' );
 		}
 
-		if ( ! $wp_filesystem->is_writable( WP_CONTENT_DIR ) ) {
+		if ( ! $this->canWriteToFilesystem() ) {
 			return $result->failed( 'The filesystem is not writable.' );
 		}
 
-		if ( ! $wp_filesystem->is_readable( WP_CONTENT_DIR ) ) {
+		if ( ! $this->canReadFromFilesystem() ) {
 			return $result->failed( 'The filesystem is not readable.' );
 		}
 
@@ -38,7 +36,29 @@ class FilesystemCheck extends Check {
 		return $result->ok();
 	}
 
-	protected function getDiskUsagePercentage(): string {
+	protected function canConnectToFilesystem(): bool {
+		global $wp_filesystem;
+
+		if ( ! WP_Filesystem() ) {
+			return false;
+		}
+
+		return $wp_filesystem->connect();
+	}
+
+	protected function canWriteToFilesystem(): bool {
+		global $wp_filesystem;
+
+		return $wp_filesystem->is_writable( WP_CONTENT_DIR );
+	}
+
+	protected function canReadFromFilesystem(): bool {
+		global $wp_filesystem;
+
+		return $wp_filesystem->is_readable( WP_CONTENT_DIR );
+	}
+
+	protected function getDiskUsagePercentage(): int {
 		$process = Process::fromShellCommandline( 'df -P .' );
 
 		$process->run();

--- a/inc/health/checks/class-filesystemcheck.php
+++ b/inc/health/checks/class-filesystemcheck.php
@@ -35,11 +35,7 @@ class FilesystemCheck extends Check {
 	protected function canConnectToFilesystem(): bool {
 		global $wp_filesystem;
 
-		if ( ! WP_Filesystem() ) {
-			return false;
-		}
-
-		return $wp_filesystem->connect();
+		return WP_Filesystem() ? $wp_filesystem->connect() : false;
 	}
 
 	protected function canWriteToFilesystem(): bool {

--- a/inc/health/checks/class-filesystemcheck.php
+++ b/inc/health/checks/class-filesystemcheck.php
@@ -7,10 +7,6 @@ use Pressbooks\Health\Result;
 use Symfony\Component\Process\Process;
 
 class FilesystemCheck extends Check {
-	public function __construct() {
-		$this->name = 'filesystem';
-	}
-
 	public function run(): Result {
 		$result = Result::make();
 

--- a/inc/health/checks/class-filesystemcheck.php
+++ b/inc/health/checks/class-filesystemcheck.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Pressbooks\Health\Checks;
+
+use Pressbooks\Health\Check;
+
+class FilesystemCheck extends Check {
+	public function __construct() {
+		$this->name = 'filesystem';
+	}
+
+	public function run(): array {
+		global $wp_filesystem;
+
+		$has_issue = false;
+
+		if ( ! WP_Filesystem() ) {
+			$has_issue = true;
+		}
+
+		if ( ! $wp_filesystem->connect() ) {
+			$has_issue = true;
+		}
+
+		return [
+			'status' => $has_issue ? 'Not Accessible' : 'Accessible',
+			'writable' => $wp_filesystem->is_writable( WP_CONTENT_DIR ),
+			'readable' => $wp_filesystem->is_readable( WP_CONTENT_DIR ),
+			'free_space' => $this->calculateFreeSpace(),
+			'total_space' => $this->calculateTotalSpace(),
+			'has_issue' => $has_issue,
+		];
+	}
+
+	protected function calculateFreeSpace(): string {
+		return $this->calculateSpace( disk_free_space( '.' ) );
+	}
+
+	protected function calculateTotalSpace():string {
+		return $this->calculateSpace( disk_total_space( '.' ) );
+	}
+
+	protected function calculateSpace( float $bytes ): string {
+		$base = 1024;
+		$suffixes = [ 'B', 'KB', 'MB', 'GB', 'TB' ];
+
+		$index = min( (int) log( $bytes, $base ), count( $suffixes ) - 1 );
+
+		return sprintf( '%1.2f', $bytes / pow( $base, $index ) ) . $suffixes[ $index ];
+	}
+}

--- a/inc/health/checks/class-objectcacheprocheck.php
+++ b/inc/health/checks/class-objectcacheprocheck.php
@@ -11,7 +11,7 @@ class ObjectCacheProCheck extends Check {
 		$result = Result::make();
 
 		if ( ! is_plugin_active_for_network( 'object-cache-pro/object-cache-pro.php' ) ) {
-			return $result->ok( 'Object Cache Pro plugin is not installed.' );
+			return $result->ok( 'Object Cache Pro plugin is either inactive or not installed.' );
 		}
 
 		global $wp_object_cache;

--- a/inc/health/checks/class-objectcacheprocheck.php
+++ b/inc/health/checks/class-objectcacheprocheck.php
@@ -10,6 +10,7 @@ class ObjectCacheProCheck extends Check {
 	public function __construct() {
 		$this->name = 'object-cache-pro';
 	}
+
 	public function run(): Result {
 		$result = Result::make();
 

--- a/inc/health/checks/class-objectcacheprocheck.php
+++ b/inc/health/checks/class-objectcacheprocheck.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Pressbooks\Health\Checks;
+
+use Pressbooks\Health\Check;
+use Pressbooks\Health\Result;
+use RedisCachePro\Diagnostics\Diagnostics;
+
+class ObjectCacheProCheck extends Check {
+	public function __construct() {
+		$this->name = 'object-cache-pro';
+	}
+	public function run(): Result {
+		$result = Result::make();
+
+		if ( ! is_plugin_active_for_network( 'object-cache-pro/object-cache-pro.php' ) ) {
+			return $result->ok( 'Object Cache Pro plugin is not installed.' );
+		}
+
+		global $wp_object_cache;
+
+		$diagnostics = ( new Diagnostics( $wp_object_cache ) )->toArray();
+
+		/** @var Diagnostic $status */
+		$status = $diagnostics[ Diagnostics::GENERAL ]['status'];
+
+		/** @var Diagnostic $license */
+		$license = $diagnostics[ Diagnostics::GENERAL ]['license'];
+
+		if ( $status->hasIssue() ) {
+			return $result->failed( 'Could not connect to Redis cache.' );
+		}
+
+		if ( $license->hasIssue() ) {
+			return $result->failed( 'License token is not valid or it\'s missing' );
+		}
+
+		return $result->ok();
+	}
+}

--- a/inc/health/checks/class-objectcacheprocheck.php
+++ b/inc/health/checks/class-objectcacheprocheck.php
@@ -7,10 +7,6 @@ use Pressbooks\Health\Result;
 use RedisCachePro\Diagnostics\Diagnostics;
 
 class ObjectCacheProCheck extends Check {
-	public function __construct() {
-		$this->name = 'object-cache-pro';
-	}
-
 	public function run(): Result {
 		$result = Result::make();
 

--- a/inc/health/class-check.php
+++ b/inc/health/class-check.php
@@ -2,12 +2,17 @@
 
 namespace Pressbooks\Health;
 
-abstract class Check {
-	protected ?string $name = null;
+use Illuminate\Support\Str;
+use ReflectionClass;
 
+abstract class Check {
 	abstract public function run(): Result;
 
 	public function getName(): ?string {
-		return $this->name;
+		$class = new ReflectionClass( $this );
+
+		return Str::of( $class->getShortName() )
+			->kebab()
+			->before( '-check' );
 	}
 }

--- a/inc/health/class-check.php
+++ b/inc/health/class-check.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Pressbooks\Health;
+
+abstract class Check {
+	protected ?string $name = null;
+
+	abstract public function run(): array;
+
+	public function getName(): ?string {
+		return $this->name;
+	}
+}

--- a/inc/health/class-check.php
+++ b/inc/health/class-check.php
@@ -5,7 +5,7 @@ namespace Pressbooks\Health;
 abstract class Check {
 	protected ?string $name = null;
 
-	abstract public function run(): array;
+	abstract public function run(): Result;
 
 	public function getName(): ?string {
 		return $this->name;

--- a/inc/health/class-result.php
+++ b/inc/health/class-result.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Pressbooks\Health;
+
+use Illuminate\Contracts\Support\Arrayable;
+
+class Result implements Arrayable {
+	public bool $status;
+
+	public string $message;
+
+	public function __construct( bool $status ) {
+		$this->status = $status;
+	}
+
+	public static function make(): self {
+		return new self( $status = true );
+	}
+
+	public function ok( string $message = '' ): self {
+		$this->status = true;
+
+		$this->message = $message;
+
+		return $this;
+	}
+
+	public function failed( string $message = '' ): self {
+		$this->status = false;
+
+		$this->message = $message;
+
+		return $this;
+	}
+
+	public function toArray(): array {
+		return [
+			'status' => $this->status ? 'Ok' : 'Failed',
+			'message' => $this->message,
+		];
+	}
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,6 +12,7 @@
   <php>
     <const name="WP_TESTS_MULTISITE" value="1"/>
     <const name="WP_RUN_CORE_TESTS" value="0"/>
+    <env name="PB_HEALTH_CHECK_TOKEN" value="health-check-token"/>
   </php>
   <testsuites>
     <testsuite name="Pressbooks">

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -525,4 +525,20 @@ class ApiTest extends \WP_UnitTestCase {
 		$data = $response->get_data();
 		$this->assertEquals( $protected_post['post_content'], $data['content']['raw'] );
 	}
+
+	/**
+	 * @test
+	 * @group api
+	 */
+	public function it_disable_users_endpoint(): void {
+		$server = $this->_setupRootApi();
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/users' );
+
+		$response = $server->dispatch( $request );
+		$data = $response->data;
+
+		$this->assertEquals( 404, $response->status );
+		$this->assertEquals( 'No route was found matching the URL and request method.', $data['message'] );
+	}
 }

--- a/tests/test-healthcheck.php
+++ b/tests/test-healthcheck.php
@@ -33,7 +33,7 @@ class HealthCheckTest extends \WP_UnitTestCase {
 
 		$response = $server->dispatch( $request );
 
-		$this->assertEquals( 401, $response->status );
+		$this->assertEquals( 400, $response->status );
 
 		$request->set_query_params( [
 			'_token' => 'not-a-valid-token',

--- a/tests/test-healthcheck.php
+++ b/tests/test-healthcheck.php
@@ -1,16 +1,10 @@
 <?php
 
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
-use Pressbooks\Api\Endpoints\Controller\Posts;
-use Pressbooks\Container;
-
 use Pressbooks\Health\Checks\CacheCheck;
 use Pressbooks\Health\Checks\DatabaseCheck;
 use Pressbooks\Health\Checks\FilesystemCheck;
-use function \Pressbooks\Metadata\book_information_to_schema;
 
 class HealthCheckTest extends \WP_UnitTestCase {
-	use ArraySubsetAsserts;
 	use utilsTrait;
 
 	/**
@@ -35,58 +29,65 @@ class HealthCheckTest extends \WP_UnitTestCase {
 		$request = new WP_REST_Request( 'GET', '/pressbooks/v2/health-check' );
 
 		$response = $server->dispatch( $request );
+
+//		/** @var \Illuminate\Support\Collection $data */
 		$data = $response->get_data();
 
 		$this->assertEquals( 200, $response->status );
 
-		$this->assertArraySubset( [
-			'cache' => [],
+		$this->assertEquals( [
+			'cache' => [
+				'status' => 'Ok',
+				'message' => '',
+			],
+			'object-cache-pro' => [
+				'status' => 'Ok',
+				'message' => 'Object Cache Pro plugin is not installed.',
+			],
 			'database' => [
-				'status' => 'Connected',
-				'has_issue' => false,
-				'issue' => null,
+				'status' => 'Ok',
+				'message' => '',
 			],
 			'filesystem' => [
-				'status' => 'Accessible',
-				'writable' => true,
-				'readable' => true,
-				'has_issue' => false,
-				'issues' => [],
+				'status' => 'Ok',
+				'message' => '',
 			]
-		], $data );
+		], $data->toArray() );
 	}
 
 	/**
 	 * @group health-check
 	 */
 	public function test_checks_database_connection(): void {
+		$result = (new DatabaseCheck)->run();
+
 		$this->assertEquals([
-			'status' => 'Connected',
-			'has_issue' => false,
-			'issue' => null,
-		], (new DatabaseCheck)->run());
+			'status' => 'Ok',
+			'message' => '',
+		], $result->toArray());
 	}
 
 	/**
 	 * @group health-check
 	 */
 	public function test_checks_cache_connection(): void {
-		$this->assertEquals([
-			'status' => 'Unknown',
-			'has_issue' => false,
-		], (new CacheCheck)->run());
+		$result = (new CacheCheck)->run();
+
+		$this->assertEquals( [
+			'status' => 'Ok',
+			'message' => '',
+		], $result->toArray() );
 	}
 
 	/**
 	 * @group health-check
 	 */
 	public function test_checks_filesystem(): void {
-		$this->assertArraySubset([
-			'status' => 'Accessible',
-			'writable' => true,
-			'readable' => true,
-			'has_issue' => false,
-			'issues' => [],
-		], (new FilesystemCheck)->run());
+		$result = (new FilesystemCheck)->run();
+
+		$this->assertEquals([
+			'status' => 'Ok',
+			'message' => '',
+		], $result->toArray());
 	}
 }

--- a/tests/test-healthcheck.php
+++ b/tests/test-healthcheck.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Str;
 use Pressbooks\Health\Checks\CacheCheck;
 use Pressbooks\Health\Checks\DatabaseCheck;
 use Pressbooks\Health\Checks\FilesystemCheck;
@@ -25,10 +26,36 @@ class HealthCheckTest extends \WP_UnitTestCase {
 	 * @test
 	 * @group health-check
 	 */
+	public function health_check_endpoint_forbidden_response(): void {
+		$server = $this->_setupRootApi();
+
+		$request = new WP_REST_Request( 'GET', '/pressbooks/v2/health-check' );
+
+		$response = $server->dispatch( $request );
+
+		$this->assertEquals( 401, $response->status );
+
+		$request->set_query_params( [
+			'_token' => 'not-a-valid-token',
+		] );
+
+		$response = $server->dispatch( $request );
+
+		$this->assertEquals( 401, $response->status );
+	}
+
+	/**
+	 * @test
+	 * @group health-check
+	 */
 	public function health_check_endpoint_success_response(): void {
 		$server = $this->_setupRootApi();
 
 		$request = new WP_REST_Request( 'GET', '/pressbooks/v2/health-check' );
+
+		$request->set_query_params( [
+			'_token' => env( 'PB_HEALTH_CHECK_TOKEN' ),
+		] );
 
 		$response = $server->dispatch( $request );
 

--- a/tests/test-healthcheck.php
+++ b/tests/test-healthcheck.php
@@ -71,7 +71,7 @@ class HealthCheckTest extends \WP_UnitTestCase {
 			],
 			'object-cache-pro' => [
 				'status' => 'Ok',
-				'message' => 'Object Cache Pro plugin is not installed.',
+				'message' => 'Object Cache Pro plugin is either inactive or not installed.',
 			],
 			'database' => [
 				'status' => 'Ok',

--- a/tests/test-healthcheck.php
+++ b/tests/test-healthcheck.php
@@ -1,0 +1,88 @@
+<?php
+
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
+use Pressbooks\Api\Endpoints\Controller\Posts;
+use Pressbooks\Container;
+
+use Pressbooks\Health\Checks\CacheCheck;
+use Pressbooks\Health\Checks\DatabaseCheck;
+use Pressbooks\Health\Checks\FilesystemCheck;
+use function \Pressbooks\Metadata\book_information_to_schema;
+
+class HealthCheckTest extends \WP_UnitTestCase {
+	use ArraySubsetAsserts;
+	use utilsTrait;
+
+	/**
+	 * @group health-check
+	 */
+	public function test_health_check_endpoint_exists(): void {
+		$server = $this->_setupRootApi();
+
+		$request = new WP_REST_Request( 'OPTIONS', '/pressbooks/v2/health-check' );
+
+		$data = $server->dispatch( $request )->get_data();
+
+		$this->assertEquals( 'pressbooks/v2', $data['namespace'] );
+	}
+
+	/**
+	 * @group health-check
+	 */
+	public function test_health_check_endpoint_success_response(): void {
+		$server = $this->_setupRootApi();
+
+		$request = new WP_REST_Request( 'GET', '/pressbooks/v2/health-check' );
+
+		$response = $server->dispatch( $request );
+		$data = $response->get_data();
+
+		$this->assertEquals( 200, $response->status );
+
+		$this->assertArraySubset( [
+			'cache' => [],
+			'database' => [
+				'status' => 'Connected',
+				'has_issue' => false,
+			],
+			'filesystem' => [
+				'status' => 'Accessible',
+				'writable' => true,
+				'readable' => true,
+				'has_issue' => false,
+			]
+		], $data );
+	}
+
+	/**
+	 * @group health-check
+	 */
+	public function test_checks_database_connection(): void {
+		$this->assertEquals([
+			'status' => 'Connected',
+			'has_issue' => false,
+		], (new DatabaseCheck)->run());
+	}
+
+	/**
+	 * @group health-check
+	 */
+	public function test_checks_cache_connection(): void {
+		$this->assertEquals([
+			'status' => 'Unknown',
+			'has_issue' => false,
+		], (new CacheCheck)->run());
+	}
+
+	/**
+	 * @group health-check
+	 */
+	public function test_checks_filesystem(): void {
+		$this->assertArraySubset([
+			'status' => 'Accessible',
+			'writable' => true,
+			'readable' => true,
+			'has_issue' => false,
+		], (new FilesystemCheck)->run());
+	}
+}

--- a/tests/test-healthcheck.php
+++ b/tests/test-healthcheck.php
@@ -44,12 +44,14 @@ class HealthCheckTest extends \WP_UnitTestCase {
 			'database' => [
 				'status' => 'Connected',
 				'has_issue' => false,
+				'issue' => null,
 			],
 			'filesystem' => [
 				'status' => 'Accessible',
 				'writable' => true,
 				'readable' => true,
 				'has_issue' => false,
+				'issues' => [],
 			]
 		], $data );
 	}
@@ -61,6 +63,7 @@ class HealthCheckTest extends \WP_UnitTestCase {
 		$this->assertEquals([
 			'status' => 'Connected',
 			'has_issue' => false,
+			'issue' => null,
 		], (new DatabaseCheck)->run());
 	}
 
@@ -83,6 +86,7 @@ class HealthCheckTest extends \WP_UnitTestCase {
 			'writable' => true,
 			'readable' => true,
 			'has_issue' => false,
+			'issues' => [],
 		], (new FilesystemCheck)->run());
 	}
 }


### PR DESCRIPTION
Issue #2985 

This PR aims to add a health check endpoint to help with infrastructure monitoring. It adds a `/wp-json/pressbooks/v2/health-check` endpoint that tests against a couple of checks.

It will return a **200** status code with the following output if every check passes:

<img width="577" alt="image" src="https://user-images.githubusercontent.com/1761690/201950442-6edc3bc7-40d8-4c24-b56b-f4df69d7be46.png">

If one or more checks fail the status code will be **500** and the output would be something like below:

<img width="752" alt="image" src="https://user-images.githubusercontent.com/1761690/201950908-db41a9b4-4914-491f-8468-c29ec9943488.png">

This PR also removes all **GET** requests associated with `wp-json/wp/v2/users`. The response should now be a **404** with the following output:

<img width="752" alt="image" src="https://user-images.githubusercontent.com/1761690/201953450-3262ca92-c994-4e1c-b69e-51f2c547988d.png">

**How to test**

1. Add `PB_HEALTH_CHECK_TOKEN` key to your **.env** file with a random string
2. Validate `https://pressbooks.test/wp-json/pressbooks/v2/health-check` API call fails if `_token` param is missing or is different from the one in your **.env** file.
3. Validate `https://pressbooks.test/wp-json/pressbooks/v2/health-check?_token=YOUR-TOKEN-HERE` responds with a **200** status code and all checks **Ok**
4. Make sure a **500** status code is returned if at least one of the checks is not working properly
5. Make sure `wp-json/wp/v2/users` endpoint returns a 404 and cloning and exports work as expected.

