### PR TITLE
fix: use DocRaptor constant instead of `env`

### DIFF
--- a/inc/covergenerator/class-generator.php
+++ b/inc/covergenerator/class-generator.php
@@ -434,10 +434,11 @@ abstract class Generator {
 			} else {
 				$doc->setTest( false );
 			}
+
 			$doc->setDocumentContent( $document_content );
 			$doc->setName( get_bloginfo( 'name' ) . ' Cover' );
 			$doc->setPrinceOptions( $prince_options );
-			$doc->setPipeline( ( env( 'DOCRAPTOR_PIPELINE', 9.2 ) ) ); // Prince 14.3, see: https://docraptor.com/documentation/api#api_pipeline
+			$doc->setPipeline( defined( 'DOCRAPTOR_PIPELINE' ) ? DOCRAPTOR_PIPELINE : 9.2 ); // Prince 14.3, see: https://docraptor.com/documentation/api#api_pipeline
 
 			$create_response = $docraptor->createAsyncDoc( $doc );
 			$done = false;

--- a/inc/modules/export/prince/class-docraptor.php
+++ b/inc/modules/export/prince/class-docraptor.php
@@ -100,7 +100,7 @@ class Docraptor extends Pdf {
 			}
 			$doc->setName( get_bloginfo( 'name' ) );
 			$doc->setPrinceOptions( $prince_options );
-			$doc->setPipeline( ( env( 'DOCRAPTOR_PIPELINE', 9.2 ) ) ); // Prince 14.3, see: https://docraptor.com/documentation/api#api_pipeline
+			$doc->setPipeline( defined( 'DOCRAPTOR_PIPELINE' ) ? DOCRAPTOR_PIPELINE : 9.2 ); // Prince 14.3, see: https://docraptor.com/documentation/api#api_pipeline
 
 			$create_response = $docraptor->createAsyncDoc( $doc );
 			$done = false;


### PR DESCRIPTION
Adds support for setting DocRaptor pipeline version for the cover generator tool. Partial fix for https://github.com/pressbooks/pressbooks/issues/3484.

This will make it easier for us to test updating the pipeline in various environments before bumping in production.