### PR TITLE
feat: get translated languages method

### DIFF
--- a/inc/l10n/namespace.php
+++ b/inc/l10n/namespace.php
@@ -336,6 +336,8 @@ function get_translated_languages( ?string $file_path = null ) {
 		}
 	}
 
+	asort( $languages );
+
 	return $languages;
 }
 

--- a/inc/l10n/namespace.php
+++ b/inc/l10n/namespace.php
@@ -317,6 +317,28 @@ function wplang_codes() {
 	return $languages;
 }
 
+function get_translated_languages( ?string $file_path = null ) {
+	$tx_yaml = file_get_contents( $file_path ?? PB_PLUGIN_DIR . '.tx/transifex.yaml' );
+	if ( ! $tx_yaml ) {
+		return [];
+	}
+
+	$supported = supported_languages();
+
+	$lines = explode( "\n", $tx_yaml );
+	$languages = [];
+	foreach ( $lines as $line ) {
+		if ( preg_match( '/^\s*([a-z]{2,3}(?:[_-][A-Z]{2,3})?)\s*:\s*([a-z]{2,3}(?:[_-][A-Z]{2,3})?)\s*$/i', $line, $matches ) ) {
+			$base_lang = preg_replace( '/[_-].*$/', '', strtolower( $matches[1] ) );
+			if ( isset( $supported[ $base_lang ] ) ) {
+				$languages[ $matches[2] ] = $supported[ $base_lang ];
+			}
+		}
+	}
+
+	return $languages;
+}
+
 /**
  * Override get_locale
  * For performance reasons, we only want functions in this namespace to call WP get_locale once.

--- a/tests/test-l10n.php
+++ b/tests/test-l10n.php
@@ -117,13 +117,50 @@ class L10nTest extends \WP_UnitTestCase {
 		$this->assertEquals( 'zh_CN', $output );
 	}
 
-
-//	public function test_update_user_locale() { // TODO
-//	}
-
 	public function test_get_book_language() {
 		$lang = \Pressbooks\L10n\get_book_language();
 		$this->assertNotEmpty( $lang );
 		$this->assertTrue( is_string( $lang ) );
+	}
+
+	/**
+	 * @test
+	 * @group localization
+	 */
+	public function it_gets_translated_languages(): void {
+		
+		$temp_file = tempnam( sys_get_temp_dir(), 'pb_lang_test_' );
+
+		$yaml_content = <<<YAML
+git:
+	filters:
+		- filter_type: file
+		  file_format: PO
+		  source_file: languages/pressbooks.pot
+		  source_language: en
+		  translation_files_expression: languages/pressbooks-<lang>.po
+	settings:
+		pr_branch_name: chore/update-translations-<br_unique_id>
+		language_mapping:
+			de: de_DE
+			es: es_ES
+			fr: fr_FR
+YAML;
+
+		file_put_contents( $temp_file, $yaml_content );
+
+		$translated_languages = \Pressbooks\L10n\get_translated_languages( $temp_file );
+		
+		unlink( $temp_file );
+
+		$this->assertIsArray( $translated_languages );
+		$this->assertArrayHasKey( 'de_DE', $translated_languages );
+		$this->assertArrayHasKey( 'es_ES', $translated_languages );
+		$this->assertArrayHasKey( 'fr_FR', $translated_languages );
+
+		$this->assertEquals( 'German', $translated_languages['de_DE'] );
+		$this->assertEquals( 'Spanish', $translated_languages['es_ES'] );
+		$this->assertEquals( 'French', $translated_languages['fr_FR'] );
+		
 	}
 }

--- a/tests/test-l10n.php
+++ b/tests/test-l10n.php
@@ -161,6 +161,8 @@ YAML;
 		$this->assertEquals( 'German', $translated_languages['de_DE'] );
 		$this->assertEquals( 'Spanish', $translated_languages['es_ES'] );
 		$this->assertEquals( 'French', $translated_languages['fr_FR'] );
-		
+
+		$sorted_languages = array_values( $translated_languages );
+		$this->assertEquals( [ 'French', 'German', 'Spanish' ], $sorted_languages );
 	}
 }


### PR DESCRIPTION
Issue: https://github.com/pressbooks/ideas/issues/526

This pull request introduces a new function to retrieve translated languages from a Transifex configuration file and adds corresponding unit tests to ensure its functionality. The main changes focus on enhancing localization support.
This method is intended to be used in: https://github.com/pressbooks/pressbooks-aldine/pull/507

### Localization Enhancements:

* **New Function for Translated Languages:**
  - Added the `get_translated_languages` function in `inc/l10n/namespace.php`. This function reads a Transifex YAML configuration file, extracts language mappings, and filters them based on supported languages.

* **Unit Test for Translated Languages:**
  - Introduced a new test method `it_gets_translated_languages` in `tests/test-l10n.php`. This test verifies that the `get_translated_languages` function correctly parses language mappings from a sample YAML configuration file and returns the expected results.