### PR TITLE
fix: replace Twitter references

### DIFF
--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -1652,7 +1652,7 @@ function edit_screen_navigation( $post ) {
  */
 function get_user_contact_fields() {
 	$methods = [];
-	$methods['twitter'] = esc_html__( 'Twitter URL', 'pressbooks' );
+	$methods['twitter'] = esc_html__( 'X/Twitter URL', 'pressbooks' );
 	$methods['linkedin'] = esc_html__( 'LinkedIn URL', 'pressbooks' );
 	$methods['github'] = esc_html__( 'GitHub URL', 'pressbooks' );
 	return $methods;

--- a/inc/admin/metaboxes/class-about.php
+++ b/inc/admin/metaboxes/class-about.php
@@ -25,7 +25,7 @@ class About extends Metabox {
 			new Text(
 				name: 'pb_about_140',
 				label: __( 'Book Tagline', 'pressbooks' ),
-				description: __( 'A very short description of your book. It should fit in a Twitter post, and encapsulate your book in the briefest sentence.', 'pressbooks' )
+				description: __( 'A very short description of your book. It should fit in a social media post, and encapsulate your book in the briefest sentence.', 'pressbooks' )
 			),
 			new TextArea(
 				name: 'pb_about_50',

--- a/inc/admin/metaboxes/class-additionalcataloginformation.php
+++ b/inc/admin/metaboxes/class-additionalcataloginformation.php
@@ -40,7 +40,7 @@ class AdditionalCatalogInformation extends Metabox {
 			new Text(
 				name: 'pb_hashtag',
 				label: __( 'Hashtag', 'pressbooks' ),
-				description: __( 'These are added to your webbook cover page. For those of you who like Twitter.', 'pressbooks' ),
+				description: __( 'This hashtag is added to your webbook cover page and can be referenced on social media. Will also be included in social shares to X.', 'pressbooks' ),
 			),
 			new Text(
 				name: 'pb_list_price_print',

--- a/inc/class-contributors.php
+++ b/inc/class-contributors.php
@@ -483,10 +483,10 @@ class Contributors implements BackMatter, Transferable {
 				'sanitization_method' => '\Pressbooks\Sanitize\validate_url_field',
 			],
 			self::TAXONOMY . '_twitter' => [
-				'label' => esc_html__( 'Twitter', 'pressbooks' ),
+				'label' => esc_html__( 'X/Twitter', 'pressbooks' ),
 				'tag' => self::TAXONOMY . '-twitter',
 				'input_type' => 'text',
-				'description' => esc_html__( 'Twitter profile for this contributor. Must be a valid URL.', 'pressbooks' ),
+				'description' => esc_html__( 'X/Twitter profile for this contributor. Must be a valid URL.', 'pressbooks' ),
 				'sanitization_method' => '\Pressbooks\Sanitize\validate_url_field',
 			],
 			self::TAXONOMY . '_linkedin' => [

--- a/inc/class-licensing.php
+++ b/inc/class-licensing.php
@@ -249,7 +249,7 @@ class Licensing {
 		}
 
 		// Copyright holder, set in order of precedence
-		if ( ! empty( $section_author ) && ! empty ( $section_license ) ) {
+		if ( ! empty( $section_author ) && ! empty( $section_license ) ) {
 			// section author higher priority than book author when there's a custom license
 			$copyright_holder = $section_author;
 		} elseif ( isset( $metadata['pb_copyright_holder'] ) ) {

--- a/inc/modules/themeoptions/class-weboptions.php
+++ b/inc/modules/themeoptions/class-weboptions.php
@@ -244,7 +244,7 @@ class WebOptions extends \Pressbooks\Options {
 		$deprecated = [
 			'toc_collapse',
 			'accessibility_fontsize',
-			'social_media'
+			'social_media',
 		];
 
 		foreach ( $options as $key => $value ) {
@@ -527,7 +527,7 @@ class WebOptions extends \Pressbooks\Options {
 			'pb_theme_options_web_predefined', [
 				'paragraph_separation',
 				'webbook_width',
-				'social_media_options'
+				'social_media_options',
 			]
 		);
 	}

--- a/inc/utility/namespace.php
+++ b/inc/utility/namespace.php
@@ -14,6 +14,7 @@
 // @phpcs:disable WordPress.PHP.DontExtract.extract_extract
 
 namespace Pressbooks\Utility;
+
 use RuntimeException;
 
 /**
@@ -1603,30 +1604,29 @@ function is_algolia_search_enabled(): bool {
  * @param array $array Array of objects to be converted.
  * @return string CSV representation of the array.
  */
-function objects_to_csv(array $array): string
-{
-	if (count($array) === 0) {
+function objects_to_csv( array $array ): string {
+	if ( count( $array ) === 0 ) {
 		return '';
 	}
 
-	$output = fopen('php://memory', 'w');
-	if ($output === false) {
-		throw new RuntimeException('Failed to open memory stream for CSV conversion.');
+	$output = fopen( 'php://memory', 'w' );
+	if ( $output === false ) {
+		throw new RuntimeException( 'Failed to open memory stream for CSV conversion.' );
 	}
 
 	// Extract headers from the first object
-	$headers = array_keys(get_object_vars($array[0]));
-	fputcsv($output, $headers);
+	$headers = array_keys( get_object_vars( $array[0] ) );
+	fputcsv( $output, $headers );
 
 	// Extract each row
-	foreach ($array as $obj) {
-		$row = array_values(get_object_vars($obj));
-		fputcsv($output, $row);
+	foreach ( $array as $obj ) {
+		$row = array_values( get_object_vars( $obj ) );
+		fputcsv( $output, $row );
 	}
 
-	rewind($output);
-	$csv = stream_get_contents($output);
-	fclose($output);
+	rewind( $output );
+	$csv = stream_get_contents( $output );
+	fclose( $output );
 
 	return $csv ?: '';
 }

--- a/templates/admin/organize.blade.php
+++ b/templates/admin/organize.blade.php
@@ -112,19 +112,19 @@
                 </caption>
                 <thead>
                     <tr>
-                        <th scope="col" class="title">{{ __('Title') }}</th>
-                        <th scope="col" class="authors">{{ __('Authors', 'pressbooks') }}</th>
+                        <th scope="col">{{ __('Title') }}</th>
+                        <th scope="col">{{ __('Authors', 'pressbooks') }}</th>
                         @if (false === $disable_comments)
-                            <th scope="col" class="comments">{{ __('Comments', 'pressbooks') }}</th>
+                            <th scope="col">{{ __('Comments', 'pressbooks') }}</th>
                         @endif
-                        <th scope="col" class="show web"><button class="button"
+                        <th scope="col"><button class="button"
                                 id="{{ str_contains($slug, 'part') ? 'chapters' : $slug }}_web_visibility"
                                 type="button" aria-pressed="false">{{ __('Show in Web', 'pressbooks') }}</button></th>
-                        <th scope="col" class="show exports"><button class="button"
+                        <th scope="col"><button class="button"
                                 id="{{ str_contains($slug, 'part') ? 'chapters' : $slug }}_export_visibility"
                                 type="button" aria-pressed="false">{{ __('Show in Exports', 'pressbooks') }}</button>
                         </th>
-                        <th scope="col" class="show title"><button class="button"
+                        <th scope="col"><button class="button"
                                 id="{{ str_contains($slug, 'part') ? 'chapters' : $slug }}_show_title" type="button"
                                 aria-pressed="false">{{ __('Show Title', 'pressbooks') }}</button></th>
                     </tr>

--- a/templates/admin/organize.blade.php
+++ b/templates/admin/organize.blade.php
@@ -112,19 +112,19 @@
                 </caption>
                 <thead>
                     <tr>
-                        <th scope="col">{{ __('Title') }}</th>
-                        <th scope="col">{{ __('Authors', 'pressbooks') }}</th>
+                        <th scope="col" class="title">{{ __('Title') }}</th>
+                        <th scope="col" class="authors">{{ __('Authors', 'pressbooks') }}</th>
                         @if (false === $disable_comments)
-                            <th scope="col">{{ __('Comments', 'pressbooks') }}</th>
+                            <th scope="col" class="comments">{{ __('Comments', 'pressbooks') }}</th>
                         @endif
-                        <th scope="col"><button class="button"
+                        <th scope="col" class="show web"><button class="button"
                                 id="{{ str_contains($slug, 'part') ? 'chapters' : $slug }}_web_visibility"
                                 type="button" aria-pressed="false">{{ __('Show in Web', 'pressbooks') }}</button></th>
-                        <th scope="col"><button class="button"
+                        <th scope="col" class="show exports"><button class="button"
                                 id="{{ str_contains($slug, 'part') ? 'chapters' : $slug }}_export_visibility"
                                 type="button" aria-pressed="false">{{ __('Show in Exports', 'pressbooks') }}</button>
                         </th>
-                        <th scope="col"><button class="button"
+                        <th scope="col" class="show title"><button class="button"
                                 id="{{ str_contains($slug, 'part') ? 'chapters' : $slug }}_show_title" type="button"
                                 aria-pressed="false">{{ __('Show Title', 'pressbooks') }}</button></th>
                     </tr>

--- a/templates/posttypes/contributor.blade.php
+++ b/templates/posttypes/contributor.blade.php
@@ -35,9 +35,9 @@
 							</p>
 						@else
 							<a href="{{$contributor['contributor_twitter']}}" target="_blank">
-								<svg role="img" aria-labelledby="twitter-logo-{{ $key }}" class="contributor__icon-svg">
-									<title id="twitter-logo-{{ $key }}">Twitter logo</title>
-									<use href="#twitter-icon"/>
+								<svg role="img" aria-labelledby="x-logo-{{ $key }}" class="contributor__icon-svg">
+									<title id="x-logo-{{ $key }}">X logo</title>
+									<use href="#twitter"/>
 								</svg>
 							</a>
 						@endif

--- a/tests/test-admin-laf.php
+++ b/tests/test-admin-laf.php
@@ -340,7 +340,7 @@ class Admin_LafTest extends \WP_UnitTestCase {
 
 		$this->assertCount( 3, $fields );
 
-		$this->assertEquals( 'Twitter URL', $fields['twitter'] );
+		$this->assertEquals( 'X/Twitter URL', $fields['twitter'] );
 	}
 
 	/**


### PR DESCRIPTION
Replace remaining Twitter references on book info and contributor pages. Use new X logo in contributor output. 