### PR TITLE
fix: additional home language box

### DIFF
--- a/inc/l10n/namespace.php
+++ b/inc/l10n/namespace.php
@@ -318,16 +318,12 @@ function wplang_codes() {
 }
 
 function get_translated_languages( ?string $file_path = null ) {
-	$languages_installed = get_available_languages();
+	$languages['en_US'] = \Locale::getDisplayName( 'en_US', 'en' );
 
-	$languages = [];
+	$additional_languages_installed = get_available_languages();
 
-	foreach ( $languages_installed as $lang ) {
-		$languages[ $lang ] = \Locale::getDisplayName($lang, 'en');
-	}
-
-	if ( ! isset( $languages[ 'en_US' ] ) ) {
-		$languages[ 'en_US' ] = \Locale::getDisplayName('en_US', 'en');
+	foreach ( $additional_languages_installed as $lang ) {
+		$languages[ $lang ] = \Locale::getDisplayName( $lang, 'en' );
 	}
 
 	asort( $languages );

--- a/inc/l10n/namespace.php
+++ b/inc/l10n/namespace.php
@@ -318,22 +318,16 @@ function wplang_codes() {
 }
 
 function get_translated_languages( ?string $file_path = null ) {
-	$tx_yaml = file_get_contents( $file_path ?? PB_PLUGIN_DIR . '.tx/transifex.yaml' );
-	if ( ! $tx_yaml ) {
-		return [];
+	$languages_installed = get_available_languages();
+
+	$languages = [];
+
+	foreach ( $languages_installed as $lang ) {
+		$languages[ $lang ] = \Locale::getDisplayName($lang, 'en');
 	}
 
-	$supported = supported_languages();
-
-	$lines = explode( "\n", $tx_yaml );
-	$languages = [];
-	foreach ( $lines as $line ) {
-		if ( preg_match( '/^\s*([a-z]{2,3}(?:[_-][A-Z]{2,3})?)\s*:\s*([a-z]{2,3}(?:[_-][A-Z]{2,3})?)\s*$/i', $line, $matches ) ) {
-			$base_lang = preg_replace( '/[_-].*$/', '', strtolower( $matches[1] ) );
-			if ( isset( $supported[ $base_lang ] ) ) {
-				$languages[ $matches[2] ] = $supported[ $base_lang ];
-			}
-		}
+	if ( ! isset( $languages[ 'en_US' ] ) ) {
+		$languages[ 'en_US' ] = \Locale::getDisplayName('en_US', 'en');
 	}
 
 	asort( $languages );

--- a/tests/test-l10n.php
+++ b/tests/test-l10n.php
@@ -128,41 +128,16 @@ class L10nTest extends \WP_UnitTestCase {
 	 * @group localization
 	 */
 	public function it_gets_translated_languages(): void {
-		
-		$temp_file = tempnam( sys_get_temp_dir(), 'pb_lang_test_' );
+		$languages = \Pressbooks\L10n\get_translated_languages();
 
-		$yaml_content = <<<YAML
-git:
-	filters:
-		- filter_type: file
-		  file_format: PO
-		  source_file: languages/pressbooks.pot
-		  source_language: en
-		  translation_files_expression: languages/pressbooks-<lang>.po
-	settings:
-		pr_branch_name: chore/update-translations-<br_unique_id>
-		language_mapping:
-			de: de_DE
-			es: es_ES
-			fr: fr_FR
-YAML;
+		$this->assertIsArray( $languages );
+		$this->assertArrayHasKey( 'en_US', $languages );
 
-		file_put_contents( $temp_file, $yaml_content );
-
-		$translated_languages = \Pressbooks\L10n\get_translated_languages( $temp_file );
-		
-		unlink( $temp_file );
-
-		$this->assertIsArray( $translated_languages );
-		$this->assertArrayHasKey( 'de_DE', $translated_languages );
-		$this->assertArrayHasKey( 'es_ES', $translated_languages );
-		$this->assertArrayHasKey( 'fr_FR', $translated_languages );
-
-		$this->assertEquals( 'German', $translated_languages['de_DE'] );
-		$this->assertEquals( 'Spanish', $translated_languages['es_ES'] );
-		$this->assertEquals( 'French', $translated_languages['fr_FR'] );
-
-		$sorted_languages = array_values( $translated_languages );
-		$this->assertEquals( [ 'French', 'German', 'Spanish' ], $sorted_languages );
+		$available_languages = get_available_languages();
+		foreach ( $available_languages as $lang ) {
+			$this->assertArrayHasKey( $lang, $languages );
+			$this->assertNotEmpty( $languages[$lang] );
+			$this->assertIsString( $languages[$lang] );
+		}
 	}
 }


### PR DESCRIPTION
Issue: https://github.com/pressbooks/ideas/issues/526

This pull request refactors the `get_translated_languages` function in `inc/l10n/namespace.php` to simplify its implementation and improve maintainability. The key changes include removing Transifex YAML parsing and leveraging the `get_available_languages` function to dynamically retrieve installed languages.

### Code simplification and maintainability:

* [`inc/l10n/namespace.php`](diffhunk://#diff-922ffca07c2214e43ad6933a2cbed185a43f38182005d28834859f7899971a61L321-R326): Replaced the logic for parsing a Transifex YAML file with a more streamlined approach using `get_available_languages`. This eliminates the dependency on a specific file format and reduces the complexity of the function. The `Locale::getDisplayName` method is now used to retrieve language display names directly.

### Testing notes
- Add a new Additional Home page -> create a new page at the network level and as a template use "Additional home". Paste the same content you have in your home, if you want to have the same page as you have in your home.
- Save the page.
- The Page Language metabox now should list the same languages as the ones in Settings > Network Settings> "Language Settings" selector, under the "Installed" section.