### PR TITLE
fix: disable wptexturize on mathjax pages

### DIFF
--- a/inc/class-mathjax.php
+++ b/inc/class-mathjax.php
@@ -265,6 +265,7 @@ class MathJax {
 		if ( ! is_admin() && $this->sectionHasMath() ) {
 			// If the file ends in _CHTML, then it is the CommonHTML output processor
 			wp_enqueue_script( 'pb_mathjax', 'https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js', [], null, true );
+			remove_filter( 'the_content', 'wptexturize' );
 		}
 	}
 

--- a/tests/test-mathjax.php
+++ b/tests/test-mathjax.php
@@ -73,7 +73,6 @@ class MathjaxTest extends \WP_UnitTestCase {
 		$pid = $this->factory()->post->create_object( $new_post );
 		$GLOBALS['post'] = $pid;
 		$this->assertTrue( $this->mathjax->sectionHasMath() );
-
 	}
 
 	public function testAddHeaders() {
@@ -100,8 +99,14 @@ class MathjaxTest extends \WP_UnitTestCase {
 		$GLOBALS['post'] = $pid;
 		ob_start();
 		$this->mathjax->addHeaders();
+		$this->mathjax->addScripts();
 		$buffer = ob_get_clean();
 		$this->assertStringContainsString( 'window.MathJax', $buffer );
+		$result = has_filter('the_content', 'wptexturize');
+		$this->assertFalse(
+			$result,
+			'wptexturize should be removed from the_content filter'
+		);
 	}
 
 	public function testLatexMarkup() {


### PR DESCRIPTION
This pull request updates the MathJax integration to ensure that the `wptexturize` filter is removed from post content when MathJax scripts are loaded. This prevents unwanted text transformations that could interfere with LaTeX/math rendering. Corresponding tests have also been added to verify this behavior.

**MathJax Integration Improvements:**

* Updated the `addScripts` method in `class-mathjax.php` to remove the `wptexturize` filter from `the_content` when MathJax is enabled, preventing unwanted text transformations in math content.

**Testing Enhancements:**

* Modified the `testAddHeaders` test to call `addScripts`, and added assertions to verify that `wptexturize` is no longer attached to `the_content` when MathJax is active.
* Minor cleanup in `testSectionHasMath` by removing an unnecessary blank line.