### PR TITLE
fix: exclude ampersand from decoding action

### DIFF
--- a/inc/modules/export/class-exporthelpers.php
+++ b/inc/modules/export/class-exporthelpers.php
@@ -163,7 +163,7 @@ trait ExportHelpers {
 				foreach ( $sections as $id => $subsection ) {
 					$subsections[] = [
 						'slug' => $is_slug ? "#{$id}" : "${data['href']}#{$id}",
-						'title' => Sanitize\decode( $subsection ),
+						'title' => Sanitize\decode( $subsection, false ),
 					];
 				}
 			}
@@ -172,7 +172,7 @@ trait ExportHelpers {
 		return $this->blade->render('export/bullet-toc-item', array_merge(
 			$data,
 			[
-				'title' => Sanitize\decode( $data['title'] ),
+				'title' => Sanitize\decode( $data['title'], false ),
 				'subclass' => trim( $data['subclass'] ) !== '' ? ' ' . $data['subclass'] : '', //css class space between toc item and subclasses
 				'post_type' => $post_type,
 				'href' => $is_slug ? '#' . $data['href'] : $data['href'],

--- a/inc/sanitize/namespace.php
+++ b/inc/sanitize/namespace.php
@@ -201,18 +201,18 @@ function force_ascii( $slug ) {
 }
 
 /**
- * Reverse htmlspecialchars() except ampersands.
+ * Reverse htmlspecialchars().
  *
- * @param $slug
+ * @param string $slug
+ * @param bool $exclude_ampersands (optional)
  *
  * @return mixed
  */
-function decode( $slug ) {
+function decode( string $slug, bool $exclude_ampersands = true ) {
 
 	$slug = html_entity_decode( $slug, ENT_NOQUOTES | ENT_XHTML, 'UTF-8' );
-	$slug = preg_replace( '/&([^#])(?![a-z1-4]{1,8};)/i', '&#038;$1', $slug );
 
-	return $slug;
+	return $exclude_ampersands ? preg_replace( '/&([^#])(?![a-z1-4]{1,8};)/i', '&#038;$1', $slug ) : $slug;
 }
 
 function space_to_numerical_html_entity( string $string ) {

--- a/templates/export/bullet-toc-item.blade.php
+++ b/templates/export/bullet-toc-item.blade.php
@@ -5,7 +5,7 @@
 			<span class="chapter-subtitle">{{ $subtitle }}</span>
 		@endif
 		@if( $author )
-			<span class="chapter-author">{{ $author }}</span>
+			<span class="chapter-author">{!! $author !!}</span>
 		@endif
 		@if( $license )
 			<span class="chapter-license">{{ $license }}</span>

--- a/templates/export/sub-author-partial.blade.php
+++ b/templates/export/sub-author-partial.blade.php
@@ -1,9 +1,9 @@
 @if( $output_short_title )
-	<p class="short-title">{{ $short_title }}</p>
+	<p class="short-title">{!! $short_title !!}</p>
 @endif
 @if( $subtitle )
 	<p class="chapter-subtitle">{{ $subtitle }}</p>
 @endif
 @if( $author )
-	<p class="chapter-author">{{ $author }}</p>
+	<p class="chapter-author">{!! $author !!}</p>
 @endif

--- a/tests/test-sanitize.php
+++ b/tests/test-sanitize.php
@@ -139,6 +139,17 @@ class SanitizeTest extends \WP_UnitTestCase {
 
 	/**
 	 * @group sanitize
+	 * @test
+	 */
+	public function sanitize_excluding_ampersand(): void {
+		$string = 'Hello & World';
+		$this->assertEquals( 'Hello &#038; World', \Pressbooks\Sanitize\decode( $string ) );
+
+		$this->assertEquals( 'Hello & World', \Pressbooks\Sanitize\decode( $string, false ) );
+	}
+
+	/**
+	 * @group sanitize
 	 */
 	public function test_strip_br() {
 		$test = 'Hello <br /> World!';


### PR DESCRIPTION
Issue: https://github.com/pressbooks/private/issues/1038

This PR adds a new parameter to the widely used `decode` method to include or exclude the `&` character, specifically to be used in the export routine (PDF & EPUB) to include `&` as a part of the decoding action.
In addition, the authors' section in the chapter is not being escaped anymore since some authors may contain `&` or other special chars.

### Use case sample for testing
- For a book, create a contributor which contains `&`. Example: `Music and Visual departments`.
- In a chapter, add one or more sections with & and other special chars
- Add the author created as an author of the chapter.
- Add a subtitle for the chapter; ensure you include `&` in the text.
- In Appearance > Theme Options > Global Options, ensure the `Enable two-level table of contents (displays headings under chapter titles)` and `Display information about authors at the end of each chapter` options are checked.
- Export the book to PDF and EPUB. Both exported files should look as expected.  