### PR TITLE
fix: ensure that user-configured indent setting uses theme indent

### DIFF
--- a/inc/class-styles.php
+++ b/inc/class-styles.php
@@ -344,6 +344,36 @@ class Styles {
 	}
 
 	/**
+	 * Get the paragraph indent value for a Buckram v2 theme
+	 *
+	 * @param \WP_Theme $theme (optional)
+	 *
+	 * @return ?string The paragraph indent defined in the theme, or null if no paragraph indent is defined.
+	 */
+	public function getParaIndent( $theme = null ) {
+
+		if ( null === $theme ) {
+			$theme = wp_get_theme();
+		}
+
+		if ( $this->isCurrentThemeCompatible( 2, $theme ) ) {
+			$path = realpath( $this->getDir( $theme ) . '/assets/styles/components/_elements.scss' );
+
+			if ( file_exists( $path ) ) {
+				$string = file_get_contents( $path );
+				$regex = '/\$para-indent: ([0-9]*[a-z]*) \!default;/m';
+				preg_match( $regex, $string, $matches );
+
+				if ( isset( $matches[1] ) ) {
+					return $matches[1];
+				}
+			}
+		}
+
+		return null;
+	}
+
+	/**
 	 * Are the current theme's stylesheets SCSS compatible?
 	 *
 	 * @param int $with_version

--- a/inc/modules/themeoptions/class-ebookoptions.php
+++ b/inc/modules/themeoptions/class-ebookoptions.php
@@ -597,7 +597,7 @@ class EbookOptions extends \Pressbooks\Options {
 				$styles->getSass()->setVariables(
 					[
 						'para-margin-top' => '0',
-						'para-indent' => '1em',
+						'para-indent' => $styles->getParaIndent() ?? '1em',
 					]
 				);
 			} else {

--- a/inc/modules/themeoptions/class-pdfoptions.php
+++ b/inc/modules/themeoptions/class-pdfoptions.php
@@ -2076,7 +2076,7 @@ class PDFOptions extends \Pressbooks\Options {
 				$styles->getSass()->setVariables(
 					[
 						'para-margin-top' => '0',
-						'para-indent' => '1em',
+						'para-indent' => $styles->getParaIndent() ?? '1em',
 					]
 				);
 			} else {

--- a/inc/modules/themeoptions/class-weboptions.php
+++ b/inc/modules/themeoptions/class-weboptions.php
@@ -621,7 +621,7 @@ class WebOptions extends \Pressbooks\Options {
 				$styles->getSass()->setVariables(
 					[
 						'para-margin-top' => '0',
-						'para-indent' => '1em',
+						'para-indent' => $styles->getParaIndent() ?? '1em',
 					]
 				);
 			} else {

--- a/tests/test-styles.php
+++ b/tests/test-styles.php
@@ -98,6 +98,17 @@ class StylesTest extends \WP_UnitTestCase {
 	/**
 	 * @group styles
 	 */
+	public function test_getParaIndent() {
+		$v1 = wp_get_theme( 'pressbooks-luther' );
+		$this->assertNull( $this->cs->getParaIndent( $v1 ) );
+
+		$v2 = wp_get_theme( 'pressbooks-book' );
+		$this->assertEquals( $this->cs->getParaIndent( $v2 ), '1em' );
+	}
+
+	/**
+	 * @group styles
+	 */
 	public function test_isCurrentThemeCompatible() {
 		// V1
 		$v1 = wp_get_theme( 'pressbooks-luther' );


### PR DESCRIPTION
As described in #3509, if a theme defines a paragraph indent value other than the default, `1em`, and a book author sets the theme options value to 'indent', the theme's indent value will be overwritten with a hard-coded value of `1em`.

This PR adds a small method to the `Styles` class, `getParaIndent`, which attempts to load the `$para-indent` value from the active theme and uses it instead of the default when applying theme options adjustments.

Resolves #3509.