### PR TITLE
fix: book creation from network admin form

### DIFF
--- a/hooks-admin.php
+++ b/hooks-admin.php
@@ -394,3 +394,9 @@ add_action( 'admin_enqueue_scripts', function() {
 	$assets = new Assets( 'pressbooks', 'plugin' );
 	wp_enqueue_style( 'pb-table', $assets->getPath( 'styles/pressbooks-table.css' ) );
 } );
+
+add_action( 'plugins_loaded', [ \Pressbooks\Admin\Users\User::class, 'init' ], 10 );
+
+add_action( 'pb_new_blog', function() {
+	update_option( 'blog_public', 0 );
+} );

--- a/inc/admin/users/class-user.php
+++ b/inc/admin/users/class-user.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Pressbooks\Admin\Users;
+
+use Pressbooks\Contributors;
+
+class User {
+
+	protected static ?User $instance = null;
+
+	public static function init(): User {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+			self::hooks( self::$instance );
+		}
+		return self::$instance;
+	}
+
+	public static function hooks( User $obj ): void {
+		add_filter( 'pre_user_login', [ $obj, 'sanitizeUsernameByEmail' ], 10, 1 );
+		add_action( 'pb_new_blog', [ $obj, 'setBookAdminAsAuthor' ], 10 );
+	}
+
+	public function sanitizeUsernameByEmail( string $user_login ): string {
+		if ( ! $this->isSiteNetworkScreen() ) {
+			return $user_login;
+		}
+
+		$email = filter_var( INPUT_POST['blog']['email'] ?? '', FILTER_SANITIZE_EMAIL );
+
+		$user_details = self::generateUserNameFromEmail( $email );
+
+		if ( is_wp_error( $user_details['errors'] ) && $user_details['errors']->has_errors() ) {
+			return $user_login;
+		}
+
+		return $user_details['user_name'];
+	}
+
+	private function isSiteNetworkScreen(): bool {
+		global $current_screen;
+		return $current_screen->id === 'site-new-network' && $current_screen->base === 'site-new-network';
+	}
+
+	/**
+	 * @param string $email
+	 * @return array
+	 */
+	public static function generateUserNameFromEmail( string $email ): array {
+		$email = sanitize_email( $email );
+		if ( ! $email ) {
+			return [ 'errors' => new \WP_Error( 'pb_email', __( 'Invalid email address', 'pressbooks' ) ) ];
+		}
+
+		$i = 1;
+		$username = explode( '@', $email )[0];
+		$unique_username = self::sanitizeUser( $username );
+		while ( username_exists( $unique_username ) ) {
+			$unique_username = "{$username}{$i}";
+			++$i;
+		}
+
+		return wpmu_validate_user_signup( $unique_username, $email );
+	}
+
+	/**
+	 * Multisite has more restrictions on user login character set
+	 *
+	 * @see https://core.trac.wordpress.org/ticket/17904
+	 *
+	 * @param string $username
+	 *
+	 * @return string
+	 */
+	public static function sanitizeUser( string $username ) : string {
+		$unique_username = sanitize_user( $username, true );
+		$unique_username = strtolower( $unique_username );
+		$unique_username = preg_replace( '/[^a-z0-9]/', '', $unique_username );
+
+		if ( preg_match( '/^[0-9]*$/', $unique_username ) ) {
+			$unique_username .= 'a'; // usernames must have letters too
+		}
+
+		return str_pad( $unique_username, 4, '1' );
+	}
+
+	/**
+	 * Set the default book author to the specified admin user.
+	 */
+	public function setBookAdminAsAuthor(): void {
+		if ( ! $this->isSiteNetworkScreen() ) {
+			return;
+		}
+
+		$book_admin = get_users( [
+			'role'    => 'administrator',
+			'blog_id' => get_current_blog_id(),
+		] );
+
+		$contributors = new Contributors();
+		$contributors->addBlogUser( $book_admin[0]->ID );
+
+		$metadata_post_id = ( new \Pressbooks\Metadata )->getMetaPostId();
+
+		$term = get_term_by( 'slug', $book_admin[0]->data->user_login, Contributors::TAXONOMY, ARRAY_A );
+
+		$contributors->link( $term['term_id'], $metadata_post_id );
+
+		$user_data = get_userdata( get_current_user_id() );
+		$contributors->unlink( $user_data->user_nicename, $metadata_post_id );
+	}
+}

