### PR TITLE
feat: add bulk add user page for network admins

### DIFF
--- a/inc/admin/users/class-userbulk.php
+++ b/inc/admin/users/class-userbulk.php
@@ -49,7 +49,9 @@ class UserBulk {
 	 * @param UserBulk $obj
 	 */
 	static public function hooks( UserBulk $obj ) {
-		add_action( 'admin_menu', [ $obj, 'addMenu' ] );
+		if ( Book::isBook() ) {
+			add_action( 'admin_menu', [ $obj, 'addMenu' ] );
+		}
 		add_action( 'network_admin_menu', [ $obj, 'addMenu' ] );
 	}
 

--- a/inc/admin/users/class-userbulk.php
+++ b/inc/admin/users/class-userbulk.php
@@ -7,6 +7,7 @@
 
 namespace Pressbooks\Admin\Users;
 
+use Pressbooks\Book;
 use Pressbooks\Container;
 
 class UserBulk {
@@ -48,9 +49,8 @@ class UserBulk {
 	 * @param UserBulk $obj
 	 */
 	static public function hooks( UserBulk $obj ) {
-		if ( \Pressbooks\Book::isBook() ) {
-			add_action( 'admin_menu', [ $obj, 'addMenu' ] );
-		}
+		add_action( 'admin_menu', [ $obj, 'addMenu' ] );
+		add_action( 'network_admin_menu', [ $obj, 'addMenu' ] );
 	}
 
 	public function __construct() {
@@ -60,7 +60,7 @@ class UserBulk {
 	/**
 	 * Register 'Bulk add' submenu
 	 */
-	public function addMenu() {
+	public function addMenu(): void {
 		add_submenu_page(
 			self::PARENT_SLUG,
 			__( 'Bulk Add', 'pressbooks' ),
@@ -96,13 +96,13 @@ class UserBulk {
 	/**
 	 * @return bool|array
 	 */
-	public function bulkAddUsers() {
-		if ( empty( $_POST ) || empty( $_POST['role'] ) || empty( $_POST['users'] ) || ! check_admin_referer( self::SLUG ) ) {
+	public function bulkAddUsers(): bool|array {
+		if ( empty( $_POST ) || empty( $_POST['users'] ) || ! check_admin_referer( self::SLUG ) ) {
 			return false;
 		}
 
 		$_POST = array_map( 'trim', $_POST );
-		$role = $_POST['role'];
+		$role = Book::isBook() && isset( $_POST['role'] ) ? sanitize_text_field( $_POST['role'] ) : 'subscriber';
 		$emails_input = array_unique( preg_split( '/\r\n|\r|\n/', $_POST['users'] ) );
 		$emails = array_map( 'sanitize_text_field', $emails_input );
 		$results = [];
@@ -121,12 +121,10 @@ class UserBulk {
 				$result = $this->linkNewUserToBook( $email, $role );
 			}
 
-			array_push(
-				$results, [
-					'email'  => $email,
-					'status' => $result,
-				]
-			);
+			$results[] = [
+				'email' => $email,
+				'status' => $result,
+			];
 		}
 
 		return $results;
@@ -135,9 +133,9 @@ class UserBulk {
 	/**
 	 * @param string $email
 	 * @param string $role
-	 * @return WP_Error|bool
+	 * @return \WP_Error|string
 	 */
-	public function linkNewUserToBook( string $email, string $role ) {
+	public function linkNewUserToBook( string $email, string $role ): \WP_Error|string {
 		$user_details = $this->generateUserNameFromEmail( $email );
 
 		if ( is_wp_error( $user_details['errors'] ) && $user_details['errors']->has_errors() ) {
@@ -164,7 +162,7 @@ class UserBulk {
 	 * @param string $email
 	 * @return array
 	 */
-	public function generateUserNameFromEmail( string $email ) {
+	public function generateUserNameFromEmail( string $email ): array {
 		if ( ! filter_var( $email, FILTER_VALIDATE_EMAIL ) ) {
 			return [ 'errors' => new \WP_Error( 'pb_email', __( 'Invalid email address', 'pressbooks' ) ) ];
 		}
@@ -177,8 +175,7 @@ class UserBulk {
 			++$i;
 		}
 
-		$user_details = wpmu_validate_user_signup( $unique_username, $email );
-		return $user_details;
+		return wpmu_validate_user_signup( $unique_username, $email );
 	}
 
 	/**
@@ -190,7 +187,7 @@ class UserBulk {
 	 *
 	 * @return string
 	 */
-	public function sanitizeUser( $username ) : string {
+	public function sanitizeUser( string $username ) : string {
 		$unique_username = sanitize_user( $username, true );
 		$unique_username = strtolower( $unique_username );
 		$unique_username = preg_replace( '/[^a-z0-9]/', '', $unique_username );
@@ -199,9 +196,7 @@ class UserBulk {
 			$unique_username .= 'a'; // usernames must have letters too
 		}
 
-		$unique_username = str_pad( $unique_username, 4, '1' );
-
-		return $unique_username;
+		return str_pad( $unique_username, 4, '1' );
 	}
 
 	/**
@@ -231,11 +226,11 @@ class UserBulk {
 	}
 
 	/**
-	 * @param string|\WP_Error $status
+	 * @param string $status
 	 *
 	 * @return string
 	 */
-	public function getBulkMessageSubtitle( $status ) : string {
+	public function getBulkMessageSubtitle( string $status ): string {
 		$subtitle = '';
 
 		switch ( $status ) {
@@ -243,7 +238,9 @@ class UserBulk {
 				$subtitle = __( 'The following user(s) could not be added.', 'pressbooks' );
 				break;
 			case self::USER_STATUS_INVITED:
-				$subtitle = __( 'User(s) successfully added to this book.', 'pressbooks' );
+				$subtitle = Book::isBook() ?
+					__( 'User(s) successfully added to this book.', 'pressbooks' ) :
+					__( 'User(s) successfully added to the network.', 'pressbooks' );
 				break;
 			case self::USER_STATUS_NEW:
 				$subtitle = __( 'An invitation email has been sent to the user(s) below. A confirmation link must be clicked before their account is created.', 'pressbooks' );

--- a/templates/admin/user_bulk_new.blade.php
+++ b/templates/admin/user_bulk_new.blade.php
@@ -13,13 +13,15 @@
 					</div>
 				</td>
 			</tr>
-			<tr class="form-field">
-				<th scope="row"><label for="adduser-role">@php _e( 'Role' ); @endphp</label></th>
-				<td><select name="role" id="adduser-role">
-						@php wp_dropdown_roles( get_option( 'default_role' ) ); @endphp
-					</select>
-				</td>
-			</tr>
+			@if( \Pressbooks\Book::isBook() )
+				<tr class="form-field">
+					<th scope="row"><label for="adduser-role">@php _e( 'Role' ); @endphp</label></th>
+					<td><select name="role" id="adduser-role">
+							@php wp_dropdown_roles( get_option( 'default_role' ) ); @endphp
+						</select>
+					</td>
+				</tr>
+			@endif
 		</table>
 		{!! get_submit_button( __( 'Add users', 'users' ) ) !!}
 	</form>

--- a/tests/test-userbulk.php
+++ b/tests/test-userbulk.php
@@ -40,8 +40,12 @@ class UserBulkTest extends \WP_UnitTestCase {
 		$this->assertInstanceOf( UserBulk::class, $result );
 		$this->user_bulk->hooks( $result );
 		$this->assertNotEmpty( $wp_filter );
-		$this->assertEquals( 10, has_action( 'admin_menu', [ $result, 'addMenu' ] ) );
 		$this->assertEquals( 10, has_action( 'network_admin_menu', [ $result, 'addMenu' ] ) );
+		$this->assertFalse( has_action( 'admin_menu', [ $result, 'addMenu' ] ) );
+
+		$this->_book();
+		$this->user_bulk->hooks( $result );
+		$this->assertEquals( 10, has_action( 'admin_menu', [ $result, 'addMenu' ] ) );
 	}
 
 	public function test_init() {

--- a/tests/test-userbulk.php
+++ b/tests/test-userbulk.php
@@ -3,7 +3,13 @@
 use Pressbooks\Admin\Users\UserBulk;
 use Pressbooks\HtmlParser;
 
+/**
+ * @group users-bulk
+ */
 class UserBulkTest extends \WP_UnitTestCase {
+
+	use utilsTrait;
+
 	/**
 	 * @var UserBulk
 	 */
@@ -28,42 +34,33 @@ class UserBulkTest extends \WP_UnitTestCase {
 		$this->user_bulk = new UserBulk();
 	}
 
-	/**
-	 * @group userbulk
-	 */
 	public function test_hooks() {
 		global $wp_filter;
 		$result = $this->user_bulk->init();
 		$this->assertInstanceOf( UserBulk::class, $result );
 		$this->user_bulk->hooks( $result );
 		$this->assertNotEmpty( $wp_filter );
+		$this->assertEquals( 10, has_action( 'admin_menu', [ $result, 'addMenu' ] ) );
+		$this->assertEquals( 10, has_action( 'network_admin_menu', [ $result, 'addMenu' ] ) );
 	}
 
-	/**
-	 * @group userbulk
-	 */
 	public function test_init() {
 		$instance = UserBulk::init();
 		$this->assertInstanceOf( UserBulk::class, $instance );
 	}
 
-	/**
-	 * @group userbulk
-	 */
 	public function test_addMenu() {
 		$this->user_bulk->addMenu( );
 		$this->assertTrue( true ); // Did not crash
 	}
 
 	/**
-	 * @group userbulk
+	 * @test
 	 */
-	public function test_printMenu() {
-		ob_start();
-		$this->user_bulk->printMenu();
-		$html = ob_get_clean();
-		$parser = new HtmlParser( true );
-		$doc = $parser->loadHTML( $html );
+	public function print_menu_for_book_admins(): void {
+		$this->_book();
+		$doc = $this->printMenu();
+
 		$users_input = $doc->getElementById( 'users' );
 		$user_rol_dropdown = $doc->getElementById( 'adduser-role' );
 
@@ -76,8 +73,28 @@ class UserBulkTest extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * @group userbulk
+	 * @test
 	 */
+	public function print_menu_for_network_admins(): void {
+		$doc = $this->printMenu();
+
+		$users_input = $doc->getElementById( 'users' );
+
+		$this->assertInstanceOf( \DOMDocument::class, $doc );
+		$this->assertEquals( 1, $doc->getElementsByTagName( 'form' )->length );
+		$this->assertInstanceOf( DOMElement::class, $users_input );
+		$this->assertNull( $doc->getElementById( 'adduser-role' ) );
+		$this->assertEquals( 'users', $users_input->getAttribute( 'name' ) );
+	}
+
+	private function printMenu(): DOMDocument {
+		ob_start();
+		$this->user_bulk->printMenu();
+		$html = ob_get_clean();
+		$parser = new HtmlParser( true );
+		return $parser->loadHTML( $html );
+	}
+
 	public function test_printMenuException() {
 		$_REQUEST['_wpnonce'] = 'fsdflkjdfsiofueriu';
 		$_POST['users'] = implode( "\r\n", $this->post_users );
@@ -90,9 +107,6 @@ class UserBulkTest extends \WP_UnitTestCase {
 		$this->assertNotFalse( strpos( $html, 'class="error notice is-dismissible"' ) );
 	}
 
-	/**
-	 * @group userbulk
-	 */
 	public function test_bulkAddUsers() {
 		$_REQUEST['_wpnonce'] = wp_create_nonce( 'user_bulk_new' );
 		$_POST['users'] = implode( "\r\n", $this->post_users );
@@ -131,9 +145,6 @@ class UserBulkTest extends \WP_UnitTestCase {
 		}
 	}
 
-	/**
-	 * @group userbulk
-	 */
 	public function test_linkNewUserToBook() {
 		$existing_user = $this->factory()->user->create_and_get(
 			[
@@ -149,9 +160,6 @@ class UserBulkTest extends \WP_UnitTestCase {
 		$this->assertEquals( $success, $this->user_bulk::USER_STATUS_NEW );
 	}
 
-	/**
-	 * @group userbulk
-	 */
 	public function test_generateUserNameFromEmail() {
 		$invalid_email = 'invalid@email@.com';
 		$invalid_user_name = $this->user_bulk->generateUserNameFromEmail( $invalid_email );
@@ -178,9 +186,6 @@ class UserBulkTest extends \WP_UnitTestCase {
 		$this->assertFalse( $valid_user_data_dedup['errors']->has_errors() );
 	}
 
-	/**
-	 * @group userbulk
-	 */
 	public function test_sanitizeUser() {
 		$this->assertEquals( 'test', $this->user_bulk->sanitizeUser( 'test' ) );
 		$this->assertEquals( 'test', $this->user_bulk->sanitizeUser( '(:test:)' ) );
@@ -192,24 +197,21 @@ class UserBulkTest extends \WP_UnitTestCase {
 		$this->assertEquals( '1a11', $this->user_bulk->sanitizeUser( '1' ) );
 	}
 
-	/**
-	 * @group userbulk
-	 */
 	public function test_getBulkResultHtml() {
 		$success = [];
 		$errors = [];
 
 		foreach( $this->post_users as $email ) {
 			if ( rand( 0, 1 ) ) {
-				array_push( $success, [
-					'email'     => $email,
-					'status'    => true
-				] );
+				$success[] = [
+					'email' => $email,
+					'status' => true
+				];
 			} else {
-				array_push( $errors, [
-					'email'     => $email,
-					'status'    => new WP_Error( 1, 'WP error message' )
-				] );
+				$errors[] = [
+					'email' => $email,
+					'status' => new WP_Error(1, 'WP error message')
+				];
 			}
 		}
 
@@ -220,28 +222,30 @@ class UserBulkTest extends \WP_UnitTestCase {
 		if ( ! empty( $success ) ) {
 			$success_message_str = $doc->getElementById( 'bulk-success' )->textContent;
 			foreach( $success as $result ) {
-				$this->assertTrue( false !== strpos( $success_message_str, $result['email'] ) );
+				$this->assertTrue( str_contains( $success_message_str, $result['email'] ) );
 			}
 		}
 
 		if ( ! empty( $errors ) ) {
 			$error_message_str = $doc->getElementById( 'bulk-errors' )->textContent;
 			foreach( $errors as $result ) {
-				$this->assertTrue( false !== strpos( $error_message_str, $result['email'] ) );
+				$this->assertTrue( str_contains( $error_message_str, $result['email'] ) );
 			}
 		}
 	}
 
-	/**
-	 * @group userbulk
-	 */
 	public function test_getBulkMessageSubtitle() {
 		$subtitle_error =  'The following user(s) could not be added.';
-		$subtitle_success_invite = 'User(s) successfully added to this book.';
+		$subtitle_success_invite_book = 'User(s) successfully added to this book.';
+		$subtitle_success_invite_network = 'User(s) successfully added to the network.';
 		$subtitle_success = 'An invitation email has been sent to the user(s) below. A confirmation link must be clicked before their account is created.';
 
 		$this->assertEquals( $this->user_bulk->getBulkMessageSubtitle( $this->user_bulk::USER_STATUS_ERROR ), $subtitle_error );
-		$this->assertEquals( $this->user_bulk->getBulkMessageSubtitle( $this->user_bulk::USER_STATUS_INVITED ), $subtitle_success_invite );
+		$this->assertEquals( $this->user_bulk->getBulkMessageSubtitle( $this->user_bulk::USER_STATUS_INVITED ), $subtitle_success_invite_network );
 		$this->assertEquals( $this->user_bulk->getBulkMessageSubtitle( $this->user_bulk::USER_STATUS_NEW ), $subtitle_success );
+
+		$this->_book();
+
+		$this->assertEquals( $this->user_bulk->getBulkMessageSubtitle( $this->user_bulk::USER_STATUS_INVITED ), $subtitle_success_invite_book );
 	}
 }


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks/issues/3151

This PR enables the `Users bulk add` page for network admins following the specs in the related issue.

### Testing case
- A new action in Network Admin > Users must be present: Bulk Add
- You should see Emails (textarea) and an `Add users` button.
- Enter multiple emails in the text area (1 per line).
- 1 activation email per user must be sent to the new users. You can see them in mailhog. You can check the mailhog URL by inspecting `lando info`.
- Activate 1 or more users.
- The activated users should contain `subscriber` role.

For more use cases, you could add invalid/repeated emails in the textarea. Also, you could try to add an email using the first part of the string, before the `@` with an existing username in your system.