### PR TITLE
fix: sanitize URL buy options

### DIFF
--- a/inc/admin/class-publishoptions.php
+++ b/inc/admin/class-publishoptions.php
@@ -195,7 +195,7 @@ class PublishOptions extends \Pressbooks\Options {
 				'id' => 'amazon',
 				'name' => $this->getSlug(),
 				'option' => 'amazon',
-				'value' => ( isset( $this->options['amazon'] ) ) ? $this->options['amazon'] : '',
+				'value' => ( isset( $this->options['amazon'] ) ) ? esc_url( $this->options['amazon'] ) : '',
 				'type' => 'url',
 				'class' => 'regular-text code',
 			]
@@ -211,7 +211,7 @@ class PublishOptions extends \Pressbooks\Options {
 				'id' => 'oreilly',
 				'name' => $this->getSlug(),
 				'option' => 'oreilly',
-				'value' => ( isset( $this->options['oreilly'] ) ) ? $this->options['oreilly'] : '',
+				'value' => ( isset( $this->options['oreilly'] ) ) ? esc_url( $this->options['oreilly'] ) : '',
 				'type' => 'url',
 				'class' => 'regular-text code',
 			]
@@ -227,7 +227,7 @@ class PublishOptions extends \Pressbooks\Options {
 				'id' => 'barnesandnoble',
 				'name' => $this->getSlug(),
 				'option' => 'barnesandnoble',
-				'value' => ( isset( $this->options['barnesandnoble'] ) ) ? $this->options['barnesandnoble'] : '',
+				'value' => ( isset( $this->options['barnesandnoble'] ) ) ? esc_url( $this->options['barnesandnoble'] ) : '',
 				'type' => 'url',
 				'class' => 'regular-text code',
 			]
@@ -243,7 +243,7 @@ class PublishOptions extends \Pressbooks\Options {
 				'id' => 'kobo',
 				'name' => $this->getSlug(),
 				'option' => 'kobo',
-				'value' => ( isset( $this->options['kobo'] ) ) ? $this->options['kobo'] : '',
+				'value' => ( isset( $this->options['kobo'] ) ) ? esc_url( $this->options['kobo'] ) : '',
 				'type' => 'url',
 				'class' => 'regular-text code',
 			]
@@ -259,7 +259,7 @@ class PublishOptions extends \Pressbooks\Options {
 				'id' => 'applebooks',
 				'name' => $this->getSlug(),
 				'option' => 'applebooks',
-				'value' => ( isset( $this->options['applebooks'] ) ) ? $this->options['applebooks'] : '',
+				'value' => ( isset( $this->options['applebooks'] ) ) ? esc_url( $this->options['applebooks'] ) : '',
 				'type' => 'url',
 				'class' => 'regular-text code',
 			]
@@ -275,7 +275,7 @@ class PublishOptions extends \Pressbooks\Options {
 				'id' => 'otherservice',
 				'name' => $this->getSlug(),
 				'option' => 'otherservice',
-				'value' => ( isset( $this->options['otherservice'] ) ) ? $this->options['otherservice'] : '',
+				'value' => ( isset( $this->options['otherservice'] ) ) ? esc_url( $this->options['otherservice'] ) : '',
 				'type' => 'url',
 				'class' => 'regular-text code',
 			]

--- a/inc/admin/class-publishoptions.php
+++ b/inc/admin/class-publishoptions.php
@@ -70,59 +70,27 @@ class PublishOptions extends \Pressbooks\Options {
 			$_page
 		);
 
-		add_settings_field(
-			'amazon',
-			__( 'Amazon URL', 'pressbooks' ),
-			[ $this, 'renderAmazonField' ],
-			$_page,
-			$_section,
-			[ 'label_for' => 'amazon' ]
-		);
+		$fields = [
+			'amazon'         => __( 'Amazon URL', 'pressbooks' ),
+			'oreilly'        => __( 'O\'Reilly URL', 'pressbooks' ),
+			'barnesandnoble' => __( 'Barnes and Noble URL', 'pressbooks' ),
+			'kobo'           => __( 'Kobo URL', 'pressbooks' ),
+			'applebooks'     => __( 'Apple Books URL', 'pressbooks' ),
+			'otherservice'   => __( 'Other Service URL', 'pressbooks' ),
+		];
 
