### PR TITLE
fix: delete options cache after a plugin was activated

### DIFF
--- a/hooks.php
+++ b/hooks.php
@@ -343,3 +343,5 @@ add_filter( 'admin_email_check_interval', '__return_false' );
 // Book directory event actions
 // -------------------------------------------------------------------------------------------------------------------
 add_filter( 'init', [ '\Pressbooks\BookDirectory', 'init' ], 10, 2 );
+
+add_action( 'activated_plugin', '\Pressbooks\Utility\delete_options_cached' );

--- a/inc/utility/namespace.php
+++ b/inc/utility/namespace.php
@@ -1604,3 +1604,12 @@ function handle_image_upload( $url, $filename = 'profile.jpg' ) {
 
 	return wp_get_attachment_url( $pid );
 }
+
+/**
+ * Remove 'alloptions' cache key from the 'options' cache group.
+ *
+ * @return void
+ */
+function delete_options_cached() : void {
+	wp_cache_delete( 'alloptions', 'options' );
+}


### PR DESCRIPTION
Fix for: https://github.com/pressbooks/private/issues/1029

This PR deletes the 'alloptions` cache key from the `options` cache group right after a plugin is activated.

Some plugins like H5P store default values right after being activated. Those values are immediately replaced after specific hooks and are not updated at the cache level.

In order to understand the reason for this, please read https://core.trac.wordpress.org/ticket/31245.

Since we are using [the splitting option in object cache pro](https://objectcache.pro/docs/configuration-options/#splitting-alloptions), it is possible to remove a single option from the cache by doing:
```PHP
       $all_options_cached = wp_cache_get( 'all options', 'options' );
	if ( $all_options_cached['h5p_track_user'] ) {
		unset( $all_options_cached['h5p_track_user'] );
	}
	wp_cache_set( 'alloptions', $all_options_cached, 'options' );
```
It would solve only the specific H5P Plugin issue for a particular option (related to the results specified in the related issue). Nevertheless, it won't work for open-source users who are not using Object Cache Pro.

### Testing case
- Make sure the H5P plugin is deactivated at the network level
- Redis Plugin must be activated.
- Create a new book
- Activate H5P Plugin at the book level
- Create a new activity
- Complete the new Activity
- Click on Results (above the Activity)
- You should be able to see your results there.

### Testing with Results for LMS plugin
- Make sure the H5P plugin is deactivated at the network level
- Redis Plugin must be activated.
- Activate Results for the LMS plugin
- Create a new book
- Make sure the new book has LTI Enabled
- Activate H5P Plugin at the book level
- Create a new activity
- Go to a chapter within the book and add the new Activity you just created
- Save the chapter
- You should now see a new section in the chapter with the LTI activity
- Complete the new H5P Activity
- Go again to the chapter, and you should be able to see the score in the LTI activities section.