### PR TITLE
fix: apply accessible name to custom styles editor

### DIFF
--- a/templates/admin/custom-styles.php
+++ b/templates/admin/custom-styles.php
@@ -67,5 +67,6 @@ if ( ! empty( $_GET['custom_styles_error'] ) ) {
 		matchBrackets: true,
 		mode: 'text/x-scss'
 	} );
+	$( e2.display.input.textarea ).attr({ 'aria-label': '<?php printf( __( 'Your %s Styles', 'pressbooks' ), $current_label ); ?>' })
 })( window.jQuery, window.wp );
 </script>

--- a/templates/admin/custom-styles.php
+++ b/templates/admin/custom-styles.php
@@ -67,6 +67,7 @@ if ( ! empty( $_GET['custom_styles_error'] ) ) {
 		matchBrackets: true,
 		mode: 'text/x-scss'
 	} );
+	$( e1.display.input.textarea ).attr({ 'aria-label': '<?php printf( __( 'Theme %1$s Styles (%2$s)', 'pressbooks' ), $current_label, $theme ); ?>', 'aria-disabled': true })
 	$( e2.display.input.textarea ).attr({ 'aria-label': '<?php printf( __( 'Your %s Styles', 'pressbooks' ), $current_label ); ?>' })
 })( window.jQuery, window.wp );
 </script>


### PR DESCRIPTION
Resolves https://github.com/pressbooks/private/issues/1641.

See: https://github.com/WordPress/WordPress/blob/36f146497211a7d451dcfa768be4941ae2f06914/wp-admin/js/theme-plugin-editor.js#L402-L409