### PR TITLE
fix: improve title encoding on organize page

### DIFF
--- a/templates/admin/organize.blade.php
+++ b/templates/admin/organize.blade.php
@@ -37,7 +37,7 @@
             </div>
         </div>
     @endif
-    <h1 class="wp-heading-inline">{{ get_bloginfo('name') }}</h1>
+    <h1 class="wp-heading-inline">{!! get_bloginfo('name') !!}</h1>
     @if (is_super_admin())
         <div class="page-title-actions">
             <a class="page-title-action" href="{!! admin_url('edit.php?post_type=front-matter') !!}">{{ __('Front Matter', 'pressbooks') }}</a>

--- a/templates/admin/organize.blade.php
+++ b/templates/admin/organize.blade.php
@@ -69,9 +69,9 @@
         <div role="region" aria-labelledby="{{ $slug }}">
             <h2 class="wp-heading-inline">
                 @if (!str_contains($slug, 'part'))
-                    {{ $group['name'] }}
+                    {!! $group['name'] !!}
                 @else
-                    {{ $group['title'] }}
+                    {!! $group['title'] !!}
                 @endif
             </h2>
             @if ($can_edit_posts)
@@ -137,14 +137,14 @@
                                 <div class="row-title">
                                     @if (current_user_can('edit_post', $content['ID']))
                                         <a href="{!! admin_url('post.php?post=' . $content['ID'] . '&action=edit') !!}">
-                                            {{ $content['post_title'] }}
+                                            {!! $content['post_title'] !!}
                                             @if ($start_point === $content['ID'])
                                                 <span class="ebook-start-point"
                                                     title="{{ __('Ebook start point', 'pressbooks') }}">&#9733;</span>
                                             @endif
                                         </a>
                                     @else
-                                        {{ $content['post_title'] }}
+                                        {!! $content['post_title'] !!}
                                         @if ($start_point === $content['ID'])
                                             <span class="ebook-start-point"
                                                 title="{{ __('Ebook start point', 'pressbooks') }}">&#9733;</span>


### PR DESCRIPTION
Fix for #3146. 

To test:
1. Enter a title that includes characters like `'`, `"`, `&`, or `<` and `>`
2. Visit the organize page
3. Observe that the title is rendered as expected, rather than with unencoded HTML entitites

Before: 
![Screenshot from 2023-01-26 06-46-56](https://user-images.githubusercontent.com/13485451/214866219-88a32764-c99d-4547-b4a9-0f90d5954a99.png)

After:
![Screenshot from 2023-01-26 06-47-14](https://user-images.githubusercontent.com/13485451/214866243-6b60a674-98df-46de-a6ca-360a80567028.png)