### PR TITLE
fix: require physics conditionally

### DIFF
--- a/inc/class-mathjax.php
+++ b/inc/class-mathjax.php
@@ -382,8 +382,6 @@ STYLES;
 			// Base64 encode parameter for better PB MathJax parsing
 			$url .= '&isBase64=1';
 
-			error_log( 'MathJax URL: ' . $url );
-
 			$alt = str_replace( '\\', '&#92;', esc_attr( $formula ) );
 			return '<img src="' . $url . '" alt="' . $alt . '" title="' . $alt . '" class="' . $type . ' mathjax" />';
 		} else {

--- a/inc/class-mathjax.php
+++ b/inc/class-mathjax.php
@@ -321,7 +321,6 @@ window.MathJax = {
                 'textmacros', // Text formatting macros
                 'newcommand', // Define custom LaTeX commands useful for macros
                 'noerrors',   // Suppresses errors
-                'physics',    // Physics notation
                 'unicode'     // Unicode math symbols
             ]
         },
@@ -382,6 +381,8 @@ STYLES;
 
 			// Base64 encode parameter for better PB MathJax parsing
 			$url .= '&isBase64=1';
+
+			error_log( 'MathJax URL: ' . $url );
 
 			$alt = str_replace( '\\', '&#92;', esc_attr( $formula ) );
 			return '<img src="' . $url . '" alt="' . $alt . '" title="' . $alt . '" class="' . $type . ' mathjax" />';


### PR DESCRIPTION
## Description

This pull request includes changes to the `inc/class-mathjax.php` file to improve how the `physics` package is handled.

### Key Changes
- **No automatic physics package parsing**: The `physics` TeX package is no longer parsed by default. It will only be included when explicitly required using `\require{physics}`.  
  This prevents the package from overriding standard math operators like `\div` (division symbol) with the physics alias `\divergence`.
- **Improved error handling and logging**.
- Removed `physics` notation package from the list of TeX input in the `addHeaders` method ([see diff](diffhunk://#diff-75471e261b56521dd46690fedb88783fbf2ce63be3148866d236767dfe25fde2L324)).

### Why
Including the `physics` package by default changes behavior for users not working with physics formulas, when using division operator. `\div`

---

## Examples

### Inline math

**Before (without explicit require):**

`\( \div$ \)` → Rendered as `\divergence` (Physics package behavior, unexpected)

**After (default behavior):**

`\( \div \)` → Rendered as `÷` (Standard division symbol)

**To enable Physics behavior explicitly:**

`\( \require{physics} \divergence \)` → Rendered as `\divergence`

---

### Display math

**Before (without explicit require):**

```tex
\[
\div
\]
```
→ Rendered as `\divergence` (Physics package behavior, unexpected)

**After (default behavior):**

```tex
\[
\div
\]
```
→ Rendered as `÷` (Standard division symbol)

**To enable Physics behavior explicitly:**

```tex
\[
\require{physics}
\divergence
\]
```
→ Rendered as `\divergence`

> Unfortunately, MathJax's \require command doesn't work quite the same way in MathJax 3 as it did in MathJax 2. In MathJax 3, packages need to be configured at initialization time, and \require is mainly kept for backwards compatibility.

### Not supported as expected

```
\( \require{physics} \div 2 \) //expected to be printed as divergence symbol triangle but it will show a division symbol
```

It should be written like this:

```
\( \require{physics} \divergence 2 \) //divergence triangle symbol 
```

---

## Related

- Issue: [#117](https://github.com/pressbooks/pb-mathjax/issues/117)
- Should be tested and deployed along with: [#118](https://github.com/pressbooks/pb-mathjax/pull/118)

### About docs
This would require to update the docs to make a note about `\div` behaviour on physics context and explain that `\divergence` should be used instead in physics formulas