### PR TITLE
fix: media attributions display for subscriber users

### DIFF
--- a/inc/class-privacy.php
+++ b/inc/class-privacy.php
@@ -82,7 +82,7 @@ class Privacy {
 				$current_user = wp_get_current_user();
 				$permissive_roles = [ 'subscriber', 'collaborator', 'author' ];
 				if ( $permissive_private_content && array_intersect( $permissive_roles, $current_user->roles ) ) {
-					$query->set( 'post_status', [ 'publish', 'pending', 'draft', 'private', 'web-only' ] );
+					$query->set( 'post_status', [ 'publish', 'pending', 'draft', 'private', 'web-only', 'inherit' ] );
 				}
 			}
 			return $query;


### PR DESCRIPTION
This pull request includes a modification to the `showPermissivePrivateContent` function in the `inc/class-privacy.php` file. The change updates the `post_status` array to include the `inherit` status.

* [`inc/class-privacy.php`](diffhunk://#diff-b0976e639346b3ab57c98060810d7f4e990df6bd78877c52a2d2a1f5c9b1fc7fL85-R85): Added `'inherit'` to the `post_status` array in the `showPermissivePrivateContent` function.

Inherit is the post status for attachments and revisions

https://wordpress.org/documentation/article/post-status/#inherit

See https://github.com/pressbooks/pressbooks/issues/4001