### PR TITLE
fix: authors cleaned up during collection

### DIFF
--- a/inc/datacollector/class-book.php
+++ b/inc/datacollector/class-book.php
@@ -307,12 +307,6 @@ class Book {
 		$in_catalog = empty( get_option( get_in_catalog_option() ) ) ? 0 : 1;
 		update_site_meta( $book_id, self::IN_CATALOG, $in_catalog );
 
-		// pb_authors is being skipped by the getBookInformation() method when reading metadata from the database
-		// we need to check if it's empty and if so, read it from the database
-		if ( count( $metadata['pb_authors'] ) === 0 ) {
-			$metadata['pb_authors'] = get_site_meta( $book_id, self::AUTHORS );
-		}
-
 		$this->saveArrayMetadata( $book_id, self::AUTHORS, 'name', $metadata );
 
 		$this->saveArrayMetadata( $book_id, self::EDITORS, 'name', $metadata );
@@ -434,12 +428,13 @@ class Book {
 	 * @return void
 	 */
 	private function saveArrayMetadata( int $blog_id, string $meta_key, string $array_key, array $metadata ): void {
-		// clean up meta key before adding
-		delete_site_meta( $blog_id, $meta_key );
-
 		if ( isset( $metadata[ $meta_key ] ) && is_array( $metadata[ $meta_key ] ) ) {
 			foreach ( $metadata[ $meta_key ] as $value ) {
-				add_site_meta( $blog_id, $meta_key, $value[ $array_key ] );
+				// clean up meta key before adding
+				delete_site_meta( $blog_id, $meta_key, $value[ $array_key ] );
+				if ( is_array( $value ) ) {
+					add_site_meta( $blog_id, $meta_key, $value[ $array_key ] );
+				}
 			}
 		}
 	}

--- a/inc/datacollector/class-book.php
+++ b/inc/datacollector/class-book.php
@@ -307,6 +307,12 @@ class Book {
 		$in_catalog = empty( get_option( get_in_catalog_option() ) ) ? 0 : 1;
 		update_site_meta( $book_id, self::IN_CATALOG, $in_catalog );
 
+		// pb_authors is being skipped by the getBookInformation() method when reading metadata from the database
+		// we need to check if it's empty and if so, read it from the database
+		if ( count( $metadata['pb_authors'] ) === 0 ) {
+			$metadata['pb_authors'] = get_site_meta( $book_id, self::AUTHORS );
+		}
+
 		$this->saveArrayMetadata( $book_id, self::AUTHORS, 'name', $metadata );
 
 		$this->saveArrayMetadata( $book_id, self::EDITORS, 'name', $metadata );


### PR DESCRIPTION
Related https://github.com/pressbooks/pressbooks-network-catalog/issues/195

To test this

1. Save the book information adding some authors
2. Run the data collector to copy metadata on blog meta (https://github.com/pressbooks/pressbooks-network-analytics#setup)
3. Review the catalog has the authors after the data collector run
4. Review the endpoints has the authors as expected