### PR TITLE
fix: ttf mime type following epub 3.2 specs

### DIFF
--- a/inc/modules/export/epub/class-epub.php
+++ b/inc/modules/export/epub/class-epub.php
@@ -642,14 +642,11 @@ class Epub extends ExportGenerator {
 		exec( $command, $output, $return_var );
 
 		foreach ( $output as $k => $v ) {
-			if ( strpos( $v, 'Picked up _JAVA_OPTIONS:' ) !== false ) {
-				// Remove JAVA warnings that are not actually errors
-				unset( $output[ $k ] );
-			} elseif ( strpos( $v, 'non-standard font type application/x-font-ttf' ) !== false ) {
-				// @see https://github.com/IDPF/epubcheck/issues/586, https://github.com/IDPF/epubcheck/pull/633
-				unset( $output[ $k ] );
-			} elseif ( strpos( $v, 'non-standard font type application/font-sfnt' ) !== false ) {
-				// @see https://github.com/w3c/epubcheck/issues/339
+			if (
+				str_contains( $v, 'Picked up _JAVA_OPTIONS:' ) ||
+				str_contains( $v, 'non-standard font type application/x-font-ttf' ) ||
+				str_contains( $v, 'non-standard font type application/font-sfnt' )
+			) {
 				unset( $output[ $k ] );
 			}
 		}
@@ -676,7 +673,7 @@ class Epub extends ExportGenerator {
 		$mime = static::mimeType( $file );
 		$mime = explode( ';', $mime );
 
-		return trim( $mime[0] );
+		return $mime[0] === 'font/sfnt' ? 'application/font-sfnt' : trim( $mime[0] );
 	}
 
 	/**


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks/issues/3136

This PR specifies the media type for ttf fonts following the [EPUB 3.2 specs](https://www.w3.org/publishing/epub3/epub-spec.html#sec-cmt-supported).

### Context
For `ttf` fonts we should specify `font/ttf` or `application/font-ttf media`, see: https://github.com/w3c/epubcheck/issues/607#issuecomment-646350691

We get the media type from PHP using [finfo_file](https://www.php.net/manual/en/function.finfo-file.php) -using [mime_type](https://www.php.net/manual/en/function.mime-content-type.php) or `FILEINFO_MIME_TYPE ` constant, instead `FILEINFO_MIME` would be enough in https://github.com/pressbooks/pressbooks/blob/324733bcbe828b5592db0f3a6aec33bbe9645793/inc/media/namespace.php#L191. But this method is widely used-.  It returns `font/sfnt` for ttf fonts, which is correct. But EPUB 3.2 specs, expect a different format for the same mime type: `font/ttf` or `application/font-ttf media` for ttf fonts.


### Testing case
Export books to EPUB with multiple fonts. You should not see validation errors, except those from the book content itself.

One way to check validations is to watch logs while exporting:
```bash
lando ssh
tail -f /app/web/app/debug.log
```
Or you can enable the email logs.