### PR TITLE
fix: Rename variable to trigger bedrock update

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -126,7 +126,7 @@ jobs:
         AWS_SNS_ARN_DEV: ${{ secrets.AWS_SNS_ARN_DEV }}
         AWS_SNS_ARN_STAGING: ${{ secrets.AWS_SNS_ARN_STAGING }}
         INPUT_TRIGGERED_BY: ${{ github.repository }}
-        INPUT_BRANCH: ${{ github.ref }}
+        BRANCH: ${{ github.ref }}
 
   coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Resolves: pressbooks/private#1405
This PR includes changes to rename a variable which is necessary to trigger a specific update in the bedrock configuration.