### PR TITLE
feat: collect is based on data

### DIFF
--- a/inc/datacollector/class-book.php
+++ b/inc/datacollector/class-book.php
@@ -44,6 +44,8 @@ class Book {
 
 	const IS_CLONE = 'pb_is_clone';
 
+	const IS_BASED_ON = 'pb_is_based_on';
+
 	const HAS_EXPORTS = 'pb_has_exports';
 
 	const LAST_EXPORT = 'pb_last_export';
@@ -332,6 +334,7 @@ class Book {
 
 		// pb_is_based_on
 		update_site_meta( $book_id, self::IS_CLONE, empty( $metadata['pb_is_based_on'] ) ? 0 : 1 );
+		update_site_meta( $book_id, self::IS_BASED_ON, $metadata['pb_is_based_on'] ?? null );
 
 		// pb_total_revisions
 		$revisions = $this->revisions();


### PR DESCRIPTION
Issue pressbooks/private#1055

This PR adds a new `pb_is_based_on` information to the book data collector.

**How to test**

1. Make sure you have cloned books as well as original books
2. Run the books data collector (see https://github.com/pressbooks/pressbooks-network-analytics/) or run:
```console
cd /srv/www/pressbooks.test/current && wp eval-file web/app/plugins/pressbooks-network-analytics/bin/sync/books.php
```
3. The table `wp_blogmeta` should now have a new meta key `pb_is_based_on` for each book with the url of the cloned book
4. If the book was not cloned, this value will be `null`