### PR TITLE
fix: remove unnecessary alt text

### DIFF
--- a/templates/admin/dashboard/book.blade.php
+++ b/templates/admin/dashboard/book.blade.php
@@ -72,10 +72,7 @@
 				@if( $write_chapter_url || $import_content_url )
 					<div class="pb-dashboard-panel">
 						<div class="pb-dashboard-image">
-							<img
-									src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-write.png" }}"
-									alt="{{ __( 'Write a new chapter art', 'pressbooks' ) }}"
-							/>
+							<img src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-write.png" }}" alt="" />
 						</div>
 						<div class="pb-dashboard-content">
 							<div class="pb-dashboard-action">
@@ -104,40 +101,28 @@
 				<ul class="horizontal">
 					<li class="resources" id="getting-started">
 						<a href="https://youtube.com/playlist?list=PLMFmJu3NJhevTbp5XAbdif8OloNhqOw5n" target="_blank">
-							<img
-								src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-getting-started.png" }}"
-								alt=""
-							/>
+							<img src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-getting-started.png" }}" alt="" />
 							{{ __('Getting started with Pressbooks', 'pressbooks' )}}
 						</a>
 						<p>{{ __( 'Watch a short video series on how to get started with Pressbooks.', 'pressbooks' ) }}</p>
 					</li>
 					<li class="resources" id="pressbooks-guide">
 						<a href="https://guide.pressbooks.com" target="_blank">
-							<img
-								src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-guide.png" }}"
-								alt=""
-							/>
+							<img src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-guide.png" }}" alt="" />
 							{{ __('Pressbooks user guide', 'pressbooks' )}}
 						</a>
 						<p>{{ __( 'Find help and how-tos for your publishing project in this detailed handbook.', 'pressbooks' ) }}</p>
 					</li>
 					<li class="resources" id="forum">
 						<a href="https://pressbooks.community" target="_blank">
-							<img
-								src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-forum.png" }}"
-								alt=""
-							/>
+							<img src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-forum.png" }}" alt="" />
 							{{ __('Pressbooks community forum', 'pressbooks' ) }}
 						</a>
 						<p>{{ __( 'Discuss Pressbooks related questions with other users in our public forum.', 'pressbooks' ) }}</p>
 					</li>
 					<li class="resources" id="webinars">
 						<a href="https://pressbooks.com/webinars" target="_blank">
-							<img
-								src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-webinars.png" }}"
-								alt=""
-							/>
+							<img src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-webinars.png" }}" alt="" />
 							{{ __('Pressbooks training webinars', 'pressbooks') }}
 						</a>
 						<p>{{ __( 'Register for free webinars to learn about Pressbooks features and best practices.', 'pressbooks' ) }}</p>

--- a/templates/admin/dashboard/network.blade.php
+++ b/templates/admin/dashboard/network.blade.php
@@ -41,34 +41,24 @@
 					<h2>{{ __( 'Update homepage', 'pressbooks' ) }}</h2>
 
 					<div class="pb-dashboard-flex">
-						<img
-							class="pb-dashboard-flex-image"
-							src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-root-site.png" }}"
-							alt="{{ __( 'Update homepage art', 'pressbooks' ) }}"
-						/>
+						<img class="pb-dashboard-flex-image" src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-root-site.png" }}" alt="" />
 
 						<ul class="actions">
 							<li>
-								<a
-									href="{!! admin_url( 'customize.php?return=' . network_admin_url() ) !!}"
-								>
+								<a href="{!! admin_url( 'customize.php?return=' . network_admin_url() ) !!}">
 									<i aria-hidden="true" class="pb-heroicons pb-heroicons-outline_sparkles"></i>
 									<span>{{ __( 'Customize network appearance', 'pressbooks' ) }}</span>
 								</a>
 							</li>
 							<li>
-								<a
-									href="{!! admin_url( 'edit.php?post_type=page' ) !!}"
-								>
+								<a href="{!! admin_url( 'edit.php?post_type=page' ) !!}">
 									<i aria-hidden="true" class="pb-heroicons pb-heroicons-outline_pencil-square"></i>
 									<span>{{ __( 'Create or edit pages', 'pressbooks' ) }}</span>
 								</a>
 							</li>
 							@if( $koko_analytics_active )
 								<li>
-									<a
-										href="{!! admin_url( 'index.php?page=koko-analytics' ) !!}"
-									>
+									<a href="{!! admin_url( 'index.php?page=koko-analytics' ) !!}">
 										<i aria-hidden="true" class="pb-heroicons pb-heroicons-outline_presentation-char-bar"></i>
 										<span>{{ __( 'View homepage analytics', 'pressbooks' ) }}</span>
 									</a>
@@ -84,33 +74,23 @@
 					<h2>{{ __( 'Administer network', 'pressbooks' ) }}</h2>
 
 					<div class="pb-dashboard-flex">
-						<img
-							class="pb-dashboard-flex-image"
-							src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-network-settings.png" }}"
-							alt="{{ __( 'Administer network art', 'pressbooks' ) }}"
-						/>
+						<img class="pb-dashboard-flex-image" src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-network-settings.png" }}" alt="" />
 
 						<ul class="actions">
 							<li>
