### PR TITLE
fix: remove link to Pressbooks.com from admin top nav-bar

### DIFF
--- a/inc/admin/menus/class-topbar.php
+++ b/inc/admin/menus/class-topbar.php
@@ -106,8 +106,8 @@ class TopBar {
 		$bar->add_menu(
 			[
 				'id' => 'pb-logo',
-				'title' => '<span class="ab-icon"></span><span class="screen-reader-text">' . __( 'About Pressbooks', 'pressbooks' ) . '</span>',
-				'href' => 'https://pressbooks.com',
+				'title' => '<span class="ab-icon"></span><span class="screen-reader-text">' . __( 'Pressbooks logo', 'pressbooks' ) . '</span>',
+				'href' => '#',
 			]
 		);
 	}

--- a/tests/test-admin-topbar.php
+++ b/tests/test-admin-topbar.php
@@ -26,7 +26,7 @@ class testAdminTopbar extends \WP_UnitTestCase {
 			'Settings',
 			false,
 			"<span class='blavatar'></span> {$site_name}",
-			'<span class="ab-icon"></span><span class="screen-reader-text">About Pressbooks</span>',
+			'<span class="ab-icon"></span><span class="screen-reader-text">Pressbooks logo</span>',
 			'<span>Administer Network</span>',
 			'<span>My Books</span>',
 			'<span>Create Book</span>',
@@ -52,7 +52,7 @@ class testAdminTopbar extends \WP_UnitTestCase {
 		$expected_order = [
 			false,
 			"<span class='blavatar'></span> {$site_name}",
-			'<span class="ab-icon"></span><span class="screen-reader-text">About Pressbooks</span>',
+			'<span class="ab-icon"></span><span class="screen-reader-text">Pressbooks logo</span>',
 			'<span>My Books</span>',
 			'<span>Create Book</span>',
 			'<span>Clone Book</span>',


### PR DESCRIPTION
Remove link to Pressbooks.com from admin top nav-bar. A link leading people away from their admin dashboard to the Pressbooks marketing site produces more confusion that it helps. Fix for https://github.com/pressbooks/private/issues/1681. See discussion in internal #support Slack channel for more context.

To test:
1. log into Pressbooks and view the top nav bar
2. Click the PB logo -- you should not leave the page you're on