### PR TITLE
fix: release notes dashboard display

### DIFF
--- a/inc/admin/dashboard/class-dashboard.php
+++ b/inc/admin/dashboard/class-dashboard.php
@@ -9,6 +9,8 @@ abstract class Dashboard {
 
 	protected string $root_page = 'index.php';
 
+	protected array $recentUpdates = [];
+
 	protected string $page_name;
 
 	public static function init(): Dashboard {
@@ -78,5 +80,25 @@ abstract class Dashboard {
 
 	protected function doRedirect(): bool {
 		return wp_redirect( $this->getUrl() );
+	}
+	protected function fetchUpdates(): void {
+		$environment = defined( 'WP_ENV' ) ? WP_ENV : 'production';
+		$domain = in_array( $environment, [ 'staging', 'production' ], true ) ? 'https://pressbooks.com' : 'https://dev.pressbooks.com';
+
+		$response = wp_remote_get( "{$domain}/wp-json/dashboard/v1/release-notes", [
+			'timeout' => 10,
+		] );
+
+		if ( is_wp_error( $response ) || wp_remote_retrieve_response_code( $response ) !== 200 ) {
+			$this->recentUpdates = [];
+			return;
+		}
+
+		$updates = json_decode( $response['body'], true );
+
+		$this->recentUpdates = [
+			...$updates,
+			'domain' => $domain,
+		];
 	}
 }

--- a/inc/admin/dashboard/class-networkdashboard.php
+++ b/inc/admin/dashboard/class-networkdashboard.php
@@ -15,6 +15,7 @@ class NetworkDashboard extends Dashboard {
 		add_action( 'load-index.php', [ $this, 'redirect' ] );
 		add_action( 'network_admin_menu', [ $this, 'removeDefaultPage' ] );
 		add_action( 'network_admin_menu', [ $this, 'addNewPage' ] );
+		$this->fetchUpdates();
 	}
 
 	public function getUrl(): string {
@@ -24,15 +25,6 @@ class NetworkDashboard extends Dashboard {
 	public function render(): void {
 		$blade = Container::get( 'Blade' );
 
-		$environment = defined( 'WP_ENV' ) ? WP_ENV : 'production';
-		$domain = in_array( $environment, [ 'staging', 'production' ], true ) ? 'https://pressbooks.com' : 'https://dev.pressbooks.com';
-
-		$response = wp_remote_get( "{$domain}/wp-json/dashboard/v1/release-notes", [
-			'timeout' => 10,
-		] );
-
-		$recent_updates = is_wp_error( $response ) ? [] : (array) json_decode( $response['body'] );
-
 		echo $blade->render( 'admin.dashboard.network', [
 			'network_name' => get_bloginfo( 'name' ),
 			'network_url' => network_home_url(),
@@ -41,8 +33,8 @@ class NetworkDashboard extends Dashboard {
 			'network_analytics_active' => is_plugin_active( 'pressbooks-network-analytics/pressbooks-network-analytics.php' ),
 			'koko_analytics_active' => is_plugin_active( 'koko-analytics/koko-analytics.php' ),
 			'updates' => [
-				'text' => $recent_updates['content'] ?? '',
-				'url' => isset( $recent_updates['post_id'] ) ? "{$domain}?p={$recent_updates['post_id']}" : null,
+				'text' => $this->recentUpdates['content'] ?? '',
+				'url' => isset( $this->recentUpdates['post_id'] ) ? "{$this->recentUpdates['domain']}?p={$this->recentUpdates['post_id']}" : null,
 			],
 		] );
 	}

--- a/templates/admin/dashboard/network.blade.php
+++ b/templates/admin/dashboard/network.blade.php
@@ -101,24 +101,9 @@
 			</div>
 		</div>
 	</div>
-
 	<div class="pb-dashboard-row">
 		<div class="pb-dashboard-grid">
-			@include('admin.dashboard.support')
-
-			@if($updates['url'])
-				<div class="pb-dashboard-panel recent-updates">
-					<div class="pb-dashboard-content">
-						<h2>{{ __('Pressbooks product updates', 'pressbooks') }}</h2>
-
-						<div>
-							{!! $updates['text'] !!}
-						</div>
-
-						<a href="{{ $updates['url'] }}" target="_blank">View the monthly product release notes</a>
-					</div>
-				</div>
-			@endif
+			@include('admin.dashboard.support', ['updates' => $updates])
 		</div>
 	</div>
 </div>

--- a/templates/admin/dashboard/support.blade.php
+++ b/templates/admin/dashboard/support.blade.php
@@ -31,3 +31,16 @@
 		</ul>
 	</div>
 </div>
+@isset($updates['url'])
+	<div class="pb-dashboard-panel recent-updates">
+		<div class="pb-dashboard-content">
+			<h2>{{ __('Pressbooks product updates', 'pressbooks') }}</h2>
+
+			<div>
+				{!! $updates['text'] !!}
+			</div>
+
+			<a href="{{ $updates['url'] }}" target="_blank">View the monthly product release notes</a>
+		</div>
+	</div>
+@endisset

--- a/tests/test-admin-bookdashboard.php
+++ b/tests/test-admin-bookdashboard.php
@@ -1,6 +1,7 @@
 <?php
 
 use Pressbooks\Admin\Dashboard\BookDashboard;
+use Pressbooks\Admin\Dashboard\NetworkDashboard;
 use Pressbooks\Metadata;
 use function Pressbooks\Admin\Metaboxes\upload_cover_image;
 
@@ -166,4 +167,88 @@ class Admin_BookDashboardTest extends \WP_UnitTestCase {
 			BookDashboard::init()->redirect()
 		);
 	}
+
+	/**
+	 * @test
+	 */
+	public function it_populates_release_notes(): void {
+
+		$mock_response = [
+			'body' => json_encode([
+				[
+					'post_id' => 5,
+					'content' => 'Test Release',
+				]
+			]),
+			'response' => [
+				'code' => 200,
+			],
+		];
+		// Mock the HTTP response for the release notes endpoint
+		add_filter('pre_http_request', function($preempt, $args, $url) use ($mock_response) {
+			if (str_contains($url, 'wp-json/dashboard/v1/release-notes')) {
+				return $mock_response;
+			}
+			return $preempt;
+		}, 10, 3);
+
+		$dashboard = new class extends Pressbooks\Admin\Dashboard\Dashboard {
+			public function fetchReleaseNotes(): array
+			{
+				parent::fetchUpdates();
+				return $this->recentUpdates;
+			}
+
+			public function render(): void
+			{
+				// This method is not used in this test, but it is required to instantiate the class.
+			}
+
+			protected function shouldRedirect(): bool
+			{
+				return true;
+			}
+		};
+
+		$result = $dashboard->fetchReleaseNotes();
+
+		$this->assertEquals(
+			[
+				[
+					'post_id' => 5,
+					'content' => 'Test Release',
+				],
+				'domain' => 'https://pressbooks.com',
+			],
+			$result
+		);
+
+		$mock_response = [
+			'body' => json_encode([
+				[
+					'post_id' => 5,
+					'content' => 'Test Release',
+				]
+			]),
+			'response' => [
+				'code' => 502, // Simulating a server error
+			],
+		];
+		// Mock the HTTP response for the release notes endpoint
+		add_filter('pre_http_request', function($preempt, $args, $url) use ($mock_response) {
+			if (str_contains($url, 'wp-json/dashboard/v1/release-notes')) {
+				return $mock_response;
+			}
+			return $preempt;
+		}, 10, 3);
+
+		$result = $dashboard->fetchReleaseNotes();
+
+		$this->assertEquals(
+			[],
+			$result
+		);
+
+	}
+
 }


### PR DESCRIPTION
This pull request introduces a feature to display recent product updates on the Pressbooks admin dashboard, along with refactoring and adjustments to improve code reusability and maintainability. The changes include adding a method to fetch updates, modifying templates to display the updates, and introducing unit tests to ensure the functionality works as expected.

### Feature Addition: Recent Product Updates

* [`inc/admin/dashboard/class-dashboard.php`](diffhunk://#diff-a2b4de82d52c76c76c5cc610127247a5bd63e9431150d735c6108e4911f6e302R84-R103): Added a new `fetchUpdates` method to retrieve release notes from a remote API and store them in the `recentUpdates` property. This method handles different environments (`production`, `staging`, `development`) and ensures graceful fallback in case of errors.
* [`inc/admin/dashboard/class-networkdashboard.php`](diffhunk://#diff-f4f3944518feb861f3876fe46a7440bc4888e26384a29e6e39b3cfed6893a074R18): Integrated the `fetchUpdates` method into the `hooks` lifecycle, enabling the dashboard to populate and render the updates dynamically. [[1]](diffhunk://#diff-f4f3944518feb861f3876fe46a7440bc4888e26384a29e6e39b3cfed6893a074R18) [[2]](diffhunk://#diff-f4f3944518feb861f3876fe46a7440bc4888e26384a29e6e39b3cfed6893a074L44-R37)

### Template Updates

* [`templates/admin/dashboard/network.blade.php`](diffhunk://#diff-68cfa51b025e7198945067c123add1729f58e52a68da57ce0899c31b510dd392L104-R106): Refactored the layout to delegate the rendering of recent updates to the `support.blade.php` template.
* [`templates/admin/dashboard/support.blade.php`](diffhunk://#diff-6e9046782d33466e9587dbe79e33f9d1f806952608d919b440cdd3abf1504483R34-R46): Added logic to conditionally display the recent updates section based on the availability of update data.

### Unit Testing

* [`tests/test-admin-bookdashboard.php`](diffhunk://#diff-04ffdaef84753d44d9c4d6b81e74bf8be4ae1b6dfb7daf316d458b102ad380d4R170-R253): Added a test case to verify the functionality of fetching and handling release notes, including scenarios where the API returns valid data and error responses.