### PR TITLE
fix: analytics permission check

### DIFF
--- a/inc/admin/dashboard/class-bookdashboard.php
+++ b/inc/admin/dashboard/class-bookdashboard.php
@@ -109,7 +109,7 @@ class BookDashboard {
 			'edit_posts' => $is_super_admin || current_user_can( 'edit_posts' ),
 			'switch_themes' => $is_super_admin || current_user_can( 'switch_themes' ),
 			'list_users' => $is_super_admin || current_user_can( 'list_users' ),
-			'view_koko_analytics' => $is_super_admin || current_user_can( 'view_koko_analytics' ),
+			'view_koko_analytics' => is_plugin_active( 'koko-analytics/koko-analytics.php' ) && current_user_can( 'view_koko_analytics' ),
 			'delete_site' => $is_super_admin || current_user_can( 'delete_site' ),
 		];
 	}


### PR DESCRIPTION
Fixes #3099 

This PR fixes the permission check for the Koko Analytics link in the new book dashboard. 

**How to test**

With the plugin enabled, try different combinations of users (super admin, book admins, book editors...)
- Super admins and book admins should see the link to Koko Analytics
- Other users shouldn't see the link

With the plugin disabled, try the same combinations
- No one should see the link to Koko Analytics
