### PR TITLE
chore: reuse objects to csv function

### DIFF
--- a/inc/utility/namespace.php
+++ b/inc/utility/namespace.php
@@ -14,6 +14,7 @@
 // @phpcs:disable WordPress.PHP.DontExtract.extract_extract
 
 namespace Pressbooks\Utility;
+use RuntimeException;
 
 /**
  * Return a value for a given key even if not set
@@ -1594,4 +1595,38 @@ function delete_options_cached() : void {
  */
 function is_algolia_search_enabled(): bool {
 	return env( 'ALGOLIA_APP_ID' ) && env( 'ALGOLIA_API_KEY' ) && env( 'ALGOLIA_INDEX_NAME' );
+}
+
+/**
+ * Convert an array of objects to a CSV string.
+ *
+ * @param array $array Array of objects to be converted.
+ * @return string CSV representation of the array.
+ */
+function objects_to_csv(array $array): string
+{
+	if (count($array) === 0) {
+		return '';
+	}
+
+	$output = fopen('php://memory', 'w');
+	if ($output === false) {
+		throw new RuntimeException('Failed to open memory stream for CSV conversion.');
+	}
+
+	// Extract headers from the first object
+	$headers = array_keys(get_object_vars($array[0]));
+	fputcsv($output, $headers);
+
+	// Extract each row
+	foreach ($array as $obj) {
+		$row = array_values(get_object_vars($obj));
+		fputcsv($output, $row);
+	}
+
+	rewind($output);
+	$csv = stream_get_contents($output);
+	fclose($output);
+
+	return $csv ?: '';
 }

--- a/tests/test-utility.php
+++ b/tests/test-utility.php
@@ -1,5 +1,7 @@
 <?php
 
+use function Pressbooks\Utility\objects_to_csv;
+
 class UtilityTest extends \WP_UnitTestCase {
 	use utilsTrait;
 
@@ -784,7 +786,28 @@ class UtilityTest extends \WP_UnitTestCase {
 		$this->assertTrue( is_a( $class2->getMethod( 'display' ), '\ReflectionMethod' ) );
 	}
 
+	/**
+	 * @group utility
+	 */
 	public function test_objects_to_csv() {
 		
+		$data = [
+			(object) [
+				'title' => 'foo',
+				'author' => 'bar',
+				'isbn' => 'baz',
+			],
+			(object) [
+				'title' => 'foo2',
+				'author' => 'bar2',
+				'isbn' => 'baz2',
+			],
+		];
+
+
+		$csv = objects_to_csv( $data );
+
+		$this->assertStringContainsString( 'title,author,isbn', $csv );
+		$this->assertStringContainsString( 'foo,bar,baz', $csv );
 	}
 }

--- a/tests/test-utility.php
+++ b/tests/test-utility.php
@@ -770,7 +770,7 @@ class UtilityTest extends \WP_UnitTestCase {
 	/**
 	 * @group utility
 	 */
-	public function test_contractAndTraits() {
+	public function test_contracts_and_traits() {
 		$contributors = new \Pressbooks\Contributors();
 		$glossary = new Pressbooks\Shortcodes\Glossary\Glossary();
 
@@ -782,5 +782,9 @@ class UtilityTest extends \WP_UnitTestCase {
 
 		$this->assertTrue( is_a( $class1->getMethod( 'display' ), '\ReflectionMethod' ) );
 		$this->assertTrue( is_a( $class2->getMethod( 'display' ), '\ReflectionMethod' ) );
+	}
+
+	public function test_objects_to_csv() {
+		
 	}
 }


### PR DESCRIPTION
This PR adds this function used by results to convert object arrays to csv without any library