### PR TITLE
fix: edit capabilities for authors

### DIFF
--- a/hooks-admin.php
+++ b/hooks-admin.php
@@ -105,6 +105,7 @@ add_action( 'network_admin_menu', '\Pressbooks\Admin\Laf\network_admin_menu' );
 if ( ! is_network_admin() ) {
 	add_action( 'admin_init', '\Pressbooks\Admin\Laf\privacy_settings_init' );
 }
+add_filter( 'map_meta_cap', '\Pressbooks\Admin\Laf\allow_edit_to_book_authors', 10, 4 );
 
 // Network settings
 add_action( 'network_admin_menu', [ '\Pressbooks\Admin\Network\NetworkSettings', 'init' ] );

--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -17,6 +17,7 @@ namespace Pressbooks\Admin\Laf;
 use function Pressbooks\Admin\NetworkManagers\is_restricted;
 use function Pressbooks\PostType\get_post_type_label;
 use function Pressbooks\Sanitize\sanitize_string;
+use function Pressbooks\Utility\disable_comments;
 use function Pressbooks\Utility\str_starts_with;
 use PressbooksMix\Assets;
 use Pressbooks\Admin\ExportOptions;
@@ -27,6 +28,7 @@ use Pressbooks\BookDirectory;
 use Pressbooks\CloneComplete;
 use Pressbooks\Cloner\Cloner;
 use Pressbooks\Container;
+use Pressbooks\Contributors;
 use Pressbooks\DataCollector\Book as DataCollector;
 use Pressbooks\Metadata;
 use WP_Error;
@@ -667,7 +669,7 @@ function add_cloning_stats_page() {
  */
 function display_organize() {
 	$blade = \Pressbooks\Container::get( 'Blade' );
-	$book_structure = \Pressbooks\Book::getBookStructure();
+	$book_structure = Book::getBookStructure();
 	$ebook_options = get_option( 'pressbooks_theme_options_ebook' );
 	$structure = [];
 
@@ -701,15 +703,15 @@ function display_organize() {
 		[
 			'statuses' => get_post_stati( [], 'objects' ),
 			'parts' => count( $book_structure['part'] ),
-			'meta_post' => ( new \Pressbooks\Metadata() )->getMetaPost(),
+			'meta_post' => ( new Metadata() )->getMetaPost(),
 			'book_is_public' => ( ! empty( get_option( 'blog_public' ) ) ) ? 1 : 0,
-			'disable_comments' => \Pressbooks\Utility\disable_comments(),
-			'wc' => \Pressbooks\Book::wordCount(),
-			'wc_selected_for_export' => \Pressbooks\Book::wordCount( true ),
+			'disable_comments' => disable_comments(),
+			'wc' => Book::wordCount(),
+			'wc_selected_for_export' => Book::wordCount( true ),
 			'can_manage_options' => current_user_can( 'manage_options' ),
 			'can_edit_posts' => current_user_can( 'edit_posts' ),
 			'can_edit_others_posts' => current_user_can( 'edit_others_posts' ),
-			'contributors' => new \Pressbooks\Contributors(),
+			'contributors' => new Contributors(),
 			'ebook_options' => $ebook_options,
 			'start_point' => ( isset( $ebook_options['ebook_start_point'] ) && ! empty( $ebook_options['ebook_start_point'] ) )
 				? (int) $ebook_options['ebook_start_point']
@@ -1721,3 +1723,24 @@ function remove_emoji() {
 		}
 	});
 }
+
+/**
+ * @param array $caps
+ * @param string $cap
+ * @param int $user_id
+ * @param array $args
+ *
+ * @return array
+ */
+function allow_edit_to_book_authors( $caps, $cap, $user_id, $args ) {
+	if ( 'edit_post' === $cap && isset( $args[0] ) ) {
+		$post_id = $args[0];
+		$post_author_id = get_post_field( 'post_author', $post_id );
+
+		if ( (int) $user_id === (int) $post_author_id ) {
+			return [ 'edit_posts' ];
+		}
+	}
+	return $caps;
+}
+

--- a/tests/test-admin-laf.php
+++ b/tests/test-admin-laf.php
@@ -1,6 +1,6 @@
 <?php
 
-use function Pressbooks\Admin\Laf\can_create_new_books;
+use function Pressbooks\Admin\Laf\allow_edit_to_book_authors;
 
 require_once( PB_PLUGIN_DIR . 'inc/admin/laf/namespace.php' );
 
@@ -418,5 +418,43 @@ class Admin_LafTest extends \WP_UnitTestCase {
 		$this->assertFalse( has_filter( 'wp_mail', 'wp_staticize_emoji_for_email' ) );
 		$this->assertFalse( has_filter( 'wp_staticize_emoji', 'the_content_feed' ) );
 		$this->assertFalse( has_filter( 'wp_staticize_emoji', 'comment_text_css' ) );
+	}
+
+	function test_capabilities_remains_the_same_for_regular_authors() {
+
+		$author_id = $this->factory->user->create(['role' => 'author']);
+		$post_id = $this->factory->post->create(['post_author' => $author_id]);
+
+		// Test when user is the post author
+		$caps = allow_edit_to_book_authors(
+			['edit_others_posts'],
+			'edit_post',
+			$author_id,
+			[$post_id]
+		);
+
+		$this->assertEquals(['edit_posts'], $caps);
+		wp_set_current_user($author_id);
+		$this->assertTrue(current_user_can('edit_post', $post_id));
+	}
+
+	function test_new_user_authors_editing_capabilities() {
+
+		$author_id = $this->factory->user->create(['role' => 'author']);
+		$other_user_id = $this->factory->user->create(['role' => 'author']);
+		$post_id = $this->factory->post->create(['post_author' => $author_id]);
+
+		$original_caps = ['edit_others_posts'];
+
+		$caps = allow_edit_to_book_authors(
+			$original_caps,
+			'edit_post',
+			$other_user_id,
+			[$post_id]
+		);
+
+		$this->assertEquals($original_caps, $caps);
+		wp_set_current_user($other_user_id);
+		$this->assertFalse(current_user_can('edit_post', $post_id));
 	}
 }


### PR DESCRIPTION
#3992 

This pull request introduces a new capability filter to allow post authors to edit their own posts and refactors code for improved readability and consistency. It also includes corresponding unit tests to ensure the new functionality works as intended. Below are the most significant changes grouped by theme.

### New Feature: Author Editing Capability
* Added the `allow_edit_to_book_authors` function to grant authors the ability to edit their own posts by modifying the `map_meta_cap` filter. (`inc/admin/laf/namespace.php`)
* Hooked the `allow_edit_to_book_authors` function into the `map_meta_cap` filter in `hooks-admin.php`. (`hooks-admin.php`)

### Unit Tests
* Added tests for the `allow_edit_to_book_authors` function to verify that:
  - Authors can edit their own posts. (`tests/test-admin-laf.php`)
  - Non-authors cannot edit posts they do not own. (`tests/test-admin-laf.php`)
* Included the `allow_edit_to_book_authors` function in the test file imports. (`tests/test-admin-laf.php`)

These changes enhance functionality for authors while ensuring the codebase remains clean and maintainable.

### How to test

1. Assign a different author for a chapter in the metabox at the bottom when editing a chapter

<img width="1044" alt="image" src="https://github.com/user-attachments/assets/2e6b8e3e-6a25-475c-a5e9-4024662ae24b" />

2. Login as that author and notice you can edit that chapter