### PR TITLE
fix: remove privacy option on signup

### DIFF
--- a/inc/class-privacy.php
+++ b/inc/class-privacy.php
@@ -31,6 +31,7 @@ class Privacy {
 	 */
 	static public function hooks( Privacy $obj ) {
 		add_filter( 'schedule_event', [ $obj, 'reschedulePrivacyCron' ] );
+		self::$instance->removePublicOptionFromSignup();
 	}
 
 	/**
@@ -93,5 +94,13 @@ class Privacy {
 		switch_to_blog( $site->blog_id );
 		update_option( 'permissive_private_content', 1 );
 		restore_current_blog();
+	}
+
+	public function removePublicOptionFromSignup(): void {
+		if ( isset( $_SERVER['SCRIPT_FILENAME'] ) && basename( sanitize_text_field( wp_unslash( $_SERVER['SCRIPT_FILENAME'] ) ) ) === 'wp-signup.php' ) {
+			ob_start( function( $buffer ) {
+				return preg_replace( '/<div id="privacy">.*?<\/div>/s', '', $buffer );
+			});
+		}
 	}
 }

--- a/tests/test-privacy.php
+++ b/tests/test-privacy.php
@@ -232,4 +232,17 @@ EOT;
 		$this->assertEquals( get_option( 'permissive_private_content' ), 1 );
 		restore_current_blog();
 	}
+
+	/**
+	 * @test
+	 */
+	public function it_removes_privacy_options_from_signup() {
+		//render signup page
+		global $pagenow;
+		$pagenow = 'wp-signup.php';
+		ob_start();
+		$this->privacy->removePublicOptionFromSignup();
+		$buffer = ob_get_clean();
+		$this->assertStringNotContainsString( '<div id="privacy">', $buffer );
+	}
 }

--- a/tests/test-privacy.php
+++ b/tests/test-privacy.php
@@ -1,6 +1,7 @@
 <?php
 
 use Pressbooks\DataCollector\Book as DataCollector;
+use Pressbooks\Privacy;
 use function Pressbooks\Admin\Laf\book_directory_excluded_callback;
 use Pressbooks\Admin\Network\SharingAndPrivacyOptions;
 
@@ -11,7 +12,7 @@ class GdprTest extends \WP_UnitTestCase {
 	use utilsTrait;
 
 	/**
-	 * @var \Pressbooks\Privacy
+	 * @var Privacy
 	 * @group privacy
 	 */
 	protected $privacy;
@@ -21,7 +22,7 @@ class GdprTest extends \WP_UnitTestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
-		$this->privacy = new \Pressbooks\Privacy();
+		$this->privacy = new Privacy();
 	}
 
 	/**
@@ -239,8 +240,10 @@ EOT;
 	public function it_removes_privacy_options_from_signup() {
 		//render signup page
 		global $pagenow;
+		$_SERVER['SCRIPT_FILENAME'] = 'wp-signup.php';
 		$pagenow = 'wp-signup.php';
 		ob_start();
+		$this->privacy = Privacy::init();
 		$this->privacy->removePublicOptionFromSignup();
 		$buffer = ob_get_clean();
 		$this->assertStringNotContainsString( '<div id="privacy">', $buffer );


### PR DESCRIPTION
This pull request introduces a new privacy-related feature that removes the public/private site option from the WordPress signup page, ensuring users cannot select site visibility during signup. The main logic is implemented in the `Privacy` class and is now covered by a dedicated test.

Privacy option removal from signup page:

* Added the `removePublicOptionFromSignup` method to the `Privacy` class, which uses output buffering and a regex to remove the privacy option HTML from the signup page (`wp-signup.php`).
* Called `removePublicOptionFromSignup` inside the `hooks` method to ensure it's triggered during initialization.

Testing:

* Added a new test `it_removes_privacy_options_from_signup` in `tests/test-privacy.php` to verify that the privacy options are removed from the signup page output.