### PR TITLE
fix: rest_api_init priority for cloning routine

### DIFF
--- a/hooks.php
+++ b/hooks.php
@@ -55,7 +55,7 @@ if ( $is_book ) {
 	add_filter( 'rest_prepare_attachment', '\Pressbooks\Api\fix_attachment', 10, 3 );
 } elseif ( $enable_network_api ) {
 	add_action( 'rest_api_init', '\Pressbooks\Api\init_book' );
-	add_action( 'rest_api_init', '\Pressbooks\Api\init_root' );
+	add_action( 'rest_api_init', '\Pressbooks\Api\init_root', 9 );
 }
 
 add_action( 'plugins_loaded', [ '\Pressbooks\DataCollector\User', 'init' ] );


### PR DESCRIPTION
It fixes https://github.com/pressbooks/pressbooks/issues/3046.

This PR increments the `rest_api_init` priority to 9 (default is 10) for an earlier execution of the `init_root` method, used to register necessary API routes for the cloning routine.
For some reason, this action is dispatched in a different order when the cloning routine is performed from the network level, causing the following error when calling some taxonomy endpoints: `No route was found matching the URL and request method.`.

### Testing case
- Clone a local book from the network level, i.e.: `https://pressbooks.test/wp/wp-admin/admin.php?page=pb_cloner`
- Clone should succeed.
- Clone a local book from a book level, i.e.: `<BOOK_URL>/wp-admin/admin.php?page=pb_cloner`
- Clone should succeed.