### PR TITLE
fix: allow access to user activation keys page to network managers

### DIFF
--- a/inc/admin/menus/class-sidebar.php
+++ b/inc/admin/menus/class-sidebar.php
@@ -84,14 +84,12 @@ class SideBar {
 				'sites.php',
 				'users.php',
 				'users.php',
-				'users.php',
 			],
 			[
 				'pb_network_analytics_booklist',
 				'site-new.php',
 				'pb_network_analytics_userlist',
 				'user-new.php',
-				'act_keys',
 			]
 		);
 
@@ -355,7 +353,7 @@ class SideBar {
 			require_once WP_PLUGIN_DIR . '/user-activation-keys/ds_wp3_user_activation_keys.php';
 			$ds_wp3_user_activation_keys = new \DS_User_Activation_Keys();
 			add_submenu_page(
-				$this->usersSlug,
+				null,
 				__( 'User Activation Keys', 'pressbooks' ),
 				__( 'User Activation Keys', 'pressbooks' ),
 				'edit_users',


### PR DESCRIPTION
Issue: #3313 

This PR adds the User Activation Keys access for network managers and removes it as a submenu item for Users menu for super admin users.
The only way to access to the page is through `<NETWORK_URL>/wp-admin/network/admin.php?page=act_keys`.

### Testing case
- Log in as a super admin user.
- `User Activation Keys` submenu item should NOT be present in any menu item, including Users.
- You should be able to access it through `<NETWORK_URL>/wp-admin/network/admin.php?page=act_keys`.
- Log in as a Network Manager user.
- `User Activation Keys` submenu item should NOT be present in any menu item, including Users.
- You should be able to access it through `<NETWORK_URL>/wp-admin/network/admin.php?page=act_keys`.