### PR TITLE
fix: recognize all supported math delimiters in web book interface

### DIFF
--- a/inc/class-mathjax.php
+++ b/inc/class-mathjax.php
@@ -229,15 +229,32 @@ class MathJax {
 			return true;
 		}
 
+		$id = $post->ID;
+		if ( isset( $this->sectionHasMath[ $id ] ) ) {
+			return $this->sectionHasMath[ $id ];
+		}
+
 		$content = $post->post_content;
 
 		// Check for shortcodes (better than searching manually)
 		if ( has_shortcode( $content, 'latex' ) || has_shortcode( $content, 'asciimath' ) ) {
+			$this->sectionHasMath[ $id ] = true;
 			return true;
 		}
 
-		// Use a single regex to check for LaTeX delimiters
-		return (bool) preg_match( '/(?:\\\\\[|\\\\\]|\\\\\(|\\\\\)|\$\$)/', $content );
+		// Check for specific math tags
+		$math_tags = [ '[table id=', '[/latex]', '$latex', '[/asciimath]', '$asciimath', '</math>' ];
+		foreach ( $math_tags as $math_tag ) {
+			if ( str_contains( $content, $math_tag ) ) {
+				$this->sectionHasMath[ $id ] = true;
+				return true;
+			}
+		}
+
+		// Use regex to check for LaTeX delimiters
+		$has_math = (bool) preg_match( '/(?:\\\\\[|\\\\\]|\\\\\(|\\\\\)|\$\$|\$latex\s+[^$]+\$|\$\s+[^$]+\s+\$)/', $content );
+		$this->sectionHasMath[ $id ] = $has_math;
+		return $has_math;
 	}
 
 	/**


### PR DESCRIPTION
This pull request includes an enhancement to the `sectionHasMath` function in the `inc/class-mathjax.php` file to improve performance and accuracy in detecting math content within sections. The most important changes include adding caching for previously checked sections, extending the types of math content detected, and refining the regex used for LaTeX delimiters.

Performance improvements:

* Added caching mechanism to store and retrieve results of previously checked sections using the `$this->sectionHasMath` array.

Detection improvements:

* Extended the detection to include specific math tags such as `[table id=`, `[/latex]`, `$latex`, `[/asciimath]`, `$asciimath`, and `</math>`.
* Refined the regex pattern to include additional LaTeX delimiters and inline math expressions.

> I just bring back a couple of caching conditionals we used to have on this method and I added the support for previous and our new supported delimiters

### Additional things to consider for testing

* Test every supported delimiter in isolation on a chapter to confirm this fix works as expected