### PR TITLE
fix: user menu priority

### DIFF
--- a/inc/admin/menus/class-topbar.php
+++ b/inc/admin/menus/class-topbar.php
@@ -30,9 +30,9 @@ class TopBar {
 	}
 
 	public function hooks(): void {
-		add_action( 'admin_bar_menu', [ $this, 'reset' ], 999 );
-		add_action( 'admin_bar_menu', [ $this, 'add' ], 999 );
-		add_action( 'admin_bar_menu', [ $this, 'reorder' ], 999 );
+		add_action( 'admin_bar_menu', [ $this, 'reset' ], 9999 );
+		add_action( 'admin_bar_menu', [ $this, 'add' ], 9999 );
+		add_action( 'admin_bar_menu', [ $this, 'reorder' ], 9999 );
 	}
 
 	public function reset( WP_Admin_Bar $bar ): void {


### PR DESCRIPTION
This PR aims to fix an issue with the User Avatar after upgrading to WP 6.6.1.

See: https://core.trac.wordpress.org/ticket/61615