### PR TITLE
fix: remove unused get_translated_languages method

### DIFF
--- a/inc/l10n/namespace.php
+++ b/inc/l10n/namespace.php
@@ -317,30 +317,6 @@ function wplang_codes() {
 	return $languages;
 }
 
-function get_translated_languages( ?string $file_path = null ) {
-	$tx_yaml = file_get_contents( $file_path ?? PB_PLUGIN_DIR . '.tx/transifex.yaml' );
-	if ( ! $tx_yaml ) {
-		return [];
-	}
-
-	$supported = supported_languages();
-
-	$lines = explode( "\n", $tx_yaml );
-	$languages = [];
-	foreach ( $lines as $line ) {
-		if ( preg_match( '/^\s*([a-z]{2,3}(?:[_-][A-Z]{2,3})?)\s*:\s*([a-z]{2,3}(?:[_-][A-Z]{2,3})?)\s*$/i', $line, $matches ) ) {
-			$base_lang = preg_replace( '/[_-].*$/', '', strtolower( $matches[1] ) );
-			if ( isset( $supported[ $base_lang ] ) ) {
-				$languages[ $matches[2] ] = $supported[ $base_lang ];
-			}
-		}
-	}
-
-	asort( $languages );
-
-	return $languages;
-}
-
 /**
  * Override get_locale
  * For performance reasons, we only want functions in this namespace to call WP get_locale once.

--- a/tests/test-l10n.php
+++ b/tests/test-l10n.php
@@ -122,47 +122,4 @@ class L10nTest extends \WP_UnitTestCase {
 		$this->assertNotEmpty( $lang );
 		$this->assertTrue( is_string( $lang ) );
 	}
-
-	/**
-	 * @test
-	 * @group localization
-	 */
-	public function it_gets_translated_languages(): void {
-		
-		$temp_file = tempnam( sys_get_temp_dir(), 'pb_lang_test_' );
-
-		$yaml_content = <<<YAML
-git:
-	filters:
-		- filter_type: file
-		  file_format: PO
-		  source_file: languages/pressbooks.pot
-		  source_language: en
-		  translation_files_expression: languages/pressbooks-<lang>.po
-	settings:
-		pr_branch_name: chore/update-translations-<br_unique_id>
-		language_mapping:
-			de: de_DE
-			es: es_ES
-			fr: fr_FR
-YAML;
-
-		file_put_contents( $temp_file, $yaml_content );
-
-		$translated_languages = \Pressbooks\L10n\get_translated_languages( $temp_file );
-		
-		unlink( $temp_file );
-
-		$this->assertIsArray( $translated_languages );
-		$this->assertArrayHasKey( 'de_DE', $translated_languages );
-		$this->assertArrayHasKey( 'es_ES', $translated_languages );
-		$this->assertArrayHasKey( 'fr_FR', $translated_languages );
-
-		$this->assertEquals( 'German', $translated_languages['de_DE'] );
-		$this->assertEquals( 'Spanish', $translated_languages['es_ES'] );
-		$this->assertEquals( 'French', $translated_languages['fr_FR'] );
-
-		$sorted_languages = array_values( $translated_languages );
-		$this->assertEquals( [ 'French', 'German', 'Spanish' ], $sorted_languages );
-	}
 }


### PR DESCRIPTION
Issue: https://github.com/pressbooks/ideas/issues/526

Requires: https://github.com/pressbooks/pressbooks-aldine/pull/511

This pull request removes the `get_translated_languages` function and its associated test case, simplifying the codebase by eliminating unused functionality.

### Codebase simplification:

* Removed the `get_translated_languages` function from `inc/l10n/namespace.php`, which parsed a Transifex YAML file to retrieve translated languages. This functionality is no longer needed.
* Deleted the `it_gets_translated_languages` test case from `tests/test-l10n.php`, which verified the behavior of the `get_translated_languages` function. This test is obsolete due to the removal of the function.