### PR TITLE
chore: remove O'Reilly as book sales option

### DIFF
--- a/inc/admin/class-publishoptions.php
+++ b/inc/admin/class-publishoptions.php
@@ -72,9 +72,8 @@ class PublishOptions extends \Pressbooks\Options {
 
 		$fields = [
 			'amazon'         => __( 'Amazon URL', 'pressbooks' ),
-			'oreilly'        => __( 'O\'Reilly URL', 'pressbooks' ),
 			'barnesandnoble' => __( 'Barnes and Noble URL', 'pressbooks' ),
-			'kobo'           => __( 'Kobo URL', 'pressbooks' ),
+			'kobo'           => __( 'Rakuten Kobo URL', 'pressbooks' ),
 			'applebooks'     => __( 'Apple Books URL', 'pressbooks' ),
 			'otherservice'   => __( 'Other Service URL', 'pressbooks' ),
 		];
@@ -191,7 +190,6 @@ class PublishOptions extends \Pressbooks\Options {
 	static function getDefaults() {
 		return [
 			'amazon' => '',
-			'oreilly' => '',
 			'barnesandnoble' => '',
 			'kobo' => '',
 			'ibooks' => '',
@@ -207,7 +205,6 @@ class PublishOptions extends \Pressbooks\Options {
 	static function getUrlOptions() {
 		return [
 			'amazon',
-			'oreilly',
 			'barnesandnoble',
 			'kobo',
 			'applebooks',


### PR DESCRIPTION
Remove O'Reilly from the list of places where authors can sell their book. O'Reilly retired this service in 2017: https://www.oreilly.com/content/the-mission-of-spreading-the-knowledge-of-innovators-continues/. Accompanies https://github.com/pressbooks/pressbooks-book/pull/1379 (partially related to https://github.com/pressbooks/pressbooks-book/issues/1332)

To test:
1. Visit the book's 'Publish' page
2. Observe that O'Reilly is no longer an option