### PR TITLE
fix: remove unnecessary dependency

### DIFF
--- a/inc/health/checks/class-filesystemcheck.php
+++ b/inc/health/checks/class-filesystemcheck.php
@@ -51,10 +51,7 @@ class FilesystemCheck extends Check {
 	}
 
 	protected function getDiskUsagePercentage(): int {
-		$process = Process::fromShellCommandline( 'df -P .' );
-
-		$process->run();
-		$output = $process->getOutput();
+		$output = shell_exec( 'df -P .' );
 
 		$matches = [];
 		preg_match( '/(\d*)%/', $output, $matches, PREG_UNMATCHED_AS_NULL );


### PR DESCRIPTION
This PR fixes an issue introduced by #3020.

We were using a dependency that exists only as a dev dependency. I replaced it by the built-in method `shell_exec` to get the disk usage for now