### PR TITLE
Add new institutions in Indiana

### DIFF
--- a/symbionts/institutions/institutions.json
+++ b/symbionts/institutions/institutions.json
@@ -5046,6 +5046,56 @@
             "code": "US-IN-037",
             "name": "Wabash College",
             "url": "https:\/\/www.wabash.edu\/"
+          },
+          {
+            "code": "US-IN-038",
+            "name": "Anabaptist Mennonite Biblical Seminary",
+            "url": "https:\/\/www.ambs.edu\/"
+          },
+          {
+            "code": "US-IN-039",
+            "name": "Christian Theological Seminary",
+            "url": "https:\/\/www.cts.edu\/"
+          },
+          {
+            "code": "US-IN-040",
+            "name": "Earlham College",
+            "url": "https:\/\/www.earlham.edu\/"
+          },
+          {
+            "code": "US-IN-041",
+            "name": "Concordia Theological Seminary",
+            "url": "https:\/\/www.ctsfw.edu\/"
+          },
+          {
+            "code": "US-IN-042",
+            "name": "Goshen College",
+            "url": "https:\/\/www.goshen.edu\/"
+          },
+          {
+            "code": "US-IN-043",
+            "name": "Grace College",
+            "url": "https:\/\/www.grace.edu\/"
+          },
+          {
+            "code": "US-IN-044",
+            "name": "Oakland City University",
+            "url": "https:\/\/www.oak.edu\/"
+          },
+          {
+            "code": "US-IN-045",
+            "name": "Saint Mary-of-the-Woods College",
+            "url": "https:\/\/www.smwc.edu\/"
+          },
+          {
+            "code": "US-IN-045",
+            "name": "Saint Mary-of-the-Woods College",
+            "url": "https:\/\/www.smwc.edu\/"
+          },
+          {
+            "code": "US-IN-046",
+            "name": "Saint Meinrad Seminary and School of Theology",
+            "url": "https:\/\/www.saintmeinrad.edu\/"
           }
         ]
       },


### PR DESCRIPTION
Fix for https://github.com/pressbooks/pressbooks/issues/3027. Add the following nine Indiana institutions of higher education:

1. Anabaptist Mennonite Biblical Seminary
2. Christian Theological Seminary
3. Earlham College
4. Concordia Theological Seminary
5. Goshen College
6. Grace College and Theological Seminary
7. Oakland City University
8. Saint Mary-of-the-Woods College
9. Saint Meinrad Seminary and School of Theology

To test:
1. Attempt to add any of the new institutions via book info. 
2. Confirm that the new institutions appear under the Indiana heading and display as expected