### PR TITLE
fix: tablepress not rendering on exports

### DIFF
--- a/inc/shortcodes/class-tablepress.php
+++ b/inc/shortcodes/class-tablepress.php
@@ -41,20 +41,22 @@ class TablePress {
 	}
 
 	/**
-	 * Add actions and filters to TablePress to load shortcodes in the admin context.
+	 * Add actions and filters to TablePress to load shortcodes in the admin or exports context.
 	 */
 	public function loadShortcodes() {
 		add_action(
 			'tablepress_run', function () {
-					\TablePress::$model_options = \TablePress::load_model( 'options' );
-					\TablePress::$model_table = \TablePress::load_model( 'table' );
-					$GLOBALS['tablepress_frontend_controller'] = \TablePress::load_controller( 'frontend' );
+				\TablePress::$model_options = \TablePress::load_model( 'options' );
+				\TablePress::$model_table = \TablePress::load_model( 'table' );
+				$GLOBALS['tablepress_frontend_controller'] = \TablePress::load_controller( 'frontend' );
 			}
 		);
-		add_filter(
-			'tablepress_edit_link_below_table', function ( $show ) {
-				return $show;
-			}
-		);
+		add_action('pb_pre_export', function () {
+			add_filter(
+				'tablepress_edit_link_below_table', function () {
+					return false;
+				}
+			);
+		});
 	}
 }

--- a/inc/shortcodes/class-tablepress.php
+++ b/inc/shortcodes/class-tablepress.php
@@ -2,8 +2,6 @@
 
 namespace Pressbooks\Shortcodes;
 
-use function Pressbooks\Modules\Export\is_form_submission;
-
 /**
  * This class wedges itself in between Pressbooks and the TablePress WordPress Plugin
  *
@@ -48,18 +46,13 @@ class TablePress {
 	public function loadShortcodes() {
 		add_action(
 			'tablepress_run', function () {
-				if ( is_form_submission() ) {
 					\TablePress::$model_options = \TablePress::load_model( 'options' );
 					\TablePress::$model_table = \TablePress::load_model( 'table' );
 					$GLOBALS['tablepress_frontend_controller'] = \TablePress::load_controller( 'frontend' );
-				}
 			}
 		);
 		add_filter(
 			'tablepress_edit_link_below_table', function ( $show ) {
-				if ( is_form_submission() ) {
-					return false;
-				}
 				return $show;
 			}
 		);


### PR DESCRIPTION
With the new background export processing, we now attach hooks differently. Previously, these hooks were registered only when an export submission occurred. However, since export submission and processing are now decoupled, we need to ensure the hooks are triggered whenever TablePress runs.

This change does not introduce performance overhead, as the hooks will only be triggered when a TablePress table is rendered.

### Note

Tablepress tables on exports appears **unstyled**, this was a previous behavior too I tested it with the previous export system.

### How to test

1. Create a TablePress Table
2. Include it in your chapter to be exported using the shortcode for ie: `[table id=1 /]`
3. Create an export including that chapter
4. An unstyled table should be rendered **without an Edit button** below the content.
5. TablePress **should display an Edit button in webview** below the table