### PR TITLE
feat: update post_modified fields when menu_order is updated

### DIFF
--- a/inc/admin/organize/namespace.php
+++ b/inc/admin/organize/namespace.php
@@ -122,6 +122,7 @@ function reorder() {
 		parse_str( $_POST['old_order'], $old_order );
 		$new_parent = (int) $_POST['new_parent'];
 		$old_parent = (int) $_POST['old_parent'];
+		$updated_at = current_time( 'mysql' );
 		// If the parent changed, set new parent for chapter
 		// and new order for parent
 		if ( $new_parent !== $old_parent ) {
@@ -136,6 +137,8 @@ function reorder() {
 						$wpdb->update(
 							$wpdb->posts, [
 								'menu_order' => $position,
+								'post_modified' => $updated_at,
+								'post_modified_gmt' => get_gmt_from_date( $updated_at ),
 							], [
 								'ID' => $id,
 							]
@@ -153,6 +156,8 @@ function reorder() {
 					$wpdb->update(
 						$wpdb->posts, [
 							'menu_order' => $position,
+							'post_modified' => $updated_at,
+							'post_modified_gmt' => get_gmt_from_date( $updated_at ),
 						], [
 							'ID' => $id,
 						]


### PR DESCRIPTION
This will help us to track menu_order changes.

### Problem
`menu_order` gets updated when chapters are reordered in the organize page but we are not touching the timestamp of each chapter so we don't have a way to track menu_order changes.

### Solution 
Touch timestamp fields when menu_order changes

### How to test
Reorder, delete, create new posts and check timestamp fields to see if those gets updated