### PR TITLE
feat: add LinkedIn and Email sharing options, update Twitter, allow users to choose which to display

### DIFF
--- a/inc/modules/themeoptions/class-weboptions.php
+++ b/inc/modules/themeoptions/class-weboptions.php
@@ -134,13 +134,13 @@ class WebOptions extends \Pressbooks\Options {
 		}
 
 		add_settings_field(
-			'social_media',
-			__( 'Enable Social Media', 'pressbooks' ),
-			[ $this, 'renderSocialMediaField' ],
+			'social_media_options',
+			__( 'Social Media Options', 'pressbooks' ),
+			[ $this, 'renderSocialMediaOptionsField' ],
 			$_page,
 			$_section,
 			[
-				__( 'Adds a button to cover page and each chapter which allows readers to share links to your book through Twitter', 'pressbooks' ),
+				__( 'Select which social media buttons to display.', 'pressbooks' ),
 			]
 		);
 
@@ -244,6 +244,7 @@ class WebOptions extends \Pressbooks\Options {
 		$deprecated = [
 			'toc_collapse',
 			'accessibility_fontsize',
+			'social_media'
 		];
 
 		foreach ( $options as $key => $value ) {
@@ -255,22 +256,23 @@ class WebOptions extends \Pressbooks\Options {
 		update_option( 'pressbooks_theme_options_' . $_option, $options );
 	}
 
-	/**
-	 * Render the social_media checkbox.
-	 *
-	 * @param array $args
-	 */
-	function renderSocialMediaField( $args ) {
-		unset( $args['label_for'], $args['class'] );
-		$this->renderCheckbox(
-			[
-				'id' => 'social_media',
-				'name' => 'pressbooks_theme_options_' . $this->getSlug(),
-				'option' => 'social_media',
-				'value' => ( isset( $this->options['social_media'] ) ) ? $this->options['social_media'] : '',
-				'label' => $args[0],
-			]
-		);
+	function renderSocialMediaOptionsField( $args ) {
+		$options = isset( $this->options['social_media_options'] ) ? $this->options['social_media_options'] : [];
+		$all_options = [
+			'twitter' => __( 'X (formerly Twitter)', 'pressbooks' ),
+			'linkedin' => __( 'LinkedIn', 'pressbooks' ),
+			'email' => __( 'Email', 'pressbooks' ),
+		];
+
+		foreach ( $all_options as $key => $label ) {
+			printf(
+				'<label><input type="checkbox" name="pressbooks_theme_options_%1$s[social_media_options][]" value="%2$s" %3$s /> %4$s</label><br>',
+				esc_attr( $this->getSlug() ),
+				esc_attr( $key ),
+				in_array( $key, $options, true ) ? 'checked' : '',
+				esc_html( $label )
+			);
+		}
 	}
 
 	/**
@@ -414,7 +416,7 @@ class WebOptions extends \Pressbooks\Options {
 			'pb_theme_options_web_defaults', [
 				'webbook_header_font' => '',
 				'webbook_body_font' => '',
-				'social_media' => 1,
+				'social_media_options' => [ 'twitter', 'linkedin', 'email' ],
 				'paragraph_separation' => 'skiplines',
 				'part_title' => 0,
 				'webbook_width' => '40em',
@@ -449,7 +451,6 @@ class WebOptions extends \Pressbooks\Options {
 		 */
 		return apply_filters(
 			'pb_theme_options_web_booleans', [
-				'social_media',
 				'part_title',
 				'collapse_sections',
 			]
@@ -516,7 +517,7 @@ class WebOptions extends \Pressbooks\Options {
 	 */
 	static function getPredefinedOptions() {
 		/**
-		 * Allow custom predifined options to be passed to sanitization routines.
+		 * Allow custom predefined options to be passed to sanitization routines.
 		 *
 		 * @param array $value
 		 *
@@ -526,6 +527,7 @@ class WebOptions extends \Pressbooks\Options {
 			'pb_theme_options_web_predefined', [
 				'paragraph_separation',
 				'webbook_width',
+				'social_media_options'
 			]
 		);
 	}

--- a/tests/test-options.php
+++ b/tests/test-options.php
@@ -494,6 +494,24 @@ class OptionsTest extends \WP_UnitTestCase {
 
 	/**
 	 * @group options
+	 * Test the renderSocialMediaOptionsField function.
+	 */
+	public function test_renderSocialMediaOptionsField() {
+		$options = new Pressbooks\Modules\ThemeOptions\WebOptions( [ ] );
+		ob_start();
+		$options->renderSocialMediaOptionsField([]);
+		$buffer = ob_get_clean();
+		$this->assertStringContainsString('name="pressbooks_theme_options_web[social_media_options][]"', $buffer);
+		$this->assertStringContainsString('value="twitter"', $buffer);
+		$this->assertStringContainsString('checked', $buffer);
+		$this->assertStringContainsString('value="email"', $buffer);
+		$this->assertStringContainsString('checked', $buffer);
+		$this->assertStringContainsString('value="linkedin"', $buffer);
+		$this->assertStringContainsString('checked', $buffer);
+	}
+
+	/**
+	 * @group options
 	 */
 	public function test_renderAboutTheAuthorField() {
 		$options = new \Pressbooks\Modules\ThemeOptions\GlobalOptions( [] );


### PR DESCRIPTION
Instead of a boolean that displays the Twitter share icon or not, this PR presents users with three social sharing options (X/Twitter, LinkedIn, and email). Each of these options will be selected by default. If selected, each option will display the relevant icon on the book homepage. When clicked, we use the sharer.js utility to initiate a social sharing action. Also replaces the Twitter logo with the new X logo. Addresses https://github.com/pressbooks/ideas/issues/500

To test:
1. Check out this branch
2. Go to theme options -> web options and turn any of the three options on or off
3. Visit the book's homepage and observe the icons appear/disappear
4. Click on the relevant icon and observe the expected social sharing behaviour.

Note: depends on https://github.com/pressbooks/pressbooks-book/pull/1290