### PR TITLE
fix: remove patterns menu

### DIFF
--- a/inc/admin/menus/class-sidebar.php
+++ b/inc/admin/menus/class-sidebar.php
@@ -75,7 +75,7 @@ class SideBar {
 
 	public function removePatternsSubMenuItem(): void {
 		remove_submenu_page( 'themes.php', 'edit.php?post_type=wp_block' );
-		remove_submenu_page( 'themes.php', 'site-editor.php?path=/patterns' );
+		remove_submenu_page( 'themes.php', 'site-editor.php?p=/pattern' );
 	}
 
 	public function restrictPatternsPageAccess(): void {


### PR DESCRIPTION
This pull request includes a small change to the `inc/admin/menus/class-sidebar.php` file. The change updates the URL parameter for removing the submenu page related to patterns in the site editor.

The patterns page path was changed on WP 6.8

* [`inc/admin/menus/class-sidebar.php`](diffhunk://#diff-a00b7b4a852a41e3414d829866be6102271cec9eef745d5131a254ae581770a1L78-R78): Updated the URL parameter in the `removePatternsSubMenuItem` method to correct the path for removing the submenu page from `site-editor.php?path=/patterns` to `site-editor.php?p=/pattern`.