### PR TITLE
fix: add coloris class and tablepress hooks during bg exports

### DIFF
--- a/inc/class-options.php
+++ b/inc/class-options.php
@@ -309,7 +309,7 @@ abstract class Options {
 		$args = wp_parse_args( $args, $defaults );
 
 		printf(
-			'<input id="%1$s" class="color-picker" name="%2$s[%3$s]" type="text" data-default-color="%4$s" value="%5$s" %6$s/>',
+			'<input id="%1$s" class="coloris" name="%2$s[%3$s]" type="text" data-default-color="%4$s" value="%5$s" %6$s/>',
 			$args['id'],
 			$args['name'],
 			$args['option'],

--- a/inc/shortcodes/class-tablepress.php
+++ b/inc/shortcodes/class-tablepress.php
@@ -44,13 +44,16 @@ class TablePress {
 	 * Add actions and filters to TablePress to load shortcodes in the admin or exports context.
 	 */
 	public function loadShortcodes() {
-		add_action(
-			'tablepress_run', function () {
-				\TablePress::$model_options = \TablePress::load_model( 'options' );
-				\TablePress::$model_table = \TablePress::load_model( 'table' );
-				$GLOBALS['tablepress_frontend_controller'] = \TablePress::load_controller( 'frontend' );
-			}
-		);
+		//only re-enable tablepress shortcodes when doing cron aka bg export
+		if ( wp_doing_cron() ) {
+			add_action(
+				'tablepress_run', function () {
+					\TablePress::$model_options = \TablePress::load_model( 'options' );
+					\TablePress::$model_table = \TablePress::load_model( 'table' );
+					$GLOBALS['tablepress_frontend_controller'] = \TablePress::load_controller( 'frontend' );
+				}
+			);
+		}
 		add_action('pb_pre_export', function () {
 			add_filter(
 				'tablepress_edit_link_below_table', function () {

--- a/tests/test-options.php
+++ b/tests/test-options.php
@@ -387,7 +387,7 @@ class OptionsTest extends \WP_UnitTestCase {
 		]);
 		$buffer = ob_get_clean();
 
-		$this->assertEquals( '<input id="test_color" class="color-picker" name="pressbooks_options_test[test_color]" type="text" data-default-color="#c00" value="" />', $buffer );
+		$this->assertEquals( '<input id="test_color" class="coloris" name="pressbooks_options_test[test_color]" type="text" data-default-color="#c00" value="" />', $buffer );
 	}
 
 	/**


### PR DESCRIPTION
This pull request introduces updates to improve functionality and maintain compatibility with new tools. The primary changes include replacing the color picker library in the options rendering function and adding conditional logic for TablePress shortcodes during cron jobs.

### Updates to color picker implementation:

* [`inc/class-options.php`](diffhunk://#diff-14021d9bd5ab3a5949109f11f486f811a44d57ff3b4ef1cd8b4481761efeb0c7L312-R312): Replaced the `color-picker` class with `coloris` in the `renderColorField` function to switch to a new color picker library.
* [`tests/test-options.php`](diffhunk://#diff-b17b6416906dc61d1a4f943bf5ac75e441d8f18fa50689f33ddfdcac551aeb6eL390-R390): Updated the test for `renderColorField` to reflect the change from `color-picker` to `coloris`.

<img width="736" height="900" alt="image" src="https://github.com/user-attachments/assets/a5d7a2a0-03c1-4357-bda7-e28acf148525" />


### Enhancements to TablePress shortcode handling:

* [`inc/shortcodes/class-tablepress.php`](diffhunk://#diff-f99b10cd4b7453461f801a1b0b0268f01d9c94d3069ff7f8ecbf553464a8c255R47-R56): Added a conditional check to only enable TablePress shortcodes during cron jobs, ensuring they are loaded appropriately in the background export context.

Address the following warning on dev
```
. Block type "tablepress/table" is already registered. 
Please see incorrectly[Debugging in WordPress](https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/)Notice: Function WP_Block_Type_Registry::register was called for more information. 
(This message was added in version 5.0.0.) in /app/web/wp/wp-includes/functions.php on line 6121
```