### PR TITLE
Change Westminster College to Westminster University

### DIFF
--- a/symbionts/institutions/institutions.json
+++ b/symbionts/institutions/institutions.json
@@ -12792,8 +12792,8 @@
           },
           {
             "code": "US-PA-100",
-            "name": "Westminster University",
-            "url": "https:\/\/www.westminsteru.edu\/"
+            "name": "Westminster College",
+            "url": "https:\/\/www.westminster.edu\/"
           },
           {
             "code": "US-PA-101",
@@ -14132,8 +14132,8 @@
           },
           {
             "code": "US-UT-011",
-            "name": "Westminster College",
-            "url": "https:\/\/westminstercollege.edu\/"
+            "name": "Westminster University",
+            "url": "https:\/\/westminsteru.edu\/"
           }
         ]
       },

--- a/symbionts/institutions/institutions.json
+++ b/symbionts/institutions/institutions.json
@@ -12792,8 +12792,8 @@
           },
           {
             "code": "US-PA-100",
-            "name": "Westminster College",
-            "url": "https:\/\/www.westminster.edu\/"
+            "name": "Westminster University",
+            "url": "https:\/\/www.westminsteru.edu\/"
           },
           {
             "code": "US-PA-101",


### PR DESCRIPTION
Change name and URL from "Westminster College" (www.westminstercollege.edu) to "Westminster University" (www.westminsteru.edu)