### PR TITLE
fix: deprecation notices

### DIFF
--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -19,12 +19,12 @@ jobs:
     - name: Setup PHP with tools
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '8.0'
+        php-version: '8.1'
         tools: composer, wp-cli/wp-cli-bundle
     - name: Update POT file
       run: wp i18n make-pot . languages/pressbooks.pot --domain=pressbooks --slug=pressbooks --package-name="Pressbooks" --headers="{\"Report-Msgid-Bugs-To\":\"https://github.com/pressbooks/pressbooks/issues\"}"
     - name: Commit updated POT file
       uses: stefanzweifel/git-auto-commit-action@v4.16.0
       with:
-        commit_message: 'chore(l10n): update languages/pressbooks.pot'
+        commit_message: 'chore(l10n): update languages/pressbooks.pot [ci skip]'
         file_pattern: '*.pot'

--- a/inc/admin/class-exportoptions.php
+++ b/inc/admin/class-exportoptions.php
@@ -32,6 +32,13 @@ class ExportOptions extends \Pressbooks\Options {
 	public $defaults;
 
 	/**
+	 * Export booleans.
+	 *
+	 * @var array
+	 */
+	public $booleans;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param array $options

--- a/inc/admin/class-publishoptions.php
+++ b/inc/admin/class-publishoptions.php
@@ -32,6 +32,13 @@ class PublishOptions extends \Pressbooks\Options {
 	public $defaults;
 
 	/**
+	 * Publish URLs.
+	 *
+	 * @var array
+	 */
+	private $urls;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param array $options

--- a/inc/admin/class-publishoptions.php
+++ b/inc/admin/class-publishoptions.php
@@ -36,7 +36,7 @@ class PublishOptions extends \Pressbooks\Options {
 	 *
 	 * @var array
 	 */
-	private $urls;
+	public $urls;
 
 	/**
 	 * Constructor.

--- a/inc/admin/network/class-sharingandprivacyoptions.php
+++ b/inc/admin/network/class-sharingandprivacyoptions.php
@@ -44,6 +44,20 @@ class SharingAndPrivacyOptions extends \Pressbooks\Options {
 	public $defaults;
 
 	/**
+	 * Sharing and Privacy booleans.
+	 *
+	 * @var array
+	 */
+	public $booleans;
+
+	/**
+	 * Sharing and Privacy multiline strings.
+	 *
+	 * @var array
+	 */
+	public $multiline_strings;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param array $options

--- a/inc/class-contributors.php
+++ b/inc/class-contributors.php
@@ -717,7 +717,7 @@ class Contributors implements BackMatter, Transferable {
 				} else {
 					$suffix = '';
 				}
-				$name = $suffix ? "${name}${suffix}" : $name;
+				$name = $suffix ? "{$name}{$suffix}" : $name;
 			} elseif ( ! empty( $term->name ) ) {
 				$name = $term->name;
 			}

--- a/inc/class-htmlparser.php
+++ b/inc/class-htmlparser.php
@@ -44,7 +44,7 @@ class HtmlParser {
 		$html = '<div><!-- pb_fixme -->' . $html . '<!-- pb_fixme --></div>';
 		if ( $this->parser instanceof \DOMDocument ) {
 			libxml_use_internal_errors( true );
-			$this->parser->loadHTML( htmlspecialchars( $html, ENT_COMPAT | ENT_HTML5, 'UTF-8' ), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
+			$this->parser->loadHTML( mb_convert_encoding( $html, 'HTML-ENTITIES', 'UTF-8' ), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
 			$this->errors = libxml_get_errors();
 			libxml_clear_errors();
 			return $this->parser;

--- a/inc/class-htmlparser.php
+++ b/inc/class-htmlparser.php
@@ -44,7 +44,7 @@ class HtmlParser {
 		$html = '<div><!-- pb_fixme -->' . $html . '<!-- pb_fixme --></div>';
 		if ( $this->parser instanceof \DOMDocument ) {
 			libxml_use_internal_errors( true );
-			$this->parser->loadHTML( mb_convert_encoding( $html, 'HTML-ENTITIES', 'UTF-8' ), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
+			$this->parser->loadHTML( htmlspecialchars( $html, ENT_COMPAT | ENT_HTML5, 'UTF-8' ), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
 			$this->errors = libxml_get_errors();
 			libxml_clear_errors();
 			return $this->parser;

--- a/inc/image/namespace.php
+++ b/inc/image/namespace.php
@@ -43,7 +43,7 @@ function default_cover_url( $size = 'full' ) {
 	 *
 	 * @since 5.4.0
 	 */
-	return apply_filters( 'pb_default_cover_url', PB_PLUGIN_URL . "assets/dist/images/default-book-cover${suffix}.jpg", $suffix );
+	return apply_filters( 'pb_default_cover_url', PB_PLUGIN_URL . "assets/dist/images/default-book-cover{$suffix}.jpg", $suffix );
 }
 
 /**
@@ -78,7 +78,7 @@ function default_cover_path( $size = 'full' ) {
 	 *
 	 * @since 5.4.0
 	 */
-	return apply_filters( 'pb_default_cover_path', PB_PLUGIN_DIR . "assets/dist/images/default-book-cover${suffix}.jpg", $suffix );
+	return apply_filters( 'pb_default_cover_path', PB_PLUGIN_DIR . "assets/dist/images/default-book-cover{$suffix}.jpg", $suffix );
 }
 
 /**

--- a/inc/metadata/namespace.php
+++ b/inc/metadata/namespace.php
@@ -1268,7 +1268,7 @@ function transform_institutions( array $institutions ): array {
  */
 function transform_regions( string $country, array $regions ): array {
 	return array_reduce( $regions, static function( $values, $region ) use ( $country ) {
-		$institutions = [ "${country}/${region['name']}" => transform_institutions( $region['institutions'] ?? [] ) ];
+		$institutions = [ "{$country}/{$region['name']}" => transform_institutions( $region['institutions'] ?? [] ) ];
 
 		return array_merge( $values, $institutions );
 	}, [] );

--- a/inc/modules/export/class-exporthelpers.php
+++ b/inc/modules/export/class-exporthelpers.php
@@ -163,7 +163,7 @@ trait ExportHelpers {
 			if ( $sections ) {
 				foreach ( $sections as $id => $subsection ) {
 					$subsections[] = [
-						'slug' => $is_slug ? "#{$id}" : "${data['href']}#{$id}",
+						'slug' => $is_slug ? "#{$id}" : "{$data['href']}#{$id}",
 						'title' => Sanitize\decode( $subsection, $exclude_ampersand ),
 					];
 				}

--- a/inc/modules/export/epub/class-epub.php
+++ b/inc/modules/export/epub/class-epub.php
@@ -927,7 +927,7 @@ class Epub extends ExportGenerator {
 	 * @throws \Exception
 	 */
 	protected function createContainer(): void {
-		$this->createEpubFile( 'mimetype', utf8_decode( 'application/epub+zip' ), [ 'directory' => $this->tmpDir ] );
+		$this->createEpubFile( 'mimetype', mb_convert_encoding( 'application/epub+zip', 'ISO-8859-1', 'UTF-8' ), [ 'directory' => $this->tmpDir ] );
 
 		mkdir( $this->metaInfDir );
 		mkdir( $this->epubDir );

--- a/inc/modules/export/epub/class-epub.php
+++ b/inc/modules/export/epub/class-epub.php
@@ -1952,7 +1952,7 @@ class Epub extends ExportGenerator {
 				$chapter_type = $this->taxonomy->getChapterType( $chapter_data['ID'] );
 
 				if ( 'numberless' !== $chapter_type && $this->numbered ) {
-					$chapter_data['title'] = "${chapters_count}. ${chapter_data['title']}";
+					$chapter_data['title'] = "{$chapters_count}. {$chapter_data['title']}";
 					$chapters_count++;
 				}
 

--- a/inc/modules/themeoptions/class-ebookoptions.php
+++ b/inc/modules/themeoptions/class-ebookoptions.php
@@ -19,18 +19,53 @@ class EbookOptions extends \Pressbooks\Options {
 	const VERSION = 2;
 
 	/**
-	 * Web theme options.
+	 * Ebook theme options.
 	 *
 	 * @var array
 	 */
 	public $options;
 
 	/**
-	 * Web theme defaults.
+	 * Ebook theme defaults.
 	 *
 	 * @var array
 	 */
 	public $defaults;
+
+	/**
+	 * Ebook theme booleans.
+	 *
+	 * @var array
+	 */
+	private $booleans;
+
+	/**
+	 * Ebook theme strings.
+	 *
+	 * @var array
+	 */
+	private $strings;
+
+	/**
+	 * Ebook theme integers.
+	 *
+	 * @var array
+	 */
+	private $integers;
+
+	/**
+	 * Ebook theme floats.
+	 *
+	 * @var array
+	 */
+	private $floats;
+
+	/**
+	 * Ebook theme predefined options.
+	 *
+	 * @var array
+	 */
+	private $predefined;
 
 	/**
 	 * Constructor.

--- a/inc/modules/themeoptions/class-ebookoptions.php
+++ b/inc/modules/themeoptions/class-ebookoptions.php
@@ -37,35 +37,35 @@ class EbookOptions extends \Pressbooks\Options {
 	 *
 	 * @var array
 	 */
-	private $booleans;
+	public $booleans;
 
 	/**
 	 * Ebook theme strings.
 	 *
 	 * @var array
 	 */
-	private $strings;
+	public $strings;
 
 	/**
 	 * Ebook theme integers.
 	 *
 	 * @var array
 	 */
-	private $integers;
+	public $integers;
 
 	/**
 	 * Ebook theme floats.
 	 *
 	 * @var array
 	 */
-	private $floats;
+	public $floats;
 
 	/**
 	 * Ebook theme predefined options.
 	 *
 	 * @var array
 	 */
-	private $predefined;
+	public $predefined;
 
 	/**
 	 * Constructor.

--- a/inc/modules/themeoptions/class-globaloptions.php
+++ b/inc/modules/themeoptions/class-globaloptions.php
@@ -36,6 +36,41 @@ class GlobalOptions extends \Pressbooks\Options {
 	public $defaults;
 
 	/**
+	 * Global theme booleans.
+	 *
+	 * @var array
+	 */
+	private $booleans;
+
+	/**
+	 * Global theme strings.
+	 *
+	 * @var array
+	 */
+	private $strings;
+
+	/**
+	 * Global theme integers.
+	 *
+	 * @var array
+	 */
+	private $integers;
+
+	/**
+	 * Global theme floats.
+	 *
+	 * @var array
+	 */
+	private $floats;
+
+	/**
+	 * Global theme predefined options.
+	 *
+	 * @var array
+	 */
+	private $predefined;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param array $options

--- a/inc/modules/themeoptions/class-globaloptions.php
+++ b/inc/modules/themeoptions/class-globaloptions.php
@@ -40,35 +40,35 @@ class GlobalOptions extends \Pressbooks\Options {
 	 *
 	 * @var array
 	 */
-	private $booleans;
+	public $booleans;
 
 	/**
 	 * Global theme strings.
 	 *
 	 * @var array
 	 */
-	private $strings;
+	public $strings;
 
 	/**
 	 * Global theme integers.
 	 *
 	 * @var array
 	 */
-	private $integers;
+	public $integers;
 
 	/**
 	 * Global theme floats.
 	 *
 	 * @var array
 	 */
-	private $floats;
+	public $floats;
 
 	/**
 	 * Global theme predefined options.
 	 *
 	 * @var array
 	 */
-	private $predefined;
+	public $predefined;
 
 	/**
 	 * Constructor.

--- a/inc/modules/themeoptions/class-pdfoptions.php
+++ b/inc/modules/themeoptions/class-pdfoptions.php
@@ -41,35 +41,35 @@ class PDFOptions extends \Pressbooks\Options {
 	 *
 	 * @var array
 	 */
-	private $booleans;
+	public $booleans;
 
 	/**
 	 * PDF theme strings.
 	 *
 	 * @var array
 	 */
-	private $strings;
+	public $strings;
 
 	/**
 	 * PDF theme integers.
 	 *
 	 * @var array
 	 */
-	private $integers;
+	public $integers;
 
 	/**
 	 * PDF theme floats.
 	 *
 	 * @var array
 	 */
-	private $floats;
+	public $floats;
 
 	/**
 	 * PDF theme predefined options.
 	 *
 	 * @var array
 	 */
-	private $predefined;
+	public $predefined;
 
 	/**
 	 * Constructor.

--- a/inc/modules/themeoptions/class-pdfoptions.php
+++ b/inc/modules/themeoptions/class-pdfoptions.php
@@ -37,6 +37,41 @@ class PDFOptions extends \Pressbooks\Options {
 	public $defaults;
 
 	/**
+	 * PDF theme booleans.
+	 *
+	 * @var array
+	 */
+	private $booleans;
+
+	/**
+	 * PDF theme strings.
+	 *
+	 * @var array
+	 */
+	private $strings;
+
+	/**
+	 * PDF theme integers.
+	 *
+	 * @var array
+	 */
+	private $integers;
+
+	/**
+	 * PDF theme floats.
+	 *
+	 * @var array
+	 */
+	private $floats;
+
+	/**
+	 * PDF theme predefined options.
+	 *
+	 * @var array
+	 */
+	private $predefined;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param array $options

--- a/inc/modules/themeoptions/class-weboptions.php
+++ b/inc/modules/themeoptions/class-weboptions.php
@@ -36,6 +36,41 @@ class WebOptions extends \Pressbooks\Options {
 	public $defaults;
 
 	/**
+	 * Web theme booleans.
+	 *
+	 * @var array
+	 */
+	private $booleans;
+
+	/**
+	 * Web theme strings.
+	 *
+	 * @var array
+	 */
+	private $strings;
+
+	/**
+	 * Web theme integers.
+	 *
+	 * @var array
+	 */
+	private $integers;
+
+	/**
+	 * Web theme floats.
+	 *
+	 * @var array
+	 */
+	private $floats;
+
+	/**
+	 * Web theme predefined options.
+	 *
+	 * @var array
+	 */
+	private $predefined;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param array $options

--- a/inc/modules/themeoptions/class-weboptions.php
+++ b/inc/modules/themeoptions/class-weboptions.php
@@ -40,35 +40,35 @@ class WebOptions extends \Pressbooks\Options {
 	 *
 	 * @var array
 	 */
-	private $booleans;
+	public $booleans;
 
 	/**
 	 * Web theme strings.
 	 *
 	 * @var array
 	 */
-	private $strings;
+	public $strings;
 
 	/**
 	 * Web theme integers.
 	 *
 	 * @var array
 	 */
-	private $integers;
+	public $integers;
 
 	/**
 	 * Web theme floats.
 	 *
 	 * @var array
 	 */
-	private $floats;
+	public $floats;
 
 	/**
 	 * Web theme predefined options.
 	 *
 	 * @var array
 	 */
-	private $predefined;
+	public $predefined;
 
 	/**
 	 * Constructor.

--- a/tests/test-exporthelpers.php
+++ b/tests/test-exporthelpers.php
@@ -13,8 +13,8 @@ class ExportHelpersTest extends \WP_UnitTestCase {
 
 	protected $wrapHeaderElements = false;
 
-	private $taxonomy;
-	private $contributors;
+	public $taxonomy;
+	public $contributors;
 
 	/**
 	 * @group export_helpers

--- a/tests/test-exporthelpers.php
+++ b/tests/test-exporthelpers.php
@@ -13,6 +13,9 @@ class ExportHelpersTest extends \WP_UnitTestCase {
 
 	protected $wrapHeaderElements = false;
 
+	private $taxonomy;
+	private $contributors;
+
 	/**
 	 * @group export_helpers
 	 */

--- a/tests/test-image.php
+++ b/tests/test-image.php
@@ -249,8 +249,8 @@ class ImageTest extends \WP_UnitTestCase {
 		 * Test PNGs with alpha channel
 		 */
 		$path = __DIR__ . '/data/';
-		$original = "${path}alpha.png";
-		$resized = "${path}alpha_resized.png";
+		$original = "{$path}alpha.png";
+		$resized = "{$path}alpha_resized.png";
 		copy( $original, $resized );
 
 		\Pressbooks\Image\resize_down( 'png', $resized, 400 );
@@ -264,8 +264,8 @@ class ImageTest extends \WP_UnitTestCase {
 		 * Test Jpeg
 		 */
 
-		$original = "${path}skates.jpg";
-		$resized = "${path}skates_resized.jpg";
+		$original = "{$path}skates.jpg";
+		$resized = "{$path}skates_resized.jpg";
 		copy( $original, $resized );
 
 		\Pressbooks\Image\resize_down( 'jpeg', $resized, 200 );

--- a/tests/test-options.php
+++ b/tests/test-options.php
@@ -27,6 +27,41 @@ class OptionsMock extends \Pressbooks\Options {
 	public $defaults;
 
 	/**
+	 * Export booleans.
+	 *
+	 * @var array
+	 */
+	private $booleans;
+
+	/**
+	 * Export strings.
+	 *
+	 * @var array
+	 */
+	private $strings;
+
+	/**
+	 * Export integers.
+	 *
+	 * @var array
+	 */
+	private $integers;
+
+	/**
+	 * Export floats.
+	 *
+	 * @var array
+	 */
+	private $floats;
+
+	/**
+	 * Export predefined options.
+	 *
+	 * @var array
+	 */
+	private $predefined;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param array $options The retrieved options.

--- a/tests/test-options.php
+++ b/tests/test-options.php
@@ -31,35 +31,35 @@ class OptionsMock extends \Pressbooks\Options {
 	 *
 	 * @var array
 	 */
-	private $booleans;
+	public $booleans;
 
 	/**
 	 * Export strings.
 	 *
 	 * @var array
 	 */
-	private $strings;
+	public $strings;
 
 	/**
 	 * Export integers.
 	 *
 	 * @var array
 	 */
-	private $integers;
+	public $integers;
 
 	/**
 	 * Export floats.
 	 *
 	 * @var array
 	 */
-	private $floats;
+	public $floats;
 
 	/**
 	 * Export predefined options.
 	 *
 	 * @var array
 	 */
-	private $predefined;
+	public $predefined;
 
 	/**
 	 * Constructor.
@@ -411,6 +411,7 @@ class OptionsTest extends \WP_UnitTestCase {
 	 * @group options
 	 */
 	public function test_deleteCacheAfterUpdate() {
+		define( 'DAY_IN_SECONDS', 24 * 60 * 60 );
 		$now = time() - 60;
 		set_transient( 'pb_cache_deleted', $now, DAY_IN_SECONDS );
 

--- a/tests/test-options.php
+++ b/tests/test-options.php
@@ -411,7 +411,6 @@ class OptionsTest extends \WP_UnitTestCase {
 	 * @group options
 	 */
 	public function test_deleteCacheAfterUpdate() {
-		define( 'DAY_IN_SECONDS', 24 * 60 * 60 );
 		$now = time() - 60;
 		set_transient( 'pb_cache_deleted', $now, DAY_IN_SECONDS );
 

--- a/tests/test-templates-export.php
+++ b/tests/test-templates-export.php
@@ -8,7 +8,7 @@ class TemplateExportTest extends \WP_UnitTestCase {
 	/**
 	 * @var Closure|\Jenssegers\Blade\Blade|mixed|object|null
 	 */
-	private mixed $blade;
+	public mixed $blade;
 
 	public function set_up() {
 		parent::set_up();

--- a/tests/test-templates-export.php
+++ b/tests/test-templates-export.php
@@ -5,6 +5,11 @@ use Pressbooks\Container;
 class TemplateExportTest extends \WP_UnitTestCase {
 	use utilsTrait;
 
+	/**
+	 * @var Closure|\Jenssegers\Blade\Blade|mixed|object|null
+	 */
+	private mixed $blade;
+
 	public function set_up() {
 		parent::set_up();
 		$this->blade = Container::get( 'Blade' );

--- a/tests/test-userbulk.php
+++ b/tests/test-userbulk.php
@@ -226,7 +226,7 @@ class UserBulkTest extends \WP_UnitTestCase {
 		if ( ! empty( $success ) ) {
 			$success_message_str = $doc->getElementById( 'bulk-success' )->textContent;
 			foreach( $success as $result ) {
-				$this->assertTrue( str_contains( $success_message_str, $result['email'] ) );
+				$this->assertTrue( str_contains( $success_message_str ?? '', $result['email'] ) );
 			}
 		}
 


### PR DESCRIPTION
This PR fixes PHP deprecation notices that display on CI test runs. It doesn't address the use of mb_convert_encoding in https://github.com/pressbooks/pressbooks/blob/8d8ed90ba313774146842cf438c6d32356a8e382/inc/class-htmlparser.php#L47. See https://php.watch/versions/8.2/mbstring-qprint-base64-uuencode-html-entities-deprecated#html for details on that one.