### PR TITLE
chore: update wp 6.6 test runner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,13 +14,13 @@ jobs:
       fail-fast: false
       matrix:
         php: [ 8.1, 8.2 ]
-        wordpress: [ '6.5', 'latest' ]
+        wordpress: [ '6.6', 'latest' ]
         experimental: [ false ]
         epubcheck: [ 4.2.6 ]
         prince: [ 14.3-1 ]
         include:
           - php: 8.2
-            wordpress: 6.5
+            wordpress: 6.6
             prince: 14.3-1
             epubcheck: 4.2.6
             experimental: true


### PR DESCRIPTION
Just bumps the default WP test runner