### PR TITLE
chore: add tinymce to dependabot ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,7 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: [ "version-update:semver-major" ]
+      - dependency-name: "tinymce"
     groups:
       npm-dependencies:
         dependency-type: "production"


### PR DESCRIPTION
This pull request makes a small update to the Dependabot configuration by adding `tinymce` to the list of dependencies to ignore. This means Dependabot will no longer create update PRs for `tinymce`.