### PR TITLE
fix: avoid applying shortcodes during mathjax content analysis

### DIFF
--- a/inc/class-mathjax.php
+++ b/inc/class-mathjax.php
@@ -253,8 +253,8 @@ class MathJax {
 			if ( isset( $this->sectionHasMath[ $id ] ) ) {
 				$has_math = $this->sectionHasMath[ $id ];
 			} else {
-				$content = apply_shortcodes( $post->post_content );
-				$math_tags = [ '[/latex]', '$latex', '[/asciimath]', '$asciimath', '</math>' ];
+				$content = $post->post_content;
+				$math_tags = [ '[table id=', '[/latex]', '$latex', '[/asciimath]', '$asciimath', '</math>' ];
 				foreach ( $math_tags as $math_tag ) {
 					if ( str_contains( $content, $math_tag ) ) {
 						$has_math = true;


### PR DESCRIPTION
This PR fixes the fact that footnotes are displayed twice in the web format of a chapter when the footnotes contain latex shortcode.

At the same time, if process latex formulas within the TablePress [table] shortcode when it contains latex formulas. Even the table may not contain formulas, the code considers it may have.

For testing:
- Add tablePress without any formulas in a chapter
- Add tablePress table with formulas in another chapter
- Add footnotes with and without latex formulas in different chapters

Make sure the formulas and tables are rendered as expected.