### PR TITLE
fix: translation domain namespace

### DIFF
--- a/inc/admin/dashboard/namespace.php
+++ b/inc/admin/dashboard/namespace.php
@@ -18,8 +18,8 @@ function init_network_integrations_menu(): string {
 	static $init_pb_network_integrations_menu = false;
 	if ( ! $init_pb_network_integrations_menu ) {
 		add_menu_page(
-			esc_html__( 'Integrations', 'pressbooks-lti-provider' ),
-			esc_html__( 'Integrations', 'pressbooks-lti-provider' ),
+			esc_html__( 'Integrations', 'pressbooks' ),
+			esc_html__( 'Integrations', 'pressbooks' ),
 			'manage_network',
 			$parent_slug,
 			'',


### PR DESCRIPTION
The integrations menu should work for any kind of "integrations" it should not be translated on the lti-provider namespace