### PR TITLE
fix: allow webp uploads

### DIFF
--- a/inc/media/namespace.php
+++ b/inc/media/namespace.php
@@ -30,6 +30,7 @@ function add_mime_types( $existing_mimes = [] ) {
 		'vorbis' => 'audio/vorbis',
 		'wav' => 'audio/wav',
 		'webm' => 'video/webm',
+		'webp' => 'image/webp',
 	];
 
 	return array_merge( $add_mimes, $existing_mimes );


### PR DESCRIPTION
Allow wepb file uploads in Pressbooks. Fix for #2426. These are now allowed by WordPress, but to allow them in Pressbooks, a super admin has to add the file extension to the mime type list. This PR makes it so they'll just work by default.

To test:
1. Attempt to upload a webp file to Pressbooks. Observe the 'you're not allowed to upload this file type' message
2. Check out this branch & upload a webp file. Observe a successful file upload