### PR TITLE
fix: my books top nav redirect to user dashboard

### DIFF
--- a/inc/admin/menus/class-topbar.php
+++ b/inc/admin/menus/class-topbar.php
@@ -109,7 +109,7 @@ class TopBar {
 			[
 				'id' => 'pb-logo',
 				'title' => '<span class="ab-icon"></span><span class="screen-reader-text">' . __( 'About Pressbooks', 'pressbooks' ) . '</span>',
-				'href' => ( 'https://pressbooks.com/' ),
+				'href' => 'https://pressbooks.com',
 			]
 		);
 	}
@@ -124,7 +124,7 @@ class TopBar {
 		$submenus = [
 			'pb-administer-network-d' => [
 				'title' => __( 'Dashboard', 'pressbooks' ),
-				'href' => network_admin_url( 'index.php?pb_network_page' ),
+				'href' => network_admin_url( 'index.php?page=pb_network_page' ),
 				'visible' => true,
 			],
 			'pb-administer-books' => [
@@ -170,7 +170,7 @@ class TopBar {
 		$bar->add_node( [
 			'id' => $main_id,
 			'title' => "$svg <span>{$title}</span>",
-			'href' => network_admin_url( 'index.php?pb_network_page' ),
+			'href' => network_admin_url( 'index.php?page=pb_network_page' ),
 			'meta' => [
 				'class' => is_network_admin() ? 'you-are-here' : null,
 			],
@@ -197,7 +197,7 @@ class TopBar {
 		$bar->add_node( [
 			'id' => 'pb-my-books',
 			'title' => "$svg <span>{$title}</span>",
-			'href' => admin_url( 'index.php?pb_home_page' ),
+			'href' => get_admin_url( get_main_site_id() ) . 'index.php?page=pb_home_page',
 			'meta' => array_filter( $metadata ),
 		] );
 

--- a/inc/admin/menus/class-topbar.php
+++ b/inc/admin/menus/class-topbar.php
@@ -197,7 +197,7 @@ class TopBar {
 		$bar->add_node( [
 			'id' => 'pb-my-books',
 			'title' => "$svg <span>{$title}</span>",
-			'href' => get_admin_url( get_main_site_id() ) . 'index.php?page=pb_home_page',
+			'href' => get_admin_url( get_main_site_id(), 'index.php?page=pb_home_page' ),
 			'meta' => array_filter( $metadata ),
 		] );
 


### PR DESCRIPTION
Issue #3208 

This PR addresses an issue where "My Books" top nav wouldn't redirect users to the user dashboard if they were in a book context. This was happening because `admin_url` method takes into account the current context to retrieve the URL, this was fixed by always requesting the main site admin url.

This also addresses some missing `page` parameter.

**How to test**

1. Log in to your network and visit the admin dashboard
2. Visit a book admin dashboard
3. When clicking "My Books" option you should be redirected to the user dashboard and not to the current book's dashboard