### PR TITLE
fix: append release please sections

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,5 +7,23 @@
     ".": {
       "extra-files": ["pressbooks.php", "README.md"]
     }
-  }
+  },
+  "changelog-sections": [
+		{
+			"type": "feat",
+			"section": "Features"
+		},
+		{
+			"type": "fix",
+			"section": "Bug Fixes"
+		},
+		{
+			"type": "docs",
+			"section": "Documentation"
+		},
+		{
+			"type": "chore",
+			"section": "Chores"
+		}
+	]
 }


### PR DESCRIPTION
This will include chores and documentation units in release notes (for instance: translations, and dependency bumps to have more visibility)