### PR TITLE
chore: add missing import

### DIFF
--- a/inc/admin/plugins/namespace.php
+++ b/inc/admin/plugins/namespace.php
@@ -9,6 +9,8 @@
 namespace Pressbooks\Admin\Plugins;
 
 use function Pressbooks\add_notice;
+use function Pressbooks\Admin\NetworkManagers\is_restricted;
+
 
 /**
  * Hide unapproved plugins for book admins & network managers (only applies to books).


### PR DESCRIPTION
is_restricted is namespaced so is not in the same namespace, so an import is required