### PR TITLE
fix: remove patterns submenu item

### DIFF
--- a/inc/admin/menus/class-sidebar.php
+++ b/inc/admin/menus/class-sidebar.php
@@ -75,6 +75,7 @@ class SideBar {
 
 	public function removePatternsSubMenuItem(): void {
 		remove_submenu_page( 'themes.php', 'edit.php?post_type=wp_block' );
+		remove_submenu_page( 'themes.php', 'site-editor.php?path=/patterns' );
 	}
 
 	public function restrictPatternsPageAccess(): void {


### PR DESCRIPTION
This PR removes the new Patterns submenu items introduced in WP 6.6.