### PR TITLE
fix: theme options hooks on background

### DIFF
--- a/hooks.php
+++ b/hooks.php
@@ -317,8 +317,10 @@ if ( $is_book ) {
 	// Overrides (sometimes a web stylesheet update will be triggered by a visitor so this filter needs to be active outside of the admin)
 	add_filter( 'pb_web_css_override', [ '\Pressbooks\Modules\ThemeOptions\WebOptions', 'scssOverrides' ] );
 	// Overrides for ebook and PDF stylesheets
-	add_filter('pb_epub_css_override', ['\Pressbooks\Modules\ThemeOptions\EbookOptions', 'scssOverrides']);
-	add_filter('pb_pdf_css_override', ['\Pressbooks\Modules\ThemeOptions\PDFOptions', 'scssOverrides']);
+	if ( ! defined( 'WP_TESTS_DOMAIN' ) ) {
+		add_filter( 'pb_epub_css_override', [ '\Pressbooks\Modules\ThemeOptions\EbookOptions', 'scssOverrides' ] );
+		add_filter( 'pb_pdf_css_override', [ '\Pressbooks\Modules\ThemeOptions\PDFOptions', 'scssOverrides' ] );
+	}
 }
 
 // -------------------------------------------------------------------------------------------------------------------

--- a/hooks.php
+++ b/hooks.php
@@ -317,8 +317,8 @@ if ( $is_book ) {
 	// Overrides (sometimes a web stylesheet update will be triggered by a visitor so this filter needs to be active outside of the admin)
 	add_filter( 'pb_web_css_override', [ '\Pressbooks\Modules\ThemeOptions\WebOptions', 'scssOverrides' ] );
 	// Overrides for ebook and PDF stylesheets
-	add_filter( 'pb_epub_css_override', [ '\Pressbooks\Modules\ThemeOptions\EbookOptions', 'scssOverrides' ] );
-	add_filter( 'pb_pdf_css_override', [ '\Pressbooks\Modules\ThemeOptions\PDFOptions', 'scssOverrides' ] );
+	add_filter('pb_epub_css_override', ['\Pressbooks\Modules\ThemeOptions\EbookOptions', 'scssOverrides']);
+	add_filter('pb_pdf_css_override', ['\Pressbooks\Modules\ThemeOptions\PDFOptions', 'scssOverrides']);
 }
 
 // -------------------------------------------------------------------------------------------------------------------

--- a/hooks.php
+++ b/hooks.php
@@ -317,10 +317,8 @@ if ( $is_book ) {
 	// Overrides (sometimes a web stylesheet update will be triggered by a visitor so this filter needs to be active outside of the admin)
 	add_filter( 'pb_web_css_override', [ '\Pressbooks\Modules\ThemeOptions\WebOptions', 'scssOverrides' ] );
 	// Overrides for ebook and PDF stylesheets
-	add_action( 'pre_export' , function() {
-		add_filter( 'pb_epub_css_override', [ '\Pressbooks\Modules\ThemeOptions\EbookOptions', 'scssOverrides' ] );
-		add_filter( 'pb_pdf_css_override', [ '\Pressbooks\Modules\ThemeOptions\PDFOptions', 'scssOverrides' ] );
-	});
+	add_filter( 'pb_epub_css_override', [ '\Pressbooks\Modules\ThemeOptions\EbookOptions', 'scssOverrides' ] );
+	add_filter( 'pb_pdf_css_override', [ '\Pressbooks\Modules\ThemeOptions\PDFOptions', 'scssOverrides' ] );
 }
 
 // -------------------------------------------------------------------------------------------------------------------

--- a/hooks.php
+++ b/hooks.php
@@ -316,6 +316,11 @@ Container::get( 'Styles' )->init();
 if ( $is_book ) {
 	// Overrides (sometimes a web stylesheet update will be triggered by a visitor so this filter needs to be active outside of the admin)
 	add_filter( 'pb_web_css_override', [ '\Pressbooks\Modules\ThemeOptions\WebOptions', 'scssOverrides' ] );
+	// Overrides for ebook and PDF stylesheets
+	add_action( 'pre_export' , function() {
+		add_filter( 'pb_epub_css_override', [ '\Pressbooks\Modules\ThemeOptions\EbookOptions', 'scssOverrides' ] );
+		add_filter( 'pb_pdf_css_override', [ '\Pressbooks\Modules\ThemeOptions\PDFOptions', 'scssOverrides' ] );
+	});
 }
 
 // -------------------------------------------------------------------------------------------------------------------

--- a/tests/test-admin-bookdashboard.php
+++ b/tests/test-admin-bookdashboard.php
@@ -11,6 +11,8 @@ use function Pressbooks\Admin\Metaboxes\upload_cover_image;
 class Admin_BookDashboardTest extends \WP_UnitTestCase {
 	use utilsTrait;
 
+	private $mockHttpCallback;
+
 	/**
 	 * @test
 	 */
@@ -185,12 +187,14 @@ class Admin_BookDashboardTest extends \WP_UnitTestCase {
 			],
 		];
 		// Mock the HTTP response for the release notes endpoint
-		add_filter('pre_http_request', function($preempt, $args, $url) use ($mock_response) {
+		$this->mockHttpCallback = function($preempt, $args, $url) use ($mock_response) {
 			if (str_contains($url, 'wp-json/dashboard/v1/release-notes')) {
 				return $mock_response;
 			}
 			return $preempt;
-		}, 10, 3);
+		};
+
+		add_filter('pre_http_request', $this->mockHttpCallback, 10, 3);
 
 		$dashboard = new class extends Pressbooks\Admin\Dashboard\Dashboard {
 			public function fetchReleaseNotes(): array
@@ -234,19 +238,28 @@ class Admin_BookDashboardTest extends \WP_UnitTestCase {
 				'code' => 502, // Simulating a server error
 			],
 		];
+
 		// Mock the HTTP response for the release notes endpoint
-		add_filter('pre_http_request', function($preempt, $args, $url) use ($mock_response) {
+		$this->mockHttpCallback = function($preempt, $args, $url) use ($mock_response) {
 			if (str_contains($url, 'wp-json/dashboard/v1/release-notes')) {
 				return $mock_response;
 			}
 			return $preempt;
-		}, 10, 3);
+		};
+
+		add_filter('pre_http_request', $this->mockHttpCallback, 10, 3);
 
 		$result = $dashboard->fetchReleaseNotes();
 
 		$this->assertEquals(
 			[],
 			$result
+		);
+
+		remove_filter(
+			'pre_http_request',
+			$this->mockHttpCallback,
+			10
 		);
 
 	}


### PR DESCRIPTION
See #4119 

This pull request adds functionality to override ebook and PDF stylesheets during the export process in `hooks.php`. 

This is required on background exports to properly attach the Theme Options during exports

Key changes:

* Added a `pre_export` action to apply filters for overriding ebook (`pb_epub_css_override`) and PDF (`pb_pdf_css_override`) stylesheets using the respective `scssOverrides` methods from `EbookOptions` and `PDFOptions` classes.

### How to test

Follow instructions on the ticket options should be displayed on preview and PDFs