### PR TITLE
chore: bump action versions and add CODECOV_TOKEN secret

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,12 +80,13 @@ jobs:
       if: matrix.experimental == false
 
     - name: Save code coverage to artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: matrix.experimental == false
       with:
         name: code-coverage
         path: "coverage.xml"
         retention-days: 5
+        overwrite: true
 
     - name: Prepare Build
       if: startsWith(github.ref, 'refs/tags/') && matrix.experimental == false
@@ -136,8 +137,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Fetch code coverage artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: code-coverage
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Addresses #3665. I followed these instructions: https://docs.codecov.com/docs/adding-the-codecov-token#github-actions to generate the required Codecov token and added it as a repository secret.