### PR TITLE
fix: remove unneeded filters & functions

### DIFF
--- a/hooks.php
+++ b/hooks.php
@@ -130,7 +130,6 @@ add_filter( 'plupload_default_params', '\Pressbooks\Media\force_attach_media' );
 
 add_filter( 'upload_mimes', '\Pressbooks\Media\add_mime_types' );
 add_filter( 'upload_mimes', '\Pressbooks\Media\add_lord_of_the_files_types', 11 );
-add_filter( 'lotf_get_mime_aliases', '\Pressbooks\Media\get_lord_of_the_files_mime_aliases', 10, 2 );
 add_action( 'plugins_loaded', [ '\Pressbooks\Interactive\Content', 'init' ] );
 
 // -------------------------------------------------------------------------------------------------------------------

--- a/inc/media/namespace.php
+++ b/inc/media/namespace.php
@@ -79,7 +79,9 @@ function add_lord_of_the_files_types( $existing_mimes = [] ) {
 	$lord_of_the_files_activated = ( is_plugin_active_for_network( 'blob-mimes/index.php' ) || is_plugin_active( 'blob-mimes/h5p.php' ) ) && class_exists( 'blobfolio\\wp\\bm\\mime\\aliases' );
 	if ( $lord_of_the_files_activated ) {
 		foreach ( unknown_upload_types( $existing_mimes ) as $k => $v ) {
-			if ( isset( \blobfolio\wp\bm\mime\aliases::TYPES[ $k ] ) ) {
+			if ( $k === 'nlogo' )
+				$upload_filetype_mimes[ $k ] = 'text/plain';
+			elseif ( isset( \blobfolio\wp\bm\mime\aliases::TYPES[ $k ] ) ) {
 				$upload_filetype_mimes[ $k ] = \blobfolio\wp\bm\mime\aliases::TYPES[ $k ][0];
 			}
 		}
@@ -89,32 +91,6 @@ function add_lord_of_the_files_types( $existing_mimes = [] ) {
 	}
 
 	return $existing_mimes;
-}
-
-/**
- * Override the list of MIME aliases matching a particular file extension.
- * Hooked into blobmimes_get_mime_aliases (Lord Of The Files)
- *
- * @param mixed $match
- * @param string $ext
- *
- * @return array|bool
- * @see https://github.com/Blobfolio/blob-mimes/blob/master/wp/lib/blobfolio/wp/bm/mime/aliases.php
- */
-function get_lord_of_the_files_mime_aliases( $match, $ext ) {
-	if ( $match === false ) {
-		$match = []; // Recast
-	}
-
-	if ( $ext === 'nlogo' ) {
-		$match[] = 'text/plain';
-	}
-
-	if ( empty( $match ) ) {
-		return false;
-	} else {
-		return array_unique( $match );
-	}
 }
 
 /**

--- a/inc/media/namespace.php
+++ b/inc/media/namespace.php
@@ -79,9 +79,7 @@ function add_lord_of_the_files_types( $existing_mimes = [] ) {
 	$lord_of_the_files_activated = ( is_plugin_active_for_network( 'blob-mimes/index.php' ) || is_plugin_active( 'blob-mimes/h5p.php' ) ) && class_exists( 'blobfolio\\wp\\bm\\mime\\aliases' );
 	if ( $lord_of_the_files_activated ) {
 		foreach ( unknown_upload_types( $existing_mimes ) as $k => $v ) {
-			if ( $k === 'nlogo' )
-				$upload_filetype_mimes[ $k ] = 'text/plain';
-			elseif ( isset( \blobfolio\wp\bm\mime\aliases::TYPES[ $k ] ) ) {
+			if ( isset( \blobfolio\wp\bm\mime\aliases::TYPES[ $k ] ) ) {
 				$upload_filetype_mimes[ $k ] = \blobfolio\wp\bm\mime\aliases::TYPES[ $k ][0];
 			}
 		}

--- a/tests/test-media.php
+++ b/tests/test-media.php
@@ -52,23 +52,6 @@ class MediaTest extends \WP_UnitTestCase {
 		// TODO: Test with LOTF plugin enabled
 	}
 
-	public function test_get_lord_of_the_files_mime_aliases() {
-		$match = \Pressbooks\Media\get_lord_of_the_files_mime_aliases( false, 'unknown' );
-		$this->assertFalse( $match );
-
-		$match = \Pressbooks\Media\get_lord_of_the_files_mime_aliases( false, 'nlogo' );
-		$this->assertEquals( [ 'text/plain' ], $match );
-
-		$match = \Pressbooks\Media\get_lord_of_the_files_mime_aliases( [ 'text/plain' ], 'nlogo' ); // No duplicates
-		$this->assertEquals( [ 'text/plain' ], $match );
-
-		$match = \Pressbooks\Media\get_lord_of_the_files_mime_aliases( [ 'fake/records' ], 'nlogo' );
-		$this->assertEquals( [ 'fake/records', 'text/plain' ], $match );
-
-		$match = \Pressbooks\Media\get_lord_of_the_files_mime_aliases( [ 'fake/records' ], '.nlogo' ); // Not expected to match dot
-		$this->assertEquals( [ 'fake/records' ], $match );
-	}
-
 	/**
 	 * @group media
 	 */


### PR DESCRIPTION
Removes unneeded filters/functions, following 1.4.0 release of Lord of the Files. Ensures that nlogo files can be uploaded if Lord of the Files is activated and nlogo is added to the list of permitted file types. Fix for https://github.com/pressbooks/pressbooks/issues/3483. See https://github.com/pressbooks/pressbooks/issues/3483#issuecomment-2569940422 for comments.

To test:
**NOTE:** You must update to the latest release of Lord of the Files (1.4.0), which now includes nlogo in its MIME list.
1. Add nlogo to the list of allowed file types in network settings (https://NETWORK.URL/wp-admin/network/settings.php)
2. Go to a book on the network and attempt to upload a NLOGO file
3. Observe that you can successfully do this. 

Sample NLOGO files can be downloaded from https://ccl.northwestern.edu/netlogo/models/models/Code%20Examples/ if desired.