### PR TITLE
feat: personalize Getting Started playlist URL based on network type

### DIFF
--- a/inc/admin/dashboard/class-bookdashboard.php
+++ b/inc/admin/dashboard/class-bookdashboard.php
@@ -22,6 +22,16 @@ class BookDashboard extends Dashboard {
 
 		$permissions = $this->getUserPermissions();
 
+		$getting_started_playlist_url = 'https://youtube.com/playlist?list=PLMFmJu3NJhevTbp5XAbdif8OloNhqOw5n';
+
+		if ( is_plugin_active_for_network( 'pressbooks-vip/pressbooks-vip.php' ) ) {
+			$getting_started_playlist_url = 'https://www.youtube.com/playlist?list=PLMFmJu3NJhetTsZAkWTzyipvbMIi0XBc5';
+		}
+
+		if ( is_plugin_active_for_network( 'pressbooks-biblioboard-oauth/pressbooks-biblioboard-oauth.php' ) ) {
+			$getting_started_playlist_url = 'https://www.youtube.com/playlist?list=PLMFmJu3NJheulEpTdwZ0TqWM4KdL4L8ut';
+		}
+
 		echo $blade->render( 'admin.dashboard.book', [
 			'is_current_user_subscriber' => count( $current_user->roles ) === 1 && $current_user->roles[0] === 'subscriber',
 			'site_name' => get_bloginfo( 'name' ),
@@ -35,6 +45,7 @@ class BookDashboard extends Dashboard {
 			'delete_book_url' => $permissions['delete_site'] ? admin_url( 'ms-delete-site.php' ) : false,
 			'write_chapter_url' => $permissions['edit_posts'] ? admin_url( 'post-new.php?post_type=chapter' ) : false,
 			'import_content_url' => $permissions['edit_posts'] ? admin_url( 'admin.php?page=pb_import' ) : false,
+			'getting_started_playlist_url' => $getting_started_playlist_url,
 		] );
 	}
 

--- a/templates/admin/dashboard/book.blade.php
+++ b/templates/admin/dashboard/book.blade.php
@@ -97,10 +97,10 @@
 		<div class="pb-dashboard-panel">
 			<div class="pb-dashboard-content">
 				<h2>{{ __('Support resources', 'pressbooks') }}</h2>
-				{{-- TODO: add link to new YouTube playlist. --}}
 				<ul class="horizontal">
 					<li class="resources" id="getting-started">
-						<a href="https://youtube.com/playlist?list=PLMFmJu3NJhevTbp5XAbdif8OloNhqOw5n" target="_blank">
+
+						<a href="{{ $getting_started_playlist_url }}" target="_blank">
 							<img src="{{ PB_PLUGIN_URL . "assets/dist/images/pb-getting-started.png" }}" alt="" />
 							{{ __('Getting started with Pressbooks', 'pressbooks' )}}
 						</a>


### PR DESCRIPTION
Customize the Getting Started YouTube playlist link displayed on the book dashboard based on the type of network. Addresses https://github.com/pressbooks/private/issues/1730

To test:
1. Install and network activate pressbooks-vip (only present on Pressbooks Self-Publisher, i.e. pressbooks.pub). Confirm that the playlist URL in the book dashboard is the Pressbooks Self-Publisher one
2. Deactivate pressbooks-vip and install & network activate pressbooks-biblioboard-auth (only present on Pressbooks Public [Bibliolabs] networks). Confirm that the playlist URL in the book dashboard is the Pressbooks Public one
3. Deactivate both plugins and confirm that the playlist URL in the book dashboard is the general Pressbooks one