### PR TITLE
fix: handle Ontario Commons licenses

### DIFF
--- a/inc/class-licensing.php
+++ b/inc/class-licensing.php
@@ -427,7 +427,7 @@ class Licensing {
 		} elseif ( $this->isSupportedType( $license ) ) {
 			$name = $this->getNameForLicense( $license );
 			$url  = $this->getUrlForLicense( $license );
-			if ( \Pressbooks\Utility\str_starts_with( $license, 'cc' ) || \Pressbooks\Utility\str_starts_with( $license, 'ontario' ) && $license !== 'cc-zero' ) {
+			if ( str_starts_with( $license, 'cc' ) && $license !== 'cc-zero' ) {
 				return sprintf(
 					'<div class="license-attribution"><p>%1$s</p><p>%2$s</p></div>',
 					sprintf( '<img src="%1$s" alt="%2$s" />', get_template_directory_uri() . '/packages/buckram/assets/images/' . $license . '.svg', sprintf( __( 'Icon for the %s', 'pressbooks' ), $name ) ),
@@ -476,6 +476,14 @@ class Licensing {
 						$copyright_holder,
 						sprintf( '<a href="%1$s">%2$s</a>', $link, $title )
 					)
+				);
+			} else {
+				return sprintf(
+					__( '%1$s Copyright &copy;%2$s by %3$s is licensed under a %4$s, except where otherwise noted.', 'pressbooks' ),
+					sprintf( '<a href="%1$s" property="dc:title">%2$s</a>', $link, $title ),
+					( $copyright_year ) ? ' ' . $copyright_year : '',
+					sprintf( '<span>%1$s</span>', $copyright_holder ),
+					sprintf( '<a rel="license" href="%1$s">%2$s</a>', $url, $name )
 				);
 			}
 		}

--- a/inc/class-licensing.php
+++ b/inc/class-licensing.php
@@ -427,7 +427,7 @@ class Licensing {
 		} elseif ( $this->isSupportedType( $license ) ) {
 			$name = $this->getNameForLicense( $license );
 			$url  = $this->getUrlForLicense( $license );
-			if ( \Pressbooks\Utility\str_starts_with( $license, 'cc' ) && $license !== 'cc-zero' ) {
+			if ( \Pressbooks\Utility\str_starts_with( $license, 'cc' ) || \Pressbooks\Utility\str_starts_with( $license, 'ontario' ) && $license !== 'cc-zero' ) {
 				return sprintf(
 					'<div class="license-attribution"><p>%1$s</p><p>%2$s</p></div>',
 					sprintf( '<img src="%1$s" alt="%2$s" />', get_template_directory_uri() . '/packages/buckram/assets/images/' . $license . '.svg', sprintf( __( 'Icon for the %s', 'pressbooks' ), $name ) ),


### PR DESCRIPTION
Partial fix for https://github.com/pressbooks/pressbooks/issues/3249. Ensure that the output for Ontario Commons licenses on copyright pages in exports are handled as expected.

To test:
1. Make sure the eCampusOntario plugin is network activated
2. Go to book info and add a date and apply one of the eCampusOntario copyright licenses
3. Produce a PDF and EPUB export
4. Ensure that the output on the title page includes the copyright name and year