### PR TITLE
fix: permissive content display

### DIFF
--- a/hooks.php
+++ b/hooks.php
@@ -4,6 +4,7 @@
  * @license GPLv3 (or any later version)
  */
 
+use Pressbooks\Privacy;
 use function \Pressbooks\Utility\include_plugins as include_symbionts;
 use Pressbooks\Book;
 use Pressbooks\CloneComplete;
@@ -352,4 +353,5 @@ add_action( 'init', [ CloneComplete::class, 'install' ] );
 
 add_filter( 'init', [ '\Pressbooks\Utility\ErrorHandler', 'init' ] );
 
-
+// Open up private content to subscribers and collaborators when permissive_private_content is enabled
+add_filter( 'init', [ Privacy::class, 'showPermissivePrivateContent' ] );

--- a/hooks.php
+++ b/hooks.php
@@ -4,11 +4,11 @@
  * @license GPLv3 (or any later version)
  */
 
-use Pressbooks\Privacy;
 use function \Pressbooks\Utility\include_plugins as include_symbionts;
 use Pressbooks\Book;
 use Pressbooks\CloneComplete;
 use Pressbooks\Container;
+use Pressbooks\Privacy;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/inc/class-privacy.php
+++ b/inc/class-privacy.php
@@ -80,7 +80,7 @@ class Privacy {
 				$current_user = wp_get_current_user();
 				$permissive_roles = [ 'subscriber', 'collaborator', 'author' ];
 				if ( $permissive_private_content && array_intersect( $permissive_roles, $current_user->roles ) ) {
-					$query->set( 'post_status', [ 'publish', 'pending', 'draft', 'web-only' ] );
+					$query->set( 'post_status', [ 'publish', 'pending', 'draft', 'private', 'web-only' ] );
 				}
 			}
 			return $query;

--- a/inc/class-privacy.php
+++ b/inc/class-privacy.php
@@ -67,4 +67,24 @@ class Privacy {
 
 		wp_add_privacy_policy_content( 'Pressbooks', wp_kses_post( wpautop( $content, false ) ) );
 	}
+
+	/**
+	 * @since 6.15.2
+	 *
+	 * A filter to allow permissive private content for certain roles.
+	 */
+	public static function showPermissivePrivateContent(): void
+	{
+		add_filter( 'pre_get_posts', function ( $query ) {
+			if( is_user_logged_in() ){
+				$permissive_private_content = (int) get_option( 'permissive_private_content', 0 );
+				$current_user = wp_get_current_user();
+				$permissive_roles = [ 'subscriber', 'collaborator', 'author' ];
+				if ( $permissive_private_content && array_intersect( $permissive_roles, $current_user->roles ) ) {
+					$query->set( 'post_status', ['publish', 'pending', 'draft', 'web-only'] );
+				}
+			}
+			return $query;
+		});
+	}
 }

--- a/inc/class-privacy.php
+++ b/inc/class-privacy.php
@@ -73,15 +73,14 @@ class Privacy {
 	 *
 	 * A filter to allow permissive private content for certain roles.
 	 */
-	public static function showPermissivePrivateContent(): void
-	{
+	public static function showPermissivePrivateContent(): void {
 		add_filter( 'pre_get_posts', function ( $query ) {
-			if( is_user_logged_in() ){
+			if ( is_user_logged_in() ) {
 				$permissive_private_content = (int) get_option( 'permissive_private_content', 0 );
 				$current_user = wp_get_current_user();
 				$permissive_roles = [ 'subscriber', 'collaborator', 'author' ];
 				if ( $permissive_private_content && array_intersect( $permissive_roles, $current_user->roles ) ) {
-					$query->set( 'post_status', ['publish', 'pending', 'draft', 'web-only'] );
+					$query->set( 'post_status', [ 'publish', 'pending', 'draft', 'web-only' ] );
 				}
 			}
 			return $query;


### PR DESCRIPTION
This PR addresses #3508

I added a little extra hook to allow logged users to view the content as expected because when a post is set as **not show in web** is being set as a draft and drafts automatically are excluded from the wp loop.