### PR TITLE
Add missing restore_current_blog call in getCoverThumbnail

### DIFF
--- a/inc/datacollector/class-book.php
+++ b/inc/datacollector/class-book.php
@@ -635,6 +635,8 @@ SQL;
 			$cover_path = wp_get_attachment_image_url( $cover_id, 'pb_cover_large', false );
 		}
 
+		restore_current_blog();
+
 		return  is_ssl() ? str_replace( 'http://', 'https://', $cover_path ) : $cover_path;
 	}
 


### PR DESCRIPTION
The getCoverThumbnail method in Pressbooks\DataCollector\Book calls switch_to_blog( $book_id ); to get the attachment information but then fails to call restore_current_blog. In my case this lead to issues with other plugins trying to save metadata.
This pull request simply adds said restore_current_blog call to the function.