### PR TITLE
fix: h5p cloning local book

### DIFF
--- a/inc/interactive/class-h5p.php
+++ b/inc/interactive/class-h5p.php
@@ -68,7 +68,9 @@ class H5P {
 	 */
 	public function apiInit() {
 		try {
-			if ( ! is_plugin_active( 'h5p/h5p.php' ) ) {
+			$plugin = 'h5p/h5p.php';
+			// Initialize H5P REST API only if the plugin is not already initialized or is network disabled
+			if ( ! is_plugin_active( $plugin ) || ! is_plugin_active_for_network( $plugin ) ) {
 				\H5P_Plugin::get_instance()->rest_api_init();
 			}
 			if (


### PR DESCRIPTION
This PR fix #3075 

REST API endpoints were not being loaded properly during cloning routine on local books because the plugin was activated on cloning but this conditional was false to init the REST Api methods

The trick part here is that we didn't noticed that behaviour because if you try to clone a local book meanwhile you are located in the source book it will succeed but if you selected the clone book menu from the main site this would trigger the unexpected behaviour, this PR works for both scenarios I changed the conditional to enable the REST api if the plugin is not network active (that is our use case) in other cases the REST api is being activated when needed.

This would work for both scenarios triggering the clone routine locally, for instance:

1. When book source book is loaded (usually works and it should work)
https://integrations.pressbooks.network/ltidemo/wp-admin/admin.php?page=pb_cloner

**For example this book is a clone of the above: (ltidemo)**

https://integrations.pressbooks.network/thisshouldwork/

2. When is triggered through the main site (this is not currently working)
https://integrations.pressbooks.network/wp/wp-admin/admin.php?page=pb_cloner