### PR TITLE
fix: mathml base64 formulas

### DIFF
--- a/inc/class-mathjax.php
+++ b/inc/class-mathjax.php
@@ -823,7 +823,7 @@ STYLES;
 				if ( apply_filters( 'pb_mathjax_use', $this->usePbMathJax ) && PB_MATHJAX_URL ) {
 					$options = $this->getOptions();
 					$url = rtrim( PB_MATHJAX_URL, '/' );
-					$url .= '/mathml?mathml=' . rawurlencode( $mathml ) . '&fg=' . $options['fg'];
+					$url .= '/mathml?mathml=' . str_replace( '=', '', strtr( base64_encode( $mathml ), '+/', '-_' ) ) . '&fg=' . $options['fg'];
 					/**
 					 * Return a SVG instead of a PNG
 					 *
@@ -835,6 +835,8 @@ STYLES;
 					if ( apply_filters( 'pb_mathjax_use_svg', $this->useSVG ) ) {
 						$url .= '&svg=1';
 					}
+					// Base64 encode parameter for better PB MathJax parsing
+					$url .= '&isBase64=1';
 					$url = esc_url( $url );
 					$alt = str_replace( "\n", '', normalize_whitespace( wp_strip_all_tags( $mathml ) ) );
 					$alt = str_replace( '\\', '&#92;', esc_attr( $alt ) );


### PR DESCRIPTION
This pull request updates the `inc/class-mathjax.php` file to improve the handling of MathML encoding and enhance compatibility with PB MathJax parsing. The changes focus on encoding the `mathml` parameter using Base64 and adding a flag to indicate the encoding format.

### Changes to MathML encoding and URL construction:

* Updated the `mathml` parameter to use a URL-safe Base64 encoding instead of `rawurlencode`, improving compatibility and ensuring safer transmission of the data. (`[inc/class-mathjax.phpL826-R826](diffhunk://#diff-75471e261b56521dd46690fedb88783fbf2ce63be3148866d236767dfe25fde2L826-R826)`)
* Added an `isBase64=1` flag to the URL to indicate that the `mathml` parameter is Base64-encoded, aiding in better PB MathJax parsing. (`[inc/class-mathjax.phpR838-R839](diffhunk://#diff-75471e261b56521dd46690fedb88783fbf2ce63be3148866d236767dfe25fde2R838-R839)`)