### PR TITLE
fix: remove patterns sub-menu items for book admin context

### DIFF
--- a/hooks-admin.php
+++ b/hooks-admin.php
@@ -379,7 +379,5 @@ add_action( 'edit_user_profile', '\Pressbooks\Admin\Laf\add_user_profile_fields'
 add_action( 'edit_user_profile_update', '\Pressbooks\Admin\Laf\update_user_profile_fields', 11 );
 add_action( 'personal_options_update', '\Pressbooks\Admin\Laf\update_user_profile_fields', 11 );
 
-if ( ! $is_book ) {
-	add_action( 'plugins_loaded', [ SideBar::class, 'init' ] );
-}
+add_action( 'plugins_loaded', [ SideBar::class, 'init' ] );
 add_action( 'plugins_loaded', [ TopBar::class, 'init' ] );

--- a/inc/admin/menus/class-sidebar.php
+++ b/inc/admin/menus/class-sidebar.php
@@ -54,7 +54,8 @@ class SideBar {
 
 	public function hooks(): void {
 		if ( ! is_main_site() ) {
-			add_action( 'admin_menu', [ $this, 'removePatternsSubMenuItem' ], 999 );
+			add_action( 'admin_menu', [ $this, 'removePatternsSubMenuItem' ] );
+			add_action( 'admin_init', [ $this, 'restrictPatternsPageAccess' ] );
 			return;
 		}
 
@@ -74,6 +75,16 @@ class SideBar {
 
 	public function removePatternsSubMenuItem(): void {
 		remove_submenu_page( 'themes.php', 'edit.php?post_type=wp_block' );
+	}
+
+	public function restrictPatternsPageAccess(): void {
+		global $pagenow;
+
+		if ( $pagenow !== 'edit.php' || ! isset( $_GET['post_type'] ) || $_GET['post_type'] !== 'wp_block' ) {
+			return;
+		}
+
+		wp_die( __('Sorry, you are not allowed to access this page.', 'pressbooks' ), 403 );
 	}
 
 	public function manageNetworkAdminMenu(): void {

--- a/inc/admin/menus/class-sidebar.php
+++ b/inc/admin/menus/class-sidebar.php
@@ -53,6 +53,11 @@ class SideBar {
 	}
 
 	public function hooks(): void {
+		if ( ! is_main_site() ) {
+			add_action( 'admin_menu', [ $this, 'removePatternsSubMenuItem' ], 999 );
+			return;
+		}
+
 		if ( ! is_super_admin() ) {
 			return;
 		}
@@ -65,6 +70,10 @@ class SideBar {
 		}
 
 		remove_action( 'admin_init', '\Pressbooks\Admin\NetworkManagers\restrict_access' );
+	}
+
+	public function removePatternsSubMenuItem(): void {
+		remove_submenu_page( 'themes.php', 'edit.php?post_type=wp_block' );
 	}
 
 	public function manageNetworkAdminMenu(): void {

--- a/inc/admin/menus/class-sidebar.php
+++ b/inc/admin/menus/class-sidebar.php
@@ -84,7 +84,7 @@ class SideBar {
 			return;
 		}
 
-		wp_die( __('Sorry, you are not allowed to access this page.', 'pressbooks' ), 403 );
+		wp_die( __( 'Sorry, you are not allowed to access this page.', 'pressbooks' ), 403 ); // phpcs:ignore Pressbooks.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	public function manageNetworkAdminMenu(): void {

--- a/tests/test-admin-sidebar.php
+++ b/tests/test-admin-sidebar.php
@@ -1,0 +1,65 @@
+<?php
+
+use Pressbooks\Admin\Menus\SideBar;
+
+/**
+ * @group sidebar-menu
+ */
+class testAdminSidebar extends \WP_UnitTestCase
+{
+	use utilsTrait;
+
+	/**
+	 * @test
+	 */
+	public function it_adds_hooks_for_book_context(): void
+	{
+		global $wp_filter;
+
+		SideBar::init();
+
+		$this->assertArrayHasKey('admin_menu', $wp_filter);
+		$this->assertArrayHasKey('admin_init', $wp_filter);
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_removes_patterns_submenu_item(): void
+	{
+		global $submenu;
+
+		$submenu['themes.php'] = [
+			[
+				'Patterns',
+				'edit_theme_options',
+				'edit.php?post_type=wp_block',
+			],
+			[
+				'Theme Options',
+				'edit_theme_options',
+				'themes.php?page=pressbooks_theme_options',
+			]
+		];
+
+		(new SideBar)->removePatternsSubMenuItem();
+
+		$this->assertCount(1, $submenu['themes.php']);
+		$this->assertNotContains('edit.php?post_type=wp_block', $submenu['themes.php'][1]);
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_restricts_patterns_page_access(): void {
+		global $pagenow;
+		$pagenow = 'edit.php';
+		$_GET['post_type'] = 'wp_block';
+
+		try {
+			(new SideBar)->restrictPatternsPageAccess();
+		} catch (WPDieException $e) {
+			$this->assertEquals('Sorry, you are not allowed to access this page.', $e->getMessage());
+		}
+	}
+}

--- a/tests/test-admin-sidebar.php
+++ b/tests/test-admin-sidebar.php
@@ -14,6 +14,8 @@ class testAdminSidebar extends \WP_UnitTestCase
 	 */
 	public function it_adds_hooks_for_book_context(): void
 	{
+		$this->_book();
+
 		global $wp_filter;
 
 		SideBar::init();
@@ -60,6 +62,22 @@ class testAdminSidebar extends \WP_UnitTestCase
 			(new SideBar)->restrictPatternsPageAccess();
 		} catch (WPDieException $e) {
 			$this->assertEquals('Sorry, you are not allowed to access this page.', $e->getMessage());
+		}
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_does_not_restrict_other_edit_pages(): void {
+		global $pagenow;
+		$pagenow = 'edit.php';
+		$_GET['post_type'] = 'another_post_type';
+
+		try {
+			(new SideBar)->restrictPatternsPageAccess();
+			$this->assertTrue(true);
+		} catch (WPDieException) {
+			$this->fail('Should not restrict access to other edit pages');
 		}
 	}
 }


### PR DESCRIPTION
Issue: https://github.com/pressbooks/private/issues/1395.

This PR removes the `Patterns` sub-menu item under `Appearance` added in WP 6.5.

### Testing case
- Go to any book admin context and make sure Appearance does not have any sub-menu items called `Patterns`.
- If you manually enter the `<BOOK_URL>/wp-admin/edit.php?post_type=wp_block` URL, you should see the `Sorry, you are not allowed to access this page.` page.