### PR TITLE
fix: prevent subscriber role when not needed

### DIFF
--- a/inc/class-activation.php
+++ b/inc/class-activation.php
@@ -438,11 +438,21 @@ class Activation {
 	}
 
 	public function addUserDefaultRole( $id ) {
-		if ( is_numeric( $id ) ) {
-			$user_id = $id;
-			$user = get_userdata( $user_id );
-			$user->add_role( 'subscriber' );
+		if ( ! is_numeric( $id ) ) {
+			return;
 		}
+
+		$user = get_userdata( $id );
+
+		if ( ! $user ) {
+			return;
+		}
+
+		if ( ! empty( $user->roles ) ) {
+			return;
+		}
+
+		$user->add_role( 'subscriber' );
 	}
 
 	/**

--- a/inc/class-book.php
+++ b/inc/class-book.php
@@ -978,7 +978,7 @@ class Book {
 				$new = absint( $new );
 			}
 
-			$updated_at = current_time('mysql');
+			$updated_at = current_time( 'mysql' );
 
 			$success = $wpdb->query(
 				$wpdb->prepare(
@@ -997,7 +997,7 @@ class Book {
 
 		}
 
-		return (bool)$success;
+		return (bool) $success;
 	}
 
 	/**
@@ -1023,7 +1023,7 @@ class Book {
 		$order = $post_to_delete->menu_order;
 		$type = $post_to_delete->post_type;
 		$parent = $post_to_delete->post_parent;
-		$updated_at = current_time('mysql');
+		$updated_at = current_time( 'mysql' );
 
 		if ( 'chapter' === $type ) {
 			$success = $wpdb->query(
@@ -1098,7 +1098,7 @@ class Book {
 
 		static::deleteBookObjectCache();
 
-		return (bool)$success;
+		return (bool) $success;
 	}
 
 	/**


### PR DESCRIPTION
Issue #3648 

This PR aims to fix an issue where `subscriber` role was added to a user while updating them. Users would have two roles in place causing some issues with permissions.

**How to test**

- Follow the steps from this comment: https://github.com/pressbooks/pressbooks/issues/3648#issuecomment-2430301503
- Users should be updated without having an additional role
- In addition, follow the steps from this PR https://github.com/pressbooks/pressbooks/pull/2269#issue-950986539 to make sure lowly users are still able to create/clone books