### PR TITLE
fix: add header_bg to customizer colors array

### DIFF
--- a/inc/admin/branding/namespace.php
+++ b/inc/admin/branding/namespace.php
@@ -132,6 +132,7 @@ function admin_title( $admin_title ) {
  */
 function get_customizer_colors() {
 	$colors = [
+		'header_bg',
 		'primary',
 		'accent',
 		'primary_fg',


### PR DESCRIPTION
Adds header background to the array of color variables that can be overridden with the theme customizer. Partial fix for https://github.com/pressbooks/pressbooks-aldine/issues/198