### PR TITLE
fix: pot workflow

### DIFF
--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -17,4 +17,3 @@ jobs:
       slug: 'pressbooks'
       package_name: 'Pressbooks'
       headers: '{"Report-Msgid-Bugs-To": "https://github.com/pressbooks/pressbooks/issues"}'
-      pull_request_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Remove unrequired parameter on push triggers