### PR TITLE
fix: set up proper redirect for super admins/network managers

### DIFF
--- a/hooks.php
+++ b/hooks.php
@@ -179,6 +179,7 @@ add_filter( 'init', '\Pressbooks\Redirect\rewrite_rules_for_catalog', 1 );
 add_filter( 'init', '\Pressbooks\Redirect\rewrite_rules_for_open', 1 );
 add_action( 'plugins_loaded', '\Pressbooks\Redirect\migrate_generated_content', 1 );
 add_filter( 'login_redirect', '\Pressbooks\Redirect\break_reset_password_loop', 10, 3 );
+add_filter( 'login_redirect', '\Pressbooks\Redirect\handle_dashboard_redirect', 10, 3 );
 
 // -------------------------------------------------------------------------------------------------------------------
 // Sitemap

--- a/inc/redirect/namespace.php
+++ b/inc/redirect/namespace.php
@@ -511,7 +511,7 @@ function handle_dashboard_redirect( string $redirect_to, string $requested_redir
 		return $redirect_to;
 	}
 
-	if ( str_contains( $redirect_to, 'page=pb_home_page' ) ) {
+	if ( $redirect_to === admin_url() || str_contains( $redirect_to, 'page=pb_home_page' ) ) {
 		return network_admin_url( 'admin.php?page=pb_network_page' );
 	}
 

--- a/inc/redirect/namespace.php
+++ b/inc/redirect/namespace.php
@@ -492,3 +492,28 @@ function break_reset_password_loop( $redirect_to, $requested_redirect_to, $user 
 	}
 	return $redirect_to;
 }
+
+/**
+ * Handles the dashboard redirect in case of super admin users
+ *
+ * @param string $redirect_to The redirect destination URL.
+ * @param string $requested_redirect_to The requested redirect destination URL passed as a parameter.
+ * @param \WP_User|\WP_Error $user
+ *
+ * @return string
+ */
+function handle_dashboard_redirect( string $redirect_to, string $requested_redirect_to, \WP_User|\WP_Error $user ): string {
+	if ( $user instanceof \WP_Error ) {
+		return $redirect_to;
+	}
+
+	if ( ! is_super_admin( $user->ID ) ) {
+		return $redirect_to;
+	}
+
+	if ( str_contains( $redirect_to, 'page=pb_home_page' ) ) {
+		return network_admin_url( 'admin.php?page=pb_network_page' );
+	}
+
+	return $redirect_to;
+}

--- a/tests/test-redirect.php
+++ b/tests/test-redirect.php
@@ -210,10 +210,10 @@ class RedirectTest extends \WP_UnitTestCase {
 
 		$redirect_to = admin_url( 'index.php?page=pb_home_page' );
 
-		$this->assertSame(
-			network_admin_url( 'admin.php?page=pb_network_page' ),
-			\Pressbooks\Redirect\handle_dashboard_redirect( $redirect_to, $redirect_to, $user )
-		);
+		$redirected = \Pressbooks\Redirect\handle_dashboard_redirect( $redirect_to, $redirect_to, $user );
+
+		$this->assertNotSame( $redirect_to, $redirected );
+		$this->assertSame( network_admin_url( 'admin.php?page=pb_network_page' ), $redirected );
 	}
 
 	/**

--- a/tests/test-redirect.php
+++ b/tests/test-redirect.php
@@ -236,4 +236,26 @@ class RedirectTest extends \WP_UnitTestCase {
 			\Pressbooks\Redirect\handle_dashboard_redirect( $redirect_to, $redirect_to, $user )
 		);
 	}
+
+	/**
+	 * @test
+	 * @group redirect
+	 */
+	public function it_uses_redirect_to_when_no_user_is_provided(): void {
+		$redirect_to = home_url( 'wp-login.php' );
+
+		$this->assertSame(
+			$redirect_to,
+			\Pressbooks\Redirect\handle_dashboard_redirect( $redirect_to, $redirect_to, new WP_Error )
+		);
+
+		$this->_book();
+
+		$redirect_to = get_site_url( get_current_blog_id() );
+
+		$this->assertSame(
+			$redirect_to,
+			\Pressbooks\Redirect\handle_dashboard_redirect( $redirect_to, $redirect_to, new WP_Error )
+		);
+	}
 }

