### PR TITLE
fix: improve handling of archived books

### DIFF
--- a/inc/api/endpoints/controller/books/class-booksquerybuilder.php
+++ b/inc/api/endpoints/controller/books/class-booksquerybuilder.php
@@ -35,7 +35,7 @@ class BooksQueryBuilder {
 		global $wpdb;
 
 		$this->query = "SELECT SQL_CALC_FOUND_ROWS blog_id FROM {$wpdb->blogs} AS b
-		WHERE public = 1 AND spam = 0 AND deleted = 0 AND blog_id != %d";
+		WHERE public = 1 AND spam = 0 AND blog_id != %d";
 		$this->placeholder_values[] = get_main_site_id();
 
 		foreach ( $this->parameters as $parameter ) {

--- a/inc/api/endpoints/controller/books/class-booksquerybuilder.php
+++ b/inc/api/endpoints/controller/books/class-booksquerybuilder.php
@@ -35,7 +35,7 @@ class BooksQueryBuilder {
 		global $wpdb;
 
 		$this->query = "SELECT SQL_CALC_FOUND_ROWS blog_id FROM {$wpdb->blogs} AS b
-		WHERE public = 1 AND spam = 0 AND blog_id != %d";
+		WHERE public = 1 AND spam = 0 AND deleted = 0 AND blog_id != %d";
 		$this->placeholder_values[] = get_main_site_id();
 
 		foreach ( $this->parameters as $parameter ) {

--- a/inc/api/endpoints/controller/books/class-booksquerybuilder.php
+++ b/inc/api/endpoints/controller/books/class-booksquerybuilder.php
@@ -35,7 +35,7 @@ class BooksQueryBuilder {
 		global $wpdb;
 
 		$this->query = "SELECT SQL_CALC_FOUND_ROWS blog_id FROM {$wpdb->blogs} AS b
-		WHERE public = 1 AND archived = 0 AND spam = 0 AND deleted = 0 AND blog_id != %d";
+		WHERE public = 1 AND spam = 0 AND deleted = 0 AND blog_id != %d";
 		$this->placeholder_values[] = get_main_site_id();
 
 		foreach ( $this->parameters as $parameter ) {

--- a/inc/datacollector/class-book.php
+++ b/inc/datacollector/class-book.php
@@ -329,6 +329,25 @@ class Book {
 		update_site_meta( $book_id, self::CREATED, $blog_info->registered );
 		update_site_meta( $book_id, self::DEACTIVATED, $blog_info->deleted );
 
+		// pb_book_archived_date
+		// pb_book_archived_by
+		// Only preserve archived metadata if the book is currently archived in WordPress
+		if ( '1' === $blog_info->archived ) {
+			// Preserve existing values if they exist, otherwise set them now
+			$existing_date = get_site_meta( $book_id, self::ARCHIVED_DATE, true );
+			$existing_by = get_site_meta( $book_id, self::ARCHIVED_BY, true );
+			if ( empty( $existing_date ) ) {
+				update_site_meta( $book_id, self::ARCHIVED_DATE, gmdate( 'Y-m-d H:i:s' ) );
+			}
+			if ( empty( $existing_by ) ) {
+				update_site_meta( $book_id, self::ARCHIVED_BY, get_current_user_id() );
+			}
+		} else {
+			// Book is not archived, ensure metadata is cleared
+			delete_site_meta( $book_id, self::ARCHIVED_DATE );
+			delete_site_meta( $book_id, self::ARCHIVED_BY );
+		}
+
 		// pb_word_count
 		$word_count = \Pressbooks\Book::wordCount();
 		update_site_meta( $book_id, self::WORD_COUNT, $word_count );
@@ -574,7 +593,7 @@ class Book {
 
 			global $wpdb;
 			$main_site_id = get_network()->site_id;
-			$books = $wpdb->get_col( $wpdb->prepare( "SELECT blog_id FROM {$wpdb->blogs} WHERE archived = 0 AND spam = 0 AND blog_id != %d ", $main_site_id ) );
+			$books = $wpdb->get_col( $wpdb->prepare( "SELECT blog_id FROM {$wpdb->blogs} WHERE spam = 0 AND deleted = 0 AND blog_id != %d ", $main_site_id ) );
 
 			// Purging books that no longer exist (from wp_blogmeta)...
 			if ( count( $books ) ) {

--- a/inc/datacollector/class-book.php
+++ b/inc/datacollector/class-book.php
@@ -593,7 +593,7 @@ class Book {
 
 			global $wpdb;
 			$main_site_id = get_network()->site_id;
-			$books = $wpdb->get_col( $wpdb->prepare( "SELECT blog_id FROM {$wpdb->blogs} WHERE spam = 0 AND deleted = 0 AND blog_id != %d ", $main_site_id ) );
+			$books = $wpdb->get_col( $wpdb->prepare( "SELECT blog_id FROM {$wpdb->blogs} WHERE spam = 0 AND blog_id != %d ", $main_site_id ) );
 
 			// Purging books that no longer exist (from wp_blogmeta)...
 			if ( count( $books ) ) {

--- a/inc/datacollector/class-book.php
+++ b/inc/datacollector/class-book.php
@@ -331,7 +331,7 @@ class Book {
 
 		// pb_book_archived_date
 		// pb_book_archived_by
-		// Only preserve archived metadata if the book is currently archived in WordPress
+		// Only preserve archived metadata if the book is currently archived
 		if ( '1' === $blog_info->archived ) {
 			// Preserve existing values if they exist, otherwise set them now
 			$existing_date = get_site_meta( $book_id, self::ARCHIVED_DATE, true );
@@ -343,7 +343,7 @@ class Book {
 				update_site_meta( $book_id, self::ARCHIVED_BY, get_current_user_id() );
 			}
 		} else {
-			// Book is not archived, ensure metadata is cleared
+			// Book is not archived, ensure archived metadata is cleared
 			delete_site_meta( $book_id, self::ARCHIVED_DATE );
 			delete_site_meta( $book_id, self::ARCHIVED_BY );
 		}

--- a/tests/test-datacollector-book.php
+++ b/tests/test-datacollector-book.php
@@ -428,7 +428,7 @@ class DataCollector_BookTest extends \WP_UnitTestCase {
 		$this->assertIsString( $archived_date );
 		$this->assertMatchesRegularExpression( '/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $archived_date );
 		$this->assertNotFalse( $archived_by, 'archived_by should be set' );
-		$this->assertIsInt( $archived_by );
+		$this->assertIsNumeric( $archived_by );
 	}
 
 	/**

--- a/tests/test-datacollector-book.php
+++ b/tests/test-datacollector-book.php
@@ -252,7 +252,7 @@ class DataCollector_BookTest extends \WP_UnitTestCase {
 	/**
 	 * @group datacollector
 	 */
-	public function test_get_LogicExeption() {
+	public function test_get_LogicException() {
 		$this->expectException(\LogicException::class);
 		$this->_book();
 		$book_id = get_current_blog_id();
@@ -361,5 +361,145 @@ class DataCollector_BookTest extends \WP_UnitTestCase {
 		$path = $this->bookDataCollector->getCoverThumbnail( $blog_id, $attachment_path, $attachment_id );
 
 		$this->assertEquals( 1, preg_match( '/https:\/\/.*-350x467\.jpg/', $path ) );
+	}
+
+	/**
+	 * @group datacollector
+	 */
+	public function test_copyBookMetaIntoSiteTable_preserves_archived_metadata_when_archived() {
+		$this->_book();
+		$book_id = get_current_blog_id();
+
+		// Set archived metadata
+		$archived_date = '2025-12-01 10:00:00';
+		$archived_by = 42;
+		update_site_meta( $book_id, BookDataCollector::ARCHIVED_DATE, $archived_date );
+		update_site_meta( $book_id, BookDataCollector::ARCHIVED_BY, $archived_by );
+
+		// Archive the book
+		global $wpdb;
+		$wpdb->update(
+			$wpdb->blogs,
+			[ 'archived' => '1' ],
+			[ 'blog_id' => $book_id ],
+			[ '%s' ],
+			[ '%d' ]
+		);
+		clean_blog_cache( $book_id );
+
+		// Run sync
+		$this->bookDataCollector->copyBookMetaIntoSiteTable( $book_id );
+
+		// Verify archived metadata is preserved
+		$this->assertEquals( $archived_date, get_site_meta( $book_id, BookDataCollector::ARCHIVED_DATE, true ) );
+		$this->assertEquals( $archived_by, get_site_meta( $book_id, BookDataCollector::ARCHIVED_BY, true ) );
+	}
+
+	/**
+	 * @group datacollector
+	 */
+	public function test_copyBookMetaIntoSiteTable_sets_archived_metadata_when_missing() {
+		$this->_book();
+		$book_id = get_current_blog_id();
+
+		// Archive the book without setting metadata
+		global $wpdb;
+		$wpdb->update(
+			$wpdb->blogs,
+			[ 'archived' => '1' ],
+			[ 'blog_id' => $book_id ],
+			[ '%s' ],
+			[ '%d' ]
+		);
+		clean_blog_cache( $book_id );
+
+		// Ensure no archived metadata exists
+		delete_site_meta( $book_id, BookDataCollector::ARCHIVED_DATE );
+		delete_site_meta( $book_id, BookDataCollector::ARCHIVED_BY );
+
+		// Run sync
+		$this->bookDataCollector->copyBookMetaIntoSiteTable( $book_id );
+
+		// Verify archived metadata is now set
+		$archived_date = get_site_meta( $book_id, BookDataCollector::ARCHIVED_DATE, true );
+		$archived_by = get_site_meta( $book_id, BookDataCollector::ARCHIVED_BY, true );
+
+		$this->assertNotEmpty( $archived_date );
+		$this->assertIsString( $archived_date );
+		$this->assertMatchesRegularExpression( '/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $archived_date );
+		$this->assertNotEmpty( $archived_by );
+	}
+
+	/**
+	 * @group datacollector
+	 */
+	public function test_copyBookMetaIntoSiteTable_clears_archived_metadata_when_not_archived() {
+		$this->_book();
+		$book_id = get_current_blog_id();
+
+		// Set archived metadata
+		update_site_meta( $book_id, BookDataCollector::ARCHIVED_DATE, '2025-12-01 10:00:00' );
+		update_site_meta( $book_id, BookDataCollector::ARCHIVED_BY, 42 );
+
+		// Ensure book is NOT archived
+		global $wpdb;
+		$wpdb->update(
+			$wpdb->blogs,
+			[ 'archived' => '0' ],
+			[ 'blog_id' => $book_id ],
+			[ '%s' ],
+			[ '%d' ]
+		);
+		clean_blog_cache( $book_id );
+
+		// Run sync
+		$this->bookDataCollector->copyBookMetaIntoSiteTable( $book_id );
+
+		// Verify archived metadata is cleared
+		$this->assertEmpty( get_site_meta( $book_id, BookDataCollector::ARCHIVED_DATE, true ) );
+		$this->assertEmpty( get_site_meta( $book_id, BookDataCollector::ARCHIVED_BY, true ) );
+	}
+
+	/**
+	 * @group datacollector
+	 */
+	public function test_copyAllBooksIntoSiteTable_includes_archived_books() {
+		// Create an archived book
+		$this->_book();
+		$archived_book_id = get_current_blog_id();
+
+		global $wpdb;
+		$wpdb->update(
+			$wpdb->blogs,
+			[ 'archived' => '1' ],
+			[ 'blog_id' => $archived_book_id ],
+			[ '%s' ],
+			[ '%d' ]
+		);
+		clean_blog_cache( $archived_book_id );
+
+		// Set archived metadata
+		update_site_meta( $archived_book_id, BookDataCollector::ARCHIVED_DATE, '2025-12-01 10:00:00' );
+		update_site_meta( $archived_book_id, BookDataCollector::ARCHIVED_BY, 42 );
+
+		// Run full sync
+		$synced_count = 0;
+		foreach ( $this->bookDataCollector->copyAllBooksIntoSiteTable() as $_ ) {
+			$synced_count++;
+		}
+
+		// Verify archived book was synced
+		$this->assertGreaterThan( 0, $synced_count );
+
+		// Verify archived metadata is still present after sync
+		$archived_date = get_site_meta( $archived_book_id, BookDataCollector::ARCHIVED_DATE, true );
+		$archived_by = get_site_meta( $archived_book_id, BookDataCollector::ARCHIVED_BY, true );
+
+		$this->assertEquals( '2025-12-01 10:00:00', $archived_date );
+		$this->assertEquals( 42, $archived_by );
+
+		// Verify book metadata exists (wasn't purged)
+		$timestamp = get_site_meta( $archived_book_id, BookDataCollector::TIMESTAMP, true );
+		$this->assertNotEmpty( $timestamp );
 	}
 }

--- a/tests/test-datacollector-book.php
+++ b/tests/test-datacollector-book.php
@@ -427,7 +427,8 @@ class DataCollector_BookTest extends \WP_UnitTestCase {
 		$this->assertNotEmpty( $archived_date );
 		$this->assertIsString( $archived_date );
 		$this->assertMatchesRegularExpression( '/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/', $archived_date );
-		$this->assertNotEmpty( $archived_by );
+		$this->assertNotFalse( $archived_by, 'archived_by should be set' );
+		$this->assertIsInt( $archived_by );
 	}
 
 	/**


### PR DESCRIPTION
Improve handling of archived books in data collectors. Ensure that archived book metadata is preserved or cleared appropriately, and that archived books are included in key queries and sync operations. Adds new unit tests. Partial fix for https://github.com/pressbooks/private/issues/2230. Accompanies https://github.com/pressbooks/pressbooks-network-analytics/pull/432

**Data Collection and Sync Improvements:**

* The `copyBookMetaIntoSiteTable` method now preserves archived metadata (`ARCHIVED_DATE`, `ARCHIVED_BY`) only if a book is currently archived, and clears these fields when a book is not archived.
* The `copyAllBooksIntoSiteTable` method now includes archived books in its sync operation by removing the `archived = 0` condition from its query.
* The books API query in `BooksQueryBuilder` has been updated to include archived books by removing the `archived = 0` condition.

**Test changes**

* Several new tests have been added to verify that archived metadata is preserved, set, or cleared as appropriate when syncing book metadata, and that archived books are included in the full sync process.
* Fixed a typo in a test method name from `test_get_LogicExeption` to `test_get_LogicException`.

**To test:**
1. Check out this branch and the PR branch in pressbooks-network-analytics
2. Set one or more books to archived
3. Run the book sync manually (https://pressbooks.test/wp/wp-admin/network/admin.php?page=pb_network_analytics_booklist_sync)
4. Observe that archived metadata has not been destroyed (archived date still appears on book homepage) and archived books remain in the book list as expected