### PR TITLE
fix: encode PDF and EPUB fields for export routine

### DIFF
--- a/.github/workflows/standards-and-tests.yml
+++ b/.github/workflows/standards-and-tests.yml
@@ -115,7 +115,7 @@ jobs:
 
     - name: Trigger Bedrock Update
       if: github.ref == 'refs/heads/dev' && matrix.experimental == false
-      uses: pressbooks/composer-autoupdate-bedrock@v1.1
+      uses: pressbooks/composer-autoupdate-bedrock@v1
       with:
         triggered-by: ${{ github.repository }}
         token: ${{ secrets.PAT_COMPOSER_UPDATE }}

--- a/inc/modules/export/class-export.php
+++ b/inc/modules/export/class-export.php
@@ -825,8 +825,8 @@ abstract class Export {
 
 		if ( is_countable( $validation_warning ) && count( $validation_warning ) ) {
 			// Validation warning
-			$exportoptions = get_option( 'pressbooks_export_options' );
-			if ( 1 === (int) $exportoptions['email_validation_logs'] || is_super_admin() ) {
+			$exportoptions = get_option( 'pressbooks_export_options', [] );
+			if ( ! empty( $exportoptions ) && 1 === (int) $exportoptions['email_validation_logs'] || is_super_admin() ) {
 				$export_warning = sprintf(
 					'<p>%s</p>%s',
 					__( 'Warning: The export has validation errors. See logs for more details.', 'pressbooks' ),

--- a/inc/modules/export/class-exporthelpers.php
+++ b/inc/modules/export/class-exporthelpers.php
@@ -152,7 +152,7 @@ trait ExportHelpers {
 	 * @param bool $exclude_ampersand
 	 * @return string
 	 */
-	public function renderTocItem(string $post_type, array $data, bool $is_slug = true, bool $exclude_ampersand = false ) {
+	public function renderTocItem( string $post_type, array $data, bool $is_slug = true, bool $exclude_ampersand = false ) {
 
 		$subsections = [];
 

--- a/inc/modules/export/class-exporthelpers.php
+++ b/inc/modules/export/class-exporthelpers.php
@@ -146,12 +146,13 @@ trait ExportHelpers {
 	}
 
 	/**
-	 * @param $post_type
-	 * @param $data
-	 * @param  bool  $is_slug
+	 * @param string $post_type
+	 * @param array $data
+	 * @param bool $is_slug
+	 * @param bool $exclude_ampersand
 	 * @return string
 	 */
-	public function renderTocItem( $post_type, $data, $is_slug = true ) {
+	public function renderTocItem(string $post_type, array $data, bool $is_slug = true, bool $exclude_ampersand = false ) {
 
 		$subsections = [];
 
@@ -163,7 +164,7 @@ trait ExportHelpers {
 				foreach ( $sections as $id => $subsection ) {
 					$subsections[] = [
 						'slug' => $is_slug ? "#{$id}" : "${data['href']}#{$id}",
-						'title' => Sanitize\decode( $subsection, false ),
+						'title' => Sanitize\decode( $subsection, $exclude_ampersand ),
 					];
 				}
 			}
@@ -172,7 +173,7 @@ trait ExportHelpers {
 		return $this->blade->render('export/bullet-toc-item', array_merge(
 			$data,
 			[
-				'title' => Sanitize\decode( $data['title'], false ),
+				'title' => Sanitize\decode( $data['title'], $exclude_ampersand ),
 				'subclass' => trim( $data['subclass'] ) !== '' ? ' ' . $data['subclass'] : '', //css class space between toc item and subclasses
 				'post_type' => $post_type,
 				'href' => $is_slug ? '#' . $data['href'] : $data['href'],

--- a/inc/modules/export/epub/class-epub.php
+++ b/inc/modules/export/epub/class-epub.php
@@ -9,9 +9,8 @@
 
 namespace Pressbooks\Modules\Export\Epub;
 
-use function Pressbooks\Sanitize\sanitize_xml_attribute;
 use function Pressbooks\Sanitize\decode;
-use function Pressbooks\Sanitize\encode_ampersand;
+use function Pressbooks\Sanitize\sanitize_xml_attribute;
 use function Pressbooks\Utility\debug_error_log;
 use function Pressbooks\Utility\explode_remove_and;
 use function Pressbooks\Utility\get_contributors_name_imploded;
@@ -1924,7 +1923,7 @@ class Epub extends ExportGenerator {
 
 				$matter_data = $this->getExtendedPostInformation( $type, $query_data );
 
-				$rendered_items[] = $this->renderTocItem( $type, $matter_data, false , true);
+				$rendered_items[] = $this->renderTocItem( $type, $matter_data, false, true );
 
 			} elseif ( 0 === strpos( $k, 'chapter-' ) ) { //Process chapters
 
@@ -2582,7 +2581,7 @@ class Epub extends ExportGenerator {
 				$metadata[ $key ] = sanitize_xml_attribute( $val );
 				if ( $this->contributors->isValid( $key ) ) {
 					$contributors = decode( $metadata[ $key ], false );
-					$metadata[$key] = array_map(
+					$metadata[ $key ] = array_map(
 						'\Pressbooks\Sanitize\encode_ampersand',
 						explode_remove_and( ';', $contributors )
 					);

--- a/inc/modules/export/epub/class-epub.php
+++ b/inc/modules/export/epub/class-epub.php
@@ -2582,10 +2582,10 @@ class Epub extends ExportGenerator {
 				$metadata[ $key ] = sanitize_xml_attribute( $val );
 				if ( $this->contributors->isValid( $key ) ) {
 					$contributors = decode( $metadata[ $key ], false );
-					$metadata[ $key ] = [];
-					foreach ( explode_remove_and( ';', $contributors ) as $contributor ) {
-						$metadata[ $key ][] = Sanitize\encode_ampersand( $contributor );
-					}
+					$metadata[$key] = array_map(
+						'\Pressbooks\Sanitize\encode_ampersand',
+						explode_remove_and( ';', $contributors )
+					);
 				}
 			}
 		}

--- a/inc/modules/export/epub/class-epub.php
+++ b/inc/modules/export/epub/class-epub.php
@@ -10,7 +10,10 @@
 namespace Pressbooks\Modules\Export\Epub;
 
 use function Pressbooks\Sanitize\sanitize_xml_attribute;
+use function Pressbooks\Sanitize\decode;
+use function Pressbooks\Sanitize\encode_ampersand;
 use function Pressbooks\Utility\debug_error_log;
+use function Pressbooks\Utility\explode_remove_and;
 use function Pressbooks\Utility\get_contributors_name_imploded;
 use function Pressbooks\Utility\implode_add_and;
 use function Pressbooks\Utility\str_ends_with;
@@ -1921,7 +1924,7 @@ class Epub extends ExportGenerator {
 
 				$matter_data = $this->getExtendedPostInformation( $type, $query_data );
 
-				$rendered_items[] = $this->renderTocItem( $type, $matter_data, false );
+				$rendered_items[] = $this->renderTocItem( $type, $matter_data, false , true);
 
 			} elseif ( 0 === strpos( $k, 'chapter-' ) ) { //Process chapters
 
@@ -1934,7 +1937,7 @@ class Epub extends ExportGenerator {
 					$chapters_count++;
 				}
 
-				$rendered_items[] = $this->renderTocItem( 'chapter', $chapter_data, false );
+				$rendered_items[] = $this->renderTocItem( 'chapter', $chapter_data, false, true );
 			}
 		}
 
@@ -2577,6 +2580,13 @@ class Epub extends ExportGenerator {
 				}
 			} else {
 				$metadata[ $key ] = sanitize_xml_attribute( $val );
+				if ( $this->contributors->isValid( $key ) ) {
+					$contributors = decode( $metadata[ $key ], false );
+					$metadata[ $key ] = [];
+					foreach ( explode_remove_and( ';', $contributors ) as $contributor ) {
+						$metadata[ $key ][] = Sanitize\encode_ampersand( $contributor );
+					}
+				}
 			}
 		}
 		$vars['meta'] = $metadata;

--- a/inc/modules/export/xhtml/class-xhtml11.php
+++ b/inc/modules/export/xhtml/class-xhtml11.php
@@ -1389,7 +1389,7 @@ class Xhtml11 extends ExportGenerator {
 					? \Pressbooks\Modules\Export\get_contributors_section( $chapter_id )
 					: '';
 
-				$chapter_number = strpos( $chapter_subclass, 'numberless' ) === false ? $chapter_index : '';
+				$chapter_number = ! str_contains( $chapter_subclass, 'numberless' ) ? $chapter_index : '';
 
 				$rendered_chapters .= $this->blade->render(
 					'export/chapter',
@@ -1398,7 +1398,7 @@ class Xhtml11 extends ExportGenerator {
 						'slug' => $chapter_slug,
 						'sanitized_title' => $chapter_short_title ?: wp_strip_all_tags( \Pressbooks\Sanitize\decode( $chapter['post_title'] ) ),
 						'number' => $chapter_number,
-						'title' => \Pressbooks\Sanitize\decode( $chapter_title ),
+						'title' => \Pressbooks\Sanitize\decode( $chapter_title, false ),
 						'is_new_buckram' => $this->wrapHeaderElements,
 						'output_short_title' => $this->outputShortTitle,
 						'author' => $chapter_author,

--- a/inc/sanitize/namespace.php
+++ b/inc/sanitize/namespace.php
@@ -212,7 +212,12 @@ function decode( string $slug, bool $exclude_ampersands = true ) {
 
 	$slug = html_entity_decode( $slug, ENT_NOQUOTES | ENT_XHTML, 'UTF-8' );
 
-	return $exclude_ampersands ? preg_replace( '/&([^#])(?![a-z1-4]{1,8};)/i', '&#038;$1', $slug ) : $slug;
+	return $exclude_ampersands ? encode_ampersand( $slug ) : $slug;
+}
+
+function encode_ampersand( string $slug ): string {
+
+	return preg_replace( '/&([^#])(?![a-z1-4]{1,8};)/i', '&#038;$1', $slug );
 }
 
 function space_to_numerical_html_entity( string $string ) {

--- a/inc/utility/namespace.php
+++ b/inc/utility/namespace.php
@@ -1348,13 +1348,13 @@ function oxford_comma_explode( string $string ) {
  * Output:
  * [ 'Carl Calson', 'Mark Thomson, PhD', 'John K.' ]
  *
- * @param string $str_explode
+ * @param string $separator
  * @param string $string
  * @return array
  */
-function explode_remove_and( string $separator, string $string ) {
+function explode_remove_and( string $separator, string $string ): array {
 	$results = [];
-	if ( strpos( $string, $separator ) !== false ) {
+	if ( str_contains( $string, $separator ) ) {
 		$items = explode( $separator, $string );
 		if ( count( $items ) === 2 ) {
 			$items = explode( ' ' . __( 'and', 'pressbooks' ) . ' ', $string );

--- a/templates/export/bullet-section.blade.php
+++ b/templates/export/bullet-section.blade.php
@@ -1,5 +1,5 @@
 <li class="section">
 	<a href="{{ $slug }}">
-		<span class="toc-subsection-title">{{ $title }}</span>
+		<span class="toc-subsection-title">{!! $title !!}</span>
 	</a>
 </li>

--- a/templates/export/chapter.blade.php
+++ b/templates/export/chapter.blade.php
@@ -1,4 +1,4 @@
-<div class="chapter {{ $subclass }} {{ $subsection_class ?? '' }}" id="{{ $slug }}" title="{{ $sanitized_title }}">
+<div class="chapter {{ $subclass }} {{ $subsection_class ?? '' }}" id="{{ $slug }}" title="{!! $sanitized_title !!}">
 	<div class="chapter-title-wrap">
 		<p class="chapter-number">{{ $number }}</p>
 		<h1 class="chapter-title">{!! $title !!}</h1>

--- a/templates/export/epub/contributor-partial.blade.php
+++ b/templates/export/epub/contributor-partial.blade.php
@@ -4,8 +4,8 @@ $contributor_number = str_pad( $index, 2, '0', STR_PAD_LEFT );
 @endphp
 
 @if( $role === 'ctb' )
-	<dc:contributor id="{{ $type . '-' . $contributor_number }}">{{ $contributor }}</dc:contributor>
+	<dc:contributor id="{{ $type . '-' . $contributor_number }}">{!! $contributor !!}</dc:contributor>
 @else
-	<dc:creator id="{{ $type . '-' . $contributor_number }}">{{ $contributor }}</dc:creator>
+	<dc:creator id="{{ $type . '-' . $contributor_number }}">{!! $contributor !!}</dc:creator>
 @endif
 <meta refines="#{{ $type . '-' . $contributor_number }}" property="role" scheme="marc:relators">{{ $role }}</meta>

--- a/templates/export/epub/opf.blade.php
+++ b/templates/export/epub/opf.blade.php
@@ -24,7 +24,7 @@
 		@endphp
 
 		@if( ! \Pressbooks\Utility\empty_space( $meta['pb_editors'] ) )
-			@foreach( \Pressbooks\Utility\explode_remove_and( ';', $meta['pb_editors'] ) as $editor )
+			@foreach( $meta['pb_editors'] as $editor )
 				@include('export/epub/contributor-partial', ['contributor' => $editor, 'role' => 'edt', 'index' => $index])
 
 				@php
@@ -34,7 +34,7 @@
 		@endif
 
 		@if( ! \Pressbooks\Utility\empty_space( $meta['pb_authors'] ) )
-			@foreach( \Pressbooks\Utility\explode_remove_and( ';', $meta['pb_authors'] ) as $author )
+			@foreach( $meta['pb_authors'] as $author )
 				@include('export/epub/contributor-partial', ['contributor' => $author, 'role' => 'aut', 'index' => $index])
 
 				@php
@@ -44,7 +44,7 @@
 		@endif
 
 		@if( ! \Pressbooks\Utility\empty_space( $meta['pb_translators'] ) )
-			@foreach( \Pressbooks\Utility\explode_remove_and( ';', $meta['pb_translators'] ) as $translator )
+			@foreach( $meta['pb_translators'] as $translator )
 				@include('export/epub/contributor-partial', ['contributor' => $translator, 'role' => 'trl', 'index' => $index])
 
 				@php
@@ -54,7 +54,7 @@
 		@endif
 
 		@if( ! \Pressbooks\Utility\empty_space( $meta['pb_illustrators'] ) )
-			@foreach( \Pressbooks\Utility\explode_remove_and( ';', $meta['pb_illustrators'] ) as $illustrator )
+			@foreach( $meta['pb_illustrators'] as $illustrator )
 				@include('export/epub/contributor-partial', ['contributor' => $illustrator, 'role' => 'ill', 'index' => $index])
 
 				@php
@@ -68,7 +68,7 @@
 		@endif
 
 		@if( ! \Pressbooks\Utility\empty_space( $meta['pb_contributors'] ) )
-			@foreach( \Pressbooks\Utility\explode_remove_and( ';', $meta['pb_contributors'] ) as $index => $contributor )
+			@foreach( $meta['pb_contributors'] as $index => $contributor )
 				@include('export/epub/contributor-partial', ['contributor' => $contributor, 'role' => 'ctb', 'index' => $index + 1])
 			@endforeach
 		@endif

--- a/templates/export/generic-post-type.blade.php
+++ b/templates/export/generic-post-type.blade.php
@@ -1,5 +1,5 @@
 @if( isset( $short_title ) )
-	<div class="{{$post_type_class}} {{ $subclass }} {{ $subsection_class ?? '' }}" id="{{ $slug }}" title="{{ $short_title }}">
+	<div class="{{$post_type_class}} {{ $subclass }} {{ $subsection_class ?? '' }}" id="{{ $slug }}" title="{!! $short_title !!}">
 @else
 	<div class="{{$post_type_class}} {{ $subclass }} {{ $subsection_class ?? '' }}" id="{{ $slug }}">
 @endif

--- a/templates/export/part-wrapper.blade.php
+++ b/templates/export/part-wrapper.blade.php
@@ -1,3 +1,3 @@
-<div class="part-wrapper" id="{{ $id  }}-wrapper">
+<div class="part-wrapper" id="{{ $id }}-wrapper">
     {!! $content !!}
 </div>

--- a/templates/export/title.blade.php
+++ b/templates/export/title.blade.php
@@ -5,10 +5,10 @@
 		<h1 class="title">{!! $title !!}</h1>
 		<h2 class="subtitle">{!! $subtitle !!}</h2>
 		@if( $authors )
-			<p class="author">{{ $authors }}</p>
+			<p class="author">{!! $authors !!}</p>
 		@endif
 		@if( $contributors )
-			<p class="author">{{ $contributors }}</p>
+			<p class="author">{!! $contributors !!}</p>
 		@endif
 		@if( $logo )
 			<div class="publisher-logo">

--- a/templates/posttypes/contributor.blade.php
+++ b/templates/posttypes/contributor.blade.php
@@ -8,14 +8,14 @@
 				@if ( !isset( $exporting ) )
 					<span class="screen-reader-text">name: </span>
 				@endif
-				{{ $contributor['name'] }}
+				{!! $contributor['name'] !!}
 			</p>
 			@if ( $contributor['contributor_institution'] )
 				<p class="contributor__institution">
 					@if ( !isset( $exporting ) )
 						<span class="screen-reader-text">institution: </span>
 					@endif
-					{{ $contributor['contributor_institution'] }}
+					{!! $contributor['contributor_institution'] !!}
 				</p>
 			@endif
 			@if ( $contributor['contributor_user_url'] )


### PR DESCRIPTION
Issue: https://github.com/pressbooks/private/issues/1038

This PR renders decoded book fields for PDF and EPUB export routines, allowing to include or exclude ampersands in some cases when needed, especially on EPUB exports.
It also decodes the footer for PDF for titles with ampersands.

### Testing case
We want to test HTML tags and `&` in some books fields and inspect the output for EPUB and PDF exports.
- Pick a book and add `<em>` or similar allowed tags to the title of a chapter. 
- Add titles to the chapter (Headings 1) with `&` within them.
- Add a new contributor to the book and ensure the name contains `&`.
- For a chapter, adds the just created contributor as an author of the chapter.
- Add the contributor as illustrator, editor, author and other contributors' role for the book (In the Book Info page).
- In Appearance > Theme Options > Global Options, ensure `Enable two-level table of contents (displays headings under chapter titles)`, `Display information about authors at the end of each chapter` and `Display attributions at the end of a chapter` are enabled.
- In the PDF Options tab, use the following settings:
    <img width="701" alt="Screen Shot 2023-01-19 at 2 40 47 PM" src="https://user-images.githubusercontent.com/13248424/213531992-b668af62-1cb6-4039-a6a1-c6ff7370df63.png">
- Export the book to PDF and EPUB.

#### Analyzing the exports
Make sure everything looks as expected.
In the TOC, check the titles, authors and sections, especially those with ampersands.
At the footer of each page, you be able to see the chapter titles. Check the ones you added an ampersand within the title.
Check the About the authors' section at the end of each chapter, especially the one with the author that contains an ampersand in it.