### PR TITLE
fix: improve file export time precision (resolves #1869)

### DIFF
--- a/inc/modules/export/class-table.php
+++ b/inc/modules/export/class-table.php
@@ -344,7 +344,7 @@ class Table extends \WP_List_Table {
 				'format' => $this->getFormat( $file ),
 				'size' => $stat['size'],
 				'pin' => $this->hasPin( $id ) ? 1 : 0,
-				'exported' => date_i18n( 'Y-m-d H:i', $stat['mtime'] ),
+				'exported' => date_i18n( 'Y-m-d H:i:s', $stat['mtime'] ),
 			];
 		}
 		return $files;

--- a/tests/test-modules-export-table.php
+++ b/tests/test-modules-export-table.php
@@ -114,4 +114,49 @@ class Modules_Export_TableTest extends \WP_UnitTestCase {
 		$this->assertStringContainsString( "var _pb_export_formats_map = ", $x );
 		$this->assertStringContainsString( "var _pb_export_pins_inventory =", $x );
 	}
+
+	/**
+	 * Test export file sorting when files have the same minute but different seconds.
+	 * 
+	 * @group export
+	 */
+	public function test_exported_sorting_with_same_minute_different_seconds() {
+		$mock_data = [
+			[
+				'ID' => 'file_523',
+				'file' => 'Test-1575485523_print.pdf',
+				'format' => 'PDF',
+				'size' => 1000,
+				'pin' => 0,
+				'exported' => '2019-12-04 18:52:03',
+			],
+			[
+				'ID' => 'file_532', 
+				'file' => 'Test-1575485532_print.pdf',
+				'format' => 'PDF',
+				'size' => 1000,
+				'pin' => 0,
+				'exported' => '2019-12-04 18:52:12',
+			],
+		];
+
+		// Test descending sort (default - most recent first)
+		$sorted_desc = wp_list_sort( $mock_data, [ 'exported' => 'desc' ] );
+		
+		$this->assertEquals( 'file_532', $sorted_desc[0]['ID'], 'File ending in 532 (12 seconds) should be first in desc order' );
+		$this->assertEquals( 'file_523', $sorted_desc[1]['ID'], 'File ending in 523 (3 seconds) should be second in desc order' );
+
+		// Test ascending sort (oldest first)  
+		$sorted_asc = wp_list_sort( $mock_data, [ 'exported' => 'asc' ] );
+		
+		$this->assertEquals( 'file_523', $sorted_asc[0]['ID'], 'File ending in 523 (3 seconds) should be first in asc order' );
+		$this->assertEquals( 'file_532', $sorted_asc[1]['ID'], 'File ending in 532 (12 seconds) should be second in asc order' );
+
+		// Verify the display shows seconds precision (the key fix)
+		$this->assertStringContainsString( '18:52:03', $mock_data[0]['exported'], 'Should show seconds precision for first file' );
+		$this->assertStringContainsString( '18:52:12', $mock_data[1]['exported'], 'Should show seconds precision for second file' );
+		
+		// Verify that the seconds values are different (this would have been the same before the fix)
+		$this->assertNotEquals( $mock_data[0]['exported'], $mock_data[1]['exported'], 'Files should have different export times when precision includes seconds' );
+	}
 }


### PR DESCRIPTION
Ensure that sort order by date exported works correctly for file exports by increasing precision to include seconds. Addresses https://github.com/pressbooks/pressbooks/issues/1869