### PR TITLE
feat: expose latest files field in api

### DIFF
--- a/inc/api/endpoints/controller/books/class-books.php
+++ b/inc/api/endpoints/controller/books/class-books.php
@@ -275,6 +275,7 @@ class Books extends \WP_REST_Controller {
 			BookDataCollector::IN_CATALOG,
 			BookDataCollector::BOOK_URL,
 			BookDataCollector::BOOK_DIRECTORY_EXCLUDED,
+			BookDataCollector::ALLOWS_DOWNLOADS,
 		] );
 
 		if ( ! isset( $metadata_blog_meta[ BookDataCollector::BOOK_DIRECTORY_EXCLUDED ] ) ) {

--- a/inc/metadata/namespace.php
+++ b/inc/metadata/namespace.php
@@ -223,6 +223,7 @@ function book_information_to_schema( array $book_information, bool $network_excl
 		'pb_storage_size' => 'storageSize',
 		'pb_h5p_activities' => 'h5pActivities',
 		'pb_in_catalog' => 'inCatalog',
+		'pb_latest_files_public' => 'latestFilesPublic',
 		'pb_book_directory_excluded' => 'bookDirectoryExcluded',
 		'pb_authors' => 'author',
 		'pb_editors' => 'editor',
@@ -393,6 +394,10 @@ function book_information_to_schema( array $book_information, bool $network_excl
 
 	if ( isset( $book_information['pb_in_catalog'] ) ) {
 		$book_schema['inCatalog'] = $book_information['pb_in_catalog'] === '1';
+	}
+
+	if ( isset( $book_information['pb_latest_files_public'] ) ) {
+		$book_schema['latestFilesPublic'] = $book_information['pb_latest_files_public'] === '1';
 	}
 
 	if ( true === $network_excluded_directory ) {

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -44,6 +44,7 @@ class ApiTest extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'storageSize', $data['metadata'] );
 		$this->assertArrayHasKey( 'h5pActivities', $data['metadata'] );
 		$this->assertArrayHasKey( 'inCatalog', $data['metadata'] );
+		$this->assertArrayHasKey( 'latestFilesPublic', $data['metadata'] );
 		$this->assertArrayHasKey( 'bookDirectoryExcluded', $data['metadata'] );
 		$this->assertArrayHasKey( 'license', $data['metadata'] );
 		$this->assertArrayHasKey( 'code', $data['metadata']['license'] );
@@ -493,6 +494,7 @@ class ApiTest extends \WP_UnitTestCase {
 			"pb_word_count" => "4840",
             "pb_storage_size" => "39570177",
             "pb_in_catalog" => 1,
+			"pb_latest_files_public" => 1,
             "pb_h5p_activities" => 6,
             "pb_book_url" => "https://pressbooks.test/theonboarding",
             "pb_book_directory_excluded" => 1,
@@ -506,6 +508,7 @@ class ApiTest extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'h5pActivities', $schema );
 		$this->assertArrayHasKey( 'thumbnailUrl', $schema );
 		$this->assertArrayHasKey( 'author', $schema );
+		$this->assertArrayHasKey( 'latestFilesPublic', $schema );
 	}
 
 	/**


### PR DESCRIPTION
This pull request adds support for the new `latestFilesPublic` metadata field for books, included in the API schema, and properly tested. The most important changes are grouped below.

### Metadata and API Enhancements

* Added `BookDataCollector::ALLOWS_DOWNLOADS` to the list of collected metadata fields in `class-books.php`.
* Mapped the `pb_latest_files_public` field to the `latestFilesPublic` property in the schema within `namespace.php`.
* Updated the schema conversion logic to include the `latestFilesPublic` property when present in book information.

### Testing Updates

* Added assertions in `test-api.php` to verify that the `latestFilesPublic` field is present in both the API metadata and schema. [[1]](diffhunk://#diff-0eb8371b72c3645321e39c8bae29c8c4ef73c133564e8d4e09cdd952aa6f5c00R47) [[2]](diffhunk://#diff-0eb8371b72c3645321e39c8bae29c8c4ef73c133564e8d4e09cdd952aa6f5c00R511)
* Updated test data in `test-api.php` to include the `pb_latest_files_public` field for comprehensive test coverage.