### PR TITLE
fix: remove network manager collector

### DIFF
--- a/inc/datacollector/class-user.php
+++ b/inc/datacollector/class-user.php
@@ -6,8 +6,6 @@
 
 namespace Pressbooks\DataCollector;
 
-use function Pressbooks\Admin\NetworkManagers\_restricted_users;
-
 class User {
 
 	// Meta Key Constants:

--- a/inc/datacollector/class-user.php
+++ b/inc/datacollector/class-user.php
@@ -98,23 +98,6 @@ class User {
 	}
 
 	/**
-	 * Updates the network manager's site meta data
-	 *
-	 * @return void
-	 */
-	public function updateNetworkManagers(): void {
-		$users = _restricted_users();
-
-		if ( is_array( $users ) && ! empty( $users ) ) {
-			update_site_option( 'pressbooks_network_managers_ids', implode( ',', $users ) );
-
-			return;
-		}
-
-		delete_site_option( 'pressbooks_network_managers_ids' );
-	}
-
-	/**
 	 * Sync user meta into wp_usermeta table.
 	 *
 	 * @param int $user_id

--- a/tests/test-datacollector-user.php
+++ b/tests/test-datacollector-user.php
@@ -53,37 +53,6 @@ class DataCollector_UserTest extends \WP_UnitTestCase {
 	/**
 	 * @group datacollector
 	 */
-	public function test_updateNetworkManagers() {
-		delete_site_option( 'pressbooks_network_managers_ids' );
-		$user_id = $this->factory()->user->create( [ 'role' => 'administrator' ] );
-
-		grant_super_admin( $user_id );
-		wp_set_current_user( $user_id );
-
-		$_REQUEST['_ajax_nonce'] = wp_create_nonce( 'pb-network-managers' );
-		$_POST['admin_id'] = $user_id;
-		$_POST['status'] = 1;
-
-		\Pressbooks\Admin\NetworkManagers\update_admin_status();
-
-		$this->assertEmpty( get_site_option( 'pressbooks_network_managers_ids', [] ) );
-
-		$this->userDataCollector->updateNetworkManagers();
-
-		$this->assertNotEmpty( get_site_option( 'pressbooks_network_managers_ids' ) );
-
-		$_POST['status'] = 0;
-
-		\Pressbooks\Admin\NetworkManagers\update_admin_status();
-
-		$this->userDataCollector->updateNetworkManagers();
-
-		$this->assertEmpty( get_site_option( 'pressbooks_network_managers_ids', [] ) );
-	}
-
-	/**
-	 * @group datacollector
-	 */
 	public function test_updateAllUsersMetadata() {
 		$user = $this->factory()->user->create_and_get( [ 'role' => 'contributor' ] );
 		$i = 0;


### PR DESCRIPTION
This PR is part of pressbooks/bi-data-manager#468. Accompanies pressbooks/pressbooks-network-analytics#356

We're dropping the data collection for `pressbooks_network_managers_ids` since it's not being kept in sync with `pressbooks_network_managers`. 

This might be a breaking change if others use the method or if they are reading `pressbooks_network_managers_ids` meta value from the database.