### PR TITLE
fix: allow spans with lang attributes in section titles

### DIFF
--- a/inc/sanitize/namespace.php
+++ b/inc/sanitize/namespace.php
@@ -251,6 +251,7 @@ function filter_title( $title ) {
 		'br' => [],
 		'span' => [
 			'class' => [],
+			'lang' => [],
 		],
 		'em' => [],
 		'strong' => [],

--- a/tests/test-sanitize.php
+++ b/tests/test-sanitize.php
@@ -186,6 +186,10 @@ class SanitizeTest extends \WP_UnitTestCase {
 		$test = '<del><strike>Keep me</strike></del>';
 		$test = \Pressbooks\Sanitize\filter_title( $test );
 		$this->assertEquals( '<del>Keep me</del>', $test );
+
+		$test = 'A Central Asian Trilogy: the Legacy of Aitmatov in Ismailov’s <span lang="de"><em>Vunderkind Erzhan</em></span>';
+		$test = \Pressbooks\Sanitize\filter_title( $test );
+		$this->assertEquals( 'A Central Asian Trilogy: the Legacy of Aitmatov in Ismailov’s <span lang="de"><em>Vunderkind Erzhan</em></span>', $test );
 	}
 
 	/**


### PR DESCRIPTION
Resolves #3936, resolves pressbooks/ideas#493.