### PR TITLE
fix: replace external import fonts in css for epub

### DIFF
--- a/inc/modules/export/epub/class-epub.php
+++ b/inc/modules/export/epub/class-epub.php
@@ -2244,7 +2244,7 @@ class Epub extends ExportGenerator {
 				'',
 				' ',
 			];
-			$filename = preg_replace( $patterns, $replacements, $url );
+			$filename = preg_replace( $patterns, $replacements, $url ) . '.css';
 		} else {
 			// Basename without query string
 			$filename = explode( '?', basename( $url ) );

--- a/inc/modules/export/epub/class-epub.php
+++ b/inc/modules/export/epub/class-epub.php
@@ -2230,9 +2230,26 @@ class Epub extends ExportGenerator {
 			return '';
 		}
 
-		// Basename without query string
-		$filename = explode( '?', basename( $url ) );
-		$filename = array_shift( $filename );
+		// if it is a Google font, we could get the actual font name
+		if ( str_contains( $url, 'fonts.googleapis.com' ) ) {
+			$patterns = [
+				'!^https://fonts.googleapis.com/css\?!',
+				'!(family=[^&:]+).*$!',
+				'!family=!',
+				'/[^A-Za-z0-9\-]/',
+			];
+			$replacements = [
+				'',
+				'$1',
+				'',
+				' ',
+			];
+			$filename = preg_replace( $patterns, $replacements, $url );
+		} else {
+			// Basename without query string
+			$filename = explode( '?', basename( $url ) );
+			$filename = array_shift( $filename );
+		}
 
 		$filename = sanitize_file_name( urldecode( $filename ) );
 		$filename = Sanitize\force_ascii( $filename );

--- a/tests/test-modules-export-export.php
+++ b/tests/test-modules-export-export.php
@@ -605,7 +605,7 @@ class Modules_Export_ExportTest extends \WP_UnitTestCase {
 		$this->assertStringNotContainsString( $css_font_import_1, $css );
 		$this->assertStringNotContainsString( $css_font_import_2, $css );
 
-		$this->assertStringContainsString( '@import url(assets/Roboto);', $css );
-		$this->assertStringContainsString( '@import url(assets/Roboto-Slab);', $css );
+		$this->assertStringContainsString( '@import url(assets/Roboto.css);', $css );
+		$this->assertStringContainsString( '@import url(assets/Roboto-Slab.css);', $css );
 	}
 }

--- a/tests/test-modules-export-export.php
+++ b/tests/test-modules-export-export.php
@@ -588,4 +588,23 @@ class Modules_Export_ExportTest extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'class', $attributes );
 		$this->assertEquals( 'endnote', $attributes['class'] );
 	}
+
+
+	/**
+	 * @group export
+	 * @test
+	 */
+	public function normalize_external_url_references():void  {
+		$epub = new \Pressbooks\Modules\Export\Epub\Epub( [] );
+		$css_font_import_1 = "@import \"https://fonts.googleapis.com/css?family=Roboto:400,400i,700,700i\";\n";
+		$css_font_import_2 = "@import \"https://fonts.googleapis.com/css?family=Roboto+Slab:400,700\";\n";
+		$css = $css_font_import_1 . $css_font_import_2 . "body { font-family: 'Roboto', sans-serif; }";
+
+		$css = $epub->normalizeExternalFontsUrls( $css, 'epub/assets/' );
+
+		$this->assertStringNotContainsString( $css_font_import_1, $css );
+		$this->assertStringNotContainsString( $css_font_import_2, $css );
+
+		$this->assertStringContainsString( '@import url(assets/', $css );
+	}
 }

--- a/tests/test-modules-export-export.php
+++ b/tests/test-modules-export-export.php
@@ -605,6 +605,7 @@ class Modules_Export_ExportTest extends \WP_UnitTestCase {
 		$this->assertStringNotContainsString( $css_font_import_1, $css );
 		$this->assertStringNotContainsString( $css_font_import_2, $css );
 
-		$this->assertStringContainsString( '@import url(assets/', $css );
+		$this->assertStringContainsString( '@import url(assets/Roboto);', $css );
+		$this->assertStringContainsString( '@import url(assets/Roboto-Slab);', $css );
 	}
 }


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks/issues/3136

This PRs replaces the `@import "FONT_URL"` occurrences in the CSS compiled string for the EPUB export routine by `@import url(assets/<INTERNAL_DOWNLOADED_FILE>)`. 

The bug mentioned in the main ticket is due to the lack of custom font downloading. When other than `Default Theme` font is selected in Ebook Theme Options, instead downloading them as expected, the compiled CSS looks like:
```css
@import "https://fonts.googleapis.com/css?family=Roboto&display=swap";
@import "https://fonts.googleapis.com/css?family=Cormorant+Garamond&display=swap";
body, .entry-content {
  color: initial;
}
...
```

### Testing case
- Pick a book and go to Appearance > Theme Options > Ebook.
- Change Header Font and/or Body Font and pick any font != `Theme default`.
- Export the book to EPUB
- You should not see the following validation issues (or similar according to the book theme):
```
ERROR(OPF-014): /srv/www/university.pressbooks.pub/releases/20221223162849/web/app/uploads/sites/966/pressbooks/exports/Test-Shape-Shifter-1675102779.epub/EPUB/mcluhan.css(0,0): The property "remote-resources" should be declared in the OPF file.
ERROR(RSC-006): /srv/www/university.pressbooks.pub/releases/20221223162849/web/app/uploads/sites/966/pressbooks/exports/Test-Shape-Shifter-1675102779.epub/EPUB/mcluhan.css(2,9): Remote resource reference not allowed; resource must be placed in the OCF.
ERROR(RSC-006): /srv/www/university.pressbooks.pub/releases/20221223162849/web/app/uploads/sites/966/pressbooks/exports/Test-Shape-Shifter-1675102779.epub/EPUB/mcluhan.css(3,9): Remote resource reference not allowed; resource must be placed in the OCF.
```
- Inspect the EPUB exported (unzip it). In the `.css` file you should not see any `@import "<FONT_URL>"` line.
