### PR TITLE
feat: collect more book metadata for bi data manager

### DIFF
--- a/inc/datacollector/class-book.php
+++ b/inc/datacollector/class-book.php
@@ -321,17 +321,19 @@ class Book {
 		$supported_types = $licensing->getSupportedTypes();
 
 		// pb_license_code
+		$book_license = $metadata['pb_book_license'] ?? 'all-rights-reserved';
+
 		update_site_meta(
 			$book_id,
 			self::LICENSE_CODE,
-			$supported_types[ $metadata['pb_book_license'] ?? 'all-rights-reserved' ]['abbreviation'] ?? 'All Rights Reserved'
+			$supported_types[ $book_license ]['abbreviation'] ?? 'All Rights Reserved'
 		);
 
 		// pb_license_name
 		update_site_meta(
 			$book_id,
 			self::LICENSE_NAME,
-			$supported_types[ $metadata['pb_book_license'] ?? 'all-rights-reserved' ]['desc'] ?? 'all-rights-reserved'
+			$supported_types[ $book_license ]['desc'] ?? 'all-rights-reserved'
 		);
 
 		// pb_is_public

--- a/inc/datacollector/class-book.php
+++ b/inc/datacollector/class-book.php
@@ -279,11 +279,8 @@ class Book {
 		update_site_meta( $book_id, self::LANGUAGE, $book_language );
 
 		$languages = \Pressbooks\L10n\supported_languages();
-		$language = ( array_key_exists( $book_language, $languages ) ) ?
-			$languages[ $book_language ] : 'English';
-
 		// pb_language_name
-		update_site_meta( $book_id, self::LANGUAGE_NAME, $language );
+		update_site_meta( $book_id, self::LANGUAGE_NAME, $languages[ $book_language ] ?? 'English' );
 
 		// pb_subject
 		$subject_list = '';

--- a/tests/test-datacollector-book.php
+++ b/tests/test-datacollector-book.php
@@ -144,7 +144,6 @@ class DataCollector_BookTest extends \WP_UnitTestCase {
 		add_post_meta( $metadata_post->ID, 'pb_publisher', 'Publisher Name' );
 		add_post_meta( $metadata_post->ID, 'pb_language', 'en' );
 		add_post_meta( $metadata_post->ID, 'pb_book_license', 'public-domain' );
-		add_post_meta( $metadata_post->ID, 'pb_book_license', 'public-domain' );
 
 		wp_cache_flush();
 

--- a/tests/test-datacollector-book.php
+++ b/tests/test-datacollector-book.php
@@ -120,6 +120,10 @@ class DataCollector_BookTest extends \WP_UnitTestCase {
 				[ 'name' =>  'Pat Metheny', 'slug' => 'pat' ],
 				[ 'name' =>  'Pedro Aznar', 'slug' => 'pedro' ],
 			],
+			'pb_contributors' => [
+				[ 'name' =>  'Lyle Mays', 'slug' => 'lyle' ],
+				[ 'name' =>  'Steve Rodby', 'slug' => 'steve' ],
+			],
 		];
 
 		$site = get_site();
@@ -138,6 +142,9 @@ class DataCollector_BookTest extends \WP_UnitTestCase {
 		add_post_meta( $metadata_post->ID, 'pb_additional_subjects', 'AVP, AVR, AVRQ' );
 		add_post_meta( $metadata_post->ID, 'pb_institutions', 'CA-ON-002' );
 		add_post_meta( $metadata_post->ID, 'pb_publisher', 'Publisher Name' );
+		add_post_meta( $metadata_post->ID, 'pb_language', 'en' );
+		add_post_meta( $metadata_post->ID, 'pb_book_license', 'public-domain' );
+		add_post_meta( $metadata_post->ID, 'pb_book_license', 'public-domain' );
 
 		wp_cache_flush();
 
@@ -146,6 +153,7 @@ class DataCollector_BookTest extends \WP_UnitTestCase {
 		$data_collected = [
 			'pb_authors' => get_site_meta( $site->id, BookDataCollector::AUTHORS ),
 			'pb_editors' => get_site_meta( $site->id, BookDataCollector::EDITORS ),
+			'pb_contributors' => get_site_meta( $site->id, BookDataCollector::CONTRIBUTORS ),
 		];
 
 		foreach ( $contributors as $contributor_type => $contributors_array ) {
@@ -164,6 +172,8 @@ class DataCollector_BookTest extends \WP_UnitTestCase {
 		$this->assertContains( 'AVRQ', $subjects_collected );
 		$this->assertEquals( 'Publisher Name', get_site_meta( $site->id, BookDataCollector::PUBLISHER, true ) );
 		$this->assertEquals( 'Theory of art', get_site_meta( $site->id, BookDataCollector::SUBJECT, true ) );
+		$this->assertEquals( 'English', get_site_meta( $site->id, BookDataCollector::LANGUAGE_NAME, true ) );
+		$this->assertEquals( 'Public Domain', get_site_meta( $site->id, BookDataCollector::LICENSE_NAME, true ) );
 	}
 
 	/**


### PR DESCRIPTION
Issue: https://github.com/pressbooks/book-directory-fetcher/issues/476

This PR adds more book metadata to the book data collector in order to use it in BI data manager app and be available to send it to Algolia.

### Testing case
- For a particular book complete: authors, editors, contributors, subtitle, language, license and cover image.
- Run the collector through `https://pressbooks.test/wp/wp-admin/network/admin.php?page=pb_network_analytics_booklist_sync`
- Inspect the `wp_blogmeta` table and make sure the following metadata is included and is correct:
  - `pb_thumbnail_image`
  - `pb_language_name `
  - `pb_license_code `
  - `pb_license_name`
  - `pb_contributors `