--- a/tests/test-redirect.php
+++ b/tests/test-redirect.php
@@ -214,6 +214,13 @@ class RedirectTest extends \WP_UnitTestCase {
 
 		$this->assertNotSame( $redirect_to, $redirected );
 		$this->assertSame( network_admin_url( 'admin.php?page=pb_network_page' ), $redirected );
+
+		$redirect_to = admin_url();
+
+		$redirected = \Pressbooks\Redirect\handle_dashboard_redirect( $redirect_to, $redirect_to, $user );
+
+		$this->assertNotSame( $redirect_to, $redirected );
+		$this->assertSame( network_admin_url( 'admin.php?page=pb_network_page' ), $redirected );
 	}
 
 	/**

--- a/tests/test-redirect.php
+++ b/tests/test-redirect.php
@@ -133,7 +133,11 @@ class RedirectTest extends \WP_UnitTestCase {
 		$this->assertEquals( $logged_in->user_login, $user->user_login );
 	}
 
-	public function test_break_reset_password_loop() {
+	/**
+	 * @test
+	 * @group redirect
+	 */
+	public function test_break_reset_password_loop(): void {
 		$user_id = $this->factory()->user->create( [ 'role' => 'subscriber' ] );
 		$user = get_userdata( $user_id );
 		$requested_redirect_to = 'ignored';
@@ -155,5 +159,81 @@ class RedirectTest extends \WP_UnitTestCase {
 		$user = new WP_Error();
 		$url = \Pressbooks\Redirect\break_reset_password_loop( $redirect_to, $requested_redirect_to, $user );
 		$this->assertNotEquals( admin_url(), $url );
+	}
+
+	/**
+	 * @test
+	 * @group redirect
+	 */
+	public function it_redirects_regular_users_to_the_new_user_dashboard(): void {
+		$user = get_userdata(
+			$this->factory()->user->create( [ 'role' => 'subscriber' ] )
+		);
+
+		$redirect_to = admin_url( 'index.php?page=pb_home_page' );
+
+		$this->assertSame(
+			$redirect_to,
+			\Pressbooks\Redirect\handle_dashboard_redirect( $redirect_to, $redirect_to, $user )
+		);
+	}
+
+	/**
+	 * @test
+	 * @group redirect
+	 */
+	public function it_redirects_regular_users_to_the_book_page(): void {
+		$user = get_userdata(
+			$this->factory()->user->create( [ 'role' => 'subscriber' ] )
+		);
+
+		$this->_book();
+
+		$redirect_to = get_site_url( get_current_blog_id() );
+
+		$this->assertSame(
+			$redirect_to,
+			\Pressbooks\Redirect\handle_dashboard_redirect( $redirect_to, $redirect_to, $user )
+		);
+	}
+
+	/**
+	 * @test
+	 * @group redirect
+	 */
+	public function it_redirects_super_admins_to_the_new_network_dashboard(): void {
+		$user = get_userdata(
+			$this->factory()->user->create( [ 'role' => 'administrator' ] )
+		);
+
+		grant_super_admin( $user->ID );
+
+		$redirect_to = admin_url( 'index.php?page=pb_home_page' );
+
+		$this->assertSame(
+			network_admin_url( 'admin.php?page=pb_network_page' ),
+			\Pressbooks\Redirect\handle_dashboard_redirect( $redirect_to, $redirect_to, $user )
+		);
+	}
+
+	/**
+	 * @test
+	 * @group redirect
+	 */
+	public function it_redirects_super_admins_to_the_book_page(): void {
+		$user = get_userdata(
+			$this->factory()->user->create( [ 'role' => 'administrator' ] )
+		);
+
+		grant_super_admin( $user->ID );
+
+		$this->_book();
+
+		$redirect_to = get_site_url( get_current_blog_id() );
+
+		$this->assertSame(
+			$redirect_to,
+			\Pressbooks\Redirect\handle_dashboard_redirect( $redirect_to, $redirect_to, $user )
+		);
 	}
 }


### PR DESCRIPTION
Issue #3195 

This PR adds a hook to redirect super admins/network managers to the new network dashboard.

**How to test**

To test this, authenticate as different users from the network home page and from a book home page, users should be redirected as described in the table below

| Role | Signing in from root site | Signing in from book page |
| :--: | :-- | :-- |
| Regular user | redirect to the new user dashboard | redirect to the respective book page |
| Network manager | redirect to the new network dashboard | redirect to the respective book page |
| Super admin | redirect to the new network dashboard | redirect to the respective book page |