### PR TITLE
fix: make book api consistent

### DIFF
--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -216,7 +216,7 @@ class ApiTest extends \WP_UnitTestCase {
 			'CC BY' => 'cc-by',
 		];
 
-		$network_options = get_site_option( SharingAndPrivacyOptions::getSlug() );
+		$network_options = get_site_option( SharingAndPrivacyOptions::getSlug(), [] );
 		$network_options[ SharingAndPrivacyOptions::NETWORK_DIRECTORY_EXCLUDED ] = $exclude_directory_catalog;
 		update_site_option( SharingAndPrivacyOptions::getSlug(), $network_options );
 
@@ -253,11 +253,16 @@ class ApiTest extends \WP_UnitTestCase {
 		foreach ( $metadata as $meta ) {
 			$this->_book();
 			$book_id = get_current_blog_id();
+			$meta_post_id = ( new Pressbooks\Metadata )->getMetaPostId();
+
+			update_post_meta( $meta_post_id, Book::TITLE, $meta[ Book::TITLE ] );
+
 			foreach ( $meta as $key => $value ) {
 				$metadata_info_array = $book_collector->get( $book_id, Book::BOOK_INFORMATION_ARRAY );
 
 				if ( $key === Book::LICENSE_CODE ) {
-					$metadata_info_array['pb_book_license'] = $licenses_map[ $value ];
+					$metadata_info_array[ Book::LICENSE ] = $licenses_map[ $value ];
+					update_post_meta( $meta_post_id, Book::LICENSE, $licenses_map[ $value ] );
 				} else {
 					$metadata_info_array[ $key ] = $value;
 				}


### PR DESCRIPTION
Issue pressbooks/private#1172

This PR attempts to improve the API consistency for the books and metadata endpoints.
The books endpoint at `/pressbooks/v2/books` was retrieving inconsistent results for authors and contributors.

**How to test**

1. With the `dev` branch checked out
2. Visit the books endpoint and look for books that don't have authors or contributors
3. Visit the metadata endpoint for that book and check if the book actually has authors or contributors (If no inconsistency is found, this will be a bit harder to test locally)
4. Check out this branch
5. Visit the books endpoint and validate that authors and contributors are displayed as expected in the new branch