### PR TITLE
chore: code style improvements

### DIFF
--- a/inc/admin/class-pressbookstable.php
+++ b/inc/admin/class-pressbookstable.php
@@ -9,7 +9,9 @@ class PressbooksTable extends WP_List_Table {
 
 	public function print_column_headers( $with_id = true ): void {
 		$blade = Container::get( 'Blade' );
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo $blade->render( 'admin.pressbooks-table.column-headers', [
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			'columns' => $this->get_prepared_columns(),
 		] );
 	}
@@ -18,8 +20,8 @@ class PressbooksTable extends WP_List_Table {
 		$columns  = $this->get_columns();
 		$hidden   = get_hidden_columns( $this->screen );
 		$sortable = $this->get_sortable_columns();
-		$orderby  = $_GET['orderby'] ?? '';
-		$order    = $_GET['order'] ?? 'asc';
+		$orderby  = isset( $_GET['orderby'] ) ? sanitize_text_field( wp_unslash( $_GET['orderby'] ) ) : '';
+		$order    = isset( $_GET['order'] ) ? sanitize_text_field( wp_unslash( $_GET['order'] ) ) : 'asc';
 
 		$prepared = [];
 

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -13,6 +13,7 @@
         <!-- Exclude classes that override WP Core: -->
         <exclude-pattern>/inc/admin/class-catalog-list-table.php</exclude-pattern>
         <exclude-pattern>/inc/admin/class-network-managers-list-table.php</exclude-pattern>
+        <exclude-pattern>/inc/admin/class-pressbookstable.php</exclude-pattern>
         <exclude-pattern>/api/endpoints/controller/*</exclude-pattern>
         <exclude-pattern>/inc/modules/export/class-table.php</exclude-pattern>
     </rule>


### PR DESCRIPTION
This pull request includes changes to improve security and code quality in the `inc/admin/class-pressbookstable.php` file and updates the `phpcs.ruleset.xml` file to exclude a specific class. The most important changes are:

Security improvements:

* [`inc/admin/class-pressbookstable.php`](diffhunk://#diff-e805a8d194105ca3a8f5cb9483cce4a75ec1ef18e34af7f9f9c8c69bd92726d1L21-R24): Sanitized the `orderby` and `order` parameters using `sanitize_text_field` and `wp_unslash` to prevent potential security vulnerabilities.

Code quality improvements:

* [`inc/admin/class-pressbookstable.php`](diffhunk://#diff-e805a8d194105ca3a8f5cb9483cce4a75ec1ef18e34af7f9f9c8c69bd92726d1R12-R14): Added comments to ignore specific phpcs warnings for escaping output in the `print_column_headers` method, because blade does that.

Configuration updates:

* [`phpcs.ruleset.xml`](diffhunk://#diff-dca308ae5130cd4122c113234909f8e51132fd09b78cb86f8dd89ce58df27895R16): Excluded the `class-pressbookstable.php` file from phpcs checks to prevent conflicts with custom implementations.