### PR TITLE
fix: pass input type to Prince

### DIFF
--- a/inc/modules/export/prince/class-pdf.php
+++ b/inc/modules/export/prince/class-pdf.php
@@ -254,6 +254,7 @@ class Pdf extends Export {
 		$prince->setHTML( true );
 		$prince->setCompress( true );
 		$prince->setHttpTimeout( defined( 'WP_TESTS_MULTISITE' ) ? 5 : 600 ); // 5 seconds for tests, 10 minutes for production
+		$prince->setInputType('xml');
 		if ( defined( 'WP_ENV' ) && ( WP_ENV === 'development' ) ) {
 			$prince->setInsecure( true );
 		}
@@ -265,6 +266,7 @@ class Pdf extends Export {
 			$prince->setPDFOutputIntent( $this->pdfOutputIntent );
 		} elseif ( stripos( get_class( $this ), 'print' ) === false && empty( $this->pdfProfile ) ) {
 			$prince->setPDFProfile( 'PDF/UA-1' );
+			
 		}
 
 		yield 60 => __( 'Adding stylesheets and scripts...', 'pressbooks' );

--- a/inc/modules/export/prince/class-pdf.php
+++ b/inc/modules/export/prince/class-pdf.php
@@ -266,7 +266,6 @@ class Pdf extends Export {
 			$prince->setPDFOutputIntent( $this->pdfOutputIntent );
 		} elseif ( stripos( get_class( $this ), 'print' ) === false && empty( $this->pdfProfile ) ) {
 			$prince->setPDFProfile( 'PDF/UA-1' );
-			
 		}
 
 		yield 60 => __( 'Adding stylesheets and scripts...', 'pressbooks' );

--- a/inc/modules/export/prince/class-pdf.php
+++ b/inc/modules/export/prince/class-pdf.php
@@ -254,7 +254,7 @@ class Pdf extends Export {
 		$prince->setHTML( true );
 		$prince->setCompress( true );
 		$prince->setHttpTimeout( defined( 'WP_TESTS_MULTISITE' ) ? 5 : 600 ); // 5 seconds for tests, 10 minutes for production
-		$prince->setInputType('xml');
+		$prince->setInputType( 'xml' );
 		if ( defined( 'WP_ENV' ) && ( WP_ENV === 'development' ) ) {
 			$prince->setInsecure( true );
 		}


### PR DESCRIPTION
This addresses #4263 by adding parsing for xml:lang properties in Prince pdf exports. Because Prince can't infer the file type by the extension, it needs to be told explicitly that this is xml, otherwise it won't parse xml:* attributes, like xml:lang. 