### PR TITLE
feat: add default value for permissive_private_content option

### DIFF
--- a/hooks.php
+++ b/hooks.php
@@ -348,3 +348,5 @@ add_filter( 'init', [ '\Pressbooks\Utility\ErrorHandler', 'init' ] );
 
 // Open up private content to subscribers and collaborators when permissive_private_content is enabled
 add_filter( 'init', [ Privacy::class, 'showPermissivePrivateContent' ] );
+
+add_action( 'wp_initialize_site', [ Privacy::class, 'setDefaultPermissivePrivateContent' ], 100, 1 );

--- a/inc/class-privacy.php
+++ b/inc/class-privacy.php
@@ -6,6 +6,8 @@
 
 namespace Pressbooks;
 
+use WP_Site;
+
 class Privacy {
 
 	/**
@@ -85,5 +87,11 @@ class Privacy {
 			}
 			return $query;
 		});
+	}
+
+	public static function setDefaultPermissivePrivateContent( WP_Site $site ): void {
+		switch_to_blog( $site->blog_id );
+		update_option( 'permissive_private_content', 1 );
+		restore_current_blog();
 	}
 }

--- a/tests/test-privacy.php
+++ b/tests/test-privacy.php
@@ -213,8 +213,14 @@ class GdprTest extends \WP_UnitTestCase {
 	 * @test
 	 */
 	public function it_sets_default_permissive_private_content() {
-		$site = new WP_Site( (object) [ 'blog_id' => 2 ] );
+		$this->_book();
+		$blog_id = get_current_blog_id();
+
+		$site = new WP_Site( (object) [ 'blog_id' => $blog_id ] );
 		$this->privacy->setDefaultPermissivePrivateContent( $site );
-		$this->assertEquals( get_option( 'permissive_private_content' ), 0 );
+
+		switch_to_blog( $blog_id );
+		$this->assertEquals( get_option( 'permissive_private_content' ), 1 );
+		restore_current_blog();
 	}
 }

--- a/tests/test-privacy.php
+++ b/tests/test-privacy.php
@@ -4,6 +4,9 @@ use Pressbooks\DataCollector\Book as DataCollector;
 use function Pressbooks\Admin\Laf\book_directory_excluded_callback;
 use Pressbooks\Admin\Network\SharingAndPrivacyOptions;
 
+/**
+ * @group privacy
+ */
 class GdprTest extends \WP_UnitTestCase {
 	use utilsTrait;
 
@@ -204,5 +207,14 @@ class GdprTest extends \WP_UnitTestCase {
 				'blogs_not_updated' => [ 9876 ],
 			]
 		);
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_sets_default_permissive_private_content() {
+		$site = new WP_Site( (object) [ 'blog_id' => 2 ] );
+		$this->privacy->setDefaultPermissivePrivateContent( $site );
+		$this->assertEquals( get_option( 'permissive_private_content' ), 0 );
 	}
 }


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks/issues/3763

This PR set the `permissive_private_content` option to `1` for new books. 
Currently, this option is not being stored or defined during book creation. In order to display posts, if it is not defined (default behaviour), it will consider this value as `false`.
With this change, we set the value to `1` during book creation.

### Testing case
- Create a new book
- Go to Settings > Sharing & Privacy
- Make sure `Private Content` is defined as `All logged in users including subscribers.` option