### PR TITLE
fix: contributors media permissions

### DIFF
--- a/hooks-admin.php
+++ b/hooks-admin.php
@@ -106,6 +106,9 @@ if ( ! is_network_admin() ) {
 	add_action( 'admin_init', '\Pressbooks\Admin\Laf\privacy_settings_init' );
 }
 add_filter( 'map_meta_cap', '\Pressbooks\Admin\Laf\allow_edit_to_book_authors', 10, 4 );
+add_filter( 'ajax_query_attachments_args', '\Pressbooks\Admin\Laf\filter_media_for_contributors' );
+add_action( 'pre_get_posts', '\Pressbooks\Admin\Laf\filter_media_list_for_contributors' );
+add_action( 'init', '\Pressbooks\Admin\Laf\enable_media_buttons_for_contributors' );
 
 // Network settings
 add_action( 'network_admin_menu', [ '\Pressbooks\Admin\Network\NetworkSettings', 'init' ] );

--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -32,6 +32,7 @@ use Pressbooks\Contributors;
 use Pressbooks\DataCollector\Book as DataCollector;
 use Pressbooks\Metadata;
 use WP_Error;
+use WP_User;
 
 /**
  * @return bool
@@ -1733,14 +1734,72 @@ function remove_emoji() {
  * @return array
  */
 function allow_edit_to_book_authors( $caps, $cap, $user_id, $args ) {
-	if ( 'edit_post' === $cap && isset( $args[0] ) ) {
-		$post_id = $args[0];
-		$post_author_id = get_post_field( 'post_author', $post_id );
+	// Check if the user is a Contributor
+	$user = new WP_User( $user_id );
+	if ( in_array( 'contributor', (array) $user->roles, true ) ) {
+		// Allow contributors to upload files
+		if ( 'upload_files' === $cap ) {
+			return [ 'upload_files' ]; // Grant the upload_files capability
+		}
 
-		if ( (int) $user_id === (int) $post_author_id ) {
-			return [ 'edit_posts' ];
+		// Existing logic for allowing authors to edit their own posts
+		if ( 'edit_post' === $cap && isset( $args[0] ) ) {
+			$post_id = $args[0];
+			$post_author_id = get_post_field( 'post_author', $post_id );
+
+			if ( (int) $user_id === (int) $post_author_id ) {
+				return [ 'edit_posts' ];
+			}
 		}
 	}
+
 	return $caps;
+}
+
+function enable_media_buttons_for_contributors() {
+	$role = get_role( 'contributor' );
+	$role?->add_cap( 'upload_files', true );
+}
+
+function filter_media_for_contributors( $query ) {
+	if ( ! function_exists( 'wp_get_current_user' ) ) {
+		return $query;
+	}
+
+	if ( ! is_admin() ) {
+		return $query;
+	}
+
+	$current_user = wp_get_current_user();
+
+	if ( ! $current_user || ! $current_user->exists() || ! in_array( 'contributor', $current_user->roles, true ) ) {
+		return $query;
+	}
+
+	$query['author'] = $current_user->ID;
+
+	return $query;
+}
+
+function filter_media_list_for_contributors( $query ) {
+	global $pagenow;
+
+	if ( ! function_exists( 'wp_get_current_user' ) ) {
+		return $query;
+	}
+
+	if ( $pagenow !== 'upload.php' ) {
+		return $query;
+	}
+
+	$current_user = wp_get_current_user();
+
+	if ( ! $current_user || ! $current_user->exists() || ! in_array( 'contributor', $current_user->roles, true ) ) {
+		return $query;
+	}
+
+	$query->set( 'author', $current_user->ID );
+
+	return $query;
 }
 

--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -32,7 +32,6 @@ use Pressbooks\Contributors;
 use Pressbooks\DataCollector\Book as DataCollector;
 use Pressbooks\Metadata;
 use WP_Error;
-use WP_User;
 
 /**
  * @return bool
@@ -1734,25 +1733,14 @@ function remove_emoji() {
  * @return array
  */
 function allow_edit_to_book_authors( $caps, $cap, $user_id, $args ) {
-	// Check if the user is a Contributor
-	$user = new WP_User( $user_id );
-	if ( in_array( 'contributor', (array) $user->roles, true ) ) {
-		// Allow contributors to upload files
-		if ( 'upload_files' === $cap ) {
-			return [ 'upload_files' ]; // Grant the upload_files capability
-		}
+	if ( 'edit_post' === $cap && isset( $args[0] ) ) {
+		$post_id = $args[0];
+		$post_author_id = get_post_field( 'post_author', $post_id );
 
-		// Existing logic for allowing authors to edit their own posts
-		if ( 'edit_post' === $cap && isset( $args[0] ) ) {
-			$post_id = $args[0];
-			$post_author_id = get_post_field( 'post_author', $post_id );
-
-			if ( (int) $user_id === (int) $post_author_id ) {
-				return [ 'edit_posts' ];
-			}
+		if ( (int) $user_id === (int) $post_author_id ) {
+			return [ 'edit_posts' ];
 		}
 	}
-
 	return $caps;
 }
 

--- a/tests/test-admin-laf.php
+++ b/tests/test-admin-laf.php
@@ -420,6 +420,9 @@ class Admin_LafTest extends \WP_UnitTestCase {
 		$this->assertFalse( has_filter( 'wp_staticize_emoji', 'comment_text_css' ) );
 	}
 
+	/**
+	 * @group branding
+	 */
 	function test_capabilities_remains_the_same_for_regular_authors() {
 
 		$author_id = $this->factory->user->create(['role' => 'author']);
@@ -438,6 +441,9 @@ class Admin_LafTest extends \WP_UnitTestCase {
 		$this->assertTrue(current_user_can('edit_post', $post_id));
 	}
 
+	/**
+	 * @group branding
+	 */
 	function test_new_user_authors_editing_capabilities() {
 
 		$author_id = $this->factory->user->create(['role' => 'author']);


### PR DESCRIPTION
Address #3992 https://github.com/pressbooks/pressbooks/issues/4021

This pull request introduces changes to enhance the capabilities of WordPress contributors, specifically allowing them to upload files and filter media library access to their own uploads. The most important changes include adding new filters and actions, modifying user permissions, and introducing helper functions for contributors.

### Enhancements for Contributor Capabilities:

* **Added new filters and actions for contributors**:
  - Registered `ajax_query_attachments_args`, `pre_get_posts`, and `init` hooks to enable file upload capabilities and filter media access for contributors in `hooks-admin.php`.


* **Introduced helper functions**:
  - Added `enable_media_buttons_for_contributors` to dynamically grant the `upload_files` capability to contributors.
  - Created `filter_media_for_contributors` to restrict the media library query to show only files uploaded by the current contributor.
  - Added `filter_media_list_for_contributors` to filter the media list view in the admin panel for contributors.

### Codebase Maintenance:

* **Updated namespace imports**:
  - Added the `WP_User` class import in `inc/admin/laf/namespace.php` to support contributor-related functionality.