### PR TITLE
chore: update Lemoore College name 

### DIFF
--- a/symbionts/institutions/institutions.json
+++ b/symbionts/institutions/institutions.json
@@ -4867,7 +4867,7 @@
           },
           {
             "code": "US-CA-198",
-            "name": "West Hills College Lemoore",
+            "name": "Lemoore College",
             "url": "https:\/\/www.westhillscollege.com\/lemoore\/"
           },
           {


### PR DESCRIPTION
As requested by an OER librarian. The college’s name changed from West Hills College Lemoore to Lemoore College.