### PR TITLE
fix: allow DocRaptor pipeline to be set with env variable

### DIFF
--- a/inc/modules/export/prince/class-docraptor.php
+++ b/inc/modules/export/prince/class-docraptor.php
@@ -100,7 +100,7 @@ class Docraptor extends Pdf {
 			}
 			$doc->setName( get_bloginfo( 'name' ) );
 			$doc->setPrinceOptions( $prince_options );
-			$doc->setPipeline( ( env( 'DOCRAPTOR_PIPELINE', 9.2 ) ); // Prince 14.3, see: https://docraptor.com/documentation/api#api_pipeline
+			$doc->setPipeline( ( env( 'DOCRAPTOR_PIPELINE', 9.2 ) ) ); // Prince 14.3, see: https://docraptor.com/documentation/api#api_pipeline
 
 			$create_response = $docraptor->createAsyncDoc( $doc );
 			$done = false;

--- a/inc/modules/export/prince/class-docraptor.php
+++ b/inc/modules/export/prince/class-docraptor.php
@@ -100,7 +100,7 @@ class Docraptor extends Pdf {
 			}
 			$doc->setName( get_bloginfo( 'name' ) );
 			$doc->setPrinceOptions( $prince_options );
-			$doc->setPipeline( 9.2 ); // Prince 14.3, see: https://docraptor.com/documentation/api#api_pipeline
+			$doc->setPipeline( ( env( 'DOCRAPTOR_PIPELINE', 9.2 ) ); // Prince 14.3, see: https://docraptor.com/documentation/api#api_pipeline
 
 			$create_response = $docraptor->createAsyncDoc( $doc );
 			$done = false;


### PR DESCRIPTION
Adds support for setting DocRaptor pipeline version with a new .env variable called `DOCRAPTOR_PIPELINE` and keeps hardcoded value as fallback for any instance without this env variable.. Fix for https://github.com/pressbooks/pressbooks/issues/3484. 

Latest DocRaptor pipeline version is currently 10.1. This should make it easier for us to test updating the pipeline in various environments before bumping in production.