### PR TITLE
chore: update wp tests-pipeline

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         include:
           - php: 8.2
-            wordpress: 6.7
+            wordpress: 6.8
             prince: 14.3-1
             epubcheck: 4.2.6
             experimental: false
@@ -24,7 +24,7 @@ jobs:
             epubcheck: 4.2.6
             experimental: true
           - php: 8.3
-            wordpress: 6.7
+            wordpress: 6.8
             prince: 14.3-1
             epubcheck: 4.2.6
             experimental: true


### PR DESCRIPTION
This pull request updates the WordPress version used in the GitHub Actions test matrix from `6.7` to `6.8`.

* [`.github/workflows/tests.yml`](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL17-R17): Updated the WordPress version from `6.7` to `6.8` for both PHP 8.2. [[1]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL17-R17) [[2]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL27-R27)