### PR TITLE
chore: use reusable workflow to generate .mo files

### DIFF
--- a/.github/workflows/update-mo.yml
+++ b/.github/workflows/update-mo.yml
@@ -1,0 +1,12 @@
+name: Update .mo files
+
+on:
+  pull_request:
+    branches: [ dev ]
+    paths:
+      - 'languages/*.po'
+  workflow_dispatch:
+
+jobs:
+  update-mo-files:
+    uses: pressbooks/reusable-workflows/.github/workflows/update-mo.yml@dev

--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -31,7 +31,7 @@ jobs:
         labels: automerge-pot
         commit-message: 'chore(l10n): update pot file'
         title: 'chore(l10n): update pot file'
-        body: 'This pull request updates the POT file for this plugin.'
+        body: 'Update the POT file for this plugin.'
         branch: chore/update-pot-file
     - name: Merge pull request with updated POT file
       if: ${{ steps.cprpot.outputs.pull-request-number }}

--- a/.tx/transifex.yaml
+++ b/.tx/transifex.yaml
@@ -17,3 +17,4 @@ git:
             ka: ka_GE
             ru: ru_RU
             ta: ta_LK
+            hr_HR: hr

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Contributors: Pressbooks <code@pressbooks.com>
 Tags: ebooks, publishing, webbooks
 Requires at least: 6.4.3
 Tested up to: 6.4.3
-Stable tag: 6.17.1
+Stable tag: 6.17.2
 Requires PHP: 8.1
 License: GPL v3.0 or later
 License URI: https://github.com/pressbooks/pressbooks/blob/production/LICENSE.md
@@ -49,8 +49,8 @@ The Pressbooks plugin is supplied "as is" and all use is at your own risk.
 
 ## Changelog
 
-### 6.17.1
-* See: https://github.com/pressbooks/pressbooks/releases/tag/6.17.1
+### 6.17.2
+* See: https://github.com/pressbooks/pressbooks/releases/tag/6.17.2
 * Full release history available at: https://github.com/pressbooks/pressbooks/releases
 
 ## Upgrade Notices

--- a/pressbooks.php
+++ b/pressbooks.php
@@ -5,7 +5,7 @@ Plugin URI:         https://pressbooks.org
 GitHub Plugin URI:  pressbooks/pressbooks
 Release Asset:      true
 Description:        Simple Book Production
-Version:            6.17.1
+Version:            6.17.2
 Requires at least:  6.4.3
 Requires PHP:       8.1
 Author:             Pressbooks (Book Oven Inc.)


### PR DESCRIPTION
Partial fix for https://github.com/pressbooks/private/issues/1340