### PR TITLE
feat: allow subscript and superscript in glossary terms

### DIFF
--- a/inc/posttype/namespace.php
+++ b/inc/posttype/namespace.php
@@ -230,7 +230,7 @@ function disable_months_dropdown( $disable, $post_type ) {
 function after_title( $post ) {
 	if ( $post->post_type === 'glossary' ) {
 		echo '<p>';
-		_e( 'Links, bold text and italic text are supported in glossary terms. Other elements will be removed.', 'pressbooks' );
+		_e( 'Links, bold text, italic text, subscript and superscript are supported in glossary terms. Other elements will be removed.', 'pressbooks' );
 		echo '</p>';
 	}
 	if ( $post->post_type === 'back-matter' || $post->post_type === 'front-matter' ) {
@@ -280,7 +280,7 @@ function wp_editor_settings( $settings ) {
 	return $settings;
 }
 
-/**
+/** 
  * @param array $post_states An array of post display states.
  * @param \WP_Post $post The current post object.
  *

--- a/inc/posttype/namespace.php
+++ b/inc/posttype/namespace.php
@@ -268,7 +268,7 @@ function wp_editor_settings( $settings ) {
 		$settings['wpautop'] = true;
 		$settings['media_buttons'] = false;
 		$settings['tinymce'] = [
-			'toolbar1' => 'bold,italic,|,link,unlink,|,undo,redo',
+			'toolbar1' => 'bold,italic,superscript,subscript,|,link,unlink,|,undo,redo',
 			'toolbar2' => '',
 			'toolbar3' => '',
 		];

--- a/inc/posttype/namespace.php
+++ b/inc/posttype/namespace.php
@@ -280,7 +280,7 @@ function wp_editor_settings( $settings ) {
 	return $settings;
 }
 
-/** 
+/**
  * @param array $post_states An array of post display states.
  * @param \WP_Post $post The current post object.
  *

--- a/inc/shortcodes/glossary/class-glossary.php
+++ b/inc/shortcodes/glossary/class-glossary.php
@@ -334,6 +334,8 @@ class Glossary implements FrontOrBackMatter {
 					'em' => [],
 					'p' => [],
 					'strong' => [],
+					'sub' => [],
+					'sup' => [],
 
 				]
 			);

--- a/tests/test-shortcodes-glossary.php
+++ b/tests/test-shortcodes-glossary.php
@@ -223,6 +223,34 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 		$results = $this->gl->sanitizeGlossaryTerm( $data );
 		$this->assertEquals( '<a href="https://google.com">All</a> is <strong>good.</strong>', $results['post_content'] );
 	}
+
+	/**
+	 * Test that subscript and superscript tags are preserved in glossary terms
+	 *
+	 * @group glossary
+	 */
+	public function test_sanitizeGlossaryTermWithSubSup() {
+		// Test subscript preservation (e.g., chemical formulas like H2O)
+		$data['post_type'] = 'glossary';
+		$data['post_content'] = 'Water has the formula H<sub>2</sub>O.';
+		$results = $this->gl->sanitizeGlossaryTerm( $data );
+		$this->assertEquals( 'Water has the formula H<sub>2</sub>O.', $results['post_content'] );
+
+		// Test superscript preservation (e.g., mathematical expressions like x^2)
+		$data['post_content'] = 'The equation is x<sup>2</sup> + y<sup>2</sup> = 1.';
+		$results = $this->gl->sanitizeGlossaryTerm( $data );
+		$this->assertEquals( 'The equation is x<sup>2</sup> + y<sup>2</sup> = 1.', $results['post_content'] );
+
+		// Test combined with other allowed tags
+		$data['post_content'] = 'A <strong>bold</strong> formula: E = mc<sup>2</sup> and <em>italics</em> with CO<sub>2</sub>.';
+		$results = $this->gl->sanitizeGlossaryTerm( $data );
+		$this->assertEquals( 'A <strong>bold</strong> formula: E = mc<sup>2</sup> and <em>italics</em> with CO<sub>2</sub>.', $results['post_content'] );
+
+		// Test that disallowed tags are still stripped while sub/sup are preserved
+		$data['post_content'] = 'H<sub>2</sub>O with <script>alert("evil")</script> and x<sup>2</sup>.';
+		$results = $this->gl->sanitizeGlossaryTerm( $data );
+		$this->assertEquals( 'H<sub>2</sub>O with alert("evil") and x<sup>2</sup>.', $results['post_content'] );
+	}
 	/**
 	 * @group glossary
 	 */


### PR DESCRIPTION
Allow users to add subscript and superscript tags to glossary terms. Add relevant buttons to TinyMCE editor for glossary terms. Fix for https://github.com/pressbooks/pressbooks/issues/2175

To test:
1. Checkout this branch and edit or create a new glossary term
2. Use the tinymce button to add subscript and superscript
<img width="611" height="143" alt="Screenshot 2025-12-14 152055" src="https://github.com/user-attachments/assets/3a5d56f6-f6b1-4f5c-8013-eaa5541aa6ab" />

3. Save the term. Observe that the tags are well-formed and not stripped out upon save
4. Insert the term into book content. Observe that the term definition appears as expected in webbook and export files
<img width="821" height="236" alt="Screenshot 2025-12-14 152500" src="https://github.com/user-attachments/assets/45a699ed-a799-4387-be8f-3b5832ca4b2d" />
