### PR TITLE
fix: add pb catalog page & users activation keys submenu

### DIFF
--- a/inc/admin/menus/class-sidebar.php
+++ b/inc/admin/menus/class-sidebar.php
@@ -360,7 +360,7 @@ class SideBar {
 				__( 'User Activation Keys', 'pressbooks' ),
 				'edit_users',
 				'act_keys',
-				[ $ds_wp3_user_activation_keys, 'ds_delete_stale' ]
+				is_network_admin() ? '' : [ $ds_wp3_user_activation_keys, 'ds_delete_stale' ]
 			);
 		}
 

--- a/inc/admin/menus/class-sidebar.php
+++ b/inc/admin/menus/class-sidebar.php
@@ -84,12 +84,14 @@ class SideBar {
 				'sites.php',
 				'users.php',
 				'users.php',
+				'users.php',
 			],
 			[
 				'pb_network_analytics_booklist',
 				'site-new.php',
 				'pb_network_analytics_userlist',
 				'user-new.php',
+				'act_keys',
 			]
 		);
 
@@ -349,6 +351,19 @@ class SideBar {
 			$this->getContextSlug( 'users.php', true )
 		);
 
+		if ( is_plugin_active( 'user-activation-keys/ds_wp3_user_activation_keys.php' ) ) {
+			require_once WP_PLUGIN_DIR . '/user-activation-keys/ds_wp3_user_activation_keys.php';
+			$ds_wp3_user_activation_keys = new \DS_User_Activation_Keys();
+			add_submenu_page(
+				$this->usersSlug,
+				__( 'User Activation Keys', 'pressbooks' ),
+				__( 'User Activation Keys', 'pressbooks' ),
+				'edit_users',
+				'act_keys',
+				[ $ds_wp3_user_activation_keys, 'ds_delete_stale' ]
+			);
+		}
+
 		// Appearance
 		add_submenu_page(
 			$this->getContextSlug( 'customize.php', true ),
@@ -570,7 +585,6 @@ class SideBar {
 			}
 		}
 	}
-
 	public function reorderSuperAdminMenu( array $menu_order ): array {
 		if ( ! is_network_admin() && $this->isNetworkAnalyticsActive ) {
 			array_splice( $menu_order, 8, 0, network_admin_url( 'admin.php?page=pb_network_analytics_admin' ) );

--- a/inc/admin/menus/class-sidebar.php
+++ b/inc/admin/menus/class-sidebar.php
@@ -134,16 +134,7 @@ class SideBar {
 	}
 
 	private function removeAdminLegacyItems(): void {
-		array_map( 'remove_submenu_page',
-			[
-				'index.php',
-				'edit.php?post_type=page',
-			],
-			[
-				'pb_catalog',
-				'post-new.php?post_type=page',
-			]
-		);
+		remove_submenu_page( 'edit.php?post_type=page', 'post-new.php?post_type=page' );
 
 		array_map( 'remove_menu_page',
 			[


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks/issues/3250

This PR enables the `pb_catalog` pages to make it accessible via URL.
It also adds the Users Activation Keys submenu item when the proper plugin is active, for super admins.

Note: it also adds the `Bulk Add` submenu item in Users menu when Network Analytics plugin is inactive.

We had a pair programming session with @fdalcin (reviewer), he knows the testing process of this.