### PR TITLE
fix: remove cloning stats and h5p permissions for subscribers

### DIFF
--- a/hooks-admin.php
+++ b/hooks-admin.php
@@ -322,6 +322,8 @@ if ( $is_book ) {
 		}
 	);
 
+	add_action( 'admin_init', [ SideBar::class, 'handleH5pMenu' ] );
+
 	// Hide welcome screen
 	add_action(
 		'load-index.php', function () {

--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -661,7 +661,7 @@ function add_cloning_stats_page() {
 	add_management_page(
 		esc_html__( 'Cloning Stats', 'pressbooks' ),
 		esc_html__( 'Cloning Stats', 'pressbooks' ),
-		'read',
+		'edit_posts',
 		'pb_cloner_stats',
 		__NAMESPACE__ . '\display_cloning_stats'
 	);

--- a/inc/admin/menus/class-sidebar.php
+++ b/inc/admin/menus/class-sidebar.php
@@ -727,4 +727,13 @@ class SideBar {
 			( $is_main_site_page ? $page : network_admin_url( $page ) );
 	}
 
+	public static function handleH5pMenu(): void {
+		$user = get_user_by( 'id', get_current_user_id() );
+		if (
+			is_plugin_active( 'h5p/h5p.php' ) &&
+			in_array( 'subscriber', $user->roles, true )
+		) {
+			remove_menu_page( 'h5p' );
+		}
+	}
 }

--- a/tests/test-admin-laf.php
+++ b/tests/test-admin-laf.php
@@ -181,13 +181,13 @@ class Admin_LafTest extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * @group branding
 	 * @test
+	 * @group branding
 	 */
-	function cloning_stats_submenu_is_added() {
+	public function it_adds_cloning_stats_submenu(): void {
 		$user_id = $this->factory()->user->create();
 		$user = get_userdata( $user_id );
-		$user->add_role( 'subscriber' );
+		$user->add_role( 'contributor' );
 		wp_set_current_user( $user_id );
 		global $submenu;
 		include_once( ABSPATH . '/wp-admin/menu.php' );


### PR DESCRIPTION
Issue: https://github.com/pressbooks/private/issues/1659

This pull request includes several changes to the WordPress admin interface and related functionality. The most important changes include adding a new action to handle the H5P menu by restricting the H5P content visualization for subscribers, modifying the required capability for accessing the cloning stats page, and updating a test method to reflect these changes.

Improvements to admin interface:

* [`hooks-admin.php`](diffhunk://#diff-22bd10ffa96e759d116f39767554f68c8559aa9f379e8b6dc6f132854e6a0729R325-R326): Added a new action to handle the H5P menu for users with the 'subscriber' role.
* [`inc/admin/menus/class-sidebar.php`](diffhunk://#diff-a00b7b4a852a41e3414d829866be6102271cec9eef745d5131a254ae581770a1R730-R738): Added `handleH5pMenu` method to remove the H5P menu for 'subscriber' role users when the H5P plugin is active.

Changes to capabilities and permissions:

* [`inc/admin/laf/namespace.php`](diffhunk://#diff-f22cdc03da7e566f78087bda7488a4de9313b2fd11f2045771ebaf381ad8283eL664-R664): Changed the required capability for accessing the cloning stats page from 'read' to 'edit_posts'.

Updates to tests:

* [`tests/test-admin-laf.php`](diffhunk://#diff-3d51a1585857482c3300433d4fd88b801685bb109cbb4a01206886a7b1c7630bL184-R190): Updated the test method `it_adds_cloning_stats_submenu` to use the 'contributor' role instead of 'subscriber'.

### Testing case
- Add a new user as subscriber in a book
- Make sure you have H5P plugin active for that book
- Log in as that user and go to the book admin area
- You should not see H5P menu nor Tool > Cloning Stats pages
- You should not see the H5P > All Contents submenu item