### PR TITLE
fix: improve ampersand replacement regex

### DIFF
--- a/inc/modules/export/epub/class-epub.php
+++ b/inc/modules/export/epub/class-epub.php
@@ -1709,7 +1709,7 @@ class Epub extends ExportGenerator {
 
 				$append_chapter_content .= $this->kneadHtml( $this->tidy( $this->doSectionLevelLicense( $metadata, $chapter_id ) ), 'chapter', $chapter_position );
 
-				$chapter_number = strpos( $chapter_subclass, 'numberless' ) === false ? $chapter_index : '';
+				$chapter_number = ! str_contains( $chapter_subclass, 'numberless' ) ? $chapter_index : '';
 
 				$vars['post_title'] = $chapter['post_title'];
 				$vars['post_content'] = $this->blade->render(

--- a/inc/sanitize/namespace.php
+++ b/inc/sanitize/namespace.php
@@ -206,9 +206,9 @@ function force_ascii( $slug ) {
  * @param string $slug
  * @param bool $exclude_ampersands (optional)
  *
- * @return mixed
+ * @return string
  */
-function decode( string $slug, bool $exclude_ampersands = true ) {
+function decode( string $slug, bool $exclude_ampersands = true ): string {
 
 	$slug = html_entity_decode( $slug, ENT_NOQUOTES | ENT_XHTML, 'UTF-8' );
 
@@ -217,7 +217,7 @@ function decode( string $slug, bool $exclude_ampersands = true ) {
 
 function encode_ampersand( string $slug ): string {
 
-	return preg_replace( '/&([^#])(?![a-z1-4]{1,8};)/i', '&#038;$1', $slug );
+	return preg_replace( '/&\S*/', '&#038;$1', $slug );
 }
 
 function space_to_numerical_html_entity( string $string ) {

--- a/inc/sanitize/namespace.php
+++ b/inc/sanitize/namespace.php
@@ -217,7 +217,7 @@ function decode( string $slug, bool $exclude_ampersands = true ): string {
 
 function encode_ampersand( string $slug ): string {
 
-	return preg_replace( '/&\S*/', '&#038;$1', $slug );
+	return preg_replace( '/&([^#])?(?![a-z1-4]{1,8};)/i', '&#038;$1', $slug );
 }
 
 function space_to_numerical_html_entity( string $string ) {


### PR DESCRIPTION
Issue: https://github.com/pressbooks/private/issues/1038

This PR improves the regex to replace `&` in certain metadata for EPUB and PDF export. Previously we only replaced the character when it is in the middle of a string (as usually expected), but it does not replace it if the character is at the end or at the beginning.

For context and more use cases for testing, please see https://github.com/pressbooks/pressbooks/pull/3135

### Testing case
Use a similar use case described in https://github.com/pressbooks/pressbooks/pull/3135 but add `&` at the end of titles, authors, contributors, parts, titles, etc.