### PR TITLE
fix: change name of Mount Royal University

### DIFF
--- a/symbionts/institutions/institutions.json
+++ b/symbionts/institutions/institutions.json
@@ -329,7 +329,7 @@
           },
           {
             "code": "CA-AB-010",
-            "name": "Mount Royal College",
+            "name": "Mount Royal University",
             "url": "https:\/\/www.mtroyal.ca\/"
           },
           {


### PR DESCRIPTION
Mount Royal College has been Mount Royal University since 2009. See https://pressbooks.community/t/institutions-list-how-to-add-to-it/2174/9 for user request.