### PR TITLE
fix: add support for DocRaptor pipeline env variable to cover generator

### DIFF
--- a/inc/covergenerator/class-generator.php
+++ b/inc/covergenerator/class-generator.php
@@ -437,7 +437,7 @@ abstract class Generator {
 			$doc->setDocumentContent( $document_content );
 			$doc->setName( get_bloginfo( 'name' ) . ' Cover' );
 			$doc->setPrinceOptions( $prince_options );
-            $doc->setPipeline( ( env( 'DOCRAPTOR_PIPELINE', 9.2 ) ) ); // Prince 14.3, see: https://docraptor.com/documentation/api#api_pipeline
+			$doc->setPipeline( ( env( 'DOCRAPTOR_PIPELINE', 9.2 ) ) ); // Prince 14.3, see: https://docraptor.com/documentation/api#api_pipeline
 
 			$create_response = $docraptor->createAsyncDoc( $doc );
 			$done = false;


### PR DESCRIPTION
Adds support for setting DocRaptor pipeline version for the cover generator tool. Partial fix for https://github.com/pressbooks/pressbooks/issues/3484.

This will make it easier for us to test updating the pipeline in various environments before bumping in production.