### PR TITLE
fix: tx config compatibility

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://www.transifex.com
 
-[pressbooks.pressbooks]
+[o:pressbooks:p:pressbooks:r:pressbooks]
 file_filter = languages/pressbooks-<lang>.po
 lang_map = de:de_DE, es:es_ES, fr:fr_FR, gl:gl_ES, nb:nb_NO, it:it_IT, ka:ka_GE, ru:ru_RU, ta:ta_LK, pa:pa_IN, hr_HR:hr
 source_file = languages/pressbooks.pot


### PR DESCRIPTION
Issue: https://github.com/pressbooks/ideas/issues/438
This PR fixes the Transifex configuration file, following the docs: https://developers.transifex.com/docs/cli

For testing, try: `tx status` and `tx pull`
Note: follow https://github.com/pressbooks/private/wiki/Translation to install transifex client.