--- a/inc/admin/users/class-user.php
+++ b/inc/admin/users/class-user.php
@@ -17,21 +17,27 @@ class User {
 	}
 
 	public static function hooks( User $obj ): void {
-		add_filter( 'pre_user_login', [ $obj, 'sanitizeUsernameByEmail' ], 10, 1 );
+		add_filter( 'pre_user_login', [ $obj, 'getUsernameFromBookForm' ], 10, 1 );
 		add_action( 'pb_new_blog', [ $obj, 'setBookAdminAsAuthor' ], 10 );
 	}
 
-	public function sanitizeUsernameByEmail( string $user_login ): string {
+	public function getUsernameFromBookForm( string $original_email ): string {
 		if ( ! $this->isSiteNetworkScreen() ) {
-			return $user_login;
+			return $original_email;
 		}
 
-		$email = filter_var( INPUT_POST['blog']['email'] ?? '', FILTER_SANITIZE_EMAIL );
+		$nonce = sanitize_text_field( wp_unslash( $_POST['_wpnonce_add-blog'] ?? '' ) );
+
+		if ( ! wp_verify_nonce( $nonce, 'add-blog' ) ) {
+			return $original_email;
+		}
+
+		$email = filter_var( wp_unslash( $_POST['blog']['email'] ?? '' ), FILTER_SANITIZE_EMAIL );
 
 		$user_details = self::generateUserNameFromEmail( $email );
 
-		if ( is_wp_error( $user_details['errors'] ) && $user_details['errors']->has_errors() ) {
-			return $user_login;
+		if ( isset( $user_details['errors'] ) && is_wp_error( $user_details['errors'] ) && $user_details['errors']->has_errors() ) {
+			return $original_email;
 		}
 
 		return $user_details['user_name'];

--- a/inc/admin/users/class-userbulk.php
+++ b/inc/admin/users/class-userbulk.php
@@ -138,14 +138,14 @@ class UserBulk {
 	 * @return \WP_Error|string
 	 */
 	public function linkNewUserToBook( string $email, string $role ): \WP_Error|string {
-		$user_details = $this->generateUserNameFromEmail( $email );
+		$user_details = User::generateUserNameFromEmail( $email );
 
 		if ( is_wp_error( $user_details['errors'] ) && $user_details['errors']->has_errors() ) {
 			return $user_details['errors'];
 		}
 
 		$user_name = $user_details['user_name'];
-		$unique_username = apply_filters( 'pre_user_login', $this->sanitizeUser( wp_unslash( $user_name ), true ) );
+		$unique_username = apply_filters( 'pre_user_login', User::sanitizeUser( wp_unslash( $user_name ) ) );
 
 		// link newly created user to book
 		wpmu_signup_user(
@@ -158,47 +158,6 @@ class UserBulk {
 		);
 
 		return self::USER_STATUS_NEW;
-	}
-
-	/**
-	 * @param string $email
-	 * @return array
-	 */
-	public function generateUserNameFromEmail( string $email ): array {
-		if ( ! filter_var( $email, FILTER_VALIDATE_EMAIL ) ) {
-			return [ 'errors' => new \WP_Error( 'pb_email', __( 'Invalid email address', 'pressbooks' ) ) ];
-		}
-
-		$i = 1;
-		$username = explode( '@', $email )[0];
-		$unique_username = $this->sanitizeUser( $username );
-		while ( username_exists( $unique_username ) ) {
-			$unique_username = $this->sanitizeUser( "{$username}{$i}" );
-			++$i;
-		}
-
-		return wpmu_validate_user_signup( $unique_username, $email );
-	}
-
-	/**
-	 * Multisite has more restrictions on user login character set
-	 *
-	 * @see https://core.trac.wordpress.org/ticket/17904
-	 *
-	 * @param string $username
-	 *
-	 * @return string
-	 */
-	public function sanitizeUser( string $username ) : string {
-		$unique_username = sanitize_user( $username, true );
-		$unique_username = strtolower( $unique_username );
-		$unique_username = preg_replace( '/[^a-z0-9]/', '', $unique_username );
-
-		if ( preg_match( '/^[0-9]*$/', $unique_username ) ) {
-			$unique_username .= 'a'; // usernames must have letters too
-		}
-
-		return str_pad( $unique_username, 4, '1' );
 	}
 
 	/**

--- a/tests/test-user.php
+++ b/tests/test-user.php
@@ -1,12 +1,16 @@
 <?php
 
 use Pressbooks\Admin\Users\User;
+use Pressbooks\Contributors;
 use Pressbooks\HtmlParser;
 
 /**
  * @group users
  */
 class UserTest extends \WP_UnitTestCase {
+
+    use utilsTrait;
+
     /**
 	 * @var User
 	 */
@@ -20,7 +24,10 @@ class UserTest extends \WP_UnitTestCase {
 		$this->user = new User();
 	}
 
-    public function test_hooks() {
+    /**
+     * @test
+     */
+    public function it_tests_hooks() {
         global $wp_filter;
 
 		$result = $this->user->init();
@@ -30,11 +37,14 @@ class UserTest extends \WP_UnitTestCase {
         $this->user->hooks( $result );
 
         $this->assertNotEmpty( $wp_filter );
-        $this->assertEquals( 10, has_filter( 'pre_user_login', [ $result, 'sanitizeUsernameByEmail' ] ) );
+        $this->assertEquals( 10, has_filter( 'pre_user_login', [ $result, 'getUsernameFromBookForm' ] ) );
         $this->assertEquals( 10, has_action( 'pb_new_blog', [ $result, 'setBookAdminAsAuthor' ] ) );
 	}
 
-    public function test_sanitizeUser() {
+    /**
+     * @test
+     */
+    public function it_test_sanitizeUser() {
 		$this->assertEquals( 'test', User::sanitizeUser( 'test' ) );
 		$this->assertEquals( 'test', $this->user->sanitizeUser( '(:test:)' ) );
 		$this->assertEquals( 'tst1', User::sanitizeUser( 'tst' ) );
@@ -45,7 +55,10 @@ class UserTest extends \WP_UnitTestCase {
 		$this->assertEquals( '1a11', User::sanitizeUser( '1' ) );
 	}
 
-    public function test_generateUserNameFromEmail() {
+    /**
+     * @test
+     */
+    public function it_tests_generateUserNameFromEmail() {
 		$invalid_email = 'invalid@email@.com';
 		$invalid_user_name = User::generateUserNameFromEmail( $invalid_email );
 		$valid_email = 'validemail@pressbooks.com';
@@ -71,4 +84,59 @@ class UserTest extends \WP_UnitTestCase {
 		$this->assertFalse( $valid_user_data_dedup['errors']->has_errors() );
 	}
 
+    /**
+     * @test
+     */
+    public function it_tests_getUsernameFromBookForm() {
+        global $current_screen;
+
+        $current_screen = \WP_Screen::get( 'random-screen' );
+        
+        $_POST['blog']['email'] = 'username@pressbooks.com';
+        $_POST['_wpnonce_add-blog'] = wp_create_nonce( 'add-blog' );
+
+        $this->assertEquals( 'username_test', $this->user->getUsernameFromBookForm( 'username_test' ) );
+
+        $current_screen = \WP_Screen::get( 'site-new-network' );
+        $current_screen->base = 'site-new-network';
+        $current_screen->id = 'site-new-network';
+
+        $this->assertEquals( 'username', $this->user->getUsernameFromBookForm( 'username_test' ) );
+        
+        unset( $_POST['blog'] );
+        unset( $_POST['_wpnonce_add-blog'] );
+    }
+
+    /**
+     * @test
+     */
+    public function it_tests_setBookAdminAsAuthor() {
+        global $current_screen;
+
+        $current_screen = \WP_Screen::get( 'site-new-network' );
+        $current_screen->base = 'site-new-network';
+        $current_screen->id = 'site-new-network';
+
+        $admin_user_id = $this->createSuperAdminUser();
+        $book_admin_id = $this->factory()->user->create( [ 
+            'role' => 'administrator', 
+            'user_email' => 'book_admin@pressbooks.com',
+            'user_login' => 'book_admin'
+        ] );
+
+        add_user_to_blog( $book_admin_id, get_current_blog_id(), 'administrator' );
+
+        $this->user->setBookAdminAsAuthor();
+
+        $this->assertTrue( user_can( $book_admin_id, 'edit_posts' ) );
+        
+        $metadata_post_id = ( new \Pressbooks\Metadata )->getMetaPostId();
+
+        $authors = (new Contributors)->getArray( $metadata_post_id, 'pb_authors' );
+        $user_details = get_userdata( $book_admin_id );
+        
+        $this->assertCount( 1, $authors );
+        $this->assertEquals( $user_details->user_login, $authors[0] );
+
+    }
 }

--- a/tests/test-user.php
+++ b/tests/test-user.php
@@ -1,0 +1,74 @@
+<?php
+
+use Pressbooks\Admin\Users\User;
+use Pressbooks\HtmlParser;
+
+/**
+ * @group users
+ */
+class UserTest extends \WP_UnitTestCase {
+    /**
+	 * @var User
+	 */
+	protected $user;
+
+    /**
+	 * Test setup
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->user = new User();
+	}
+
+    public function test_hooks() {
+        global $wp_filter;
+
+		$result = $this->user->init();
+
+		$this->assertInstanceOf( User::class, $result );
+		
+        $this->user->hooks( $result );
+		
+        $this->assertNotEmpty( $wp_filter );
+		$this->assertEquals( 10, has_filter( 'pre_user_login', [ $result, 'sanitizeUsernameByEmail' ] ) );
+		$this->assertEquals( 10, has_action( 'pb_new_blog', [ $result, 'setBookAdminAsAuthor' ] ) );
+	}
+
+    public function test_sanitizeUser() {
+		$this->assertEquals( 'test', User::sanitizeUser( 'test' ) );
+		$this->assertEquals( 'test', $this->user->sanitizeUser( '(:test:)' ) );
+		$this->assertEquals( 'tst1', User::sanitizeUser( 'tst' ) );
+		$this->assertEquals( 'tst1', User::sanitizeUser( '(:tst:)' ) );
+		$this->assertEquals( 'yo11', User::sanitizeUser( 'yo' ) );
+		$this->assertEquals( 'yo11', User::sanitizeUser( '(:yo:)' ) );
+		$this->assertEquals( '1111a', User::sanitizeUser( '1111' ) );
+		$this->assertEquals( '1a11', User::sanitizeUser( '1' ) );
+	}
+
+    public function test_generateUserNameFromEmail() {
+		$invalid_email = 'invalid@email@.com';
+		$invalid_user_name = User::generateUserNameFromEmail( $invalid_email );
+		$valid_email = 'validemail@pressbooks.com';
+		$valid_user_data = User::generateUserNameFromEmail( $valid_email );
+
+		$this->assertInstanceOf( WP_Error::class, $invalid_user_name['errors'] );
+		$this->assertEquals( 'validemail', $valid_user_data['user_name'] );
+		$this->assertEquals( $valid_email, $valid_user_data['user_email'] );
+		$this->assertFalse( $valid_user_data['errors']->has_errors() );
+
+		// Persist user in order to test user login deduplication
+		$this->factory()->user->create(
+			[
+				'user_login' => 'validemail',
+				'user_email' => 'validemail@pressbooks.com',
+			]
+		);
+		$valid_email_existing_username = 'validemail@gmail.com';
+		$valid_user_data_dedup = User::generateUserNameFromEmail( $valid_email_existing_username );
+
+		$this->assertEquals( 'validemail1', $valid_user_data_dedup['user_name'] );
+		$this->assertEquals( $valid_email_existing_username, $valid_user_data_dedup['user_email'] );
+		$this->assertFalse( $valid_user_data_dedup['errors']->has_errors() );
+	}
+
+}

--- a/tests/test-user.php
+++ b/tests/test-user.php
@@ -28,10 +28,10 @@ class UserTest extends \WP_UnitTestCase {
 		$this->assertInstanceOf( User::class, $result );
 		
         $this->user->hooks( $result );
-		
+
         $this->assertNotEmpty( $wp_filter );
-		$this->assertEquals( 10, has_filter( 'pre_user_login', [ $result, 'sanitizeUsernameByEmail' ] ) );
-		$this->assertEquals( 10, has_action( 'pb_new_blog', [ $result, 'setBookAdminAsAuthor' ] ) );
+        $this->assertEquals( 10, has_filter( 'pre_user_login', [ $result, 'sanitizeUsernameByEmail' ] ) );
+        $this->assertEquals( 10, has_action( 'pb_new_blog', [ $result, 'setBookAdminAsAuthor' ] ) );
 	}
 
     public function test_sanitizeUser() {

--- a/tests/test-userbulk.php
+++ b/tests/test-userbulk.php
@@ -164,43 +164,6 @@ class UserBulkTest extends \WP_UnitTestCase {
 		$this->assertEquals( $success, $this->user_bulk::USER_STATUS_NEW );
 	}
 
-	public function test_generateUserNameFromEmail() {
-		$invalid_email = 'invalid@email@.com';
-		$invalid_user_name = $this->user_bulk->generateUserNameFromEmail( $invalid_email );
-		$valid_email = 'validemail@pressbooks.com';
-		$valid_user_data = $this->user_bulk->generateUserNameFromEmail( $valid_email );
-
-		$this->assertInstanceOf( WP_Error::class, $invalid_user_name['errors'] );
-		$this->assertEquals( 'validemail', $valid_user_data['user_name'] );
-		$this->assertEquals( $valid_email, $valid_user_data['user_email'] );
-		$this->assertFalse( $valid_user_data['errors']->has_errors() );
-
-		// Persist user in order to test user login deduplication
-		$this->factory()->user->create(
-			[
-				'user_login' => 'validemail',
-				'user_email' => 'validemail@pressbooks.com',
-			]
-		);
-		$valid_email_existing_username = 'validemail@gmail.com';
-		$valid_user_data_dedup = $this->user_bulk->generateUserNameFromEmail( $valid_email_existing_username );
-
-		$this->assertEquals( 'validemail1', $valid_user_data_dedup['user_name'] );
-		$this->assertEquals( $valid_email_existing_username, $valid_user_data_dedup['user_email'] );
-		$this->assertFalse( $valid_user_data_dedup['errors']->has_errors() );
-	}
-
-	public function test_sanitizeUser() {
-		$this->assertEquals( 'test', $this->user_bulk->sanitizeUser( 'test' ) );
-		$this->assertEquals( 'test', $this->user_bulk->sanitizeUser( '(:test:)' ) );
-		$this->assertEquals( 'tst1', $this->user_bulk->sanitizeUser( 'tst' ) );
-		$this->assertEquals( 'tst1', $this->user_bulk->sanitizeUser( '(:tst:)' ) );
-		$this->assertEquals( 'yo11', $this->user_bulk->sanitizeUser( 'yo' ) );
-		$this->assertEquals( 'yo11', $this->user_bulk->sanitizeUser( '(:yo:)' ) );
-		$this->assertEquals( '1111a', $this->user_bulk->sanitizeUser( '1111' ) );
-		$this->assertEquals( '1a11', $this->user_bulk->sanitizeUser( '1' ) );
-	}
-
 	public function test_getBulkResultHtml() {
 		$success = [];
 		$errors = [];


### PR DESCRIPTION
This fixes: https://github.com/pressbooks/pressbooks/issues/4031

This pull request introduces a new `User` class in the `Pressbooks\Admin\Users` namespace to centralize and enhance user-related functionality. It also refactors existing code to leverage this new class, improving maintainability and test coverage. Key changes include the addition of hooks and methods for user management, the removal of duplicate logic, and the introduction of unit tests for the new functionality.

### New Features and Enhancements:
* Added the `User` class in `Pressbooks\Admin\Users` with methods for initializing hooks, sanitizing usernames, generating usernames from email addresses, and setting the default book author. (`inc/admin/users/class-user.php`)
* Added a new action in `hooks-admin.php` to initialize the `User` class and set the `blog_public` option to `0` when a new blog is created. (`hooks-admin.php`)

### Refactoring:
* Refactored `class-userbulk.php` to utilize the new `User` class for username generation and sanitization, removing duplicate methods. (`inc/admin/users/class-userbulk.php`) [[1]](diffhunk://#diff-ba96f06e6557654cb59c4d7bc39693d1d1243091eadf21a32a190bc99990cd7eL141-R148) [[2]](diffhunk://#diff-ba96f06e6557654cb59c4d7bc39693d1d1243091eadf21a32a190bc99990cd7eL163-L203)

### Testing:
* Added a new `UserTest` class with unit tests for the `User` class, including tests for hooks, username sanitization, and username generation from email. (`tests/test-user.php`)
* Removed redundant tests from `test-userbulk.php` that were covered by the new `UserTest` class. (`tests/test-userbulk.php`)

### Testing case
- Go to Network Admin area > Create Book (top bar action)
- Create a new book and use a non-existing user email.
- Go to the newly created book and ensure the new book's user in the Users section contains the first section of his email as a username.
- Go to Book Info and make sure the new user is the author of the book.
- Go to Contributors and make sure the user was added as contributor.
- Go to Settings > Sharing & Privacy, and make sure the book is private by default.