-		add_settings_field(
-			'oreilly',
-			__( 'O\'Reilly URL', 'pressbooks' ),
-			[ $this, 'renderOReillyField' ],
-			$_page,
-			$_section,
-			[ 'label_for' => 'oreilly' ]
-		);
-
-		add_settings_field(
-			'barnesandnoble',
-			__( 'Barnes and Noble URL', 'pressbooks' ),
-			[ $this, 'renderBarnesAndNobleField' ],
-			$_page,
-			$_section,
-			[ 'label_for' => 'barnesandnoble' ]
-		);
-
-		add_settings_field(
-			'kobo',
-			__( 'Kobo URL', 'pressbooks' ),
-			[ $this, 'renderKoboField' ],
-			$_page,
-			$_section,
-			[ 'label_for' => 'kobo' ]
-		);
-
-		add_settings_field(
-			'applebooks',
-			__( 'Apple Books URL', 'pressbooks' ),
-			[ $this, 'renderAppleBooksField' ],
-			$_page,
-			$_section,
-			[ 'label_for' => 'applebooks' ]
-		);
-
-		add_settings_field(
-			'otherservice',
-			__( 'Other Service URL', 'pressbooks' ),
-			[ $this, 'renderOtherServiceField' ],
-			$_page,
-			$_section,
-			[ 'label_for' => 'otherservice' ]
-		);
+		foreach ( $fields as $id => $label ) {
+			add_settings_field(
+				$id,
+				$label,
+				function() use ( $id ) {
+					$this->renderPublisherUrlField( $id );
+				},
+				$_page,
+				$_section,
+				[ 'label_for' => $id ]
+			);
+		}
 
 		register_setting(
 			$_page,
@@ -186,100 +154,15 @@ class PublishOptions extends \Pressbooks\Options {
 	function doInitialUpgrade() {
 	}
 
-	/**
-	 * Render the amazon field.
-	 */
-	function renderAmazonField() {
-		$this->renderField(
-			[
-				'id' => 'amazon',
-				'name' => $this->getSlug(),
-				'option' => 'amazon',
-				'value' => ( isset( $this->options['amazon'] ) ) ? esc_url( $this->options['amazon'] ) : '',
-				'type' => 'url',
-				'class' => 'regular-text code',
-			]
-		);
-	}
-
-	/**
-	 * Render the oreilly field.
-	 */
-	function renderOReillyField() {
-		$this->renderField(
-			[
-				'id' => 'oreilly',
-				'name' => $this->getSlug(),
-				'option' => 'oreilly',
-				'value' => ( isset( $this->options['oreilly'] ) ) ? esc_url( $this->options['oreilly'] ) : '',
-				'type' => 'url',
-				'class' => 'regular-text code',
-			]
-		);
-	}
-
-	/**
-	 * Render the barnesandnoble field.
-	 */
-	function renderBarnesAndNobleField() {
-		$this->renderField(
-			[
-				'id' => 'barnesandnoble',
-				'name' => $this->getSlug(),
-				'option' => 'barnesandnoble',
-				'value' => ( isset( $this->options['barnesandnoble'] ) ) ? esc_url( $this->options['barnesandnoble'] ) : '',
-				'type' => 'url',
-				'class' => 'regular-text code',
-			]
-		);
-	}
-
-	/**
-	 * Render the barnesandnoble field.
-	 */
-	function renderKoboField() {
-		$this->renderField(
-			[
-				'id' => 'kobo',
-				'name' => $this->getSlug(),
-				'option' => 'kobo',
-				'value' => ( isset( $this->options['kobo'] ) ) ? esc_url( $this->options['kobo'] ) : '',
-				'type' => 'url',
-				'class' => 'regular-text code',
-			]
-		);
-	}
-
-	/**
-	 * Render the Apple Books field.
-	 */
-	function renderAppleBooksField() {
-		$this->renderField(
-			[
-				'id' => 'applebooks',
-				'name' => $this->getSlug(),
-				'option' => 'applebooks',
-				'value' => ( isset( $this->options['applebooks'] ) ) ? esc_url( $this->options['applebooks'] ) : '',
-				'type' => 'url',
-				'class' => 'regular-text code',
-			]
-		);
-	}
-
-	/**
-	 * Render the other service field.
-	 */
-	function renderOtherServiceField() {
-		$this->renderField(
-			[
-				'id' => 'otherservice',
-				'name' => $this->getSlug(),
-				'option' => 'otherservice',
-				'value' => ( isset( $this->options['otherservice'] ) ) ? esc_url( $this->options['otherservice'] ) : '',
-				'type' => 'url',
-				'class' => 'regular-text code',
-			]
-		);
+	private function renderPublisherUrlField( string $id ): void {
+		$this->renderField([
+			'id'    => $id,
+			'name'  => $this->getSlug(),
+			'option' => $id,
+			'value' => isset( $this->options[ $id ] ) ? esc_url( $this->options[ $id ] ) : '',
+			'type'  => 'url',
+			'class' => 'regular-text code',
+		]);
 	}
 
 	/**


### PR DESCRIPTION
Issue: https://github.com/pressbooks/private/issues/1781

Related PR: https://github.com/pressbooks/pressbooks-book/pull/1353.

This pull request refactors the `class-publishoptions.php` file to simplify the codebase and improve maintainability. The changes consolidate redundant methods into a single reusable function and streamline the process of adding settings fields. It also improve the security by sanitizing the inputs.

### Codebase Simplification:

* **Refactored settings fields registration**:
  - Consolidated the repetitive `add_settings_field` calls into a loop that dynamically registers fields based on an array of field definitions. (`inc/admin/class-publishoptions.php`, [inc/admin/class-publishoptions.phpL73-R93](diffhunk://#diff-a395e791a1ef116a101b7fdb27274ee94d326aeca4e778dd3f77253d8b3a377bL73-R93))

* **Unified field rendering logic**:
  - Replaced individual `render<FieldName>Field` methods with a single `renderPublisherUrlField` method that dynamically handles rendering for all publisher URL fields. (`inc/admin/class-publishoptions.php`, [inc/admin/class-publishoptions.phpL189-R165](diffhunk://#diff-a395e791a1ef116a101b7fdb27274ee94d326aeca4e778dd3f77253d8b3a377bL189-R165))

### Testing notes
#### How to replicate the vulnerability
- Go to a Book dashboard > Publish.
- In one of the URL inputs, use your browser's inspector to change from `type='url'` to `type='text'`.
- Add some malicious payload, in this example: `https://example.com/" onmouseover="alert('XSS')` and Save it.
- Go to `<YOUR_BOOK_URL>/buy`. You should see the JS injected (if you use the previous point's example).
- If you reload the Publish options page in the admin side, and mouse over the input, you will see the alert also displaying in the admin area. To stop this, you can go to your DB in `wp_<BOOK_ID>_options` table, and delete the `pressbooks_ecommerce_links` option_name record.

#### How to check if the fix works
For fully testing (book web format and admin area), please use [this branch](https://github.com/pressbooks/pressbooks-book/pull/1353) as well.
Replicate the previous steps, and despite malicious payloads, you shouldn't be able to inject them and the front end shouldn't execute JS or other unexpected injections.