### PR TITLE
feat: optional h5p static representation

### DIFF
--- a/inc/admin/class-exportoptions.php
+++ b/inc/admin/class-exportoptions.php
@@ -95,6 +95,17 @@ class ExportOptions extends \Pressbooks\Options {
 			);
 		}
 
+		add_settings_field(
+			'h5p_print_on_exports',
+			__( 'H5P options', 'pressbooks' ),
+			[ $this, 'renderH5PField' ],
+			$_page,
+			$_section,
+			[
+				'0' => __( 'Enable H5P static representation on exports.', 'pressbooks' ),
+			]
+		);
+
 		register_setting(
 			$_page,
 			$_option,
@@ -161,6 +172,24 @@ class ExportOptions extends \Pressbooks\Options {
 	}
 
 	/**
+	 * Render the h5p_print_on_exports checkbox.
+	 *
+	 * @param array $args
+	 */
+	function renderH5PField( $args ) {
+		$this->renderCheckbox(
+			[
+				'id' => 'h5p_print_on_exports',
+				'name' => $this->getSlug(),
+				'option' => 'h5p_print_on_exports',
+				'value' => ( isset( $this->options['h5p_print_on_exports'] ) ) ? $this->options['h5p_print_on_exports'] : '',
+				'label' => __( 'Enable H5P static representation on exports.', 'pressbooks' ),
+				'description' => __( 'This will include a read-only version of H5P activities where possible, in PDF and EPUB exports.', 'pressbooks' ),
+			]
+		);
+	}
+
+	/**
 	 * Render the lock_theme checkbox.
 	 *
 	 * @param array $args
@@ -205,6 +234,7 @@ class ExportOptions extends \Pressbooks\Options {
 		return [
 			'email_validation_logs' => 0,
 			'theme_lock' => 0,
+			'h5p_print_on_exports' => 0,
 		];
 	}
 
@@ -217,6 +247,7 @@ class ExportOptions extends \Pressbooks\Options {
 		return [
 			'email_validation_logs',
 			'theme_lock',
+			'h5p_print_on_exports',
 		];
 	}
 

--- a/inc/class-options.php
+++ b/inc/class-options.php
@@ -9,6 +9,7 @@
 namespace Pressbooks;
 
 use function Pressbooks\Utility\str_starts_with;
+use Pressbooks\Modules\ThemeOptions\Admin;
 
 /**
  * @property array booleans
@@ -559,6 +560,10 @@ abstract class Options {
 	static function deleteCacheAfterUpdate( $option ) {
 		if ( str_starts_with( $option, 'pressbooks_' ) ) {
 			Book::deleteBookObjectCache();
+			//better to clear the entire cache when options are updated
+			( new Admin() )->clearCache();
+			Container::get( 'Styles' )->updatePdfStyleSheet();
+			update_option( 'pressbooks_last_export', time() );
 		}
 	}
 

--- a/inc/interactive/class-h5p.php
+++ b/inc/interactive/class-h5p.php
@@ -34,6 +34,11 @@ class H5P {
 	protected $dpi = 96;
 
 	/**
+	 * @var bool
+	 */
+	protected bool $enableStaticRepresentation = false;
+
+	/**
 	 * @param Blade $blade
 	 */
 	public function __construct( $blade ) {
@@ -41,6 +46,7 @@ class H5P {
 		if ( is_file( WP_PLUGIN_DIR . '/h5p/autoloader.php' ) ) {
 			require_once( WP_PLUGIN_DIR . '/h5p/autoloader.php' );
 		}
+		add_action( 'pb_pre_export', [ $this, 'shouldEnablePrint' ] );
 		add_filter( 'print_h5p_content', [ $this, 'generateCustomH5pWrapper' ], 10, 2 );
 	}
 
@@ -95,6 +101,17 @@ class H5P {
 			return false;
 		}
 		return true;
+	}
+
+	/**
+	 * Enable H5P content on export
+	 *
+	 */
+	public function shouldEnablePrint(): void {
+		$export_options = get_option( 'pressbooks_export_options' );
+		if ( isset( $export_options['h5p_print_on_exports'] ) && $export_options['h5p_print_on_exports'] ) {
+			$this->enableStaticRepresentation = $export_options['h5p_print_on_exports'];
+		}
 	}
 
 	/**
@@ -321,6 +338,11 @@ class H5P {
 	 * @return string|null HTML representation of H5P content or null.
 	 */
 	protected function getH5PRepresentation( int $h5p_id ): mixed {
+
+		if ( ! $this->enableStaticRepresentation ) {
+			return null; // Static representation is disabled
+		}
+
 		/*
 		 * Dynamically load H5PExtractor. Could be done via autloader as well, but
 		 * why load this unconditionally if if's only needed for printing?

--- a/inc/modules/export/epub/class-epub.php
+++ b/inc/modules/export/epub/class-epub.php
@@ -2859,9 +2859,6 @@ class Epub extends ExportGenerator {
 		$this->embbededCss = str_replace( "src: url('') format('truetype');", '', $this->embbededCss );
 		$this->embbededCss = str_replace( "background: url('') 10px center no-repeat;", '', $this->embbededCss );
 		$this->embbededCss = str_replace( 'font-size: unset;', '', $this->embbededCss );
-
-		file_put_contents( WP_CONTENT_DIR . '/emb.css', $this->embbededCss );
-
 		put_contents( $path, $contents . $this->embbededCss );
 
 	}

--- a/tests/test-interactive-h5p.php
+++ b/tests/test-interactive-h5p.php
@@ -146,4 +146,31 @@ class Interactive_H5PTest extends \WP_UnitTestCase {
 		$this->assertEquals( '<div>Rendered Mock H5P</div>', $result );
 	}
 
+	/**
+	 * Test H5P representation generation.
+	 *
+	 * @group interactivecontent
+	 */
+	public function test_if_h5p_export_option_is_checked() {
+		do_action( 'pb_pre_export' );
+		$this->h5p->shouldEnablePrint();
+		//change visibility of the static representation
+		$reflection = new ReflectionClass( $this->h5p );
+		$property = $reflection->getProperty( 'enableStaticRepresentation' );
+		$property->setAccessible( true );
+		//check if the static representation is enabled
+		$this->assertFalse( $property->getValue( $this->h5p ) );
+		//update options to enable static representation
+		update_option( 'pressbooks_export_options', [
+			'h5p_print_on_exports' => 1,
+		] );
+		do_action( 'pb_pre_export' );
+		$this->h5p->shouldEnablePrint();
+
+		$property = $reflection->getProperty( 'enableStaticRepresentation' );
+		$property->setAccessible( true );
+		//check if the static representation is enabled
+		$this->assertTrue( $property->getValue( $this->h5p ) );
+	}
+
 }


### PR DESCRIPTION
This pull request introduces support for enabling static representations of H5P content in exports (PDF and EPUB) and includes associated updates to settings, functionality, and tests. The changes primarily focus on adding a new export option, integrating it with the H5P export process, and ensuring proper testing and cache handling.

### H5P Export Option Integration:

* Added a new export option `h5p_print_on_exports` to enable static representations of H5P content in exports. This includes updates to the `init` function, rendering logic for the new checkbox, and default settings in `class-exportoptions.php`. [[1]](diffhunk://#diff-868bd54539ad9cc2128c0501e32ba3da16ca22eae1ce06b6c5f9661170ff7894R98-R108) [[2]](diffhunk://#diff-868bd54539ad9cc2128c0501e32ba3da16ca22eae1ce06b6c5f9661170ff7894R174-R191) [[3]](diffhunk://#diff-868bd54539ad9cc2128c0501e32ba3da16ca22eae1ce06b6c5f9661170ff7894R237) [[4]](diffhunk://#diff-868bd54539ad9cc2128c0501e32ba3da16ca22eae1ce06b6c5f9661170ff7894R250)
* Integrated the `h5p_print_on_exports` option into the H5P export process by introducing a new property `enableStaticRepresentation` in `class-h5p.php`. This property is set based on the export option and used to conditionally generate H5P representations. [[1]](diffhunk://#diff-7e3631bc1344793e025238d75c1ba7692bc2853d7b36f65aed09c31e8e332983R36-R40) [[2]](diffhunk://#diff-7e3631bc1344793e025238d75c1ba7692bc2853d7b36f65aed09c31e8e332983R49) [[3]](diffhunk://#diff-7e3631bc1344793e025238d75c1ba7692bc2853d7b36f65aed09c31e8e332983R106-R116) [[4]](diffhunk://#diff-7e3631bc1344793e025238d75c1ba7692bc2853d7b36f65aed09c31e8e332983R341-R345)

### Cache Management Enhancements:

* Updated the `deleteCacheAfterUpdate` method in `class-options.php` to clear the entire cache and update the PDF stylesheet when export options are modified.

### Testing Improvements:

* Added a new test case in `test-interactive-h5p.php` to verify the behavior of the `h5p_print_on_exports` option, ensuring that the static representation is enabled or disabled correctly based on the option value.

### Code Cleanup:

* Removed unnecessary file operations in the `updateCssFile` method of `class-epub.php` .

### How to test

By default h5p static representation is disabled, you should go to book settings to enable it.

<img width="957" alt="image" src="https://github.com/user-attachments/assets/382fd103-a2f6-4fba-b9ee-6276df00eac1" />

1. Without checking this option you should see the h5p activities as before only the little box with the URL of the activity.
2. Checking the H5P static representation will print H5P representation on exports
3. Try to swap the checkbox and export the same format again to double check export cache is being cleared when the option is updated.