### PR TITLE
fix: improve conditional before removing H5P menu

### DIFF
--- a/hooks-admin.php
+++ b/hooks-admin.php
@@ -322,7 +322,11 @@ if ( $is_book ) {
 		}
 	);
 
-	add_action( 'admin_init', [ SideBar::class, 'handleH5pMenu' ] );
+	add_action( 'admin_init', function() {
+		if ( is_admin() ) {
+			SideBar::handleH5pMenu();
+		}
+} );
 
 	// Hide welcome screen
 	add_action(

--- a/hooks-admin.php
+++ b/hooks-admin.php
@@ -322,11 +322,7 @@ if ( $is_book ) {
 		}
 	);
 
-	add_action( 'admin_init', function() {
-		if ( is_admin() ) {
-			SideBar::handleH5pMenu();
-		}
-} );
+	add_action( 'admin_init', [ SideBar::class, 'removeH5pMenuForSubscribers' ] );
 
 	// Hide welcome screen
 	add_action(

--- a/inc/admin/menus/class-sidebar.php
+++ b/inc/admin/menus/class-sidebar.php
@@ -727,16 +727,19 @@ class SideBar {
 			( $is_main_site_page ? $page : network_admin_url( $page ) );
 	}
 
-	public static function handleH5pMenu(): void {
-		$user_id = get_current_user_id();
-		if ($user_id === 0) {
+	public static function removeH5pMenuForSubscribers(): void {
+		$user = get_user_by( 'ID', get_current_user_id() );
+
+		if (
+			! $user ||
+			! is_admin() ||
+			is_super_admin( $user->ID ) ||
+			$user->roles !== [ 'subscriber' ] ||
+			! is_plugin_active( 'h5p/h5p.php' )
+		) {
 			return;
 		}
-		$user = get_user_by( 'id', $user_id );
-		if (
-			$user && is_plugin_active( 'h5p/h5p.php' ) && !is_super_admin($user->ID) && $user->roles === ['subscriber']
-		) {
-			remove_menu_page( 'h5p' );
-		}
+
+		remove_menu_page( 'h5p' );
 	}
 }

--- a/inc/admin/menus/class-sidebar.php
+++ b/inc/admin/menus/class-sidebar.php
@@ -730,7 +730,7 @@ class SideBar {
 	public static function handleH5pMenu(): void {
 		$user = get_user_by( 'id', get_current_user_id() );
 		if (
-			is_plugin_active( 'h5p/h5p.php' ) &&
+			is_plugin_active( 'h5p/h5p.php' ) && $user && isset( $user->roles ) &&
 			in_array( 'subscriber', $user->roles, true )
 		) {
 			remove_menu_page( 'h5p' );

--- a/inc/admin/menus/class-sidebar.php
+++ b/inc/admin/menus/class-sidebar.php
@@ -728,12 +728,16 @@ class SideBar {
 	}
 
 	public static function handleH5pMenu(): void {
-		$user = get_user_by( 'id', get_current_user_id() );
+		$user_id = get_current_user_id();
+		if ($user_id === 0) {
+			return;
+		}
+		$user = get_user_by( 'id', $user_id );
 		if (
-			is_plugin_active( 'h5p/h5p.php' ) &&
-			in_array( 'subscriber', $user->roles, true )
+			$user && is_plugin_active( 'h5p/h5p.php' ) && !is_super_admin($user->ID) && $user->roles === ['subscriber']
 		) {
 			remove_menu_page( 'h5p' );
 		}
 	}
+
 }


### PR DESCRIPTION
Updates hook so that it's only called on admin pages. Adds checks to ensure a user exists, is not a network manager, and ONLY has the subscriber role before proceeding into the conditional action. Should fix the 'fatal error' when users who aren't logged in attempt to view an embedded H5P activity.

To test:
1. View the URL for an embedded H5P activity while logged out of a book (e.g. `https://university.pressbooks.pub/ltidemo/wp-admin/admin-ajax.php?action=h5p_embed&id=1`). Ensure that you can view the activity
2. Visit the book dashboard where H5P is activated as a super admin or network manager who has only the subscriber role in a given book. Ensure that you see the H5P plugin menu in the sidebar
3. Visit the book dashboard where H5P is activated as a user is not a network manager but has both the Administrator and Subscriber role (see https://github.com/pressbooks/pressbooks/issues/3648) -- or any two roles as long as one of them is Subscriber. Ensure that you see the H5P plugin menu in the sidebar.
4. Visit the book dashboard where H5P is activated as a user who is not a network manager but does have the 'Subscriber' role. Ensure that you do not see the H5P plugin menu in the sidebar. Visit the URL for an embedded H5P activity (as in step 1) and ensure that you can still view the activity as expected.