### PR TITLE
fix: localize contributor titles

### DIFF
--- a/templates/posttypes/contributors.blade.php
+++ b/templates/posttypes/contributors.blade.php
@@ -1,6 +1,6 @@
 <section class="contributors book-contributors">
 	@foreach($contributors as $contributor_type)
-		<h2 class="contributor__type">{{__( $contributor_type['title'], 'pressbooks' ) }} </h2>
+		<h2 class="contributor__type">{{__( $contributor_type['title'], 'pressbooks' ) }}</h2>
 		@foreach($contributor_type['records'] as $contributor)
 			@include('posttypes.contributor',[ 'contributor' => $contributor, 'key' => str_random(), 'exporting' => $exporting ])
 		@endforeach

--- a/templates/posttypes/contributors.blade.php
+++ b/templates/posttypes/contributors.blade.php
@@ -1,6 +1,6 @@
 <section class="contributors book-contributors">
 	@foreach($contributors as $contributor_type)
-		<h2 class="contributor__type">{{$contributor_type['title']}}</h2>
+		<h2 class="contributor__type">{{__( $contributor_type['title'], 'pressbooks' )}} </h2>
 		@foreach($contributor_type['records'] as $contributor)
 			@include('posttypes.contributor',[ 'contributor' => $contributor, 'key' => str_random(), 'exporting' => $exporting ])
 		@endforeach

--- a/templates/posttypes/contributors.blade.php
+++ b/templates/posttypes/contributors.blade.php
@@ -1,6 +1,6 @@
 <section class="contributors book-contributors">
 	@foreach($contributors as $contributor_type)
-		<h2 class="contributor__type">{{__( $contributor_type['title'], 'pressbooks' )}} </h2>
+		<h2 class="contributor__type">{{__( $contributor_type['title'], 'pressbooks' ) }} </h2>
 		@foreach($contributor_type['records'] as $contributor)
 			@include('posttypes.contributor',[ 'contributor' => $contributor, 'key' => str_random(), 'exporting' => $exporting ])
 		@endforeach


### PR DESCRIPTION
Fix for https://github.com/pressbooks/pressbooks/issues/3633

To test:
1. Create a book and assign one or more contributors as editors, authors, translators, contributors, etc. in book info
2. Create a back matter of the type `Contributors`
3. Set the book's language to French or another language which has translations for the contributor type title strings
4. Observe that the titles displayed are now rendered in the target language (instead of English)
![Screenshot from 2024-03-13 09-13-08](https://github.com/pressbooks/pressbooks/assets/13485451/de14a055-63f2-45d2-afed-77cb4ba764cd)
