### PR TITLE
fix: clone pb_show_title post metadata

### DIFF
--- a/inc/api/endpoints/controller/class-sectionmetadata.php
+++ b/inc/api/endpoints/controller/class-sectionmetadata.php
@@ -415,6 +415,12 @@ class SectionMetadata extends \WP_REST_Controller {
 					'context' => [ 'view' ],
 					'readonly' => true,
 				],
+				'showTitle' => [
+					'type' => 'string',
+					'description' => __( 'Whether the title of the section should be shown in the web version.' ),
+					'context' => [ 'view' ],
+					'readonly' => true,
+				],
 				'identifier' => [
 					'type' => 'object',
 					'description' => __( 'The identifier property represents any kind of identifier for any kind of Thing, such as ISBNs, GTIN codes, UUIDs etc.' ),

--- a/inc/metadata/namespace.php
+++ b/inc/metadata/namespace.php
@@ -582,6 +582,7 @@ function section_information_to_schema( $section_information, $book_information 
 		'pb_short_title' => 'alternateName',
 		'pb_subtitle' => 'alternativeHeadline',
 		'pb_is_based_on' => 'isBasedOn',
+		'pb_show_title' => 'showTitle',
 	];
 
 	$mapped_book_properties = [
@@ -790,6 +791,12 @@ function schema_to_section_information( $section_schema, $book_schema ) {
 	if ( isset( $section_schema['isBasedOn'] ) ) {
 		if ( empty( $book_schema['isBasedOn'] ) || $section_schema['isBasedOn'] !== $book_schema['isBasedOn'] ) {
 			$section_information['pb_is_based_on'] = $section_schema['isBasedOn'];
+		}
+	}
+
+	if ( isset( $section_schema['showTitle'] ) ) {
+		if ( empty( $book_schema['showTitle'] ) || $section_schema['showTitle'] !== $book_schema['showTitle'] ) {
+			$section_information['pb_show_title'] = $section_schema['showTitle'];
 		}
 	}
 


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks/issues/3369

This pull request introduces a new property, `showTitle`, to manage whether the title of a section should be displayed in the web version. The changes include updates to schema definitions and mapping functions to incorporate this property.

### Schema updates:

* [`inc/api/endpoints/controller/class-sectionmetadata.php`](diffhunk://#diff-b5bdc6462302e19606927fc7c7706e83ec59153308e0d2c7f124b3a61fe31c88R418-R423): Added `showTitle` to the item schema with type `string`, a description, and context set to 'view'. This property is marked as readonly.

### Metadata mapping updates:

* [`inc/metadata/namespace.php`](diffhunk://#diff-09dd9cf5a50855d0b7c0466d00812524318db2a89cb0bb845897d0aa2d38ed3fR585): Updated the `section_information_to_schema` function to map the `pb_show_title` property to `showTitle` in the schema.
* [`inc/metadata/namespace.php`](diffhunk://#diff-09dd9cf5a50855d0b7c0466d00812524318db2a89cb0bb845897d0aa2d38ed3fR797-R802): Updated the `schema_to_section_information` function to handle the `showTitle` property, ensuring it is set in `section_information` only if it differs from the `book_schema` value or is not present in the `book_schema`.

### Testing notes
- Go to Organise page (Book level)
- Turn on some "Show Title" checkboxes (Chapters, front matters or back matters)
- Clone the book
- Book cloned should have the some "Show title" configuration as the original one.