### PR TITLE
fix: exclude integrations unit tests from tests suite

### DIFF
--- a/.github/workflows/standards-and-tests.yml
+++ b/.github/workflows/standards-and-tests.yml
@@ -73,7 +73,7 @@ jobs:
       run: bash bin/install-wp-tests.sh wordpress_test root root localhost ${{ matrix.wordpress }}
 
     - name: Run PHP Tests
-      run: composer test
+      run: composer test -- --exclude=integrations
       if: matrix.experimental == true
 
     - name: Run PHP Tests and PCOV

--- a/.github/workflows/standards-and-tests.yml
+++ b/.github/workflows/standards-and-tests.yml
@@ -77,7 +77,7 @@ jobs:
       if: matrix.experimental == true
 
     - name: Run PHP Tests and PCOV
-      run: composer test-coverage
+      run: vendor/bin/phpunit --configuration phpunit.xml --coverage-clover coverage.xml --coverage-html=./coverage-reports --exclude-group=integrations
       if: matrix.experimental == false
 
     - name: Upload Coverage to Codecov

--- a/.github/workflows/standards-and-tests.yml
+++ b/.github/workflows/standards-and-tests.yml
@@ -77,7 +77,7 @@ jobs:
       if: matrix.experimental == true
 
     - name: Run PHP Tests and PCOV
-      run: vendor/bin/phpunit --configuration phpunit.xml --coverage-clover coverage.xml --coverage-html=./coverage-reports --exclude-group=integrations
+      run: composer test-coverage -- --exclude=integrations
       if: matrix.experimental == false
 
     - name: Upload Coverage to Codecov


### PR DESCRIPTION
Issue: https://github.com/pressbooks/private/issues/1096

This PR excludes integrations tests from the tests suite to temporarily fix the pipeline issue we're having.

Permanent solutions to be implemented in https://github.com/pressbooks/private/issues/1860

For context, see: https://docs.google.com/document/d/16zFMx6so-27UQxhkGeOFMGBnAtIWESdsN4a5mij5QOA/edit#heading=h.281ury1ft3z5