### PR TITLE
fix: bedrock update conditional

### DIFF
--- a/.github/workflows/standards-and-tests.yml
+++ b/.github/workflows/standards-and-tests.yml
@@ -114,7 +114,7 @@ jobs:
           ${{github.workspace}}/*.zip
 
     - name: Trigger Bedrock Update
-      if: github.ref == 'refs/heads/dev'
+      if: github.ref == 'refs/heads/dev' && matrix.experimental == false
       uses: pressbooks/composer-autoupdate-bedrock@v1.0
       with:
         triggered-by: ${{ github.repository }}


### PR DESCRIPTION
This PR address the duplicated bedrock update triggers when matrix jobs are in place thanks @fdalcin 