-								<a
-									href="{!! network_admin_url( $network_analytics_active ? 'settings.php?page=pb_network_analytics_options' : 'settings.php' ) !!}"
-								>
+								<a href="{!! network_admin_url( $network_analytics_active ? 'settings.php?page=pb_network_analytics_options' : 'settings.php' ) !!}">
 									<i aria-hidden="true" class="pb-heroicons pb-heroicons-outline_cog-8-tooth"></i>
 									<span>{{ __( 'Adjust network settings', 'pressbooks' ) }}</span>
 								</a>
 							</li>
 							<li>
-								<a
-									href="{!! network_admin_url( $network_analytics_active ? 'sites.php?page=pb_network_analytics_booklist' : 'sites.php' ) !!}"
-								>
+								<a href="{!! network_admin_url( $network_analytics_active ? 'sites.php?page=pb_network_analytics_booklist' : 'sites.php' ) !!}">
 									<i aria-hidden="true" class="pb-heroicons pb-heroicons-outline_book-open"></i>
 									<span>{{ __( 'View book list', 'pressbooks' ) }}</span>
 								</a>
 							</li>
 							<li>
-								<a
-									href="{!! network_admin_url( $network_analytics_active ? 'users.php?page=pb_network_analytics_userlist' : 'users.php' ) !!}"
-								>
+								<a href="{!! network_admin_url( $network_analytics_active ? 'users.php?page=pb_network_analytics_userlist' : 'users.php' ) !!}">
 									<i aria-hidden="true" class="pb-heroicons pb-heroicons-outline_users"></i>
 									<span>{{ __( 'View user list', 'pressbooks' ) }}</span>
 								</a>

--- a/templates/admin/dashboard/support.blade.php
+++ b/templates/admin/dashboard/support.blade.php
@@ -5,30 +5,21 @@
 			<ul class="horizontal">
 				<li class="resources" id="pressbooks-guide">
 					<a href="https://networkmanagerguide.pressbooks.com/" target="_blank">
-						<img
-							src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-network-guide.png" }}"
-							alt=""
-						/>
+						<img src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-network-guide.png" }}" alt="" />
 						{{ __('Network manager guide', 'pressbooks' )}}
 					</a>
 					<p>{{ __( 'Learn how to administer your Pressbooks network from our comprehensive how-to guide.', 'pressbooks' ) }}</p>
 				</li>
 				<li class="resources" id="forum">
 					<a href="https://pressbooks.community" target="_blank">
-						<img
-							src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-forum.png" }}"
-							alt=""
-						/>
+						<img src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-forum.png" }}" alt="" />
 						{{ __('Pressbooks community forum', 'pressbooks' ) }}
 					</a>
 					<p>{{ __( 'Discuss issues of interest with other network managers and Pressbooks support staff.', 'pressbooks' ) }}</p>
 				</li>
 				<li class="resources" id="spotlight">
 					<a href="https://pressbooks.com/webinars" target="_blank">
-						<img
-							src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-spotlight-series.png" }}"
-							alt=""
-						/>
+						<img src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-spotlight-series.png" }}" alt="" />
 						{{ __('Pressbooks webinars', 'pressbooks') }}
 					</a>
 					<p>{{ __( 'Become a confident Pressbooks user by attending a free, live webinar.', 'pressbooks' ) }}</p>
@@ -36,10 +27,7 @@
 				@if( $network_analytics_active )
 					<li class="resources" id="spotlight">
 						<a href="mailto:premiumsupport@pressbooks.com" target="_blank">
-							<img
-								src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-contact-support.png" }}"
-								alt=""
-							/>
+							<img src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-contact-support.png" }}" alt="" />
 							{{ __('Contact Pressbooks Support', 'pressbooks') }}
 						</a>
 						<p>{{ __( 'Email Pressbooks’ Premium Support team to report bugs or get personalized help.', 'pressbooks' ) }}</p>

--- a/templates/admin/dashboard/user.blade.php
+++ b/templates/admin/dashboard/user.blade.php
@@ -33,10 +33,7 @@
 				@if( $can_create_new_books )
 					<div class="pb-dashboard-panel">
 						<div class="pb-dashboard-image">
-							<img
-								src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-create-book.png" }}"
-								alt="{{ __( 'Create a new book art', 'pressbooks' ) }}"
-							/>
+							<img src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-create-book.png" }}" alt="" />
 						</div>
 
 						<div class="pb-dashboard-content">
@@ -62,10 +59,7 @@
 				@if( $can_clone_books )
 					<div class="pb-dashboard-panel">
 						<div class="pb-dashboard-image">
-							<img
-								src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-adapt-book.png" }}"
-								alt="{{ __( 'Adapt a book art', 'pressbooks' ) }}"
-							/>
+							<img src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-adapt-book.png" }}" alt="" />
 						</div>
 
 						<div class="pb-dashboard-content">


### PR DESCRIPTION
Partial fix for pressbooks/private#1581

This PR removes all alt text from the images in the dashboard since all of them are decorative.
In addition, I opted to make the `<a>` and <img />` tags single line since there was no reason to have attributes spread on multiple lines anymore.