### PR TITLE
fix: improve author name encoding on organize page

### DIFF
--- a/templates/admin/organize.blade.php
+++ b/templates/admin/organize.blade.php
@@ -195,8 +195,8 @@
                             </td>
                             <td class="author column-author">
                                 <span class="author-label">{{ __('Authors', 'pressbooks') }}:</span>
-                                {{ $contributors->get($content['ID'], 'pb_authors') ?: '—' }}
-                            </td>
+                                {!! $contributors->get($content['ID'], 'pb_authors') ?: '—' !!}
+							</td>
                             @if (!$disable_comments)
                                 <td class="comments column-comments">
                                     <a class="post-comment-count" href="{!! admin_url('edit-comments.php?p=' . $content['ID']) !!}">

--- a/templates/admin/organize.blade.php
+++ b/templates/admin/organize.blade.php
@@ -196,7 +196,7 @@
                             <td class="author column-author">
                                 <span class="author-label">{{ __('Authors', 'pressbooks') }}:</span>
                                 {!! $contributors->get($content['ID'], 'pb_authors') ?: '—' !!}
-							</td>
+                            </td>
                             @if (!$disable_comments)
                                 <td class="comments column-comments">
                                     <a class="post-comment-count" href="{!! admin_url('edit-comments.php?p=' . $content['ID']) !!}">


### PR DESCRIPTION
Fix for https://github.com/pressbooks/pressbooks/issues/3146#issuecomment-1405467727

To test:
1. assign a contributor with special HTML characters in their name as an author of a chapter
2. Visit organize page and observe correct encoding

Before:
![Screenshot from 2023-01-26 16-33-07](https://user-images.githubusercontent.com/13485451/214980874-e88d7f7a-e616-403c-93b0-e27a30f83f42.png)

After:
![Screenshot from 2023-01-26 16-32-51](https://user-images.githubusercontent.com/13485451/214980881-84a7db08-155a-464c-a396-48fbb3d570dd.png)
