### PR TITLE
fix: garbled charset in 2-level ToC

### DIFF
--- a/inc/class-book.php
+++ b/inc/class-book.php
@@ -647,17 +647,24 @@ class Book {
 		} else {
 			$content = $parent->post_content;
 		}
+
 		$content = strip_tags( $content, '<h1>' );  // Strip everything except <h1> to speed up load time
+
+		if ( mb_detect_encoding( $content, 'UTF-8', true ) !== 'UTF-8' ) {
+			$content = mb_convert_encoding( $content, 'HTML-ENTITIES', 'UTF-8' );
+		}
 
 		$type = $parent->post_type;
 		$output = [];
 		$s = 1;
 
 		$doc = new HtmlParser( true ); // Because we are not saving, use internal parser to speed up load time
-		$dom = $doc->loadHTML( $content );
+		$dom = $doc->loadHTML( '<!DOCTYPE html><html><head><meta charset="UTF-8"></head><body>' . $content . '</body></html>' );
+
 		$sections = $dom->getElementsByTagName( 'h1' );
+
+		/** @var $section \DOMElement */
 		foreach ( $sections as $section ) {
-			/** @var $section \DOMElement */
 			$output[ $type . '-' . $id . '-section-' . $s ] = wptexturize( $section->textContent );
 			$s++;
 		}


### PR DESCRIPTION
Issue pressbooks/pressbooks-book#1205

This PR fixes an issue with garbled charset in 2-level ToC.

Problem: When extracting `<h1>` tags using PHP's DOMDocument, non-ASCII characters (e.g., Cyrillic, accented Latin) were rendering incorrectly, resulting in garbled output like `Ð¡Ñ‚Ñ€Ð¾ÐºÐ°`.

Cause: DOMDocument::loadHTML() does not default to UTF-8 and misinterprets raw UTF-8 strings unless the input is explicitly converted or wrapped in properly declared HTML. This leads to incorrect byte-level decoding.

Proposed fix: wrapping the content in a full HTML structure with a <meta charset="UTF-8"> tag to ensure correct character interpretation. In addition, decided to use `mb_convert_encoding(..., 'HTML-ENTITIES', 'UTF-8')` to encode multibyte characters into HTML entities that DOMDocument safely parses.

As discussed, we will not render short codes in the table of contents. Local testing shows the content is now rendering as expected without any visible side effects.

While testing, it might be necessary to flush the cache since the ToC subsections are stored in a transient.