### PR TITLE
fix: social media default values when empty

### DIFF
--- a/inc/modules/themeoptions/class-weboptions.php
+++ b/inc/modules/themeoptions/class-weboptions.php
@@ -258,6 +258,11 @@ class WebOptions extends \Pressbooks\Options {
 
 	function renderSocialMediaOptionsField( $args ) {
 		$options = isset( $this->options['social_media_options'] ) ? $this->options['social_media_options'] : [];
+		$stored_options = get_option( 'pressbooks_theme_options_' . $this->getSlug() );
+		// if empty, override default values with empty array for displaying purposes
+		if ( $stored_options && empty( $stored_options['social_media_options'] ) ) {
+			$options = [];
+		}
 		$all_options = [
 			'twitter' => __( 'X (formerly Twitter)', 'pressbooks' ),
 			'linkedin' => __( 'LinkedIn', 'pressbooks' ),
@@ -417,6 +422,7 @@ class WebOptions extends \Pressbooks\Options {
 				'webbook_header_font' => '',
 				'webbook_body_font' => '',
 				'paragraph_separation' => 'skiplines',
+				'social_media_options' => [ 'twitter', 'linkedin', 'email' ],
 				'part_title' => 0,
 				'webbook_width' => '40em',
 				'collapse_sections' => 0,

--- a/inc/modules/themeoptions/class-weboptions.php
+++ b/inc/modules/themeoptions/class-weboptions.php
@@ -416,7 +416,6 @@ class WebOptions extends \Pressbooks\Options {
 			'pb_theme_options_web_defaults', [
 				'webbook_header_font' => '',
 				'webbook_body_font' => '',
-				'social_media_options' => [ 'twitter', 'linkedin', 'email' ],
 				'paragraph_separation' => 'skiplines',
 				'part_title' => 0,
 				'webbook_width' => '40em',

--- a/tests/test-options.php
+++ b/tests/test-options.php
@@ -503,8 +503,11 @@ class OptionsTest extends \WP_UnitTestCase {
 		$buffer = ob_get_clean();
 		$this->assertStringContainsString('name="pressbooks_theme_options_web[social_media_options][]"', $buffer);
 		$this->assertStringContainsString('value="twitter"', $buffer);
+		$this->assertStringContainsString('checked', $buffer);
 		$this->assertStringContainsString('value="email"', $buffer);
+		$this->assertStringContainsString('checked', $buffer);
 		$this->assertStringContainsString('value="linkedin"', $buffer);
+		$this->assertStringContainsString('checked', $buffer);
 	}
 
 	/**

--- a/tests/test-options.php
+++ b/tests/test-options.php
@@ -503,11 +503,8 @@ class OptionsTest extends \WP_UnitTestCase {
 		$buffer = ob_get_clean();
 		$this->assertStringContainsString('name="pressbooks_theme_options_web[social_media_options][]"', $buffer);
 		$this->assertStringContainsString('value="twitter"', $buffer);
-		$this->assertStringContainsString('checked', $buffer);
 		$this->assertStringContainsString('value="email"', $buffer);
-		$this->assertStringContainsString('checked', $buffer);
 		$this->assertStringContainsString('value="linkedin"', $buffer);
-		$this->assertStringContainsString('checked', $buffer);
 	}
 
 	/**


### PR DESCRIPTION
This is the easiest solution for this problem.

The Options class isn't ready to work with checkbox arrays, for now our best bet is to check for stored values before displaying it because the way we built the checkboxes is not working well with default values behaviour.

### Problem
If you uncheck all the social media options, that will be saved on the database successfully but the UI will display the items checked (default values)

![image](https://github.com/user-attachments/assets/7e836a0b-b9f8-48ab-aa30-4e2e58c36bbe)

We can improve later this if required, hooking pb_theme_options_web_defaults or reworking the form and refactor the builtin renderCheckbox method with checkboxes group support
