### PR TITLE
fix: set shape shifter compatible with McLuhan by default

### DIFF
--- a/inc/class-styles.php
+++ b/inc/class-styles.php
@@ -662,7 +662,7 @@ class Styles {
 	 * @return bool
 	 */
 	public function isShapeShifterCompatible() {
-		return apply_filters( 'pb_is_shape_shifter_compatible', ( 'pressbooks-malala' === get_stylesheet() || 'pressbooks-book' === get_stylesheet() ) );
+		return apply_filters( 'pb_is_shape_shifter_compatible', 'pressbooks-book' === get_stylesheet() );
 	}
 
 	/**


### PR DESCRIPTION
Issue pressbooks/ideas#431. Accompanies pressbooks/pressbooks-malala#26.

This PR sets pressbooks/pressbooks Shape Shifter compatibility with McLuhan only by default. Child themes that implement the feature must explicitly apply the filter like so `add_filter( 'pb_is_shape_shifter_compatible', '__return_true' );`

**How to test**

After both PRs are merged, McLuhan and Malala shape shifter feature should work as before.