### PR TITLE
fix: pot translations workflow

### DIFF
--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -1,0 +1,20 @@
+name: Update .pot file 🌐
+
+on:
+  push:
+    branches: [dev]
+    paths:
+      - "**/*.php"
+      - "**/*.js"
+  workflow_dispatch:
+
+jobs:
+  update-pot-file:
+    uses: pressbooks/reusable-workflows/.github/workflows/update-pot.yml@main
+    secrets: inherit
+    with:
+      domain: 'pressbooks'
+      slug: 'pressbooks'
+      package_name: 'Pressbooks'
+      headers: '{"Report-Msgid-Bugs-To": "https://github.com/pressbooks/pressbooks/issues"}'
+      pull_request_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the updating of `.pot` files for localization purposes. The workflow is triggered on specific branch pushes or manually via workflow dispatch.

### New GitHub Actions Workflow:

* [`.github/workflows/update-pot.yml`](diffhunk://#diff-8741980370812fcb8b10be0bc89c075d0b3c72a30463c06f17deeffd1621eed9R1-R20): Added a reusable workflow to update `.pot` files. It triggers on pushes to the `dev` branch affecting `.php` or `.js` files, or via manual workflow dispatch. The workflow uses a reusable workflow hosted by `pressbooks` and includes configuration for domain, slug, package name, and bug reporting headers.