### PR TITLE
fix: use correct URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Developers who are interested in contributing to our project should consult our 
 The Pressbooks plugin is supplied "as is" and all use is at your own risk.
 
 ## Changelog
-### 6.9.1
-* See: https://github.com/pressbooks/pressbooks/releases/tag/6.9.1
+### 6.9.2
+* See: https://github.com/pressbooks/pressbooks/releases/tag/6.9.2
 * Full release history available at: https://github.com/pressbooks/pressbooks/releases
 
 ## Upgrade Notices

--- a/pressbooks.php
+++ b/pressbooks.php
@@ -5,7 +5,7 @@ Plugin URI:         https://pressbooks.org
 GitHub Plugin URI:  pressbooks/pressbooks
 Release Asset:      true
 Description:        Simple Book Production
-Version:            6.9.1
+Version:            6.9.2
 Requires at least:  6.1.1
 Requires PHP:       8.1
 Author:             Pressbooks (Book Oven Inc.)

--- a/templates/admin/dashboard/user.blade.php
+++ b/templates/admin/dashboard/user.blade.php
@@ -51,7 +51,7 @@
 									{{ __( 'Create a book', 'pressbooks' ) }}
 								</a>
 							@else
-								<a class="button button-hero button-primary" href="{{ network_admin_url( 'new-site.php' ) }}">
+								<a class="button button-hero button-primary" href="{{ network_admin_url( 'site-new.php' ) }}">
 									{{ __( 'Create a book', 'pressbooks' ) }}
 								</a>
 							@endif


### PR DESCRIPTION
Fix for https://github.com/pressbooks/pressbooks/issues/3241#issuecomment-1470102362

To test:
1. turn off 'Allow registered users to create & clone new books'
2. Visit user dashboard as a super admin/network manager
3. Click My Books menu to see the user dashboard
4. Click the 'Create a book' button in the user dashboard 
5. See the site creation page as expected