### PR TITLE
fix: avoid null return in getSubmenuBySlug method

### DIFF
--- a/inc/admin/menus/class-sidebar.php
+++ b/inc/admin/menus/class-sidebar.php
@@ -678,7 +678,7 @@ class SideBar {
 				return $item;
 			}
 		}
-		return array_shift( $submenu );
+		return array_values( $submenu )[0] ?? [];
 	}
 
 	private function manageIntegrationsAdminMenuItem(): void {

--- a/inc/admin/menus/class-sidebar.php
+++ b/inc/admin/menus/class-sidebar.php
@@ -678,7 +678,7 @@ class SideBar {
 				return $item;
 			}
 		}
-		return $submenu[0];
+		return array_shift( $submenu );
 	}
 
 	private function manageIntegrationsAdminMenuItem(): void {


### PR DESCRIPTION
This PR fixes: https://github.com/pressbooks/pressbooks/issues/3796

I could not set up a configuration in my network that leads to a `$submenu` array with no elements for position 0.
However, the intentation seems to be to return the first available position in `$submenu` variable. This PR intends to ensure it.