### PR TITLE
feat: remove lti references

### DIFF
--- a/inc/admin/menus/class-sidebar.php
+++ b/inc/admin/menus/class-sidebar.php
@@ -710,35 +710,6 @@ class SideBar {
 		if ( is_plugin_active( 'pressbooks-oidc-sso/pressbooks-oidc-sso.php' ) ) {
 			\PressbooksOidcSso\Admin::init()->addMenu();
 		}
-
-		if ( is_plugin_active( 'pressbooks-lti-provider-1p3/pressbooks-lti-provider.php' ) ) {
-			$lti_admin = \PressbooksLtiProvider1p3\Admin::init();
-			$lti_admin->addConsumersMenu();
-			$lti_admin->addSettingsMenu();
-
-			// Move LTI settings menu item to network admin menu page
-			if ( ! is_network_admin() && isset( $submenu['pb_network_integrations'] ) ) {
-				$submenu[ network_admin_url( 'admin.php?page=pb_lti_settings' ) ] = $submenu['pb_network_integrations'];
-				unset( $submenu['pb_network_integrations'] );
-			}
-
-			if (
-				isset( $submenu[ network_admin_url( 'admin.php?page=pb_network_integrations' ) ] ) &&
-				$submenu[ network_admin_url( 'admin.php?page=pb_network_integrations' ) ][0][2] === network_admin_url( 'admin.php?page=pb_network_integrations' )
-			) {
-				unset( $submenu[ network_admin_url( 'admin.php?page=pb_network_integrations' ) ][0] );
-			}
-		}
-
-		if ( is_plugin_active( 'pressbooks-lti/pressbooks-lti.php' ) ) {
-			( new \PressbooksLti\Bootstrap() )->registerMenus();
-
-			// Move LTI settings menu item to network admin menu page
-			if ( ! is_network_admin() && isset( $submenu['pb_network_integrations'] ) ) {
-				$submenu[ network_admin_url( 'admin.php?page=pb_lti_settings' ) ] = $submenu['pb_network_integrations'];
-				unset( $submenu['pb_network_integrations'] );
-			}
-		}
 	}
 
 	private function getKokoAnalyticsSlug(): string {

--- a/inc/class-licensing.php
+++ b/inc/class-licensing.php
@@ -249,7 +249,7 @@ class Licensing {
 		}
 
 		// Copyright holder, set in order of precedence
-		if ( ! empty( $section_author ) && ! empty ( $section_license ) ) {
+		if ( ! empty( $section_author ) && ! empty( $section_license ) ) {
 			// section author higher priority than book author when there's a custom license
 			$copyright_holder = $section_author;
 		} elseif ( isset( $metadata['pb_copyright_holder'] ) ) {

--- a/inc/datacollector/class-book.php
+++ b/inc/datacollector/class-book.php
@@ -89,8 +89,6 @@ class Book {
 
 	const BOOK_INFORMATION_ARRAY = 'pb_book_information_array';
 
-	const LTI_GRADING_ENABLED = 'pb_lti_grading_enabled';
-
 	const BOOK_DIRECTORY_EXCLUDED = 'pb_book_directory_excluded';
 
 	const AUTHORS = 'pb_authors';

--- a/inc/modules/themeoptions/class-weboptions.php
+++ b/inc/modules/themeoptions/class-weboptions.php
@@ -244,7 +244,7 @@ class WebOptions extends \Pressbooks\Options {
 		$deprecated = [
 			'toc_collapse',
 			'accessibility_fontsize',
-			'social_media'
+			'social_media',
 		];
 
 		foreach ( $options as $key => $value ) {
@@ -527,7 +527,7 @@ class WebOptions extends \Pressbooks\Options {
 			'pb_theme_options_web_predefined', [
 				'paragraph_separation',
 				'webbook_width',
-				'social_media_options'
+				'social_media_options',
 			]
 		);
 	}

--- a/inc/utility/namespace.php
+++ b/inc/utility/namespace.php
@@ -14,6 +14,7 @@
 // @phpcs:disable WordPress.PHP.DontExtract.extract_extract
 
 namespace Pressbooks\Utility;
+
 use RuntimeException;
 
 /**
@@ -1603,30 +1604,29 @@ function is_algolia_search_enabled(): bool {
  * @param array $array Array of objects to be converted.
  * @return string CSV representation of the array.
  */
-function objects_to_csv(array $array): string
-{
-	if (count($array) === 0) {
+function objects_to_csv( array $array ): string {
+	if ( count( $array ) === 0 ) {
 		return '';
 	}
 
-	$output = fopen('php://memory', 'w');
-	if ($output === false) {
-		throw new RuntimeException('Failed to open memory stream for CSV conversion.');
+	$output = fopen( 'php://memory', 'w' );
+	if ( $output === false ) {
+		throw new RuntimeException( 'Failed to open memory stream for CSV conversion.' );
 	}
 
 	// Extract headers from the first object
-	$headers = array_keys(get_object_vars($array[0]));
-	fputcsv($output, $headers);
+	$headers = array_keys( get_object_vars( $array[0] ) );
+	fputcsv( $output, $headers );
 
 	// Extract each row
-	foreach ($array as $obj) {
-		$row = array_values(get_object_vars($obj));
-		fputcsv($output, $row);
+	foreach ( $array as $obj ) {
+		$row = array_values( get_object_vars( $obj ) );
+		fputcsv( $output, $row );
 	}
 
-	rewind($output);
-	$csv = stream_get_contents($output);
-	fclose($output);
+	rewind( $output );
+	$csv = stream_get_contents( $output );
+	fclose( $output );
 
 	return $csv ?: '';
 }


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks-network-analytics/issues/375

This pull request includes several changes across different files, mainly focusing on simplifying the codebase and removing deprecated or unused elements. The most important changes include the removal of LTI-related code, cleanup of constants, and minor formatting adjustments.

### Codebase Simplification:

* [`inc/admin/menus/class-sidebar.php`](diffhunk://#diff-a00b7b4a852a41e3414d829866be6102271cec9eef745d5131a254ae581770a1L713-L741): Removed all code related to the LTI provider and LTI plugin, including menu item management and network admin menu adjustments.
* [`inc/datacollector/class-book.php`](diffhunk://#diff-29ab3f3c40495d554c34b2b53d32985b8d0ed7ea485c6d86b691bb70d27ca13bL92-L93): Removed the constant `LTI_GRADING_ENABLED` which is no longer used.

### Code Cleanup:

There are some code cleanups performed by the lint checker.