### PR TITLE
fix: fetch updates only when needed

### DIFF
--- a/inc/admin/dashboard/class-dashboard.php
+++ b/inc/admin/dashboard/class-dashboard.php
@@ -9,8 +9,6 @@ abstract class Dashboard {
 
 	protected string $root_page = 'index.php';
 
-	protected array $recentUpdates = [];
-
 	protected string $page_name;
 
 	public static function init(): Dashboard {
@@ -81,7 +79,11 @@ abstract class Dashboard {
 	protected function doRedirect(): bool {
 		return wp_redirect( $this->getUrl() );
 	}
-	protected function fetchUpdates(): void {
+
+	/**
+	 * @return array{content: string|null, post_id: integer|null, last_updated: string|null, domain: string|null}
+	 */
+	protected function fetchUpdates(): array {
 		$environment = defined( 'WP_ENV' ) ? WP_ENV : 'production';
 		$domain = in_array( $environment, [ 'staging', 'production' ], true ) ? 'https://pressbooks.com' : 'https://dev.pressbooks.com';
 
@@ -95,8 +97,7 @@ abstract class Dashboard {
 			]);
 
 			if ( is_wp_error( $response ) || wp_remote_retrieve_response_code( $response ) !== 200 ) {
-				$this->recentUpdates = [];
-				return;
+				return [];
 			}
 
 			set_transient( 'pressbooks_recent_updates', $response['body'], HOUR_IN_SECONDS );
@@ -104,7 +105,7 @@ abstract class Dashboard {
 			$updates = json_decode( $response['body'], true );
 		}
 
-		$this->recentUpdates = [
+		return [
 			...$updates,
 			'domain' => $domain,
 		];

--- a/inc/admin/dashboard/class-networkdashboard.php
+++ b/inc/admin/dashboard/class-networkdashboard.php
@@ -15,7 +15,6 @@ class NetworkDashboard extends Dashboard {
 		add_action( 'load-index.php', [ $this, 'redirect' ] );
 		add_action( 'network_admin_menu', [ $this, 'removeDefaultPage' ] );
 		add_action( 'network_admin_menu', [ $this, 'addNewPage' ] );
-		$this->fetchUpdates();
 	}
 
 	public function getUrl(): string {
@@ -25,6 +24,8 @@ class NetworkDashboard extends Dashboard {
 	public function render(): void {
 		$blade = Container::get( 'Blade' );
 
+		$updates = $this->fetchUpdates();
+
 		echo $blade->render( 'admin.dashboard.network', [
 			'network_name' => get_bloginfo( 'name' ),
 			'network_url' => network_home_url(),
@@ -33,8 +34,8 @@ class NetworkDashboard extends Dashboard {
 			'network_analytics_active' => is_plugin_active( 'pressbooks-network-analytics/pressbooks-network-analytics.php' ),
 			'koko_analytics_active' => is_plugin_active( 'koko-analytics/koko-analytics.php' ),
 			'updates' => [
-				'text' => $this->recentUpdates['content'] ?? '',
-				'url' => isset( $this->recentUpdates['post_id'] ) ? "{$this->recentUpdates['domain']}?p={$this->recentUpdates['post_id']}" : null,
+				'text' => $updates['content'] ?? '',
+				'url' => isset( $updates['post_id'] ) ? "{$updates['domain']}?p={$updates['post_id']}" : null,
 			],
 		] );
 	}

--- a/tests/test-admin-bookdashboard.php
+++ b/tests/test-admin-bookdashboard.php
@@ -8,9 +8,7 @@ use function Pressbooks\Admin\Metaboxes\upload_cover_image;
 class FakeDashboard extends Pressbooks\Admin\Dashboard\Dashboard {
 	public function fetchReleaseNotes(): array
 	{
-		parent::fetchUpdates();
-
-		return $this->recentUpdates;
+		return $this->fetchUpdates();
 	}
 
 	public function render(): void


### PR DESCRIPTION
**Issue** https://github.com/pressbooks/private/issues/2092

**Accompanies** https://github.com/pressbooks/pressbooks-multi-institution/pull/286

This PR fixes an issue where the fetchUpdates method was being called on every page load and during CLI executions. With this update, the method is only triggered when the actual page is loaded, reducing unnecessary requests and improving performance.