### PR TITLE
fix: properly label checkboxes on export page

### DIFF
--- a/inc/modules/export/class-table.php
+++ b/inc/modules/export/class-table.php
@@ -62,7 +62,7 @@ class Table extends \WP_List_Table {
 	 * @return string
 	 */
 	public function column_cb( $item ) {
-		return sprintf( '<input type="checkbox" name="ID[]" value="%s" />', $item['ID'] );
+		return sprintf( '<input type="checkbox" name="ID[]" value="%s" aria-label="%s" />', $item['ID'], __( sprintf( 'Select %s', $item['file'] ) ) );
 	}
 
 	/**
@@ -119,7 +119,7 @@ class Table extends \WP_List_Table {
 	public function column_pin( $item ) {
 		$format = $this->getTinyHash( $item['format'] );
 		$html = "<input type='checkbox' id='pin[{$item['ID']}]' name='pin[{$item['ID']}]' value='{$format}' " . checked( $item['pin'], true, false ) . '/>';
-		$html .= "<label for='pin[{$item['ID']}]'>Pin this file</label>";
+		$html .= "<label for='pin[{$item['ID']}]'>" . __( sprintf( 'Pin %s', $item['file'] ) ) . "</label>";
 		return $html;
 	}
 


### PR DESCRIPTION
See pressbooks/private#1636.

Checkboxes for selecting exported files and pinning exported files should now have meaningful labels.