### PR TITLE
fix: replace broken GA function on custom catalog page

### DIFF
--- a/templates/pb-catalog.php
+++ b/templates/pb-catalog.php
@@ -166,8 +166,9 @@ $_current_user_id = $catalog->getUserId();
 	<script src="<?php echo $assets->getPath( 'scripts/isotope.js' ); ?>" type="text/javascript"></script>
 	<script src="<?php echo $assets->getPath( 'scripts/small-menu.js' ); ?>" type="text/javascript"></script>
 	<script src="<?php echo $assets->getPath( 'scripts/catalog.js' ); ?>" type="text/javascript"></script>
-	<?php // @codingStandardsIgnoreEnd ?>
-	<?php \Pressbooks\analytics\print_analytics(); ?>
+	<?php // @codingStandardsIgnoreEnd
+		$google_analytics = new \Pressbooks\GoogleAnalytics();
+		echo $google_analytics->printScripts(); ?>
 </head>
 <?php if ( ! empty( $profile['pb_catalog_color'] ) ) : ?>
 <body style="background-image: none !important;">

--- a/templates/pb-catalog.php
+++ b/templates/pb-catalog.php
@@ -166,9 +166,8 @@ $_current_user_id = $catalog->getUserId();
 	<script src="<?php echo $assets->getPath( 'scripts/isotope.js' ); ?>" type="text/javascript"></script>
 	<script src="<?php echo $assets->getPath( 'scripts/small-menu.js' ); ?>" type="text/javascript"></script>
 	<script src="<?php echo $assets->getPath( 'scripts/catalog.js' ); ?>" type="text/javascript"></script>
-	<?php // @codingStandardsIgnoreEnd
-		$google_analytics = new \Pressbooks\GoogleAnalytics();
-		echo $google_analytics->printScripts(); ?>
+	<?php // @codingStandardsIgnoreEnd ?>
+	<?php \Pressbooks\GoogleAnalytics::init()->printScripts(); ?>
 </head>
 <?php if ( ! empty( $profile['pb_catalog_color'] ) ) : ?>
 <body style="background-image: none !important;">


### PR DESCRIPTION
Fix for https://github.com/pressbooks/pressbooks/issues/3173

To test:
1. Add GA4 and/or UA values in network settings
2. Open your individual catalog page at `https://pressbooks.test/catalog/admin`
3. Check to see that there's no fatal error and that the page head includes the expected GA scripts
4. Remove or alter GA4 and/or UA values
5. Repeat steps 2 and 3.