### PR TITLE
fix: remove create & clone blocks when network setting is off

### DIFF
--- a/inc/admin/dashboard/class-newuserdashboard.php
+++ b/inc/admin/dashboard/class-newuserdashboard.php
@@ -4,7 +4,9 @@
  */
 namespace Pressbooks\Admin\Dashboard;
 
+use function Pressbooks\Admin\Laf\can_create_new_books;
 use PressbooksMix\Assets;
+use Pressbooks\Cloner\Cloner;
 use Pressbooks\Container;
 
 class NewUserDashboard {
@@ -81,6 +83,8 @@ class NewUserDashboard {
 
 		echo $blade->render( 'admin.dashboard.new-user', [
 			'site_name' => get_bloginfo( 'name' ),
+			'can_create_new_books' => can_create_new_books(),
+			'can_clone_books' => Cloner::isEnabled() && ( can_create_new_books() || is_super_admin() ),
 			'invitations' => Invitations::getPendingInvitations(),
 		] );
 	}

--- a/templates/admin/dashboard/new-user.blade.php
+++ b/templates/admin/dashboard/new-user.blade.php
@@ -26,49 +26,55 @@
 		@endif
 	</div>
 
-	<div class="pb-dashboard-row">
-		<div class="pb-dashboard-grid">
-			<div class="pb-dashboard-panel">
-				<div class="pb-dashboard-image">
-					<img
-						src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-create-book.png" }}"
-						alt="{{ __( 'Create a new book art', 'pressbooks' ) }}"
-					/>
-				</div>
+	@if( $can_create_new_books || $can_clone_books )
+		<div class="pb-dashboard-row">
+			<div class="pb-dashboard-grid">
+				@if( $can_create_new_books )
+					<div class="pb-dashboard-panel">
+						<div class="pb-dashboard-image">
+							<img
+								src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-create-book.png" }}"
+								alt="{{ __( 'Create a new book art', 'pressbooks' ) }}"
+							/>
+						</div>
 
-				<div class="pb-dashboard-content">
-					<h2>{{ __( 'Create a book', 'pressbooks' ) }}</h2>
+						<div class="pb-dashboard-content">
+							<h2>{{ __( 'Create a book', 'pressbooks' ) }}</h2>
 
-					<p>{{ __( 'Create a new book full of engaging content: words, images, audio, video, footnotes, glossary terms, mathematical formula, interactive quizzes, and more.', 'pressbooks' ) }}</p>
-				</div>
+							<p>{{ __( 'Create a new book full of engaging content: words, images, audio, video, footnotes, glossary terms, mathematical formula, interactive quizzes, and more.', 'pressbooks' ) }}</p>
+						</div>
 
-				<div class="pb-dashboard-action">
-					<a class="button button-hero button-primary" href="{{ network_home_url( 'wp-signup.php' ) }}">
-						{{ __( 'Create a book', 'pressbooks' ) }}
-					</a>
-				</div>
-			</div>
+						<div class="pb-dashboard-action">
+							<a class="button button-hero button-primary" href="{{ network_home_url( 'wp-signup.php' ) }}">
+								{{ __( 'Create a book', 'pressbooks' ) }}
+							</a>
+						</div>
+					</div>
+				@endif
 
-			<div class="pb-dashboard-panel">
-				<div class="pb-dashboard-image">
-					<img
-						src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-adapt-book.png" }}"
-						alt="{{ __( 'Adapt a book art', 'pressbooks' ) }}"
-					/>
-				</div>
+				@if( $can_clone_books )
+					<div class="pb-dashboard-panel">
+						<div class="pb-dashboard-image">
+							<img
+								src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-adapt-book.png" }}"
+								alt="{{ __( 'Adapt a book art', 'pressbooks' ) }}"
+							/>
+						</div>
 
-				<div class="pb-dashboard-content">
-					<h2>{{ __( 'Adapt a book', 'pressbooks' ) }}</h2>
+						<div class="pb-dashboard-content">
+							<h2>{{ __( 'Adapt a book', 'pressbooks' ) }}</h2>
 
-					<p>{{ __( 'Use our cloning tool to make your own personalized copy of any of the thousands of openly licensed educational books already published with Pressbooks.', 'pressbooks' ) }}</p>
-				</div>
+							<p>{{ __( 'Use our cloning tool to make your own personalized copy of any of the thousands of openly licensed educational books already published with Pressbooks.', 'pressbooks' ) }}</p>
+						</div>
 
-				<div class="pb-dashboard-action">
-					<a class="button button-hero button-primary" href="{{ admin_url( 'admin.php?page=pb_cloner' ) }}">
-						{{ __( 'Adapt a book', 'pressbooks' ) }}
-					</a>
-				</div>
+						<div class="pb-dashboard-action">
+							<a class="button button-hero button-primary" href="{{ admin_url( 'admin.php?page=pb_cloner' ) }}">
+								{{ __( 'Adapt a book', 'pressbooks' ) }}
+							</a>
+						</div>
+					</div>
+				@endif
 			</div>
 		</div>
-	</div>
+	@endif
 </div>

--- a/templates/admin/dashboard/new-user.blade.php
+++ b/templates/admin/dashboard/new-user.blade.php
@@ -9,13 +9,14 @@
 			</div>
 		</div>
 	</div>
-	<div class="pb-dashboard-row">
-		@if($invitations->isNotEmpty())
+
+	@if( $invitations->isNotEmpty() )
+		<div class="pb-dashboard-row">
 			<div class="pb-dashboard-panel pb-dashboard-invitations">
 				<div class="pb-dashboard-content">
 					<h2>{{ __( 'Book Invitations', 'pressbooks' ) }}</h2>
 
-					@foreach($invitations as $invitation)
+					@foreach( $invitations as $invitation )
 						<div class="invitation">
 							<p>{!! sprintf( __( 'You have been invited to join %1$s as %2$s', 'pressbooks' ), $invitation['book_url'], $invitation['role'] ) !!}</p>
 							<a class="button button-primary" href="{{ $invitation['accept_link'] }}">{{ __( 'Accept', 'pressbooks' ) }}</a>
@@ -23,8 +24,8 @@
 					@endforeach
 				</div>
 			</div>
-		@endif
-	</div>
+		</div>
+	@endif
 
 	@if( $can_create_new_books || $can_clone_books )
 		<div class="pb-dashboard-row">


### PR DESCRIPTION
Issue #3092 

This PR aims to remove Create & Adapt a Book blocks when the network setting is off.

**How to test**

1. Uncheck "Allow registered users to create and clone new books" in Network Admin > Network Settings > Book & User Registration
2. Save changes.
3. Visit the user dashboard `wp/wp-admin/index.php?page=pb_home_page` and make sure Create & Adapt a Book blocks are not displayed.

>**Note**
If you're logged it as a super admin you will still be able to clone books, so you should be able to see the Clone a Book block.