### PR TITLE
fix: translate contributor type titles

### DIFF
--- a/inc/class-contributors.php
+++ b/inc/class-contributors.php
@@ -11,7 +11,6 @@ namespace Pressbooks;
 use function Pressbooks\Metadata\init_book_data_models;
 use function Pressbooks\Utility\explode_remove_and;
 use function Pressbooks\Utility\str_starts_with;
-use Illuminate\Support\Str;
 use Pressbooks\PostType\BackMatter;
 use Pressbooks\Utility\AutoDisplayable;
 use Pressbooks\Utility\HandlesTransfers;
@@ -814,12 +813,25 @@ class Contributors implements BackMatter, Transferable {
 			$contributors = $this->getContributorsWithMeta( $meta_post->ID, $contributor_type );
 			$contributors_count = count( $contributors );
 			if ( $contributors_count > 0 ) {
-				list( ,$title ) = explode( '_', $contributor_type );
-				$records[ $contributor_type ]['title'] = Str::ucfirst( $contributors_count > 1 ? $title : Str::singular( $title ) ); // ex. return Author or Authors
-				$records[ $contributor_type ]['records'] = $contributors;
+				$records[ $contributor_type ] = [
+					'title' => $this->getContributorTypeLabel( $contributor_type, $contributors_count ),
+					'records' => $contributors,
+				];
 			}
 		}
 		return $records;
+	}
+
+	public function getContributorTypeLabel( string $type, int $count ): string {
+		return match ($type) {
+			'pb_editors' => _n( 'Editor', 'Editors', $count, 'pressbooks' ),
+			'pb_authors' => _n( 'Author', 'Authors', $count, 'pressbooks' ),
+			'pb_contributors' => _n( 'Contributor', 'Contributors', $count, 'pressbooks' ),
+			'pb_translators' => _n( 'Translator', 'Translators', $count, 'pressbooks' ),
+			'pb_reviewers' => _n( 'Reviewer', 'Reviewers', $count, 'pressbooks' ),
+			'pb_illustrators' => _n( 'Illustrator', 'Illustrators', $count, 'pressbooks' ),
+			default => '',
+		};
 	}
 
 	/**

--- a/templates/posttypes/contributors.blade.php
+++ b/templates/posttypes/contributors.blade.php
@@ -1,6 +1,6 @@
 <section class="contributors book-contributors">
 	@foreach($contributors as $contributor_type)
-		<h2 class="contributor__type">{{__( $contributor_type['title'], 'pressbooks' ) }}</h2>
+		<h2 class="contributor__type">{{ $contributor_type['title'] }}</h2>
 		@foreach($contributor_type['records'] as $contributor)
 			@include('posttypes.contributor',[ 'contributor' => $contributor, 'key' => str_random(), 'exporting' => $exporting ])
 		@endforeach


### PR DESCRIPTION
Issue #3633

This PR fixes an issue where the Contributor types (authors, editors, etc.) were not available for translation.