### PR TITLE
fix: remote request POST parameters for completed cloning

### DIFF
--- a/inc/cloner/class-cloner.php
+++ b/inc/cloner/class-cloner.php
@@ -2115,7 +2115,7 @@ class Cloner {
 				'pressbooks/v2/clone',
 				'complete'
 			);
-			$response = wp_remote_post( $request_url, $params );
+			$response = wp_remote_post( $request_url, [ 'body' => $params ] );
 
 			if ( is_wp_error( $response ) ) {
 				return false;


### PR DESCRIPTION
This change fixes the external cloning confirmation and sent the body POST parameters for completed clones to `pressbooks/v2/clone/complete` endpoint.