### PR TITLE
fix: escape filenames for blob mime debug action

### DIFF
--- a/hooks-admin.php
+++ b/hooks-admin.php
@@ -406,3 +406,5 @@ add_action( 'plugins_loaded', [ \Pressbooks\Admin\Users\User::class, 'init' ], 1
 add_action( 'pb_new_blog', function() {
 	update_option( 'blog_public', 0 );
 } );
+
+add_action( 'admin_init', '\Pressbooks\Sanitize\escape_file_names_in_blob_mimes' );

--- a/inc/sanitize/namespace.php
+++ b/inc/sanitize/namespace.php
@@ -841,3 +841,18 @@ function sanitize_string( $value, $allow_html = false ) {
 function validate_url_field( $value ) {
 	return filter_var( $value, FILTER_VALIDATE_URL ) ? $value : false;
 }
+
+function escape_file_names_in_blob_mimes(): void {
+	if ( ! isset( $_GET['page'], $_POST['n'], $_FILES ) || $_GET['page'] !== 'blob-mimes-debug' ) { //phpcs:ignore Pressbooks.Security.NonceVerification.Missing
+		return;
+	}
+
+	foreach ( $_FILES as &$file ) {
+		if ( ! is_array( $file ) || ! isset( $file['name'] ) ) {
+			continue;
+		}
+
+		$file['name'] = esc_html( $file['name'] );
+	}
+	unset( $file );
+}

--- a/tests/test-sanitize.php
+++ b/tests/test-sanitize.php
@@ -636,4 +636,25 @@ RAW;
 		$test = \Pressbooks\Sanitize\sanitize_string( $test, true );
 		$this->assertEquals( '<a href="https://pressbooks.org">xxs link</a>', $test );
 	}
+
+	/**
+	 * @group sanitize
+	 * @test
+	 */
+	public function it_escapes_file_names_in_blob_mimes(): void {
+		$_GET['page'] = 'blob-mimes-debug';
+		$_FILES = [
+			'file1' => [
+				'name' => 'test<script>alert(1)</script>.txt',
+			],
+			'file2' => [
+				'name' => 'test2.txt',
+			],
+		];
+		$_POST['n'] = 'test';
+		
+		\Pressbooks\Sanitize\escape_file_names_in_blob_mimes();
+		$this->assertEquals( 'test&lt;script&gt;alert(1)&lt;/script&gt;.txt', $_FILES['file1']['name'] );
+		$this->assertEquals( 'test2.txt', $_FILES['file2']['name'] );
+	}
 }


### PR DESCRIPTION
Issue: https://github.com/pressbooks/private/issues/1786

This pull request introduces a new function to sanitize file names in specific for the blob-mime-debug action (third-party plugin) and integrates it into the system. The changes include adding the new function, ensuring its functionality through unit tests, and hooking it into the WordPress admin initialization process.

### New functionality for file name sanitization:

* [`inc/sanitize/namespace.php`](diffhunk://#diff-ab3fd07835806d40862a9075042887722666eb38834d912c47456e6a1df5ba8eR844-R858): Added the `escape_file_names_in_blob_mimes` function to sanitize file names in the `$_FILES` array by escaping HTML to prevent potential security risks. The function is triggered only when specific conditions are met, such as the presence of `blob-mimes-debug` in the request (`[inc/sanitize/namespace.phpR844-R858](diffhunk://#diff-ab3fd07835806d40862a9075042887722666eb38834d912c47456e6a1df5ba8eR844-R858)`).

### Integration with WordPress hooks:

* [`hooks-admin.php`](diffhunk://#diff-22bd10ffa96e759d116f39767554f68c8559aa9f379e8b6dc6f132854e6a0729R409-R410): Hooked the `escape_file_names_in_blob_mimes` function to the `admin_init` action, ensuring it runs during the WordPress admin initialization process (`[hooks-admin.phpR409-R410](diffhunk://#diff-22bd10ffa96e759d116f39767554f68c8559aa9f379e8b6dc6f132854e6a0729R409-R410)`).

### Unit tests for the new functionality:

* [`tests/test-sanitize.php`](diffhunk://#diff-2cfd1565eaadffbe2d162d17535363549cd763bb62396d88845dcc9a2e9a96b9R639-R659): Added a new test case, `it_escapes_file_names_in_blob_mimes`, to verify that the `escape_file_names_in_blob_mimes` function correctly escapes potentially malicious file names while leaving safe file names unchanged (`[tests/test-sanitize.phpR639-R659](diffhunk://#diff-2cfd1565eaadffbe2d162d17535363549cd763bb62396d88845dcc9a2e9a96b9R639-R659)`).

### Testing notes
To replicate the existing issue in the current `dev` branch:
- Activate "Lord of the Files" plugin.
- Go to <A BOOK URL>/wp-admin/tools.php?page=blob-mimes-debug
- Rename an image on your computer (for example), and call it something like my_img.jpegjjp<img src=a onerror=alert(1)>db9fyp84jjp
- Upload the image
- You should see the alert message.

Checkout to this branch and repeat the above steps. You shouldn't be able to inject HTML/JS.