### PR TITLE
fix: check user exists

### DIFF
--- a/inc/admin/networkmanagers/namespace.php
+++ b/inc/admin/networkmanagers/namespace.php
@@ -54,6 +54,11 @@ function _restricted_users() {
 	$restricted_users_ids = [];
 	foreach ( $network_admins as $username ) {
 		$user = get_user_by( 'login', $username );
+
+		if ( ! $user ) {
+			continue;
+		}
+
 		$is_restricted = in_array( absint( $user->ID ), $network_managers, true );
 
 		if ( $is_restricted ) {


### PR DESCRIPTION
This PR aims to fix a warning noted here https://github.com/pressbooks/private/issues/1385. 

The reason we are seeing the warning is because the user might have been deleted. If that's the case WP returns `false` in the `get_user_by` method and we are attempting to get the `ID` of a `boolean` value.