### PR TITLE
fix: display Thema qualifiers in Subjects metaboxes

### DIFF
--- a/inc/admin/metaboxes/class-subjects.php
+++ b/inc/admin/metaboxes/class-subjects.php
@@ -40,7 +40,7 @@ class Subjects extends Metabox {
 	public function getSubjects(): array {
 		$data = [];
 
-		foreach ( get_thema_subjects() as $subject_group ) {
+		foreach ( get_thema_subjects( true ) as $subject_group ) {
 			$group = $subject_group['label'];
 			$children = [];
 			foreach ( $subject_group['children'] as $key => $value ) {

--- a/inc/admin/metaboxes/class-subjects.php
+++ b/inc/admin/metaboxes/class-subjects.php
@@ -40,7 +40,7 @@ class Subjects extends Metabox {
 	public function getSubjects(): array {
 		$data = [];
 
-		foreach ( get_thema_subjects( true ) as $subject_group ) {
+		foreach ( get_thema_subjects( include_qualifiers: true ) as $subject_group ) {
 			$group = $subject_group['label'];
 			$children = [];
 			foreach ( $subject_group['children'] as $key => $value ) {

--- a/inc/class-htmlparser.php
+++ b/inc/class-htmlparser.php
@@ -40,20 +40,20 @@ class HtmlParser {
 	 *
 	 * @return \DOMDocument
 	 */
-	public function loadHTML($html, $options = []) {
+	public function loadHTML( $html, $options = [] ) {
 		$html = '<div><!-- pb_fixme -->' . $html . '<!-- pb_fixme --></div>';
-		if ($this->parser instanceof \DOMDocument) {
-			libxml_use_internal_errors(true);
+		if ( $this->parser instanceof \DOMDocument ) {
+			libxml_use_internal_errors( true );
 
 			// Modern replacement for mb_convert_encoding
-			$html = htmlspecialchars_decode(htmlentities($html, ENT_QUOTES, 'UTF-8', false));
+			$html = htmlspecialchars_decode( htmlentities( $html, ENT_QUOTES, 'UTF-8', false ) );
 
-			$this->parser->loadHTML($html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+			$this->parser->loadHTML( $html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
 			$this->errors = libxml_get_errors();
 			libxml_clear_errors();
 			return $this->parser;
 		} else {
-			return $this->parser->loadHTML($html, $options);
+			return $this->parser->loadHTML( $html, $options );
 		}
 	}
 

--- a/inc/class-mathjax.php
+++ b/inc/class-mathjax.php
@@ -120,8 +120,8 @@ class MathJax {
 		);
 		add_action( 'wp_enqueue_scripts', [ $obj, 'addScripts' ] );
 		add_action( 'wp_head', [ $obj, 'addHeaders' ] );
-		add_filter('pb_pdf_css_override', [ $obj, 'displayMathHandler' ] );
-		add_filter('pb_epub_css_override', [ $obj, 'displayMathHandler' ] );
+		add_filter( 'pb_pdf_css_override', [ $obj, 'displayMathHandler' ] );
+		add_filter( 'pb_epub_css_override', [ $obj, 'displayMathHandler' ] );
 		add_action( 'pb_pre_export', [ $obj, 'beforeExport' ] );
 	}
 
@@ -452,10 +452,10 @@ STYLES;
 			'%\$\$(.*?)\$\$%s', // $$ ... $$
 		];
 		foreach ( $patterns as $index => $pattern ) {
-			$content = preg_replace_callback($pattern, function ( $matches ) use ($index) {
+			$content = preg_replace_callback($pattern, function ( $matches ) use ( $index ) {
 				$rendered = $this->renderFormula( $matches[1], 'latex' );
 				// Wrap in div if it's display math (\[...\]) or $$...$$
-				if ($index === 0 || $index === 2) {
+				if ( $index === 0 || $index === 2 ) {
 					return '<div class="display-math">' . $rendered . '</div>';
 				}
 				return $rendered;
@@ -849,8 +849,8 @@ STYLES;
 
 	}
 
-	public function displayMathHandler($scss) {
-		$scss.= ".display-math { display: block; text-align:center; padding-top: 20px; padding-bottom:20px; } \n";
+	public function displayMathHandler( $scss ) {
+		$scss .= ".display-math { display: block; text-align:center; padding-top: 20px; padding-bottom:20px; } \n";
 		return $scss;
 	}
 

--- a/inc/modules/export/class-table.php
+++ b/inc/modules/export/class-table.php
@@ -119,7 +119,7 @@ class Table extends \WP_List_Table {
 	public function column_pin( $item ) {
 		$format = $this->getTinyHash( $item['format'] );
 		$html = "<input type='checkbox' id='pin[{$item['ID']}]' name='pin[{$item['ID']}]' value='{$format}' " . checked( $item['pin'], true, false ) . '/>';
-		$html .= "<label for='pin[{$item['ID']}]'>" . __( sprintf( 'Pin %s', $item['file'] ) ) . "</label>";
+		$html .= "<label for='pin[{$item['ID']}]'>" . __( sprintf( 'Pin %s', $item['file'] ) ) . '</label>';
 		return $html;
 	}
 


### PR DESCRIPTION
Display Thema qualifiers in the Subject selection metaboxes on the book info page. In the future we may want to update to the latest version of Thema (1.6) and provide a separate select box for qualifiers.