### PR TITLE
fix: warnings with `null` parent slug

### DIFF
--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -629,7 +629,7 @@ function fix_root_admin_menu() {
 
 function add_pb_cloner_page() {
 	$cloner_page = add_submenu_page(
-		null,
+		'pb-null',
 		esc_html__( 'Clone a Book', 'pressbooks' ),
 		esc_html__( 'Clone a Book', 'pressbooks' ),
 		'read',

--- a/inc/admin/menus/class-sidebar.php
+++ b/inc/admin/menus/class-sidebar.php
@@ -354,7 +354,7 @@ class SideBar {
 			require_once WP_PLUGIN_DIR . '/user-activation-keys/ds_wp3_user_activation_keys.php';
 			$ds_wp3_user_activation_keys = new \DS_User_Activation_Keys();
 			add_submenu_page(
-				null,
+				'pb-null',
 				__( 'User Activation Keys', 'pressbooks' ),
 				__( 'User Activation Keys', 'pressbooks' ),
 				'edit_users',

--- a/tests/test-admin-laf.php
+++ b/tests/test-admin-laf.php
@@ -150,8 +150,8 @@ class Admin_LafTest extends \WP_UnitTestCase {
 		include_once( ABSPATH . '/wp-admin/menu.php' );
 		\Pressbooks\Admin\Laf\add_pb_cloner_page();
 		$this->assertArrayHasKey( 'index.php', $submenu );
-		$this->assertArrayHasKey( '', $submenu );
-		$this->assertContains( 'Clone a Book', $submenu[''][0] );
+		$this->assertArrayHasKey( 'pb-null', $submenu );
+		$this->assertContains( 'Clone a Book', $submenu['pb-null'][0] );
 		$new_post['post_type'] = 'post';
 		$GLOBALS['post'] = get_post( $this->factory()->post->create_object( $new_post ) );
 		$GLOBALS['current_screen'] = WP_Screen::get( 'post' );


### PR DESCRIPTION
This PR aims to fix some unexpected warnings when declaring submenu pages that shouldn't be visible in the menu.

We currently call `add_submenu_page` with a `null` parent slug and it's a hack that works great. This raises deprecation warnings in PHP 8.1

To fix this, this PR uses a `pb-null` string which is an invalid slug and should function the same way.

**How to test**

1. With the `dev` branch, enable `DISPLAY_PHP8_1_DEPRECATIONS=true` in your .env file. You should start seeing the following:
```
Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /app/web/wp/wp-includes/functions.php on line 7241
Deprecated: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /app/web/wp/wp-includes/functions.php on line 2187
```
2. Switch to this branch and the warnings should not be visible anymore
3. Visit your network and make sure you're able to visit `https://{domain}/wp/wp-admin/network/admin.php?page=act_keys` if you have the **User Activation Keys** plugin active (see https://github.com/pressbooks/pressbooks/issues/3313)
4. Visit the cloner page and make sure cloning a book works