### PR TITLE
fix: conditionally register robots settings

### DIFF
--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -1239,18 +1239,20 @@ function privacy_settings_init() {
 			__NAMESPACE__ . '\privacy_blog_public_sanitize'
 		);
 
-		add_settings_field(
-			id: 'pressbooks_robots',
-			title: esc_html__( 'Robots', 'pressbooks' ),
-			callback: __NAMESPACE__ . '\privacy_robots_callback',
-			page: 'privacy_settings',
-			section: 'privacy_settings_section',
-		);
-		register_setting(
-			'privacy_settings',
-			'pressbooks_robots',
-			__NAMESPACE__ . '\privacy_robots_sanitize'
-		);
+		if ( apply_filters( 'pb_robots_settings', true ) ) {
+			add_settings_field(
+				id: 'pressbooks_robots',
+				title: esc_html__( 'Robots', 'pressbooks' ),
+				callback: __NAMESPACE__ . '\privacy_robots_callback',
+				page: 'privacy_settings',
+				section: 'privacy_settings_section',
+			);
+			register_setting(
+				'privacy_settings',
+				'pressbooks_robots',
+				__NAMESPACE__ . '\privacy_robots_sanitize'
+			);
+		}
 	}
 
 	add_settings_field(

--- a/tests/test-admin-laf.php
+++ b/tests/test-admin-laf.php
@@ -464,6 +464,27 @@ class Admin_LafTest extends \WP_UnitTestCase {
 		$this->assertFalse(current_user_can('edit_post', $post_id));
 	}
 
+	public function test_robots_settings_is_not_registered(): void
+	{
+		global $wp_registered_settings;
+
+		add_filter( 'pb_robots_settings', '__return_false' );
+
+		\Pressbooks\Admin\Laf\privacy_settings_init();
+
+		$this->assertArrayNotHasKey( 'pressbooks_robots', $wp_registered_settings );
+	}
+
+	public function test_robots_settings_is_registered(): void
+	{
+		global $wp_registered_settings;
+
+		\Pressbooks\Admin\Laf\privacy_settings_init();
+
+		$this->assertArrayHasKey('pressbooks_robots', $wp_registered_settings, 'Setting not registered');
+	}
+
+
 	public function test_privacy_robots_callback(): void
 	{
 		$this->_book();


### PR DESCRIPTION
Issue: pressbooks/private#1745

This PR updates the robots settings to be conditionally registered based on a hook