### PR TITLE
fix: wp request deprecation

### DIFF
--- a/inc/class-bookdirectory.php
+++ b/inc/class-bookdirectory.php
@@ -113,41 +113,86 @@ class BookDirectory {
 	/**
 	 * Delete book from directory.
 	 *
-	 * @param string $book_id Blog ID
-	 *
+	 * @param array|null $book_ids
 	 * @return bool
 	 * @since 5.14.3
 	 */
-	public function deleteBookFromDirectory( ?array $book_ids = null ) {
-		if ( filter_var( self::$delete_book_endpoint, FILTER_VALIDATE_URL ) ) {
-			$book_ids = $book_ids ?? [ get_current_blog_id() ];
-			$sid = sprintf( '%s-%s-%s', uniqid( self::DELETION_PREFIX, true ), wp_rand( 1, 99 ), $book_ids[0] );
+	public function deleteBookFromDirectory( ?array $book_ids = null ): bool {
 
-			$header = [
-				'Content-Type' => 'application/json',
-			];
+		if ( ! filter_var( self::$delete_book_endpoint, FILTER_VALIDATE_URL ) ) {
+			return false;
+		}
 
-			$data = [
-				'sid'       => $sid,
-				'network'   => network_home_url(),
-				'book_ids'   => $book_ids,
-			];
+		$book_ids = $book_ids ?? [ get_current_blog_id() ];
 
-			$removals = get_site_option( self::DELETIONS_META_KEY, [] );
-			update_site_option( self::DELETIONS_META_KEY, array_merge( $removals, [ $sid ] ) );
+		$sid = sprintf(
+			'%s-%s-%s',
+			uniqid( self::DELETION_PREFIX, true ),
+			wp_rand( 1, 99 ),
+			$book_ids[0]
+		);
 
-			try {
-				$result = \Requests::post( self::$delete_book_endpoint, $header, wp_json_encode( $data ) );
-			} catch ( \Exception $exception ) {
-				update_site_option( self::DELETIONS_META_KEY, $removals );
-				return false;
-			}
+		$data = [
+			'sid'      => $sid,
+			'network'  => network_home_url(),
+			'book_ids' => $book_ids,
+		];
 
-			if ( 200 === $result->status_code && true === $result->success ) {
-				return true;
+		$removals = get_site_option( self::DELETIONS_META_KEY, [] );
+		update_site_option( self::DELETIONS_META_KEY, array_merge( $removals, [ $sid ] ) );
+
+		$response = wp_remote_post(
+			self::$delete_book_endpoint,
+			[
+				'headers' => [
+					'Content-Type' => 'application/json',
+				],
+				'body'    => wp_json_encode( $data ),
+				'timeout' => 15,
+			]
+		);
+
+		if ( is_wp_error( $response ) ) {
+			update_site_option( self::DELETIONS_META_KEY, $removals );
+			error_log( 'Book deletion failed: ' . $response->get_error_message() );
+			return false;
+		}
+
+		$status_code = wp_remote_retrieve_response_code( $response );
+		$body = wp_remote_retrieve_body( $response );
+
+		if ( 200 === $status_code ) {
+			return true;
+		}
+
+		update_site_option( self::DELETIONS_META_KEY, $removals );
+
+		if ( ! empty( $body ) ) {
+			$result = json_decode( $body, true );
+
+			if ( json_last_error() === JSON_ERROR_NONE && isset( $result['message'] ) ) {
+				$error_message = $result['message'];
+
+				// Log validation errors if present
+				if ( 422 === $status_code && isset( $result['errors'] ) ) {
+					$error_details = wp_json_encode( $result['errors'] );
+					error_log( sprintf(
+						'Book deletion validation failed: %s - Details: %s',
+						$error_message,
+						$error_details
+					) );
+				} else {
+					error_log( sprintf(
+						'Book deletion failed (status %d): %s',
+						$status_code,
+						$error_message
+					) );
+				}
 			} else {
-				update_site_option( self::DELETIONS_META_KEY, $removals );
+				error_log( sprintf( 'Book deletion failed with status code: %d', $status_code ) );
 			}
+		} else {
+			error_log( sprintf( 'Book deletion failed with status code: %d (empty response)', $status_code ) );
 		}
 
 		return false;

--- a/inc/class-bookdirectory.php
+++ b/inc/class-bookdirectory.php
@@ -146,6 +146,7 @@ class BookDirectory {
 			[
 				'headers' => [
 					'Content-Type' => 'application/json',
+					'Accept'       => 'application/json',
 				],
 				'body'    => wp_json_encode( $data ),
 				'timeout' => 15,

--- a/tests/test-bookdirectory.php
+++ b/tests/test-bookdirectory.php
@@ -33,6 +33,325 @@ class BookDirectoryTest extends \WP_UnitTestCase {
 	}
 
 	public function test_deleteAction() {
-		$this->assertFalse( $this->book_directory->deleteAction( get_site() ) );
+		// Mock the HTTP request to return an error
+		add_filter( 'pre_http_request', function() {
+			return new \WP_Error( 'http_error', 'Connection failed' );
+		}, 10 );
+
+		$result = $this->book_directory->deleteAction( get_site() );
+		remove_all_filters( 'pre_http_request' );
+
+		$this->assertFalse( $result );
+	}
+
+	public function test_deleteBookFromDirectory_invalidUrl() {
+		// Set invalid endpoint URL
+		$reflection = new \ReflectionClass( BookDirectory::class );
+		$property = $reflection->getProperty( 'delete_book_endpoint' );
+		$property->setAccessible( true );
+		$property->setValue( null, 'not-a-valid-url' );
+
+		$result = $this->book_directory->deleteBookFromDirectory( [ 1 ] );
+		$this->assertFalse( $result );
+	}
+
+	public function test_deleteBookFromDirectory_usesCurrentBlogIdWhenNoIdsProvided() {
+		$reflection = new \ReflectionClass( BookDirectory::class );
+		$property = $reflection->getProperty( 'delete_book_endpoint' );
+		$property->setAccessible( true );
+		$property->setValue( null, 'https://api.example.com/delete' );
+
+		// Mock wp_remote_post
+		add_filter( 'pre_http_request', function( $response, $args, $url ) {
+			$body = json_decode( $args['body'], true );
+			$this->assertIsArray( $body['book_ids'] );
+			$this->assertCount( 1, $body['book_ids'] );
+			$this->assertEquals( get_current_blog_id(), $body['book_ids'][0] );
+			
+			return [
+				'response' => [ 'code' => 200 ],
+				'body' => '{"success": true}',
+			];
+		}, 10, 3 );
+
+		$result = $this->book_directory->deleteBookFromDirectory();
+		remove_all_filters( 'pre_http_request' );
+		
+		$this->assertTrue( $result );
+	}
+
+	public function test_deleteBookFromDirectory_successfulDeletion() {
+		$reflection = new \ReflectionClass( BookDirectory::class );
+		$property = $reflection->getProperty( 'delete_book_endpoint' );
+		$property->setAccessible( true );
+		$property->setValue( null, 'https://api.example.com/delete' );
+
+		add_filter( 'pre_http_request', function( $response, $args, $url ) {
+			return [
+				'response' => [ 'code' => 200 ],
+				'body' => '{"success": true}',
+			];
+		}, 10, 3 );
+
+		$result = $this->book_directory->deleteBookFromDirectory( [ 123 ] );
+		remove_all_filters( 'pre_http_request' );
+
+		$this->assertTrue( $result );
+	}
+
+	public function test_deleteBookFromDirectory_wpError() {
+		$reflection = new \ReflectionClass( BookDirectory::class );
+		$property = $reflection->getProperty( 'delete_book_endpoint' );
+		$property->setAccessible( true );
+		$property->setValue( null, 'https://api.example.com/delete' );
+
+		// Get current removals to verify rollback
+		$removals_before = get_site_option( BookDirectory::DELETIONS_META_KEY, [] );
+
+		add_filter( 'pre_http_request', function() {
+			return new \WP_Error( 'http_error', 'Connection timeout' );
+		}, 10 );
+
+		$result = $this->book_directory->deleteBookFromDirectory( [ 123 ] );
+		remove_all_filters( 'pre_http_request' );
+
+		$this->assertFalse( $result );
+		
+		// Verify removals were rolled back
+		$removals_after = get_site_option( BookDirectory::DELETIONS_META_KEY, [] );
+		$this->assertEquals( $removals_before, $removals_after );
+	}
+
+	public function test_deleteBookFromDirectory_nonSuccessStatusCode() {
+		$reflection = new \ReflectionClass( BookDirectory::class );
+		$property = $reflection->getProperty( 'delete_book_endpoint' );
+		$property->setAccessible( true );
+		$property->setValue( null, 'https://api.example.com/delete' );
+
+		$removals_before = get_site_option( BookDirectory::DELETIONS_META_KEY, [] );
+
+		add_filter( 'pre_http_request', function( $response, $args, $url ) {
+			return [
+				'response' => [ 'code' => 500 ],
+				'body' => '{"message": "Internal server error"}',
+			];
+		}, 10, 3 );
+
+		$result = $this->book_directory->deleteBookFromDirectory( [ 123 ] );
+		remove_all_filters( 'pre_http_request' );
+
+		$this->assertFalse( $result );
+		
+		// Verify removals were rolled back
+		$removals_after = get_site_option( BookDirectory::DELETIONS_META_KEY, [] );
+		$this->assertEquals( $removals_before, $removals_after );
+	}
+
+	public function test_deleteBookFromDirectory_validationError() {
+		$reflection = new \ReflectionClass( BookDirectory::class );
+		$property = $reflection->getProperty( 'delete_book_endpoint' );
+		$property->setAccessible( true );
+		$property->setValue( null, 'https://api.example.com/delete' );
+
+		add_filter( 'pre_http_request', function( $response, $args, $url ) {
+			return [
+				'response' => [ 'code' => 422 ],
+				'body' => '{"message": "Validation failed", "errors": {"book_ids": ["Invalid book IDs"]}}',
+			];
+		}, 10, 3 );
+
+		$result = $this->book_directory->deleteBookFromDirectory( [ 123 ] );
+		remove_all_filters( 'pre_http_request' );
+
+		$this->assertFalse( $result );
+	}
+
+	public function test_deleteBookFromDirectory_storesRemovalMetadata() {
+		$reflection = new \ReflectionClass( BookDirectory::class );
+		$property = $reflection->getProperty( 'delete_book_endpoint' );
+		$property->setAccessible( true );
+		$property->setValue( null, 'https://api.example.com/delete' );
+
+		// Clear existing removals
+		delete_site_option( BookDirectory::DELETIONS_META_KEY );
+
+		add_filter( 'pre_http_request', function( $response, $args, $url ) {
+			return [
+				'response' => [ 'code' => 200 ],
+				'body' => '{"success": true}',
+			];
+		}, 10, 3 );
+
+		$this->book_directory->deleteBookFromDirectory( [ 123 ] );
+		remove_all_filters( 'pre_http_request' );
+
+		$removals = get_site_option( BookDirectory::DELETIONS_META_KEY, [] );
+		$this->assertIsArray( $removals );
+		$this->assertCount( 1, $removals );
+		$this->assertStringStartsWith( BookDirectory::DELETION_PREFIX, $removals[0] );
+	}
+
+	public function test_deleteBookFromDirectory_sendsCorrectPayload() {
+		$reflection = new \ReflectionClass( BookDirectory::class );
+		$property = $reflection->getProperty( 'delete_book_endpoint' );
+		$property->setAccessible( true );
+		$property->setValue( null, 'https://api.example.com/delete' );
+
+		$captured_data = null;
+
+		add_filter( 'pre_http_request', function( $response, $args, $url ) use ( &$captured_data ) {
+			$this->assertEquals( 'https://api.example.com/delete', $url );
+			$this->assertEquals( 'application/json', $args['headers']['Content-Type'] );
+			$this->assertEquals( 15, $args['timeout'] );
+			
+			$captured_data = json_decode( $args['body'], true );
+			
+			return [
+				'response' => [ 'code' => 200 ],
+				'body' => '{"success": true}',
+			];
+		}, 10, 3 );
+
+		$this->book_directory->deleteBookFromDirectory( [ 123, 456 ] );
+		remove_all_filters( 'pre_http_request' );
+
+		$this->assertIsArray( $captured_data );
+		$this->assertArrayHasKey( 'sid', $captured_data );
+		$this->assertArrayHasKey( 'network', $captured_data );
+		$this->assertArrayHasKey( 'book_ids', $captured_data );
+		$this->assertEquals( [ 123, 456 ], $captured_data['book_ids'] );
+		$this->assertStringStartsWith( BookDirectory::DELETION_PREFIX, $captured_data['sid'] );
+	}
+
+	public function test_setBookPrivate_callsDeleteWhenPrivate() {
+		$reflection = new \ReflectionClass( BookDirectory::class );
+		$property = $reflection->getProperty( 'delete_book_endpoint' );
+		$property->setAccessible( true );
+		$property->setValue( null, 'https://api.example.com/delete' );
+
+		add_filter( 'pre_http_request', function( $response, $args, $url ) {
+			return [
+				'response' => [ 'code' => 200 ],
+				'body' => '{"success": true}',
+			];
+		}, 10, 3 );
+
+		$result = $this->book_directory->setBookPrivate( 1, 0 );
+		remove_all_filters( 'pre_http_request' );
+
+		$this->assertTrue( $result );
+	}
+
+	public function test_setBookPrivate_doesNothingWhenPublic() {
+		$result = $this->book_directory->setBookPrivate( 0, 1 );
+		$this->assertNull( $result );
+	}
+
+	public function test_softDeleteActions_archived() {
+		$reflection = new \ReflectionClass( BookDirectory::class );
+		$property = $reflection->getProperty( 'delete_book_endpoint' );
+		$property->setAccessible( true );
+		$property->setValue( null, 'https://api.example.com/delete' );
+
+		add_filter( 'pre_http_request', function() {
+			return [
+				'response' => [ 'code' => 200 ],
+				'body' => '{"success": true}',
+			];
+		}, 10 );
+
+		$previous = get_site();
+		$previous->archived = '0';
+		
+		$updated = clone $previous;
+		$updated->archived = '1';
+
+		$result = $this->book_directory->softDeleteActions( $updated, $previous );
+		remove_all_filters( 'pre_http_request' );
+
+		$this->assertTrue( $result );
+	}
+
+	public function test_softDeleteActions_deactivated() {
+		$reflection = new \ReflectionClass( BookDirectory::class );
+		$property = $reflection->getProperty( 'delete_book_endpoint' );
+		$property->setAccessible( true );
+		$property->setValue( null, 'https://api.example.com/delete' );
+
+		add_filter( 'pre_http_request', function() {
+			return [
+				'response' => [ 'code' => 200 ],
+				'body' => '{"success": true}',
+			];
+		}, 10 );
+
+		$previous = get_site();
+		$previous->deleted = '0';
+		
+		$updated = clone $previous;
+		$updated->deleted = '1';
+
+		$result = $this->book_directory->softDeleteActions( $updated, $previous );
+		remove_all_filters( 'pre_http_request' );
+
+		$this->assertTrue( $result );
+	}
+
+	public function test_softDeleteActions_spam() {
+		$reflection = new \ReflectionClass( BookDirectory::class );
+		$property = $reflection->getProperty( 'delete_book_endpoint' );
+		$property->setAccessible( true );
+		$property->setValue( null, 'https://api.example.com/delete' );
+
+		add_filter( 'pre_http_request', function() {
+			return [
+				'response' => [ 'code' => 200 ],
+				'body' => '{"success": true}',
+			];
+		}, 10 );
+
+		$previous = get_site();
+		$previous->spam = '0';
+		
+		$updated = clone $previous;
+		$updated->spam = '1';
+
+		$result = $this->book_directory->softDeleteActions( $updated, $previous );
+		remove_all_filters( 'pre_http_request' );
+
+		$this->assertTrue( $result );
+	}
+
+	public function test_softDeleteActions_urlChanged() {
+		$reflection = new \ReflectionClass( BookDirectory::class );
+		$property = $reflection->getProperty( 'delete_book_endpoint' );
+		$property->setAccessible( true );
+		$property->setValue( null, 'https://api.example.com/delete' );
+
+		add_filter( 'pre_http_request', function() {
+			return [
+				'response' => [ 'code' => 200 ],
+				'body' => '{"success": true}',
+			];
+		}, 10 );
+
+		$previous = get_site();
+		$previous->path = '/old-path/';
+		
+		$updated = clone $previous;
+		$updated->path = '/new-path/';
+
+		$result = $this->book_directory->softDeleteActions( $updated, $previous );
+		remove_all_filters( 'pre_http_request' );
+
+		$this->assertTrue( $result );
+	}
+
+	public function test_softDeleteActions_noChanges() {
+		$previous = get_site();
+		$updated = clone $previous;
+
+		$result = $this->book_directory->softDeleteActions( $updated, $previous );
+		$this->assertNull( $result );
 	}
 }

--- a/tests/test-privacy.php
+++ b/tests/test-privacy.php
@@ -86,7 +86,19 @@ class GdprTest extends \WP_UnitTestCase {
 		update_site_option( 'pressbooks_sharingandprivacy_options', [ 'network_directory_excluded' => 0 ] );
 		add_action( 'admin_init', '\Pressbooks\Admin\Laf\privacy_settings_init' );
 		@do_action( 'admin_init' );
+
+		// Mock HTTP requests to prevent actual API calls to BookDirectory
+		add_filter( 'pre_http_request', function( $response, $args, $url ) {
+			return [
+				'response' => [ 'code' => 200 ],
+				'body' => '{"success": true}',
+			];
+		}, 10, 3 );
+
 		do_action( 'update_option_pb_book_directory_excluded', '0', '1' );
+
+		remove_all_filters( 'pre_http_request' );
+
 		$last_updated_after = get_blog_details()->last_updated;
 		$this->assertEquals( get_site_meta( get_current_blog_id(), DataCollector::BOOK_DIRECTORY_EXCLUDED, true ), '1' );
 		$this->assertNotEquals( $last_updated_before, $last_updated_after );
@@ -164,12 +176,20 @@ EOT;
 	 * @group privacy
 	 */
 	public function test_excludeNonCatalogBooksFromDirectoryAction() {
+		// Mock HTTP requests to prevent actual API calls
+		add_filter( 'pre_http_request', function( $response, $args, $url ) {
+			return [
+				'response' => [ 'code' => 200 ],
+				'body' => '{"success": true}',
+			];
+		}, 10, 3 );
+
 		$books = $this->factory()->blog->create_many( 2 );
 
 		$this->assertEquals(
 			SharingAndPrivacyOptions::excludeNonCatalogBooksFromDirectoryAction( $books ),
 			[
-				'directory_delete_responses' => [ false ],
+				'directory_delete_responses' => [ true ],
 				'blogs_not_updated' => [],
 			]
 		);
@@ -187,7 +207,7 @@ EOT;
 		$this->assertEquals(
 			SharingAndPrivacyOptions::excludeNonCatalogBooksFromDirectoryAction( $books ),
 			[
-				'directory_delete_responses' => [ false, false ],
+				'directory_delete_responses' => [ true, true ],
 				'blogs_not_updated' => [],
 			]
 		);
@@ -205,7 +225,7 @@ EOT;
 		$this->assertEquals(
 			SharingAndPrivacyOptions::excludeNonCatalogBooksFromDirectoryAction( $books ),
 			[
-				'directory_delete_responses' => [ false, false ],
+				'directory_delete_responses' => [ true, true ],
 				'blogs_not_updated' => [ 9876 ],
 			]
 		);
@@ -217,6 +237,8 @@ EOT;
 				'blogs_not_updated' => [ 9876 ],
 			]
 		);
+
+		remove_all_filters( 'pre_http_request' );
 	}
 
 	/**


### PR DESCRIPTION
This pull request refactors the `deleteBookFromDirectory` method in `inc/class-bookdirectory.php` to improve reliability, error handling, and test coverage. The HTTP request logic is updated to use WordPress's native `wp_remote_post` instead of the `Requests` library, and detailed logging and rollback mechanisms are added for failed deletions. Additionally, comprehensive unit tests are introduced to cover various scenarios for book deletion and related actions.

**Refactor and reliability improvements:**

* Refactored `deleteBookFromDirectory` to use `wp_remote_post` for making HTTP requests, replacing the previous use of the `Requests` library. This includes improved error handling, response validation, and detailed logging for different failure scenarios, such as invalid URLs, HTTP errors, and validation errors from the API. The method now also ensures rollback of metadata changes if the deletion fails. [[1]](diffhunk://#diff-50cc1340d9dfd5d4fc7891d61e9bd31d54643c4f545d2cfbe7c85f70d4f4d431L116-R133) [[2]](diffhunk://#diff-50cc1340d9dfd5d4fc7891d61e9bd31d54643c4f545d2cfbe7c85f70d4f4d431L139-R195)

**Test coverage enhancements:**

* Added extensive unit tests in `tests/test-bookdirectory.php` for `deleteBookFromDirectory` and related methods. These tests cover scenarios such as invalid endpoint URLs, defaulting to the current blog ID, successful deletions, HTTP errors, non-success status codes, validation errors, correct payload structure, and the correct handling of metadata. Tests for `setBookPrivate` and `softDeleteActions` were also added to verify their integration with the deletion logic.