### PR TITLE
Change Touro College to Touro University

### DIFF
--- a/symbionts/institutions/institutions.json
+++ b/symbionts/institutions/institutions.json
@@ -11417,7 +11417,7 @@
           },
           {
             "code": "US-NY-138",
-            "name": "Touro College",
+            "name": "Touro University",
             "url": "https:\/\/www.touro.edu\/"
           },
           {


### PR DESCRIPTION
Change name for existing institution from "Touro College" to "Touro University"