### PR TITLE
feat: add Atkinson Hyperlegible Next to Shapeshifter font choices

### DIFF
--- a/inc/class-styles.php
+++ b/inc/class-styles.php
@@ -744,6 +744,7 @@ class Styles {
 
 		$sans_serif = [
 			'Alegreya Sans' => __( 'Alegreya Sans', 'pressbooks' ),
+			'Atkinson Hyperlegible Next' => __( 'Atkinson Hyperlegible Next', 'pressbooks' ),
 			'Barlow' => __( 'Barlow', 'pressbooks' ),
 			'FreeSans' => __( 'GNU FreeFont Sans', 'pressbooks' ),
 			'K2D' => __( 'K2D', 'pressbooks' ),


### PR DESCRIPTION
Adds Atkinson Hyperlegible Next as a sans-serif font option to the 'shapeshifter' feature in all book themes which support it. Partial fix for https://github.com/pressbooks/pressbooks-book/issues/1344. Accompanies https://github.com/pressbooks/pressbooks-book/pull/1349

To test:

Go to web/PDF/EPUB theme settings and select Atkinson Hyperlegible Next as a header or body font.
Add regular, bold, italic, and bold italic text to the book.
Visit the webbook and produce exports.
Confirm that the Atkinson Hyperlegible Next typeface is displayed as expected.