### PR TITLE
fix: change default pdf_hyphens value

### DIFF
--- a/inc/modules/themeoptions/class-pdfoptions.php
+++ b/inc/modules/themeoptions/class-pdfoptions.php
@@ -1571,7 +1571,7 @@ class PDFOptions extends \Pressbooks\Options {
 				'pdf_page_margin_inside' => '2cm',
 				'pdf_page_margin_top' => '2cm',
 				'pdf_page_margin_bottom' => '2cm',
-				'pdf_hyphens' => 0,
+				'pdf_hyphens' => 1,
 				'pdf_paragraph_separation' => 'indent',
 				'pdf_sectionopenings' => 'openauto',
 				'pdf_toc' => 1,

--- a/tests/utils-trait.php
+++ b/tests/utils-trait.php
@@ -275,7 +275,7 @@ https://youtu.be/Lqqsp8soXTo
 				'pdf_page_width' => 10,
 				'pdf_page_height' => 10,
 				'pdf_crop_marks' => 0,
-				'pdf_hyphens' => 0,
+				'pdf_hyphens' => 1,
 				'pdf_toc' => 1
 			] );
 	}


### PR DESCRIPTION
Change default PDF hyphenation value to true in PDF theme options. Fix for https://github.com/pressbooks/pressbooks/issues/4226