### PR TITLE
Add filters for pb_sanitize_webbook_content config and spec

### DIFF
--- a/inc/sanitize/namespace.php
+++ b/inc/sanitize/namespace.php
@@ -757,11 +757,11 @@ function sanitize_webbook_content( $content ) {
 	// Remove deprecated table borders
 	$spec = '';
 	$spec .= 'table=-border;';
-	
-	$spec = apply_filters('pb_sanitize_webbook_content_spec', $spec);
-	$config = apply_filters('pb_sanitize_webbook_content_config', []);
-	
-	$content = htmlawed_with_mixed_markup($content, $config, $spec);
+
+	$spec = apply_filters( 'pb_sanitize_webbook_content_spec', $spec );
+	$config = apply_filters( 'pb_sanitize_webbook_content_config', [] );
+
+	$content = htmlawed_with_mixed_markup( $content, $config, $spec) ;
 	return $content;
 }
 

--- a/inc/sanitize/namespace.php
+++ b/inc/sanitize/namespace.php
@@ -755,13 +755,12 @@ function htmlawed_with_mixed_markup( $content, $htmlawed_config = null, $htmlawe
  */
 function sanitize_webbook_content( $content ) {
 	// Remove deprecated table borders
-	$spec = '';
-	$spec .= 'table=-border;';
+	$spec = 'table=-border;';
 
 	$spec = apply_filters( 'pb_sanitize_webbook_content_spec', $spec );
 	$config = apply_filters( 'pb_sanitize_webbook_content_config', [] );
 
-	$content = htmlawed_with_mixed_markup( $content, $config, $spec) ;
+	$content = htmlawed_with_mixed_markup( $content, $config, $spec );
 	return $content;
 }
 

--- a/inc/sanitize/namespace.php
+++ b/inc/sanitize/namespace.php
@@ -757,7 +757,11 @@ function sanitize_webbook_content( $content ) {
 	// Remove deprecated table borders
 	$spec = '';
 	$spec .= 'table=-border;';
-	$content = htmlawed_with_mixed_markup( $content, [], $spec );
+	
+	$spec = apply_filters('pb_sanitize_webbook_content_spec', $spec);
+	$config = apply_filters('pb_sanitize_webbook_content_config', []);
+	
+	$content = htmlawed_with_mixed_markup($content, $config, $spec);
 	return $content;
 }
 

--- a/tests/test-sanitize.php
+++ b/tests/test-sanitize.php
@@ -469,6 +469,49 @@ RAW;
 		$this->assertStringContainsString( '<p style="text-align: center">This should be centered.</p>', $result );
 	}
 
+	public function test_sanitize_webbook_content_spec_filter(): void
+	{
+		$content = <<< RAW
+<iframe src="https://example.org" allow="fullscreen"></iframe>
+RAW;
+
+		$result = \Pressbooks\Sanitize\sanitize_webbook_content( $content );
+
+		$this->assertEquals('<iframe src="https://example.org"></iframe>', $result);
+
+		add_filter('pb_sanitize_webbook_content_spec', function (string $spec) {
+			$spec .= 'iframe=allow;';
+
+			return $spec;
+		});
+
+		$result = \Pressbooks\Sanitize\sanitize_webbook_content( $content );
+
+		$this->assertEquals('<iframe src="https://example.org" allow="fullscreen"></iframe>', $result);
+	}
+
+	public function test_sanitize_webbook_content_config_filter(): void
+	{
+		$content = <<< RAW
+<p style="text-align: center">This should be centered.</p>
+RAW;
+
+		$result = \Pressbooks\Sanitize\sanitize_webbook_content( $content );
+
+		$this->assertStringContainsString('<p style="text-align: center">This should be centered.</p>', $result);
+
+		add_filter('pb_sanitize_webbook_content_config', function (array $config) {
+			return [
+				...$config,
+				'deny_attribute' => 'style'
+			];
+		});
+
+		$result = \Pressbooks\Sanitize\sanitize_webbook_content( $content );
+
+		$this->assertEquals('<p>This should be centered.</p>', $result);
+	}
+
 	/**
 	 * @group sanitize
 	 */


### PR DESCRIPTION
The `sanitize_webbook_content` filter introduced in [#1462](https://github.com/pressbooks/pressbooks/pull/1462) filters webbook HTML using HTMLawed. This PR adds filters for the config and spec parameters passed to HTMLawed by `sanitize_webbook_content`, enabling users to customize this behavior according to their needs.

We encountered a specific issue where a Vimeo embed resulted in an iframe with the `allow` attribute being stripped out, which prevented the fullscreen option from being displayed. With this PR, this issue can be addressed as follows:
```
add_filter('pb_sanitize_webbook_content_spec',  'demo_pb_sanitize_webbook_content_spec'));

function demo_pb_sanitize_webbook_content_spec($spec)
    {
        $spec .= 'iframe=allow;';
        return $spec;
    }
```