### PR TITLE
feat: add support for Urdu, Modern Hebrew, and Amharic

### DIFF
--- a/inc/class-globaltypography.php
+++ b/inc/class-globaltypography.php
@@ -149,6 +149,7 @@ class GlobalTypography {
 				break;
 			case 'am': // Amharic
 				$lang = 'am';
+                break;
 			case 'ar': // Arabic
 			case 'ar-dz':
 			case 'ar-bh':

--- a/inc/class-globaltypography.php
+++ b/inc/class-globaltypography.php
@@ -149,7 +149,7 @@ class GlobalTypography {
 				break;
 			case 'am': // Amharic
 				$lang = 'am';
-                break;
+				break;
 			case 'ar': // Arabic
 			case 'ar-dz':
 			case 'ar-bh':

--- a/inc/class-globaltypography.php
+++ b/inc/class-globaltypography.php
@@ -38,6 +38,7 @@ class GlobalTypography {
 	function getSupportedLanguages() {
 		return [
 			'ff' => __( 'Adlam', 'pressbooks' ),
+			'am' => __( 'Amharic', 'pressbooks' ),
 			'grc' => __( 'Ancient Greek', 'pressbooks' ),
 			'hy' => __( 'Armenian', 'pressbooks' ),
 			'ar' => __( 'Arabic', 'pressbooks' ),
@@ -146,6 +147,8 @@ class GlobalTypography {
 			case 'el': // Ancient Greek
 				$lang = 'grc';
 				break;
+			case 'am': // Amharic
+				$lang = 'am';
 			case 'ar': // Arabic
 			case 'ar-dz':
 			case 'ar-bh':
@@ -300,6 +303,15 @@ class GlobalTypography {
 	 */
 	function fontPacks() {
 		$fontpacks = [
+			'am' => [
+				'baseurl' => 'https://cdn.jsdelivr.net/gh/notofonts/notofonts.github.io/fonts/',
+				'files' => [
+					'NotoSansEthiopic-Regular.otf' => 'NotoSansEthiopic/full/otf/NotoSansEthiopic-Regular.otf',
+					'NotoSansEthiopic-Bold.otf' => 'NotoSansEthiopic/full/otf/NotoSansEthiopic-Bold.otf',
+					'NotoSerifEthiopic-Regular.otf' => 'NotoSerifEthiopic/full/otf/NotoSerifEthiopic-Regular.otf',
+					'NotoSerifEthiopic-Bold.otf' => 'NotoSerifEthiopic/full/otf/NotoSerifEthiopic-Bold.otf',
+				],
+			],
 			'bn' => [
 				'baseurl' => 'https://cdn.jsdelivr.net/gh/notofonts/notofonts.github.io/fonts/',
 				'files' => [
@@ -455,7 +467,7 @@ class GlobalTypography {
 				],
 			],
 		];
-		return $fontpacks;
+			return $fontpacks;
 	}
 
 	/**

--- a/inc/class-globaltypography.php
+++ b/inc/class-globaltypography.php
@@ -42,7 +42,6 @@ class GlobalTypography {
 			'hy' => __( 'Armenian', 'pressbooks' ),
 			'ar' => __( 'Arabic', 'pressbooks' ),
 			'bn' => __( 'Bengali', 'pressbooks' ),
-			'he' => __( 'Biblical Hebrew', 'pressbooks' ),
 			'cans' => __( 'Canadian Indigenous Syllabics', 'pressbooks' ),
 			'chr' => __( 'Cherokee', 'pressbooks' ),
 			'zh_HANS' => __( 'Chinese (Simplified)', 'pressbooks' ),
@@ -50,7 +49,8 @@ class GlobalTypography {
 			'cop' => __( 'Coptic', 'pressbooks' ),
 			'hi' => __( 'Devanagari (Hindi and Sanskrit)', 'pressbooks' ),
 			'gu' => __( 'Gujarati', 'pressbooks' ),
-			'pan' => __( 'Punjabi (Gurmukhi)', 'pressbooks' ),
+			'he' => __( 'Hebrew (Biblical)', 'pressbooks' ),
+			'he_modern' => __( 'Hebrew (Modern)', 'pressbooks' ),
 			'ja' => __( 'Japanese', 'pressbooks' ),
 			'kn' => __( 'Kannada', 'pressbooks' ),
 			'ko' => __( 'Korean', 'pressbooks' ),
@@ -59,11 +59,13 @@ class GlobalTypography {
 			'music' => __( 'Musical Notation', 'pressbooks' ),
 			'nqo' => __( 'N\'Ko', 'pressbooks' ),
 			'or' => __( 'Odia', 'pressbooks' ),
+			'pan' => __( 'Punjabi (Gurmukhi)', 'pressbooks' ),
 			'syr' => __( 'Syriac', 'pressbooks' ),
 			'ta' => __( 'Tamil', 'pressbooks' ),
 			'te' => __( 'Telugu', 'pressbooks' ),
 			'bo' => __( 'Tibetan', 'pressbooks' ),
 			'tr' => __( 'Turkish', 'pressbooks' ),
+			'ur' => __( 'Urdu', 'pressbooks' ),
 		];
 	}
 
@@ -207,6 +209,9 @@ class GlobalTypography {
 			case 'tr': // Turkish
 				$lang = 'tr';
 				break;
+			case 'ur': // Urdu
+				$lang = 'ur';
+				break;
 		}
 
 		return $lang;
@@ -327,6 +332,15 @@ class GlobalTypography {
 					'NotoSansAdlamUnjoined-Bold.otf' => 'NotoSansAdlamUnjoined/full/otf/NotoSansAdlamUnjoined-Bold.otf',
 				],
 			],
+			'he_modern' => [
+				'baseurl' => 'https://cdn.jsdelivr.net/gh/notofonts/notofonts.github.io/fonts/',
+				'files' => [
+					'NotoSansHebrew-Regular.otf' => 'NotoSansHebrew/full/otf/NotoSansHebrew-Regular.otf',
+					'NotoSansHebrew-Bold.otf' => 'NotoSansHebrew/full/otf/NotoSansHebrew-Bold.otf',
+					'NotoSerifHebrew-Regular.otf' => 'NotoSerifHebrew/full/otf/NotoSerifHebrew-Regular.otf',
+					'NotoSerifHebrew-Bold.otf' => 'NotoSerifHebrew/full/otf/NotoSerifHebrew-Bold.otf',
+				],
+			],
 			'hi' => [
 				'baseurl' => 'https://cdn.jsdelivr.net/gh/notofonts/notofonts.github.io/fonts/',
 				'files' => [
@@ -416,6 +430,13 @@ class GlobalTypography {
 					'NotoSansTelugu-Bold.otf' => 'NotoSansTelugu/full/otf/NotoSansTelugu-Bold.otf',
 					'NotoSerifTelugu-Regular.otf' => 'NotoSerifTelugu/full/otf/NotoSerifTelugu-Regular.otf',
 					'NotoSerifTelugu-Bold.otf' => 'NotoSerifTelugu/full/otf/NotoSerifTelugu-Bold.otf',
+				],
+			],
+			'ur' => [
+				'baseurl' => 'https://cdn.jsdelivr.net/gh/notofonts/notofonts.github.io/fonts/',
+				'files' => [
+					'NotoNastaliqUrdu-Regular.otf' => 'NotoNastaliqUrdu/full/otf/NotoNastaliqUrdu-Regular.otf',
+					'NotoNastaliqUrdu-Bold.otf' => 'NotoNastaliqUrdu/full/otf/NotoNastaliqUrdu-Bold.otf',
 				],
 			],
 			'zh_HANS' => [


### PR DESCRIPTION
Add support for Urdu and Hebrew (Modern), and Amharic in theme options (font & script support). Partial fix for https://github.com/pressbooks/pressbooks/issues/4037, https://github.com/pressbooks/pressbooks/issues/4075, and https://pressbooks.community/t/font-not-appearing-in-pdf-export/4249. Requires accompanying change to pressbooks-book: https://github.com/pressbooks/pressbooks-book/pull/1343

**To Test:**
1. Checkout this branch and the accompanying PR branch in pressbooks-book
2. Go to theme options and add Urdu, Hebrew (Modern), and Amharic from language and script support
3. Check that the expected font files have been uploaded to `/web/app/uploads/assets/fonts` folder
4. Add text in Hebrew, Amharic, and/or Urdu/Nastaliq to your book. 
5. View webbook and confirm that font stack is loaded as expected
6. Produce EPUB and PDF exports and confirm that the font stack is loaded in export files (no tofu blocks where glyphs should be)