### PR TITLE
fix: default book theme needs to be accessible

### DIFF
--- a/pressbooks.php
+++ b/pressbooks.php
@@ -44,7 +44,7 @@ function _pb_default_book_theme() {
 		if ( defined( 'PB_BOOK_THEME' ) ) {
 			define( 'WP_DEFAULT_THEME', PB_BOOK_THEME );
 		} else {
-			define( 'WP_DEFAULT_THEME', get_site_option( 'pressbooks_default_book_theme', 'pressbooks-malala' ) );
+			define( 'WP_DEFAULT_THEME', get_site_option( 'pressbooks_default_book_theme', 'pressbooks-book' ) );
 		}
 	}
 }


### PR DESCRIPTION
1. Why did you change it to break for everyone instead of only changing it on your instance(s)?
2. If you really need it to be defined in the same version that is pushed publicly for your system to function, why not have a variable check so that it is changed on *your* instance(s) and can otherwise fall back to something accessible elsewhere?

Fixes #3807 