### PR TITLE
fix: append hooks in noon admin context

### DIFF
--- a/hooks.php
+++ b/hooks.php
@@ -350,3 +350,7 @@ add_filter( 'init', [ '\Pressbooks\Utility\ErrorHandler', 'init' ] );
 add_filter( 'init', [ Privacy::class, 'showPermissivePrivateContent' ] );
 
 add_action( 'wp_initialize_site', [ Privacy::class, 'setDefaultPermissivePrivateContent' ], 100, 1 );
+
+//Network Managers hooks via CLI
+add_action( 'revoked_super_admin', '\Pressbooks\Admin\NetworkManagers\remove_from_pressbooks_network_managers' );
+add_action( 'deleted_user', '\Pressbooks\Admin\NetworkManagers\remove_from_pressbooks_network_managers' );


### PR DESCRIPTION
This will allow to run the cleanup function for network managers using WP CLI.

Running `wp super-admin remove USER` will cleanup pressbooks_network_managers site_meta also it will do the same on user deletion