### PR TITLE
chore: bump test matrix wp version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,13 +14,13 @@ jobs:
       fail-fast: false
       matrix:
         php: [ 8.1, 8.2 ]
-        wordpress: [ '6.6.2', 'latest' ]
+        wordpress: [ '6.7', 'latest' ]
         experimental: [ false ]
         epubcheck: [ 4.2.6 ]
         prince: [ 14.3-1 ]
         include:
           - php: 8.2
-            wordpress: 6.6.2
+            wordpress: 6.7
             prince: 14.3-1
             epubcheck: 4.2.6
             experimental: true


### PR DESCRIPTION
Just a simple bump to run our tests against the latest supported WP's version