### PR TITLE
fix: resolve bug with taxonomy terms that use non-latin characters

### DIFF
--- a/inc/admin/fields/class-taxonomyreorderablemultiselect.php
+++ b/inc/admin/fields/class-taxonomyreorderablemultiselect.php
@@ -38,7 +38,7 @@ class TaxonomyReorderableMultiselect extends Field {
 		$options = [];
 
 		foreach ( $terms as $term ) {
-			$options[ $term->slug ] = $term->name;
+			$options[ urldecode( $term->slug ) ] = $term->name;
 		}
 
 		return $options;

--- a/inc/admin/fields/class-taxonomyselect.php
+++ b/inc/admin/fields/class-taxonomyselect.php
@@ -33,7 +33,7 @@ class TaxonomySelect extends Field {
 		}
 
 		foreach ( $terms as $term ) {
-			$options[ $term->slug ] = $term->name;
+			$options[ urldecode( $term->slug ) ] = $term->name;
 		}
 
 		return $options;


### PR DESCRIPTION
Resolves #3886.

### Description

Contributors are managed using the [`TaxonomyReorderableMultiselect`](https://github.com/pressbooks/pressbooks/blob/dev/inc/admin/fields/class-taxonomyreorderablemultiselect.php) field. The way this works is that it sets the selected terms and also saves a meta field of comma-separated term slugs in the user-determined order. The problem is that WordPress urlencodes slugs, so — for example — the slug `अरुंधति-राय` would be returned as `%E0%A4%85%E0%A4%B0%E0%A5%81%E0%A4%82%E0%A4%A7%E0%A4%A4%E0%A4%BF-%E0%A4%B0%E0%A4%BE%E0%A4%AF` within the return value of the `get_terms()` function. This was causing the meta value to be stored in a way that prevented the term from being retrieved on the other end— so something was saved but `get_term_by('%E0%A4%85%E0%A4%B0%E0%A5%81%E0%A4%82%E0%A4%A7%E0%A4%A4%E0%A4%BF-%E0%A4%B0%E0%A4%BE%E0%A4%AF')` was not finding the term with the slug `अरुंधति-राय`. My solution here is to run the term slugs through `urldecode` when setting up the field options for `TaxonomyReorderableMultiselect` and `TaxonomySelect` to make sure that the correct value is always stored and can be used by `get_term_by` on the other end.

Users affected by this bug will need to re-enter their contributors once this fix is deployed.