### PR TITLE
fix: always allow super admins to create books

### DIFF
--- a/inc/admin/menus/class-topbar.php
+++ b/inc/admin/menus/class-topbar.php
@@ -243,7 +243,7 @@ class TopBar {
 	protected function addCreateBook( WP_Admin_Bar $bar ): void {
 		$title = __( 'Create Book', 'pressbooks' );
 
-		$bar->add_node( [
+		$node = [
 			'id' => 'pb-create-book',
 			'parent' => 'top-secondary',
 			'title' => "<i class='pb-heroicons pb-heroicons-plus-circle-filled'></i><span>{$title}</span>",
@@ -251,6 +251,11 @@ class TopBar {
 			'meta' => [
 				'class' => 'btn action',
 			],
+		];
+
+		$bar->add_node( can_create_new_books() ? $node : [
+			...$node,
+			'href' => network_admin_url( 'site-new.php' ),
 		] );
 	}
 

--- a/inc/admin/menus/class-topbar.php
+++ b/inc/admin/menus/class-topbar.php
@@ -64,7 +64,7 @@ class TopBar {
 
 		$this->updateCurrentBook( $bar );
 
-		if ( can_create_new_books() ) {
+		if ( can_create_new_books() || is_super_admin() ) {
 			$this->addCreateBook( $bar );
 		}
 


### PR DESCRIPTION
Issue #3241 

This PR allows super admins to create books even when the option to create books is unchecked.

**Expected behaviour**

- Book creation is enabled: users should be redirected to the regular `{$NETWORK}/wp-signup.php` page to create a new book
- Book creation is disabled: super admins/network managers should be redirected to `{$NETWORK}/wp-admin/network/site-new.php` to create a new book.

**How to test**

1. Follow the steps described in the ticket to validated the expected behaviour