### PR TITLE
fix: add chapter button

### DIFF
--- a/templates/admin/organize.blade.php
+++ b/templates/admin/organize.blade.php
@@ -76,11 +76,17 @@
             </h2>
             @if ($can_edit_posts)
                 <div class="page-title-actions">
-                    <a href="{!! admin_url('post-new.php?post_type=' . $slug) !!}" class="page-title-action">{{ __('Add', 'pressbooks') }}
-                        {{ $group['name'] }}</a>
                     @if (str_contains($slug, 'part'))
-                        <a class="page-title-action"
-                            href="{!! admin_url('post-new.php?post_type=part') !!}">{{ __('Add Part', 'pressbooks') }}</a>
+						<a class="page-title-action" href="{!! admin_url("post-new.php?post_type={$group['abbreviation']}&startparent={$group['id']}") !!}">
+							{{ __('Add', 'pressbooks') }} {{ $group['name'] }}
+						</a>
+                        <a class="page-title-action" href="{!! admin_url('post-new.php?post_type=part') !!}">
+							{{ __('Add Part', 'pressbooks') }}
+						</a>
+					@else
+						<a class="page-title-action" href="{!! admin_url('post-new.php?post_type=' . $slug) !!}">
+							{{ __('Add', 'pressbooks') }} {{ $group['name'] }}
+						</a>
                     @endif
                 </div>
             @endif


### PR DESCRIPTION
Fix for #3123 

This PR fixes the Add Chapter button inside the organize page. The issue was that we were setting the wrong link when adding a part (see https://github.com/pressbooks/pressbooks/issues/3123#issuecomment-1377827290).

**How to test**

1. Navigate to a book dashboard and visit the organize page
1. Click the "Add Chapter" button right after the part name
1. You should be redirected to the "Add New Chapter" page with the correct Part selected as the parent of the chapter

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/1761690/211875886-95ceee85-43f9-4eaa-a6bf-ede149297eba.png">
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/1761690/211876169-ebd4f296-6e4d-4e56-8fd1-a27f3daeb66d.png">
