### PR TITLE
fix: improve accessibility of dashboard links which contain icons

### DIFF
--- a/hooks-admin.php
+++ b/hooks-admin.php
@@ -42,7 +42,6 @@ remove_action( 'try_gutenberg_panel', 'wp_try_gutenberg_panel' );
 add_action( 'admin_bar_menu', '\Pressbooks\Admin\Laf\replace_menu_bar_my_sites', 21 );
 add_action( 'admin_bar_menu', '\Pressbooks\Admin\Laf\remove_menu_bar_update', 41 );
 add_action( 'admin_bar_menu', '\Pressbooks\Admin\Laf\remove_menu_bar_new_content', 71 );
-add_filter( 'admin_bar_menu', '\Pressbooks\Admin\Laf\replace_wordpress_howdy', 25 );
 add_action( 'admin_head', '\Pressbooks\Admin\Branding\favicon' );
 
 // Add contact Info

--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -1733,20 +1733,6 @@ function update_user_profile_fields( $user_id ) {
 /**
  *
  * @since 5.35.0
- * @param object $wp_admin_bar
- */
-function replace_wordpress_howdy( $wp_admin_bar ) {
-	$my_account = $wp_admin_bar->get_node( 'my-account' );
-	$newtext = str_replace( 'Howdy,', 'Hello,', $my_account->title );
-	$wp_admin_bar->add_node( [
-		'id' => 'my-account',
-		'title' => $newtext,
-	] );
-}
-
-/**
- *
- * @since 5.35.0
  */
 function remove_emoji() {
 	remove_action( 'admin_print_styles', 'print_emoji_styles' );

--- a/inc/admin/menus/class-topbar.php
+++ b/inc/admin/menus/class-topbar.php
@@ -99,9 +99,6 @@ class TopBar {
 		$bar->add_node( [
 			'id' => $node->id,
 			'title' => '<span class="screen-reader-text">' . wp_get_current_user()->display_name . '</span>' . $avatar,
-			'meta' => [
-				'aria-label' => wp_get_current_user()->display_name
-			]
 		] );
 	}
 

--- a/inc/admin/menus/class-topbar.php
+++ b/inc/admin/menus/class-topbar.php
@@ -98,7 +98,10 @@ class TopBar {
 
 		$bar->add_node( [
 			'id' => $node->id,
-			'title' => $avatar,
+			'title' => '<span class="screen-reader-text">' . wp_get_current_user()->display_name . '</span>' . $avatar,
+			'meta' => [
+				'aria-label' => wp_get_current_user()->display_name
+			]
 		] );
 	}
 
@@ -166,7 +169,7 @@ class TopBar {
 
 		$bar->add_node( [
 			'id' => $main_id,
-			'title' => "<i class='pb-heroicons pb-heroicons-building-library'></i><span>{$title}</span>",
+			'title' => "<i aria-hidden='true' class='pb-heroicons pb-heroicons-building-library'></i><span>{$title}</span>",
 			'href' => network_admin_url( 'index.php?page=pb_network_page' ),
 			'meta' => [
 				'class' => is_network_admin() ? 'you-are-here' : null,
@@ -192,7 +195,7 @@ class TopBar {
 
 		$bar->add_node( [
 			'id' => 'pb-my-books',
-			'title' => "<i class='pb-heroicons pb-heroicons-my-books'></i><span>{$title}</span>",
+			'title' => "<i aria-hidden='true' class='pb-heroicons pb-heroicons-my-books'></i><span>{$title}</span>",
 			'href' => get_admin_url( get_main_site_id(), 'index.php?page=pb_home_page' ),
 			'meta' => array_filter( $metadata ),
 		] );
@@ -236,7 +239,7 @@ class TopBar {
 
 		$bar->add_node( [
 			'id' => $node->id,
-			'title' => "<i class='pb-heroicons pb-heroicons-book-open'></i><span>{$node->title}</span>",
+			'title' => "<i aria-hidden='true' class='pb-heroicons pb-heroicons-book-open'></i><span>{$node->title}</span>",
 		] );
 	}
 
@@ -246,7 +249,7 @@ class TopBar {
 		$node = [
 			'id' => 'pb-create-book',
 			'parent' => 'top-secondary',
-			'title' => "<i class='pb-heroicons pb-heroicons-plus-circle-filled'></i><span>{$title}</span>",
+			'title' => "<i aria-hidden='true' class='pb-heroicons pb-heroicons-plus-circle-filled'></i><span>{$title}</span>",
 			'href' => network_home_url( 'wp-signup.php' ),
 			'meta' => [
 				'class' => 'btn action',
@@ -265,7 +268,7 @@ class TopBar {
 		$bar->add_node( [
 			'id' => 'pb-clone-book',
 			'parent' => 'top-secondary',
-			'title' => "<i class='pb-heroicons pb-heroicons-clone-book'></i><span>{$title}</span>",
+			'title' => "<i aria-hidden='true' class='pb-heroicons pb-heroicons-clone-book'></i><span>{$title}</span>",
 			'href' => get_admin_url( get_main_site_id(), 'admin.php?page=pb_cloner' ),
 			'meta' => [
 				'class' => 'btn action',
@@ -279,7 +282,7 @@ class TopBar {
 		$bar->add_node( [
 			'id' => 'pb-add-users',
 			'parent' => 'top-secondary',
-			'title' => "<i class='pb-heroicons pb-heroicons-user-plus-filled'></i><span>{$title}</span>",
+			'title' => "<i aria-hidden='true' class='pb-heroicons pb-heroicons-user-plus-filled'></i><span>{$title}</span>",
 			'href' => network_admin_url( 'users.php?page=user_bulk_new' ),
 			'meta' => [
 				'class' => 'btn action',

--- a/templates/admin/dashboard/book.blade.php
+++ b/templates/admin/dashboard/book.blade.php
@@ -21,7 +21,7 @@
 							@if( $book_info_url )
 								<li id="book_info">
 									<a href="{!! $book_info_url !!}">
-										<i class="pb-heroicons pb-heroicons-pencil-square"></i>
+										<i aria-hidden="true" class="pb-heroicons pb-heroicons-pencil-square"></i>
 										<span>{{ __( 'Edit book info', 'pressbooks' ) }}</span>
 									</a>
 								</li>
@@ -29,7 +29,7 @@
 							@if( $organize_url )
 								<li id="organize">
 									<a href="{{ $organize_url }}">
-										<i class="pb-heroicons pb-heroicons-book-open"></i>
+										<i aria-hidden="true" class="pb-heroicons pb-heroicons-book-open"></i>
 										<span>{{ __( 'Organize book', 'pressbooks' ) }}</span>
 									</a>
 								</li>
@@ -37,7 +37,7 @@
 							@if( $themes_url )
 								<li id="theme">
 									<a href="{{ $themes_url }}">
-										<i class="pb-heroicons pb-heroicons-sparkles"></i>
+										<i aria-hidden="true" class="pb-heroicons pb-heroicons-sparkles"></i>
 										<span>{{ __( 'Change theme', 'pressbooks' ) }}</span>
 									</a>
 								</li>
@@ -45,7 +45,7 @@
 							@if( $users_url )
 							<li id="users">
 								<a href="{{ $users_url }}">
-									<i class="pb-heroicons pb-heroicons-users"></i>
+									<i aria-hidden="true" class="pb-heroicons pb-heroicons-users"></i>
 									<span>{{ __( 'Manage users', 'pressbooks' ) }}</span>
 								</a>
 							</li>
@@ -53,7 +53,7 @@
 							@if( $analytics_url )
 								<li id="analytics">
 									<a href="{{ $analytics_url }}">
-										<i class="pb-heroicons pb-heroicons-presentation-chart-bar"></i>
+										<i aria-hidden="true" class="pb-heroicons pb-heroicons-presentation-chart-bar"></i>
 										<span>{{ __( 'View Analytics', 'pressbooks' ) }}</span>
 									</a>
 								</li>
@@ -61,7 +61,7 @@
 							@if( $delete_book_url )
 								<li id="delete">
 									<a href="{{ $delete_book_url }}">
-										<i class="pb-heroicons pb-heroicons-trash"></i>
+										<i aria-hidden="true" class="pb-heroicons pb-heroicons-trash"></i>
 										<span>{{ __( 'Delete book', 'pressbooks' ) }}</span>
 									</a>
 								</li>

--- a/templates/admin/dashboard/network.blade.php
+++ b/templates/admin/dashboard/network.blade.php
@@ -98,7 +98,7 @@
 								<a
 									href="{!! admin_url( 'customize.php?return=' . network_admin_url() ) !!}"
 								>
-									<i class="pb-heroicons pb-heroicons-sparkles"></i>
+									<i aria-hidden="true" class="pb-heroicons pb-heroicons-sparkles"></i>
 									<span>{{ __( 'Customize network appearance', 'pressbooks' ) }}</span>
 								</a>
 							</li>
@@ -106,7 +106,7 @@
 								<a
 									href="{!! admin_url( 'edit.php?post_type=page' ) !!}"
 								>
-									<i class="pb-heroicons pb-heroicons-pencil-square"></i>
+									<i aria-hidden="true" class="pb-heroicons pb-heroicons-pencil-square"></i>
 									<span>{{ __( 'Create or edit pages', 'pressbooks' ) }}</span>
 								</a>
 							</li>
@@ -115,7 +115,7 @@
 									<a
 										href="{!! admin_url( 'index.php?page=koko-analytics' ) !!}"
 									>
-										<i class="pb-heroicons pb-heroicons-presentation-chart-bar"></i>
+										<i aria-hidden="true" class="pb-heroicons pb-heroicons-presentation-chart-bar"></i>
 										<span>{{ __( 'View homepage analytics', 'pressbooks' ) }}</span>
 									</a>
 								</li>
@@ -141,7 +141,7 @@
 								<a
 									href="{!! network_admin_url( $network_analytics_active ? 'settings.php?page=pb_network_analytics_options' : 'settings.php' ) !!}"
 								>
-									<i class="pb-heroicons pb-heroicons-cog-8-tooth"></i>
+									<i aria-hidden="true" class="pb-heroicons pb-heroicons-cog-8-tooth"></i>
 									<span>{{ __( 'Adjust network settings', 'pressbooks' ) }}</span>
 								</a>
 							</li>
@@ -149,7 +149,7 @@
 								<a
 									href="{!! network_admin_url( $network_analytics_active ? 'sites.php?page=pb_network_analytics_booklist' : 'sites.php' ) !!}"
 								>
-									<i class="pb-heroicons pb-heroicons-book-open"></i>
+									<i aria-hidden="true" class="pb-heroicons pb-heroicons-book-open"></i>
 									<span>{{ __( 'View book list', 'pressbooks' ) }}</span>
 								</a>
 							</li>
@@ -157,7 +157,7 @@
 								<a
 									href="{!! network_admin_url( $network_analytics_active ? 'users.php?page=pb_network_analytics_userlist' : 'users.php' ) !!}"
 								>
-									<i class="pb-heroicons pb-heroicons-users"></i>
+									<i aria-hidden="true" class="pb-heroicons pb-heroicons-users"></i>
 									<span>{{ __( 'View user list', 'pressbooks' ) }}</span>
 								</a>
 							</li>


### PR DESCRIPTION
This PR resolves a few accessibility-related issues I noticed while setting up a new local development environment:

1. The `<i class="pb-heroicons">` icons used in call to action links on the dashboard were not hidden from the accessibility tree which meant that extra characters were inserted before the link text for assistive technology. I added `aria-hidden="true"` to ensure that the icons were not part of the links' accessible names.
<img width="1247" alt="Screenshot 2024-02-28 at 9 35 52 PM" src="https://github.com/pressbooks/pressbooks/assets/605361/f251e06f-68f4-41e4-88c5-a600414fd544">
3. I noticed that the user account menu button did not have a proper label (it was announced as "profile.php") so I added the current user's display name wrapped in `<span class="screen-reader-text">` to ensure that the menu button would be properly labelled.
<img width="480" alt="Screenshot 2024-02-28 at 9 38 27 PM" src="https://github.com/pressbooks/pressbooks/assets/605361/31a52be6-7247-40f2-a9ac-c7293ce7c556">
5. While looking into the second item I realized that the `\Pressbooks\Admin\Laf\replace_wordpress_howdy` function added ~2 years ago had been effectively replaced in the design refresh that added the new dashboard and icons, so I removed it (there's no text before the user avatar now).