### PR TITLE
fix: check book information array before removing bisac

### DIFF
--- a/inc/class-book.php
+++ b/inc/class-book.php
@@ -251,7 +251,7 @@ class Book {
 		global $blog_id;
 		$book_data_collector = BookDataCollector::init();
 		$book_information_array = $book_data_collector->get( $blog_id, BookDataCollector::BOOK_INFORMATION_ARRAY );
-		if ( self::removeInvalidatedBisacCodes( $blog_id, $book_information_array ) ) {
+		if ( $book_information_array && self::removeInvalidatedBisacCodes( $blog_id, $book_information_array ) ) {
 			add_error( __(
 				"This book was using a <a href='https://bisg.org/page/InactivatedCodes' target='_blank'> retired BISAC subject term </a>, which has been replaced in your book with a recommended BISAC replacement. You may wish to check the BISAC subject terms manually to confirm that you are satisfied with these replacements."
 			) );

--- a/inc/class-book.php
+++ b/inc/class-book.php
@@ -251,7 +251,7 @@ class Book {
 		global $blog_id;
 		$book_data_collector = BookDataCollector::init();
 		$book_information_array = $book_data_collector->get( $blog_id, BookDataCollector::BOOK_INFORMATION_ARRAY );
-		if ( $book_information_array && self::removeInvalidatedBisacCodes( $blog_id, $book_information_array ) ) {
+		if ( is_array( $book_information_array ) && self::removeInvalidatedBisacCodes( $blog_id, $book_information_array ) ) {
 			add_error( __(
 				"This book was using a <a href='https://bisg.org/page/InactivatedCodes' target='_blank'> retired BISAC subject term </a>, which has been replaced in your book with a recommended BISAC replacement. You may wish to check the BISAC subject terms manually to confirm that you are satisfied with these replacements."
 			) );


### PR DESCRIPTION
This PR fixes: https://github.com/pressbooks/pressbooks/issues/3285

When `pb_book_information_array` metadata from `blogmeta` table contains invalid bisac codes, or the meta value is not available, it throws there's an error trying to update the metadata.

### Replicating the issue
Don't checkout this branch to replicate this.

- Pick a book in your local environment and add BISAC subjects (at the end of book info).
- Go to your DB and edit `pb_book_information_array` meta value in `blogmeta` table. Edit one of the `pb_bisac_subject` serialized values and replace it with an invalid one.
- Refresh the Book Info page. You should see the error mentioned in the related issue.

### Test case
Follow the previous steps. 
You should not see any errors.

Once you save your book, the metadata will be auto-updated with the correct value.