### PR TITLE
fix: default header_links primary color fallback

### DIFF
--- a/inc/admin/branding/namespace.php
+++ b/inc/admin/branding/namespace.php
@@ -155,6 +155,10 @@ function get_customizer_colors() {
 		if ( $v ) {
 			$values[ $k ] = $v;
 		}
+		// If header_links is not set, use the primary color, useful when customizer settings are not updated.
+		if ( $k === 'header_links' && ! $v ) {
+			$values[ $k ] = get_option( 'pb_network_color_primary' );
+		}
 	}
 	if ( $need_to_switch ) {
 		restore_current_blog();

--- a/tests/test-admin-branding.php
+++ b/tests/test-admin-branding.php
@@ -53,7 +53,7 @@ class Admin_BrandingTest extends \WP_UnitTestCase {
 	function test_get_customizer_colors() {
 		update_option( 'pb_network_color_primary', '#663399' );
 		$result = \Pressbooks\Admin\Branding\get_customizer_colors();
-		$this->assertEquals( $result, '<style type="text/css">:root{--primary:#663399;}</style>' );
+		$this->assertEquals( $result, '<style type="text/css">:root{--header-links:#663399;--primary:#663399;}</style>' );
 	}
 
 	/**


### PR DESCRIPTION
#Address https://github.com/pressbooks/pressbooks-aldine/issues/512

This pull request includes an enhancement to the `get_customizer_colors` function in `inc/admin/branding/namespace.php`. The change ensures a fallback mechanism for the `header_links` color when it is not explicitly set in the customizer settings.

* **Improved fallback for customizer colors:**
  * [`inc/admin/branding/namespace.php`](diffhunk://#diff-4cb12c9cea66b2010afc4f36634917c8bc62faea0b5b166c8658afeabd8de2a3R158-R161): Added a fallback to use the primary color (`pb_network_color_primary`) for `header_links` when it is not set, ensuring better defaults in case customizer settings are not updated.

### Interesting fact

Aetna will try to set default color to be the "primary" (#b01109) color https://github.com/pressbooks/aetna/blob/dev/public/styles/aetna.css#L365 BUT not the network primary color defined in the customizer, so we need to always override that css variable if it's not saved or overriden.

Related https://github.com/pressbooks/pressbooks-aldine/pull/513

### How to test
1. If you never saved the customizer values with a custom header links color, you should see the header links color as your primary color
2. If you already setup a header_links value, remove that customizer value from `wp_options` search for `pb_network_color_header_links` and delete the record, you should see your header_links color with primary color