### PR TITLE
fix: regenerate stylesheet link

### DIFF
--- a/templates/admin/diagnostics.blade.php
+++ b/templates/admin/diagnostics.blade.php
@@ -8,6 +8,6 @@
 		<p>{!! sprintf( __( '<a href="%s">View your book&rsquo;s XHTML source</a> to diagnose issues you may be encountering with your PDF exports.', 'pressbooks' ), home_url() . '/format/xhtml?debug=prince' ) !!}</p>
 		<h2>{{ __( 'Regenerate Webbook Stylesheet', 'pressbooks' ) }}</h2>
 		<p>{{ __( 'If your webbook stylesheet has issues, it may help to regenerate it.', 'pressbooks' ) }}</p>
-		<p><form action="{{ $regenerate_webbook_stylesheet_url }}" method="post"><input type="submit" name="submit" id="submit" class="button button-primary" value="{{ __( 'Regenerate Stylesheet', 'pressbooks' ) }}" /></form></p>
+		<p><form action="{!! $regenerate_webbook_stylesheet_url !!}" method="post"><input type="submit" name="submit" id="submit" class="button button-primary" value="{{ __( 'Regenerate Stylesheet', 'pressbooks' ) }}" /></form></p>
 	@endif
 </div>


### PR DESCRIPTION
Issue #3125 

This PR fixes the Regenerate Stylesheet link.

Currently when clicking the Regenerate Stylesheet button we receive an error page because the link is broken. It generates a `&amp;` character instead of the correct `&` like below.

`{BOOK_URL}/wp-admin/admin-post.php?action=pb_regenerate_webbook_stylesheet&amp;_wpnonce=6080cfc34a`

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/1761690/211855303-64fe3fa4-cdb0-47e3-96bf-5be8f16c9d2a.png">

**How to test**

- Visit the diagnostics page
- Click the Regenerate Stylesheet button
- Stylesheet should be regenerated without issues