### PR TITLE
fix: show create a book to super admins when book creation is disabled

### DIFF
--- a/inc/admin/dashboard/class-bookdashboard.php
+++ b/inc/admin/dashboard/class-bookdashboard.php
@@ -15,11 +15,6 @@ class BookDashboard extends Dashboard {
 
 	protected string $page_name = 'book_dashboard';
 
-	/**
-	 * @throws ContainerExceptionInterface
-	 * @throws Throwable
-	 * @throws NotFoundExceptionInterface
-	 */
 	public function render(): void {
 		$blade = Container::get( 'Blade' );
 

--- a/inc/admin/dashboard/class-networkdashboard.php
+++ b/inc/admin/dashboard/class-networkdashboard.php
@@ -21,11 +21,6 @@ class NetworkDashboard extends Dashboard {
 		return network_admin_url( "index.php?page={$this->page_name}" );
 	}
 
-	/**
-	 * @throws ContainerExceptionInterface
-	 * @throws Throwable
-	 * @throws NotFoundExceptionInterface
-	 */
 	public function render(): void {
 		$blade = Container::get( 'Blade' );
 

--- a/inc/admin/dashboard/class-userdashboard.php
+++ b/inc/admin/dashboard/class-userdashboard.php
@@ -13,11 +13,6 @@ class UserDashboard extends Dashboard {
 
 	protected string $page_name = 'pb_home_page';
 
-	/**
-	 * @throws ContainerExceptionInterface
-	 * @throws Throwable
-	 * @throws NotFoundExceptionInterface
-	 */
 	public function render(): void {
 		$blade = Container::get( 'Blade' );
 

--- a/inc/admin/dashboard/class-userdashboard.php
+++ b/inc/admin/dashboard/class-userdashboard.php
@@ -23,7 +23,8 @@ class UserDashboard extends Dashboard {
 
 		echo $blade->render( 'admin.dashboard.user', [
 			'site_name' => get_bloginfo( 'name' ),
-			'can_create_new_books' => can_create_new_books(),
+			'book_creation_enabled' => can_create_new_books(),
+			'can_create_new_books' => can_create_new_books() || is_super_admin(),
 			'can_clone_books' => Cloner::isEnabled() && ( can_create_new_books() || is_super_admin() ),
 			'invitations' => Invitations::getPendingInvitations(),
 		] );

--- a/inc/admin/menus/class-sidebar.php
+++ b/inc/admin/menus/class-sidebar.php
@@ -34,7 +34,7 @@ class SideBar {
 			$this->usersSlug = 'pb_network_analytics_userlist';
 
 			$this->settingsCallback = [ \PressbooksNetworkAnalytics\Admin\Options::init(), 'printMenuSettings' ];
-			$this->settingsSlug = 'pb_network_analytics_options';
+			$this->settingsSlug = $this->getContextSlug( 'admin.php?page=pb_network_analytics_options', false );
 		} else {
 			$this->booksCallback = '';
 			$this->booksSlug = $this->getContextSlug( 'sites.php', false );
@@ -123,7 +123,7 @@ class SideBar {
 					'settings.php',
 				],
 				[
-					'pb_network_analytics_options',
+					'pressbooks_network_analytics_options',
 					'pressbooks_sharingandprivacy_options',
 					'pb_analytics',
 				]
@@ -233,16 +233,27 @@ class SideBar {
 			5
 		);
 
-		if ( is_restricted() ) {
+		if ( is_restricted() && $this->isNetworkAnalyticsActive ) {
 			add_menu_page(
 				__( 'Settings', 'pressbooks' ),
 				__( 'Settings', 'pressbooks' ),
 				'manager_network',
-				$this->settingsSlug,
+				'settings.php',
 				$this->settingsCallback,
 				'dashicons-admin-settings',
 				7
 			);
+			if ( ! is_network_admin() ) {
+				add_submenu_page(
+					'settings.php',
+					__( 'Network Options', 'pressbooks' ),
+					__( 'Network Options', 'pressbooks' ),
+					'manager_network',
+					$this->settingsSlug,
+					''
+				);
+				remove_submenu_page( 'settings.php', 'settings.php' );
+			}
 		}
 
 		if ( $this->isNetworkAnalyticsActive ) {

--- a/inc/admin/menus/class-topbar.php
+++ b/inc/admin/menus/class-topbar.php
@@ -137,12 +137,12 @@ class TopBar {
 			],
 			'pb-administer-appearance' => [
 				'title' => __( 'Appearance', 'pressbooks' ),
-				'href' => admin_url( 'customize.php' ),
+				'href' => get_admin_url( get_main_site_id(), 'customize.php' ),
 				'visible' => true,
 			],
 			'pb-administer-pages' => [
 				'title' => __( 'Pages', 'pressbooks' ),
-				'href' => admin_url( 'edit.php?post_type=page' ),
+				'href' => get_admin_url( get_main_site_id(), 'edit.php?post_type=page' ),
 				'visible' => true,
 			],
 			'pb-administer-plugins' => [
@@ -266,7 +266,7 @@ class TopBar {
 			'id' => 'pb-clone-book',
 			'parent' => 'top-secondary',
 			'title' => "<i class='pb-heroicons pb-heroicons-clone-book'></i><span>{$title}</span>",
-			'href' => admin_url( 'admin.php?page=pb_cloner' ),
+			'href' => get_admin_url( get_main_site_id(), 'admin.php?page=pb_cloner' ),
 			'meta' => [
 				'class' => 'btn action',
 			],

--- a/templates/admin/dashboard/user.blade.php
+++ b/templates/admin/dashboard/user.blade.php
@@ -46,9 +46,15 @@
 						</div>
 
 						<div class="pb-dashboard-action">
-							<a class="button button-hero button-primary" href="{{ network_home_url( 'wp-signup.php' ) }}">
-								{{ __( 'Create a book', 'pressbooks' ) }}
-							</a>
+							@if( $book_creation_enabled )
+								<a class="button button-hero button-primary" href="{{ network_home_url( 'wp-signup.php' ) }}">
+									{{ __( 'Create a book', 'pressbooks' ) }}
+								</a>
+							@else
+								<a class="button button-hero button-primary" href="{{ network_admin_url( 'new-site.php' ) }}">
+									{{ __( 'Create a book', 'pressbooks' ) }}
+								</a>
+							@endif
 						</div>
 					</div>
 				@endif


### PR DESCRIPTION
Issue #3241 

Following conversations on the ticket, I've opened this PR so the user dashboard blocks behave the same way the top bar buttons.

- **Create a book:** top bar button and user dashboard block should be displayed when book creation is enabled or if the user is a super admin/network manager. In cases where the option is disabled, the redirect link should be `{$NETWORK}/wp-admin/network/new-site.php`.
- **Clone a book:** top bar button and user dashboard block should be displayed when cloner is enabled **AND** book creation is enabled or if the user is a super admin/network manager.

**How to test**

Play around with network settings, enabling book creation and the cloner. Make sure the buttons reflect the expected behaviour.