### PR TITLE
Fix: hide full plugin menu in books for network managers

### DIFF
--- a/inc/admin/plugins/namespace.php
+++ b/inc/admin/plugins/namespace.php
@@ -11,7 +11,7 @@ namespace Pressbooks\Admin\Plugins;
 use function Pressbooks\add_notice;
 
 /**
- * Hide plugins that aren't prefixed with `pressbooks-` (only applies to books).
+ * Hide unapproved plugins for book admins & network managers (only applies to books).
  * To show all plugins to all users, place the following in a plugin that loads before Pressbooks:
  * `remove_filter( 'all_plugins', '\Pressbooks\Admin\Plugins\filter_plugins', 10 );`
  *
@@ -31,7 +31,7 @@ function filter_plugins( $plugins ) {
 		];
 		$approved = [];
 		foreach ( $plugins as $slug => $value ) {
-			if ( strpos( $slug, 'pressbooks-' ) !== false || in_array( explode( '/', $slug )[0], $slugs, true ) ) {
+			if ( in_array( explode( '/', $slug )[0], $slugs, true ) ) {
 				$approved[ $slug ] = $value;
 			}
 		}

--- a/inc/admin/plugins/namespace.php
+++ b/inc/admin/plugins/namespace.php
@@ -21,7 +21,7 @@ use function Pressbooks\add_notice;
  */
 
 function filter_plugins( $plugins ) {
-	if ( ! is_super_admin() ) {
+	if ( ! is_super_admin() || is_restricted() ) {
 		$slugs = [
 			'h5p',
 			'hypothesis',

--- a/tests/test-admin-plugins.php
+++ b/tests/test-admin-plugins.php
@@ -14,8 +14,8 @@ class Admin_PluginsTest extends \WP_UnitTestCase {
 			'wordpress-seo/wordpress-seo.php' => [],
 		];
 		$filtered_plugins = \Pressbooks\Admin\Plugins\filter_plugins( $plugins );
-		$this->assertArrayHasKey( 'pressbooks-textbook/pressbooks-textbook.php', $filtered_plugins );
 		$this->assertArrayHasKey( 'parsedown-party/parsedownparty.php', $filtered_plugins );
+		$this->assertArrayNotHasKey( 'pressbooks-textbook/pressbooks-textbook.php', $filtered_plugins );
 		$this->assertArrayNotHasKey( 'hello-dolly/hello.php', $filtered_plugins );
 		$this->assertArrayNotHasKey( 'wordpress-seo/wordpress-seo.php', $filtered_plugins );
 	}


### PR DESCRIPTION
Network managers can currently see all plugins on the network when they view the plugins page in individual books, which sometimes leads to confusion. See https://github.com/pressbooks/pressbooks-ecampus-ontario/issues/48 for example.

This change makes it so that they see only the 'approved' plugins that book admins can activate/deactivate.

Before:
![Screenshot from 2024-09-04 14-26-07](https://github.com/user-attachments/assets/1e6f4a50-afc6-4f9e-9f62-4affc9ce4592)

After:
![Screenshot from 2024-09-04 14-25-27](https://github.com/user-attachments/assets/ddcb200d-3794-4ab0-af5c-5cd0a92230d6)
