### PR TITLE
fix: apply the_content filter before rendering footnotes for EPUB and PDF export routines

### DIFF
--- a/inc/admin/plugins/namespace.php
+++ b/inc/admin/plugins/namespace.php
@@ -11,7 +11,6 @@ namespace Pressbooks\Admin\Plugins;
 use function Pressbooks\add_notice;
 use function Pressbooks\Admin\NetworkManagers\is_restricted;
 
-
 /**
  * Hide unapproved plugins for book admins & network managers (only applies to books).
  * To show all plugins to all users, place the following in a plugin that loads before Pressbooks:

--- a/inc/modules/export/epub/class-epub.php
+++ b/inc/modules/export/epub/class-epub.php
@@ -493,6 +493,10 @@ class Epub extends ExportGenerator {
 	 * @throws \Exception
 	 */
 	public function convertGenerator(): \Generator {
+		if ( ! has_filter( 'the_export_content', 'do_shortcode' ) ) {
+			add_filter( 'the_export_content', 'do_shortcode', 11 ); // After wpautop
+		}
+
 		yield 1 => $this->generatorPrefix . __( 'Initializing', 'pressbooks' );
 
 		// Sanity check

--- a/inc/shortcodes/footnotes/class-footnotes.php
+++ b/inc/shortcodes/footnotes/class-footnotes.php
@@ -133,10 +133,6 @@ class Footnotes {
 
 		global $id; // This is the Post ID, [@see WP_Query::setup_postdata, ...]
 
-		if ( ! has_filter( 'the_content', 'do_shortcode' ) ) {
-			add_filter( 'the_content', 'do_shortcode', 11 );
-		}
-
 		if ( ! empty( $this->footnotes ) && isset( $this->footnotes[ $id ] ) ) {
 			$footnotes = $this->footnotes[ $id ];
 		} else {

--- a/inc/shortcodes/footnotes/class-footnotes.php
+++ b/inc/shortcodes/footnotes/class-footnotes.php
@@ -133,6 +133,10 @@ class Footnotes {
 
 		global $id; // This is the Post ID, [@see WP_Query::setup_postdata, ...]
 
+		if ( ! has_filter( 'the_content', 'do_shortcode' ) ) {
+			add_filter( 'the_content', 'do_shortcode', 11 );
+		}
+
 		if ( ! empty( $this->footnotes ) && isset( $this->footnotes[ $id ] ) ) {
 			$footnotes = $this->footnotes[ $id ];
 		} else {


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks/issues/3408

This PR process `the_content` hook for footnotes content and also ensures that `do_shortcode` is applied before footnotes rendering during export routines. That's because, in the export context, the default WordPress filters attached to the_content might not be present.

In order to fix the latex formulas style in Prince, [this PR](https://github.com/pressbooks/pressbooks-book/pull/1252) needs to be merged.

### Testing sample in local environment
- Make sure you have the `PB_MATHJAX_URL` env variable in your local environment
- In a chapter add a footnote and inside this, add a latex formula, for example: `This is a text in a chapter [footnote]This is a [latex]x^3 - 25[/latex][/footnote], make sure it is included`.
- Export the book to PDF and EPUB including this chapter.
- Make sure the chapter contains the footnote, and the latex formula is displayed as expected.