### PR TITLE
fix: add part aria-label typo

### DIFF
--- a/templates/admin/organize.blade.php
+++ b/templates/admin/organize.blade.php
@@ -91,7 +91,7 @@
 						</a>
                         <a
 							class="page-title-action" href="{!! admin_url('post-new.php?post_type=part') !!}"
-							aria-label="{{ sprintf( __( 'Add a new part below to %s part', 'pressbooks' ), $group['title'] ) }}"
+							aria-label="{{ sprintf( __( 'Add a new part below %s part', 'pressbooks' ), $group['title'] ) }}"
 						>
 							{{ __('Add Part', 'pressbooks') }}
 						</a>


### PR DESCRIPTION
This PR fixes a small typo with the Add New Part aria label, see https://github.com/pressbooks/private/issues/1588#issuecomment-2758778588