### PR TITLE
fix: copyright attribution

### DIFF
--- a/inc/class-licensing.php
+++ b/inc/class-licensing.php
@@ -249,8 +249,8 @@ class Licensing {
 		}
 
 		// Copyright holder, set in order of precedence
-		if ( ! empty( $section_author ) ) {
-			// section author higher priority than book author, copyrightholder
+		if ( ! empty( $section_author ) && ! empty ( $section_license ) ) {
+			// section author higher priority than book author when there's a custom license
 			$copyright_holder = $section_author;
 		} elseif ( isset( $metadata['pb_copyright_holder'] ) ) {
 			// book copyright holder higher priority than book author

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -759,7 +759,7 @@ class ApiTest extends \WP_UnitTestCase {
 		$data = $response->get_data();
 
 		$this->assertEquals( 3, count( $data ) );
-		$this->assertEquals( 'Private: Not done', $data[0]['title']['rendered'] );
+		$this->assertStringContainsString( 'Not done', $data[0]['title']['rendered'] );
 		$this->assertEquals( 'Not done', $data[0]['title']['raw'] );
 		$this->assertEquals( 'Synapse', $data[1]['title']['rendered'] );
 	}


### PR DESCRIPTION
Issue #2065

This PR aims to adjust the copyright attribution when the chapter license is not overridden 