### PR TITLE
Fix: restore heartbeat on non-import/export/cloning admin pages

### DIFF
--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -422,7 +422,6 @@ function replace_book_admin_menu() {
 							'reloadSnippet' => '<em>(<a href="javascript:window.location.reload(true)">' . __( 'Reload', 'pressbooks' ) . '</a>)</em>',
 						]
 					);
-					global $wp_scripts;
 					wp_enqueue_script( 'pb-cloner' );
 					wp_deregister_script( 'heartbeat' );
 				}

--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -635,7 +635,6 @@ function add_pb_cloner_page() {
 			);
 			global $wp_scripts;
 			wp_enqueue_script( 'pb-cloner' );
-			wp_deregister_script( 'heartbeat' );
 		}
 	);
 }

--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -422,6 +422,7 @@ function replace_book_admin_menu() {
 							'reloadSnippet' => '<em>(<a href="javascript:window.location.reload(true)">' . __( 'Reload', 'pressbooks' ) . '</a>)</em>',
 						]
 					);
+					global $wp_scripts;
 					wp_enqueue_script( 'pb-cloner' );
 					wp_deregister_script( 'heartbeat' );
 				}
@@ -621,21 +622,6 @@ function add_pb_cloner_page() {
 		'read',
 		'pb_cloner',
 		__NAMESPACE__ . '\display_cloner'
-	);
-	add_action(
-		'admin_enqueue_scripts',
-		function () {
-			wp_localize_script(
-				'pb-cloner', 'PB_ClonerToken', [
-					'ajaxUrl' => wp_nonce_url( admin_url( 'admin-ajax.php?action=clone-book' ), 'pb-cloner' ),
-					'redirectUrl' => admin_url( 'admin.php?page=pb_cloner' ),
-					'unloadWarning' => __( 'Cloning is not done. Leaving this page, now, will cause problems. Are you sure?', 'pressbooks' ),
-					'reloadSnippet' => '<em>(<a href="javascript:window.location.reload(true)">' . __( 'Reload', 'pressbooks' ) . '</a>)</em>',
-				]
-			);
-			global $wp_scripts;
-			wp_enqueue_script( 'pb-cloner' );
-		}
 	);
 }
 

--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -615,13 +615,30 @@ function fix_root_admin_menu() {
 }
 
 function add_pb_cloner_page() {
-	add_submenu_page(
+	$cloner_page = add_submenu_page(
 		null,
 		__( 'Clone a Book', 'pressbooks' ),
 		__( 'Clone a Book', 'pressbooks' ),
 		'read',
 		'pb_cloner',
 		__NAMESPACE__ . '\display_cloner'
+	);
+	add_action(
+		'admin_enqueue_scripts',
+		function ( $hook ) use ( $cloner_page ) {
+			if ( $hook === $cloner_page ) {
+				wp_localize_script(
+					'pb-cloner', 'PB_ClonerToken', [
+						'ajaxUrl' => wp_nonce_url( admin_url( 'admin-ajax.php?action=clone-book' ), 'pb-cloner' ),
+						'redirectUrl' => admin_url( 'admin.php?page=pb_cloner' ),
+						'unloadWarning' => __( 'Cloning is not done. Leaving this page, now, will cause problems. Are you sure?', 'pressbooks' ),
+						'reloadSnippet' => '<em>(<a href="javascript:window.location.reload(true)">' . __( 'Reload', 'pressbooks' ) . '</a>)</em>',
+					]
+				);
+				wp_enqueue_script( 'pb-cloner' );
+				wp_deregister_script( 'heartbeat' );
+			}
+		}
 	);
 }
 

--- a/inc/cloner/class-cloner.php
+++ b/inc/cloner/class-cloner.php
@@ -133,7 +133,7 @@ class Cloner {
 	 *
 	 * @var array
 	 */
-	protected $termMap = [];
+	protected $termMap = [ 'default' => true ];
 
 	/**
 	 * An array of cloned items.

--- a/tests/test-admin-laf.php
+++ b/tests/test-admin-laf.php
@@ -156,7 +156,7 @@ class Admin_LafTest extends \WP_UnitTestCase {
 		$GLOBALS['post'] = get_post( $this->factory()->post->create_object( $new_post ) );
 		$GLOBALS['current_screen'] = WP_Screen::get( 'post' );
 		\Pressbooks\Admin\Laf\init_css_js();
-		do_action( 'admin_enqueue_scripts' );
+		do_action( 'admin_enqueue_scripts', 'admin_page_pb_cloner' );
 		$this->assertContains( 'pb-cloner', $wp_scripts->queue );
 
 		unset( $GLOBALS['post'], $GLOBALS['current_screen'] ); // Cleanup


### PR DESCRIPTION
This PR addresses https://github.com/pressbooks/pressbooks/issues/3268. We need to add a check to only add pb-clone scripts and remove the heartbeat scripts on the cloner page, instead of all admin pages.