### PR TITLE
fix: contributors taxonomy on collectors

### DIFF
--- a/inc/class-taxonomy.php
+++ b/inc/class-taxonomy.php
@@ -51,9 +51,8 @@ class Taxonomy {
 	/**
 	 * @param Taxonomy $obj
 	 */
-	static public function hooks( Taxonomy $obj ) {
+	public static function hooks( Taxonomy $obj ) {
 		if ( Book::isBook() ) {
-			add_action( 'init', [ $obj, 'registerTaxonomies' ] );
 			add_action( 'init', [ $obj, 'maybeUpgrade' ], 1000 );
 			add_action( 'user_register', [ $obj->contributors, 'addBlogUser' ] );
 			add_action( 'add_user_to_blog', [ $obj, 'registerTaxonomies' ] ); // This is a workaround because newbloguser does not fire init action.
@@ -69,6 +68,7 @@ class Taxonomy {
 			add_filter( 'license_row_actions', [ $obj, 'removeTaxonomyViewLinks' ], 10, 2 );
 			add_filter( 'contributor_row_actions', [ $obj, 'removeTaxonomyViewLinks' ], 10, 2 );
 		}
+		add_action( 'init', [ $obj, 'registerTaxonomies' ] );
 	}
 
 	/**

--- a/inc/datacollector/class-book.php
+++ b/inc/datacollector/class-book.php
@@ -469,9 +469,8 @@ class Book {
 	 */
 	private function saveArrayMetadata( int $blog_id, string $meta_key, string $array_key, array $metadata ): void {
 		if ( isset( $metadata[ $meta_key ] ) && is_array( $metadata[ $meta_key ] ) ) {
+			delete_site_meta( $blog_id, $meta_key );
 			foreach ( $metadata[ $meta_key ] as $value ) {
-				// clean up meta key before adding
-				delete_site_meta( $blog_id, $meta_key, $value[ $array_key ] );
 				if ( is_array( $value ) ) {
 					add_site_meta( $blog_id, $meta_key, $value[ $array_key ] );
 				}


### PR DESCRIPTION
See #3449 

This is a very obscure issue I don't know how we didn't realize the getAll method on contributors was not retuning the required information due the contributors taxonomy not being registered on noon book contexts.

The solution enable us to cleanup entirely the contributors associated to the book and then read them again to register the latest data in the collector.

How to test:

1. Save a few contributors, try to delete one of them and then try to add a new one.
2. Contributors should look OK in the catalog after saving metadata because is refreshed at this point
3. Run the collector manually and the records should match the stored configuration on book info, no orphans pb_authors should remain on the `wp_*_postmeta` tables

Notes:

Be aware the `pb_network_analytics_booklist_sync` action has a transient to cache the execution just in case