### PR TITLE
fix: correctly handle th and td elements in thead upon save

### DIFF
--- a/hooks-admin.php
+++ b/hooks-admin.php
@@ -223,6 +223,7 @@ if ( $is_book ) {
 	add_filter( 'wp_link_query', '\Pressbooks\Editor\add_anchors_to_wp_link_query', 1, 2 );
 	add_action( 'admin_enqueue_scripts', '\Pressbooks\Editor\admin_enqueue_scripts' );
 	add_action( 'admin_init', '\Pressbooks\Editor\add_editor_style' );
+	add_filter( 'content_save_pre', '\Pressbooks\Editor\fix_table_header_cells', 10 );
 }
 if ( ! defined( 'PB_GUTENBERG_TESTING' ) || ! PB_GUTENBERG_TESTING ) {
 	// Hide Gutenberg

--- a/inc/editor/namespace.php
+++ b/inc/editor/namespace.php
@@ -16,6 +16,7 @@ use PressbooksMix\Assets;
 use Pressbooks\Container;
 use Pressbooks\HtmlParser;
 use Pressbooks\Shortcodes\Glossary\Glossary;
+use Masterminds\HTML5;
 
 /**
  * Ensure that Word formatting that we like doesn't get filtered out.
@@ -528,45 +529,28 @@ function fix_table_header_cells( string $content ): string {
 		return $content;
 	}
 
-	return preg_replace_callback(
-		pattern: '/<thead\b[^>]*>.*?<\/thead>/is',
-		callback: function( $matches ) {
-			$thead = $matches[0];
+	$parser = new HTML5();
+	$dom = $parser->loadHTML( $content );
 
-			// Convert <td> with content to <th>
-			$thead = preg_replace_callback(
-				pattern: '/<td\b([^>]*)>(.*?)<\/td>/is',
-				callback: function( $td_matches ) {
-					$attributes = $td_matches[1];
-					$content = $td_matches[2];
+	foreach ($dom->getElementsByTagName('thead') as $thead) {
+		/** Replace <td> elements with content with <th> elements */
+		foreach ($thead->getElementsByTagName('td') as $td) {
+			if (trim($td->textContent) !== '') {
+	    		$th = $dom->createElement("th", $td->nodeValue);
+	      		$td->replaceWith($th);
+			}
+		}
 
-					if ( trim( $content ) !== '' ) {
-						return '<th' . $attributes . '>' . $content . '</th>';
-					}
-					return $td_matches[0];
-				},
-				subject: $thead
-			);
+		/** Replace empty <th> elements with <td> elements */
+		foreach ($thead->getElementsByTagName('th') as $th) {
+			if (trim($th->textContent) === '') {
+	    		$td = $dom->createElement("td", '');
+     			$th->replaceWith($td);
+			}
+		}
+	}
 
-			// Convert empty <th> to <td>
-			$thead = preg_replace_callback(
-				pattern: '/<th\b([^>]*)>(.*?)<\/th>/is',
-				callback: function( $th_matches ) {
-					$attributes = $th_matches[1];
-					$content = $th_matches[2];
-
-					if ( trim( $content ) === '' ) {
-						return '<td' . $attributes . '>' . $content . '</td>';
-					}
-					return $th_matches[0];
-				},
-				subject: $thead
-			);
-
-			return $thead;
-		},
-		subject: $content
-	);
+	return $dom->saveHTML();
 }
 
 /**

--- a/inc/editor/namespace.php
+++ b/inc/editor/namespace.php
@@ -528,25 +528,16 @@ function fix_table_header_cells( string $content ): string {
 		return $content;
 	}
 
-	// Protect LaTeX backslashes before unslashing by replacing with unique placeholder
+	// Protect LaTeX backslashes through WordPress slashing/unslashing
 	$latex_placeholder = '!@#LATEXBACKSLASH#@!';
 	$content = str_replace( '\\\\', $latex_placeholder, $content );
-
-	// Unslash content to get actual HTML (WordPress adds slashes for database protection)
 	$content = wp_unslash( $content );
-
-	// Restore LaTeX backslashes
 	$content = str_replace( $latex_placeholder, '\\', $content );
 
+	// Parse HTML and transform table headers
 	libxml_use_internal_errors( true );
-
 	$dom = new \DOMDocument( '1.0', 'UTF-8' );
-	// Wrap content in div to preserve structure, load as UTF-8
-	$dom->loadHTML(
-		'<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body>' . $content . '</body></html>',
-		LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD
-	);
-
+	$dom->loadHTML( '<?xml encoding="UTF-8">' . $content, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
 	libxml_clear_errors();
 
 	$theads = $dom->getElementsByTagName( 'thead' );
@@ -588,22 +579,10 @@ function fix_table_header_cells( string $content ): string {
 		}
 	}
 
-	// Extract the body content (DOMDocument wraps content in html/body tags)
-	$html = '';
-	$body = $dom->getElementsByTagName( 'body' )->item( 0 );
-	if ( $body ) {
-		foreach ( $body->childNodes as $node ) {
-			$html .= $dom->saveHTML( $node );
-		}
-	}
-
-	// Protect LaTeX backslashes again before slashing (DOMDocument may have single backslashes)
+	// Save HTML and restore LaTeX backslashes through slashing
+	$html = $dom->saveHTML();
 	$html = str_replace( '\\', $latex_placeholder, $html );
-
-	// Re-slash for WordPress (filter expects slashed content)
 	$html = wp_slash( $html );
-
-	// Restore LaTeX backslashes as double-backslashes (for WordPress slashed output)
 	$html = str_replace( $latex_placeholder, '\\\\', $html );
 
 	return $html;

--- a/inc/editor/namespace.php
+++ b/inc/editor/namespace.php
@@ -12,11 +12,11 @@
 namespace Pressbooks\Editor;
 
 use function Pressbooks\Sanitize\normalize_css_urls;
+use Masterminds\HTML5;
 use PressbooksMix\Assets;
 use Pressbooks\Container;
 use Pressbooks\HtmlParser;
 use Pressbooks\Shortcodes\Glossary\Glossary;
-use Masterminds\HTML5;
 
 /**
  * Ensure that Word formatting that we like doesn't get filtered out.
@@ -532,20 +532,20 @@ function fix_table_header_cells( string $content ): string {
 	$parser = new HTML5();
 	$dom = $parser->loadHTML( $content );
 
-	foreach ($dom->getElementsByTagName('thead') as $thead) {
+	foreach ( $dom->getElementsByTagName( 'thead' ) as $thead ) {
 		/** Replace <td> elements with content with <th> elements */
-		foreach ($thead->getElementsByTagName('td') as $td) {
-			if (trim($td->textContent) !== '') {
-	    		$th = $dom->createElement("th", $td->nodeValue);
-	      		$td->replaceWith($th);
+		foreach ( $thead->getElementsByTagName( 'td' ) as $td ) {
+			if ( trim( $td->textContent ) !== '' ) {
+				$th = $dom->createElement( 'th', $td->nodeValue );
+				$td->replaceWith( $th );
 			}
 		}
 
 		/** Replace empty <th> elements with <td> elements */
-		foreach ($thead->getElementsByTagName('th') as $th) {
-			if (trim($th->textContent) === '') {
-	    		$td = $dom->createElement("td", '');
-     			$th->replaceWith($td);
+		foreach ( $thead->getElementsByTagName( 'th' ) as $th ) {
+			if ( trim( $th->textContent ) === '' ) {
+				$td = $dom->createElement( 'td', '' );
+				$th->replaceWith( $td );
 			}
 		}
 	}

--- a/inc/editor/namespace.php
+++ b/inc/editor/namespace.php
@@ -538,8 +538,8 @@ function fix_table_header_cells( string $content ): string {
 			if ( trim( $td->textContent ) !== '' ) {
 				$th = $dom->createElement( 'th', $td->nodeValue );
 				$attributeNames = $td->getAttributeNames();
-				foreach ($attributeNames as $attributeName) {
-					$th->setAttribute($attributeName, $td->getAttribute($attributeName));
+				foreach ( $attributeNames as $attributeName ) {
+					$th->setAttribute( $attributeName, $td->getAttribute( $attributeName ) );
 				}
 				$td->replaceWith( $th );
 			}
@@ -550,8 +550,8 @@ function fix_table_header_cells( string $content ): string {
 			if ( trim( $th->textContent ) === '' ) {
 				$td = $dom->createElement( 'td', '' );
 				$attributeNames = $th->getAttributeNames();
-				foreach ($attributeNames as $attributeName) {
-					$td->setAttribute($attributeName, $th->getAttribute($attributeName));
+				foreach ( $attributeNames as $attributeName ) {
+					$td->setAttribute( $attributeName, $th->getAttribute( $attributeName ) );
 				}
 				$th->replaceWith( $td );
 			}

--- a/inc/editor/namespace.php
+++ b/inc/editor/namespace.php
@@ -528,12 +528,19 @@ function fix_table_header_cells( string $content ): string {
 		return $content;
 	}
 
-	$html5 = new \Pressbooks\HtmlParser();
+	// Unslash content to get actual HTML (WordPress adds slashes for database protection)
+	$content = wp_unslash( $content );
 
-	$dom = $html5->loadHTML( $content );
-	if ( ! $dom ) {
-		return $content;
-	}
+	// Use internal DOMDocument parser to avoid encoding issues
+	libxml_use_internal_errors( true );
+	
+	$dom = new \DOMDocument();
+	$dom->loadHTML( 
+		'<?xml encoding="UTF-8"><div>' . $content . '</div>',
+		LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD 
+	);
+	
+	libxml_clear_errors();
 
 	$xpath = new \DOMXPath( $dom );
 	$theads = $xpath->query( '//thead' );
@@ -577,7 +584,14 @@ function fix_table_header_cells( string $content ): string {
 		}
 	}
 
-	return $html5->saveHTML( $dom );
+	// Save and strip wrapper div
+	$html = $dom->saveHTML( $dom->documentElement );
+	// Remove the wrapper div we added
+	$html = preg_replace( '/^<div>(.*)<\/div>$/s', '$1', $html );
+	// Remove the XML encoding declaration if present
+	$html = preg_replace( '/<\?xml[^>]*>/i', '', $html );
+	
+	return $html;
 }
 
 /**

--- a/inc/editor/namespace.php
+++ b/inc/editor/namespace.php
@@ -528,11 +528,11 @@ function fix_table_header_cells( string $content ): string {
 		return $content;
 	}
 
-	// Protect LaTeX backslashes through WordPress slashing/unslashing
-	$latex_placeholder = '!@#LATEXBACKSLASH#@!';
-	$content = str_replace( '\\\\', $latex_placeholder, $content );
+	// Protect backslashes through WordPress slashing/unslashing
+	$backslash_placeholder = '!@#BACKSLASH#@!';
+	$content = str_replace( '\\\\', $backslash_placeholder, $content );
 	$content = wp_unslash( $content );
-	$content = str_replace( $latex_placeholder, '\\', $content );
+	$content = str_replace( $backslash_placeholder, '\\', $content );
 
 	// Parse HTML and transform table headers
 	libxml_use_internal_errors( true );
@@ -579,11 +579,11 @@ function fix_table_header_cells( string $content ): string {
 		}
 	}
 
-	// Save HTML and restore LaTeX backslashes through slashing
+	// Save HTML and restore backslashes through slashing
 	$html = $dom->saveHTML();
-	$html = str_replace( '\\', $latex_placeholder, $html );
+	$html = str_replace( '\\', $backslash_placeholder, $html );
 	$html = wp_slash( $html );
-	$html = str_replace( $latex_placeholder, '\\\\', $html );
+	$html = str_replace( $backslash_placeholder, '\\\\', $html );
 
 	return $html;
 }

--- a/inc/editor/namespace.php
+++ b/inc/editor/namespace.php
@@ -531,25 +531,22 @@ function fix_table_header_cells( string $content ): string {
 	// Unslash content to get actual HTML (WordPress adds slashes for database protection)
 	$content = wp_unslash( $content );
 
-	// Use internal DOMDocument parser to avoid encoding issues
 	libxml_use_internal_errors( true );
-	
+
 	$dom = new \DOMDocument();
-	$dom->loadHTML( 
+	$dom->loadHTML(
 		'<?xml encoding="UTF-8"><div>' . $content . '</div>',
-		LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD 
+		LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD
 	);
-	
+
 	libxml_clear_errors();
 
-	$xpath = new \DOMXPath( $dom );
-	$theads = $xpath->query( '//thead' );
+	$theads = $dom->getElementsByTagName( 'thead' );
 
 	foreach ( $theads as $thead ) {
-		// Get all td and th elements within rows
 		$rows = $thead->getElementsByTagName( 'tr' );
 		foreach ( $rows as $row ) {
-			// Convert NodeList to array to avoid issues with live collections during DOM modification
+			// Collect cells to avoid live collection issues
 			$cells = [];
 			foreach ( $row->childNodes as $node ) {
 				if ( $node->nodeType === XML_ELEMENT_NODE && ( $node->nodeName === 'td' || $node->nodeName === 'th' ) ) {
@@ -563,8 +560,7 @@ function fix_table_header_cells( string $content ): string {
 
 				// Convert td with content to th, or th without content to td
 				if ( ( $is_td && $has_content ) || ( ! $is_td && ! $has_content ) ) {
-					$new_tag = $is_td ? 'th' : 'td';
-					$new_cell = $dom->createElement( $new_tag );
+					$new_cell = $dom->createElement( $is_td ? 'th' : 'td' );
 
 					// Copy attributes
 					if ( $cell->hasAttributes() ) {
@@ -584,13 +580,12 @@ function fix_table_header_cells( string $content ): string {
 		}
 	}
 
-	// Save and strip wrapper div
-	$html = $dom->saveHTML( $dom->documentElement );
-	// Remove the wrapper div we added
-	$html = preg_replace( '/^<div>(.*)<\/div>$/s', '$1', $html );
-	// Remove the XML encoding declaration if present
-	$html = preg_replace( '/<\?xml[^>]*>/i', '', $html );
-	
+	// Save inner HTML without wrapper div
+	$html = '';
+	foreach ( $dom->documentElement->childNodes as $node ) {
+		$html .= $dom->saveHTML( $node );
+	}
+
 	return $html;
 }
 

--- a/inc/editor/namespace.php
+++ b/inc/editor/namespace.php
@@ -537,6 +537,10 @@ function fix_table_header_cells( string $content ): string {
 		foreach ( $thead->getElementsByTagName( 'td' ) as $td ) {
 			if ( trim( $td->textContent ) !== '' ) {
 				$th = $dom->createElement( 'th', $td->nodeValue );
+				$attributeNames = $td->getAttributeNames();
+				foreach ($attributeNames as $attributeName) {
+					$th->setAttribute($attributeName, $td->getAttribute($attributeName));
+				}
 				$td->replaceWith( $th );
 			}
 		}
@@ -545,6 +549,10 @@ function fix_table_header_cells( string $content ): string {
 		foreach ( $thead->getElementsByTagName( 'th' ) as $th ) {
 			if ( trim( $th->textContent ) === '' ) {
 				$td = $dom->createElement( 'td', '' );
+				$attributeNames = $th->getAttributeNames();
+				foreach ($attributeNames as $attributeName) {
+					$td->setAttribute($attributeName, $th->getAttribute($attributeName));
+				}
 				$th->replaceWith( $td );
 			}
 		}

--- a/inc/editor/namespace.php
+++ b/inc/editor/namespace.php
@@ -537,7 +537,7 @@ function fix_table_header_cells( string $content ): string {
 		foreach ( $thead->getElementsByTagName( 'td' ) as $td ) {
 			if ( trim( $td->textContent ) !== '' ) {
 				$th = $dom->createElement( 'th', $td->nodeValue );
-				$attribute_names = $td->getattribute_names();
+				$attribute_names = $td->getAttributeNames();
 				foreach ( $attribute_names as $attribute_name ) {
 					$th->setAttribute( $attribute_name, $td->getAttribute( $attribute_name ) );
 				}
@@ -549,7 +549,7 @@ function fix_table_header_cells( string $content ): string {
 		foreach ( $thead->getElementsByTagName( 'th' ) as $th ) {
 			if ( trim( $th->textContent ) === '' ) {
 				$td = $dom->createElement( 'td', '' );
-				$attribute_names = $th->getattribute_names();
+				$attribute_names = $th->getAttributeNames();
 				foreach ( $attribute_names as $attribute_name ) {
 					$td->setAttribute( $attribute_name, $th->getAttribute( $attribute_name ) );
 				}

--- a/inc/editor/namespace.php
+++ b/inc/editor/namespace.php
@@ -586,13 +586,8 @@ function fix_table_header_cells( string $content ): string {
 		$html .= $dom->saveHTML( $node );
 	}
 
-	return $html;
-}
-
-/**
- * Force classic editor mode
- */
-function hide_gutenberg() {
+	// Re-slash for WordPress (filter expects slashed content)
+	return wp_slash( $html );
 	// 4.9.X and below
 	deactivate_plugins( [ 'gutenberg/gutenberg.php' ] );
 

--- a/inc/editor/namespace.php
+++ b/inc/editor/namespace.php
@@ -581,6 +581,8 @@ function fix_table_header_cells( string $content ): string {
 
 	// Save HTML and restore backslashes through slashing
 	$html = $dom->saveHTML();
+	// Remove the XML declaration we added for UTF-8 parsing
+	$html = str_replace( '<?xml encoding="UTF-8">', '', $html );
 	$html = str_replace( '\\', $backslash_placeholder, $html );
 	$html = wp_slash( $html );
 	$html = str_replace( $backslash_placeholder, '\\\\', $html );

--- a/inc/editor/namespace.php
+++ b/inc/editor/namespace.php
@@ -528,14 +528,22 @@ function fix_table_header_cells( string $content ): string {
 		return $content;
 	}
 
+	// Protect LaTeX backslashes before unslashing by replacing with unique placeholder
+	$latex_placeholder = '!@#LATEXBACKSLASH#@!';
+	$content = str_replace( '\\\\', $latex_placeholder, $content );
+
 	// Unslash content to get actual HTML (WordPress adds slashes for database protection)
 	$content = wp_unslash( $content );
 
+	// Restore LaTeX backslashes
+	$content = str_replace( $latex_placeholder, '\\', $content );
+
 	libxml_use_internal_errors( true );
 
-	$dom = new \DOMDocument();
+	$dom = new \DOMDocument( '1.0', 'UTF-8' );
+	// Wrap content in div to preserve structure, load as UTF-8
 	$dom->loadHTML(
-		'<?xml encoding="UTF-8"><div>' . $content . '</div>',
+		'<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head><body>' . $content . '</body></html>',
 		LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD
 	);
 
@@ -580,14 +588,25 @@ function fix_table_header_cells( string $content ): string {
 		}
 	}
 
-	// Save inner HTML without wrapper div
+	// Extract the body content (DOMDocument wraps content in html/body tags)
 	$html = '';
-	foreach ( $dom->documentElement->childNodes as $node ) {
-		$html .= $dom->saveHTML( $node );
+	$body = $dom->getElementsByTagName( 'body' )->item( 0 );
+	if ( $body ) {
+		foreach ( $body->childNodes as $node ) {
+			$html .= $dom->saveHTML( $node );
+		}
 	}
 
+	// Protect LaTeX backslashes again before slashing (DOMDocument may have single backslashes)
+	$html = str_replace( '\\', $latex_placeholder, $html );
+
 	// Re-slash for WordPress (filter expects slashed content)
-	return wp_slash( $html );
+	$html = wp_slash( $html );
+
+	// Restore LaTeX backslashes as double-backslashes (for WordPress slashed output)
+	$html = str_replace( $latex_placeholder, '\\\\', $html );
+
+	return $html;
 }
 
 /**

--- a/inc/editor/namespace.php
+++ b/inc/editor/namespace.php
@@ -533,24 +533,37 @@ function fix_table_header_cells( string $content ): string {
 		callback: function( $matches ) {
 			$thead = $matches[0];
 
-			// Replace individual td elements, checking if they have content
-			return preg_replace_callback(
+			// Convert <td> with content to <th>
+			$thead = preg_replace_callback(
 				pattern: '/<td\b([^>]*)>(.*?)<\/td>/is',
 				callback: function( $td_matches ) {
 					$attributes = $td_matches[1];
 					$content = $td_matches[2];
 
-					// Check if the td has any content (not just whitespace)
 					if ( trim( $content ) !== '' ) {
-						// Convert to th if it has content
 						return '<th' . $attributes . '>' . $content . '</th>';
 					}
-
-					// Keep as td if empty
 					return $td_matches[0];
 				},
 				subject: $thead
 			);
+
+			// Convert empty <th> to <td>
+			$thead = preg_replace_callback(
+				pattern: '/<th\b([^>]*)>(.*?)<\/th>/is',
+				callback: function( $th_matches ) {
+					$attributes = $th_matches[1];
+					$content = $th_matches[2];
+
+					if ( trim( $content ) === '' ) {
+						return '<td' . $attributes . '>' . $content . '</td>';
+					}
+					return $th_matches[0];
+				},
+				subject: $thead
+			);
+
+			return $thead;
 		},
 		subject: $content
 	);

--- a/inc/editor/namespace.php
+++ b/inc/editor/namespace.php
@@ -12,7 +12,6 @@
 namespace Pressbooks\Editor;
 
 use function Pressbooks\Sanitize\normalize_css_urls;
-use Masterminds\HTML5;
 use PressbooksMix\Assets;
 use Pressbooks\Container;
 use Pressbooks\HtmlParser;
@@ -530,7 +529,7 @@ function fix_table_header_cells( string $content ): string {
 	}
 
 	$html5 = new \Masterminds\HTML5( [ 'disable_html_ns' => true ] );
-	
+
 	$dom_fragment = $html5->loadHTMLFragment( $content );
 	if ( ! $dom_fragment ) {
 		return $content;
@@ -560,19 +559,19 @@ function fix_table_header_cells( string $content ): string {
 				if ( ( $is_td && $has_content ) || ( ! $is_td && ! $has_content ) ) {
 					$new_tag = $is_td ? 'th' : 'td';
 					$new_cell = $dom->createElement( $new_tag );
-					
+
 					// Copy attributes
 					if ( $cell->hasAttributes() ) {
 						foreach ( $cell->attributes as $attr ) {
 							$new_cell->setAttribute( $attr->name, $attr->value );
 						}
 					}
-					
+
 					// Copy child nodes
 					while ( $cell->firstChild ) {
 						$new_cell->appendChild( $cell->firstChild );
 					}
-					
+
 					$cell->parentNode->replaceChild( $new_cell, $cell );
 				}
 			}

--- a/inc/editor/namespace.php
+++ b/inc/editor/namespace.php
@@ -528,45 +528,63 @@ function fix_table_header_cells( string $content ): string {
 		return $content;
 	}
 
-	return preg_replace_callback(
-		pattern: '/<thead\b[^>]*>.*?<\/thead>/is',
-		callback: function( $matches ) {
-			$thead = $matches[0];
+	$html5 = new \Masterminds\HTML5( [ 'disable_html_ns' => true ] );
+	
+	$dom_fragment = $html5->loadHTMLFragment( $content );
+	if ( ! $dom_fragment ) {
+		return $content;
+	}
 
-			// Convert <td> with content to <th>
-			$thead = preg_replace_callback(
-				pattern: '/<td\b([^>]*)>(.*?)<\/td>/is',
-				callback: function( $td_matches ) {
-					$attributes = $td_matches[1];
-					$content = $td_matches[2];
+	$dom = $dom_fragment->ownerDocument;
+	$xpath = new \DOMXPath( $dom );
+	$theads = $xpath->query( './/thead', $dom_fragment );
 
-					if ( trim( $content ) !== '' ) {
-						return '<th' . $attributes . '>' . $content . '</th>';
+	foreach ( $theads as $thead ) {
+		// Get all td and th elements within rows
+		$rows = $thead->getElementsByTagName( 'tr' );
+		foreach ( $rows as $row ) {
+			// Convert NodeList to array to avoid issues with live collections during DOM modification
+			$cells = [];
+			foreach ( $row->childNodes as $node ) {
+				if ( $node->nodeType === XML_ELEMENT_NODE && ( $node->nodeName === 'td' || $node->nodeName === 'th' ) ) {
+					$cells[] = $node;
+				}
+			}
+
+			foreach ( $cells as $cell ) {
+				$has_content = trim( $cell->textContent ) !== '';
+				$is_td = $cell->nodeName === 'td';
+
+				// Convert td with content to th, or th without content to td
+				if ( ( $is_td && $has_content ) || ( ! $is_td && ! $has_content ) ) {
+					$new_tag = $is_td ? 'th' : 'td';
+					$new_cell = $dom->createElement( $new_tag );
+					
+					// Copy attributes
+					if ( $cell->hasAttributes() ) {
+						foreach ( $cell->attributes as $attr ) {
+							$new_cell->setAttribute( $attr->name, $attr->value );
+						}
 					}
-					return $td_matches[0];
-				},
-				subject: $thead
-			);
-
-			// Convert empty <th> to <td>
-			$thead = preg_replace_callback(
-				pattern: '/<th\b([^>]*)>(.*?)<\/th>/is',
-				callback: function( $th_matches ) {
-					$attributes = $th_matches[1];
-					$content = $th_matches[2];
-
-					if ( trim( $content ) === '' ) {
-						return '<td' . $attributes . '>' . $content . '</td>';
+					
+					// Copy child nodes
+					while ( $cell->firstChild ) {
+						$new_cell->appendChild( $cell->firstChild );
 					}
-					return $th_matches[0];
-				},
-				subject: $thead
-			);
+					
+					$cell->parentNode->replaceChild( $new_cell, $cell );
+				}
+			}
+		}
+	}
 
-			return $thead;
-		},
-		subject: $content
-	);
+	// Serialize the fragment back to HTML
+	$result = '';
+	foreach ( $dom_fragment->childNodes as $node ) {
+		$result .= $html5->saveHTML( $node );
+	}
+
+	return $result ?: $content;
 }
 
 /**

--- a/inc/editor/namespace.php
+++ b/inc/editor/namespace.php
@@ -537,9 +537,9 @@ function fix_table_header_cells( string $content ): string {
 		foreach ( $thead->getElementsByTagName( 'td' ) as $td ) {
 			if ( trim( $td->textContent ) !== '' ) {
 				$th = $dom->createElement( 'th', $td->nodeValue );
-				$attributeNames = $td->getAttributeNames();
-				foreach ( $attributeNames as $attributeName ) {
-					$th->setAttribute( $attributeName, $td->getAttribute( $attributeName ) );
+				$attribute_names = $td->getattribute_names();
+				foreach ( $attribute_names as $attribute_name ) {
+					$th->setAttribute( $attribute_name, $td->getAttribute( $attribute_name ) );
 				}
 				$td->replaceWith( $th );
 			}
@@ -549,9 +549,9 @@ function fix_table_header_cells( string $content ): string {
 		foreach ( $thead->getElementsByTagName( 'th' ) as $th ) {
 			if ( trim( $th->textContent ) === '' ) {
 				$td = $dom->createElement( 'td', '' );
-				$attributeNames = $th->getAttributeNames();
-				foreach ( $attributeNames as $attributeName ) {
-					$td->setAttribute( $attributeName, $th->getAttribute( $attributeName ) );
+				$attribute_names = $th->getattribute_names();
+				foreach ( $attribute_names as $attribute_name ) {
+					$td->setAttribute( $attribute_name, $th->getAttribute( $attribute_name ) );
 				}
 				$th->replaceWith( $td );
 			}

--- a/inc/editor/namespace.php
+++ b/inc/editor/namespace.php
@@ -528,16 +528,15 @@ function fix_table_header_cells( string $content ): string {
 		return $content;
 	}
 
-	$html5 = new \Masterminds\HTML5( [ 'disable_html_ns' => true ] );
+	$html5 = new \Pressbooks\HtmlParser();
 
-	$dom_fragment = $html5->loadHTMLFragment( $content );
-	if ( ! $dom_fragment ) {
+	$dom = $html5->loadHTML( $content );
+	if ( ! $dom ) {
 		return $content;
 	}
 
-	$dom = $dom_fragment->ownerDocument;
 	$xpath = new \DOMXPath( $dom );
-	$theads = $xpath->query( './/thead', $dom_fragment );
+	$theads = $xpath->query( '//thead' );
 
 	foreach ( $theads as $thead ) {
 		// Get all td and th elements within rows
@@ -578,13 +577,7 @@ function fix_table_header_cells( string $content ): string {
 		}
 	}
 
-	// Serialize the fragment back to HTML
-	$result = '';
-	foreach ( $dom_fragment->childNodes as $node ) {
-		$result .= $html5->saveHTML( $node );
-	}
-
-	return $result ?: $content;
+	return $html5->saveHTML( $dom );
 }
 
 /**

--- a/inc/editor/namespace.php
+++ b/inc/editor/namespace.php
@@ -516,6 +516,47 @@ function show_kitchen_sink( $args ) {
 }
 
 /**
+ * Convert <td> elements to <th> elements in table header rows if they contain content.
+ *
+ * @param string $content Post content
+ *
+ * @return string Modified content with proper <th> elements in table headers
+ */
+function fix_table_header_cells( string $content ): string {
+	// Only process if content contains tables with thead
+	if ( empty( $content ) || ! str_contains( $content, '<thead' ) ) {
+		return $content;
+	}
+
+	return preg_replace_callback(
+		pattern: '/<thead\b[^>]*>.*?<\/thead>/is',
+		callback: function( $matches ) {
+			$thead = $matches[0];
+
+			// Replace individual td elements, checking if they have content
+			return preg_replace_callback(
+				pattern: '/<td\b([^>]*)>(.*?)<\/td>/is',
+				callback: function( $td_matches ) {
+					$attributes = $td_matches[1];
+					$content = $td_matches[2];
+
+					// Check if the td has any content (not just whitespace)
+					if ( trim( $content ) !== '' ) {
+						// Convert to th if it has content
+						return '<th' . $attributes . '>' . $content . '</th>';
+					}
+
+					// Keep as td if empty
+					return $td_matches[0];
+				},
+				subject: $thead
+			);
+		},
+		subject: $content
+	);
+}
+
+/**
  * Force classic editor mode
  */
 function hide_gutenberg() {

--- a/inc/editor/namespace.php
+++ b/inc/editor/namespace.php
@@ -588,6 +588,12 @@ function fix_table_header_cells( string $content ): string {
 
 	// Re-slash for WordPress (filter expects slashed content)
 	return wp_slash( $html );
+}
+
+/**
+* Force classic editor mode
+*/
+function hide_gutenberg() {
 	// 4.9.X and below
 	deactivate_plugins( [ 'gutenberg/gutenberg.php' ] );
 

--- a/tests/test-editor.php
+++ b/tests/test-editor.php
@@ -272,13 +272,13 @@ class EditorTest extends \WP_UnitTestCase {
 		// Test comprehensive content preservation: LaTeX, quotes, mixed HTML, and table transformations
 		$input_complex = '<p>LaTeX: \[ f(x) = \frac{1}{2} \]</p><p>There are "double quotes" and \'single quotes\' here.</p><span class="strong">Bold text</span><table class="grid"><thead><tr><td>\[ x = y \]</td><td>Normal Header</td><td>\sum_{i=1}^{n} i</td></tr></thead><tbody><tr><td>Data</td><td>More data</td></tr></tbody></table><p>Paragraph after</p>';
 		$result_complex = \Pressbooks\Editor\fix_table_header_cells( wp_slash( $input_complex ) );
-		// LaTeX should be preserved both inside and outside table
-		$this->assertStringContainsString( '\\[ f(x) = \\frac{1}{2} \\]', $result_complex );
-		$this->assertStringContainsString( '<th>\\[ x = y \\]</th>', $result_complex );
-		$this->assertStringContainsString( '<th>\\sum_{i=1}^{n} i</th>', $result_complex );
+		// LaTeX should be preserved with double backslashes (slashed output)
+		$this->assertStringContainsString( '\\\\[ f(x) = \\\\frac{1}{2} \\\\]', $result_complex );
+		$this->assertStringContainsString( '<th>\\\\[ x = y \\\\]</th>', $result_complex );
+		$this->assertStringContainsString( '<th>\\\\sum_{i=1}^{n} i</th>', $result_complex );
 		// Quotes should be preserved
 		$this->assertStringContainsString( '\"double quotes\"', $result_complex );
-		$this->assertStringContainsString( "\'single quotes\'", $result_complex );
+		$this->assertStringContainsString( "\\'single quotes\\'", $result_complex );
 		// HTML elements should be preserved
 		$this->assertStringContainsString( '<span class=\"strong\">Bold text</span>', $result_complex );
 		$this->assertStringContainsString( '<p>Paragraph after</p>', $result_complex );

--- a/tests/test-editor.php
+++ b/tests/test-editor.php
@@ -239,5 +239,21 @@ class EditorTest extends \WP_UnitTestCase {
 		$input_no_table = '<p>This is just text</p>';
 		$result_no_table = \Pressbooks\Editor\fix_table_header_cells( $input_no_table );
 		$this->assertEquals( $input_no_table, $result_no_table );
+
+		// Test thead with empty th elements (should convert to td)
+		$input_empty_th = '<table><thead><tr><th>Header</th><th></th><th>  </th><th>Another Header</th></tr></thead></table>';
+		$result_empty_th = \Pressbooks\Editor\fix_table_header_cells( $input_empty_th );
+		$this->assertStringContainsString( '<th>Header</th>', $result_empty_th );
+		$this->assertStringContainsString( '<td></td>', $result_empty_th );
+		$this->assertStringContainsString( '<td>  </td>', $result_empty_th );
+		$this->assertStringContainsString( '<th>Another Header</th>', $result_empty_th );
+
+		// Test thead with mix of empty and non-empty th and td
+		$input_mixed = '<table><thead><tr><td>Header</td><td></td><th></th><td>Another Header</td><th>  </th></tr></thead></table>';
+		$result_mixed = \Pressbooks\Editor\fix_table_header_cells( $input_mixed );
+		$this->assertStringContainsString( '<th>Header</th>', $result_mixed );
+		$this->assertStringContainsString( '<td></td>', $result_mixed );
+		$this->assertStringContainsString( '<td>  </td>', $result_mixed );
+		$this->assertStringContainsString( '<th>Another Header</th>', $result_mixed );
 	}
 }

--- a/tests/test-editor.php
+++ b/tests/test-editor.php
@@ -286,5 +286,15 @@ class EditorTest extends \WP_UnitTestCase {
 		$this->assertStringContainsString( '<th>Normal Header</th>', $result_complex );
 		// Table body should be unchanged
 		$this->assertStringContainsString( '<tbody><tr><td>Data</td><td>More data</td></tr></tbody>', $result_complex );
+
+		// Test UTF-8 special characters (curly quotes, em dash, international characters)
+		$input_utf8 = '<table><thead><tr><td>Café</td><td>Niño</td><td>"Curly" Quotes</td><td>Em—Dash</td><td>中文</td></tr></thead></table>';
+		$result_utf8 = \Pressbooks\Editor\fix_table_header_cells( wp_slash( $input_utf8 ) );
+		// DOMDocument encodes special characters as HTML entities - verify they're preserved
+		$this->assertStringContainsString( '<th>Caf&eacute;</th>', $result_utf8 );
+		$this->assertStringContainsString( '<th>Ni&ntilde;o</th>', $result_utf8 );
+		$this->assertStringContainsString( '<th>\"Curly\" Quotes</th>', $result_utf8 );
+		$this->assertStringContainsString( '<th>Em&mdash;Dash</th>', $result_utf8 );
+		$this->assertStringContainsString( '<th>&#20013;&#25991;</th>', $result_utf8 );
 	}
 }

--- a/tests/test-editor.php
+++ b/tests/test-editor.php
@@ -199,4 +199,45 @@ class EditorTest extends \WP_UnitTestCase {
 		$this->assertFalse( is_plugin_active( 'gutenberg/gutenberg.php' ) );
 		$this->assertEquals( 'replace', get_option( 'classic-editor-replace' ) );
 	}
+
+	/**
+	 * @group editor
+	 */
+	public function test_fix_table_header_cells() {
+		// Test table with thead containing td elements (what TinyMCE creates)
+		$input = '<table><thead><tr><td>Header 1</td><td class="test">Header 2</td><td colspan="2">Header 3</td></tr></thead><tbody><tr><td>Data 1</td><td>Data 2</td><td>Data 3</td></tr></tbody></table>';
+		$result = \Pressbooks\Editor\fix_table_header_cells( $input );
+
+		// Should convert td to th in thead
+		$this->assertStringContainsString( '<thead><tr><th>Header 1</th>', $result );
+		$this->assertStringContainsString( '<th class="test">Header 2</th>', $result );
+		$this->assertStringContainsString( '<th colspan="2">Header 3</th>', $result );
+
+		// Should NOT convert td to th in tbody
+		$this->assertStringContainsString( '<tbody><tr><td>Data 1</td>', $result );
+		$this->assertStringContainsString( '<td>Data 2</td>', $result );
+		$this->assertStringContainsString( '<td>Data 3</td>', $result );
+
+		// Test thead with empty td elements (should remain as td)
+		$input_empty_cells = '<table><thead><tr><td>Header</td><td></td><td>  </td><td>Another Header</td></tr></thead></table>';
+		$result_empty_cells = \Pressbooks\Editor\fix_table_header_cells( $input_empty_cells );
+		$this->assertStringContainsString( '<th>Header</th>', $result_empty_cells );
+		$this->assertStringContainsString( '<td></td>', $result_empty_cells );
+		$this->assertStringContainsString( '<td>  </td>', $result_empty_cells );
+		$this->assertStringContainsString( '<th>Another Header</th>', $result_empty_cells );
+
+		// Test content without thead (should return unchanged)
+		$input_no_thead = '<table><tbody><tr><td>Data 1</td><td>Data 2</td></tr></tbody></table>';
+		$result_no_thead = \Pressbooks\Editor\fix_table_header_cells( $input_no_thead );
+		$this->assertEquals( $input_no_thead, $result_no_thead );
+
+		// Test empty content
+		$result_empty = \Pressbooks\Editor\fix_table_header_cells( '' );
+		$this->assertEquals( '', $result_empty );
+
+		// Test content with no tables
+		$input_no_table = '<p>This is just text</p>';
+		$result_no_table = \Pressbooks\Editor\fix_table_header_cells( $input_no_table );
+		$this->assertEquals( $input_no_table, $result_no_table );
+	}
 }

--- a/tests/test-editor.php
+++ b/tests/test-editor.php
@@ -206,12 +206,12 @@ class EditorTest extends \WP_UnitTestCase {
 	public function test_fix_table_header_cells() {
 		// Test table with thead containing td elements (what TinyMCE creates)
 		$input = '<table><thead><tr><td>Header 1</td><td class="test">Header 2</td><td colspan="2">Header 3</td></tr></thead><tbody><tr><td>Data 1</td><td>Data 2</td><td>Data 3</td></tr></tbody></table>';
-		$result = \Pressbooks\Editor\fix_table_header_cells( $input );
+		$result = \Pressbooks\Editor\fix_table_header_cells( wp_slash( $input ) );
 
 		// Should convert td to th in thead
 		$this->assertStringContainsString( '<thead><tr><th>Header 1</th>', $result );
-		$this->assertStringContainsString( '<th class="test">Header 2</th>', $result );
-		$this->assertStringContainsString( '<th colspan="2">Header 3</th>', $result );
+		$this->assertStringContainsString( '<th class=\"test\">Header 2</th>', $result );
+		$this->assertStringContainsString( '<th colspan=\"2\">Header 3</th>', $result );
 
 		// Should NOT convert td to th in tbody
 		$this->assertStringContainsString( '<tbody><tr><td>Data 1</td>', $result );
@@ -220,7 +220,7 @@ class EditorTest extends \WP_UnitTestCase {
 
 		// Test thead with empty td elements (should remain as td)
 		$input_empty_cells = '<table><thead><tr><td>Header</td><td></td><td>  </td><td>Another Header</td></tr></thead></table>';
-		$result_empty_cells = \Pressbooks\Editor\fix_table_header_cells( $input_empty_cells );
+		$result_empty_cells = \Pressbooks\Editor\fix_table_header_cells( wp_slash( $input_empty_cells ) );
 		$this->assertStringContainsString( '<th>Header</th>', $result_empty_cells );
 		$this->assertStringContainsString( '<td></td>', $result_empty_cells );
 		$this->assertStringContainsString( '<td>  </td>', $result_empty_cells );
@@ -228,8 +228,8 @@ class EditorTest extends \WP_UnitTestCase {
 
 		// Test content without thead (should return unchanged)
 		$input_no_thead = '<table><tbody><tr><td>Data 1</td><td>Data 2</td></tr></tbody></table>';
-		$result_no_thead = \Pressbooks\Editor\fix_table_header_cells( $input_no_thead );
-		$this->assertEquals( $input_no_thead, $result_no_thead );
+		$result_no_thead = \Pressbooks\Editor\fix_table_header_cells( wp_slash( $input_no_thead ) );
+		$this->assertEquals( wp_slash( $input_no_thead ), $result_no_thead );
 
 		// Test empty content
 		$result_empty = \Pressbooks\Editor\fix_table_header_cells( '' );
@@ -237,12 +237,12 @@ class EditorTest extends \WP_UnitTestCase {
 
 		// Test content with no tables
 		$input_no_table = '<p>This is just text</p>';
-		$result_no_table = \Pressbooks\Editor\fix_table_header_cells( $input_no_table );
-		$this->assertEquals( $input_no_table, $result_no_table );
+		$result_no_table = \Pressbooks\Editor\fix_table_header_cells( wp_slash( $input_no_table ) );
+		$this->assertEquals( wp_slash( $input_no_table ), $result_no_table );
 
 		// Test thead with empty th elements (should convert to td)
 		$input_empty_th = '<table><thead><tr><th>Header</th><th></th><th>  </th><th>Another Header</th></tr></thead></table>';
-		$result_empty_th = \Pressbooks\Editor\fix_table_header_cells( $input_empty_th );
+		$result_empty_th = \Pressbooks\Editor\fix_table_header_cells( wp_slash( $input_empty_th ) );
 		$this->assertStringContainsString( '<th>Header</th>', $result_empty_th );
 		$this->assertStringContainsString( '<td></td>', $result_empty_th );
 		$this->assertStringContainsString( '<td>  </td>', $result_empty_th );
@@ -250,7 +250,7 @@ class EditorTest extends \WP_UnitTestCase {
 
 		// Test thead with mix of empty and non-empty th and td
 		$input_mixed = '<table><thead><tr><td>Header</td><td></td><th></th><td>Another Header</td><th>  </th></tr></thead></table>';
-		$result_mixed = \Pressbooks\Editor\fix_table_header_cells( $input_mixed );
+		$result_mixed = \Pressbooks\Editor\fix_table_header_cells( wp_slash( $input_mixed ) );
 		$this->assertStringContainsString( '<th>Header</th>', $result_mixed );
 		$this->assertStringContainsString( '<td></td>', $result_mixed );
 		$this->assertStringContainsString( '<td>  </td>', $result_mixed );
@@ -258,13 +258,13 @@ class EditorTest extends \WP_UnitTestCase {
 
 		// Test that attributes are not double-encoded
 		$input_with_attrs = '<table class="grid" border="0"><thead><tr><th colspan="1" class="some-class">This is a Header</th><th colspan="1">This is another Header</th><td colspan="1"></td><td colspan="1"></td></tr></thead><tbody><tr><td>This is a column</td><td>This is another column</td><td>This is another column</td><td></td></tr></tbody></table>';
-		$result_with_attrs = \Pressbooks\Editor\fix_table_header_cells( $input_with_attrs );
+		$result_with_attrs = \Pressbooks\Editor\fix_table_header_cells( wp_slash( $input_with_attrs ) );
 
 		// Verify attributes are preserved correctly without double encoding
-		$this->assertStringContainsString( 'class="grid"', $result_with_attrs );
-		$this->assertStringContainsString( 'border="0"', $result_with_attrs );
-		$this->assertStringContainsString( 'colspan="1"', $result_with_attrs );
-		$this->assertStringContainsString( 'class="some-class"', $result_with_attrs );
+		$this->assertStringContainsString( 'class=\"grid\"', $result_with_attrs );
+		$this->assertStringContainsString( 'border=\"0\"', $result_with_attrs );
+		$this->assertStringContainsString( 'colspan=\"1\"', $result_with_attrs );
+		$this->assertStringContainsString( 'class=\"some-class\"', $result_with_attrs );
 
 		// Verify attributes are NOT double-encoded
 		$this->assertStringNotContainsString( '&quot;&quot;grid&quot;&quot;', $result_with_attrs );
@@ -273,26 +273,26 @@ class EditorTest extends \WP_UnitTestCase {
 		$this->assertStringNotContainsString( '&quot;&quot;some-class&quot;&quot;', $result_with_attrs );
 
 		// Verify empty td cells remain as td
-		$this->assertStringContainsString( '<td colspan="1"></td>', $result_with_attrs );
+		$this->assertStringContainsString( '<td colspan=\"1\"></td>', $result_with_attrs );
 
 		// Test that LaTeX backslashes are preserved
 		$input_with_latex = '<p>LaTeX: \[ f(x) = \frac{1}{2} \]</p><table><thead><tr><td>Header</td></tr></thead></table>';
-		$result_with_latex = \Pressbooks\Editor\fix_table_header_cells( $input_with_latex );
+		$result_with_latex = \Pressbooks\Editor\fix_table_header_cells( wp_slash( $input_with_latex ) );
 		$this->assertStringContainsString( '\[ f(x) = \frac{1}{2} \]', $result_with_latex );
 		$this->assertStringContainsString( '<th>Header</th>', $result_with_latex );
 
 		// Test that quotes are preserved (single and double)
 		$input_with_quotes = '<p>There are "double quotes" and \'single quotes\' here.</p><table><thead><tr><td>Header</td></tr></thead></table>';
-		$result_with_quotes = \Pressbooks\Editor\fix_table_header_cells( $input_with_quotes );
-		$this->assertStringContainsString( '"double quotes"', $result_with_quotes );
-		$this->assertStringContainsString( "'single quotes'", $result_with_quotes );
+		$result_with_quotes = \Pressbooks\Editor\fix_table_header_cells( wp_slash( $input_with_quotes ) );
+		$this->assertStringContainsString( '\"double quotes\"', $result_with_quotes );
+		$this->assertStringContainsString( "\'single quotes\'", $result_with_quotes );
 		$this->assertStringContainsString( '<th>Header</th>', $result_with_quotes );
 
 		// Test mixed content with tables and other HTML elements
 		$input_mixed = '<p>Paragraph before</p><span class="strong">Bold text</span><table class="grid"><thead><tr><td>Col 1</td><td>Col 2</td></tr></thead><tbody><tr><td>Data</td><td>More data</td></tr></tbody></table><p>Paragraph after</p>';
-		$result_mixed = \Pressbooks\Editor\fix_table_header_cells( $input_mixed );
+		$result_mixed = \Pressbooks\Editor\fix_table_header_cells( wp_slash( $input_mixed ) );
 		$this->assertStringContainsString( '<p>Paragraph before</p>', $result_mixed );
-		$this->assertStringContainsString( '<span class="strong">Bold text</span>', $result_mixed );
+		$this->assertStringContainsString( '<span class=\"strong\">Bold text</span>', $result_mixed );
 		$this->assertStringContainsString( '<th>Col 1</th>', $result_mixed );
 		$this->assertStringContainsString( '<th>Col 2</th>', $result_mixed );
 		$this->assertStringContainsString( '<p>Paragraph after</p>', $result_mixed );

--- a/tests/test-editor.php
+++ b/tests/test-editor.php
@@ -278,7 +278,7 @@ class EditorTest extends \WP_UnitTestCase {
 		// Test that LaTeX backslashes are preserved
 		$input_with_latex = '<p>LaTeX: \[ f(x) = \frac{1}{2} \]</p><table><thead><tr><td>Header</td></tr></thead></table>';
 		$result_with_latex = \Pressbooks\Editor\fix_table_header_cells( wp_slash( $input_with_latex ) );
-		$this->assertStringContainsString( '\[ f(x) = \frac{1}{2} \]', $result_with_latex );
+		$this->assertStringContainsString( '\\[ f(x) = \\frac{1}{2} \\]', $result_with_latex );
 		$this->assertStringContainsString( '<th>Header</th>', $result_with_latex );
 
 		// Test that quotes are preserved (single and double)

--- a/tests/test-editor.php
+++ b/tests/test-editor.php
@@ -204,97 +204,48 @@ class EditorTest extends \WP_UnitTestCase {
 	 * @group editor
 	 */
 	public function test_fix_table_header_cells() {
-		// Test table with thead containing td elements (what TinyMCE creates)
-		$input = '<table><thead><tr><td>Header 1</td><td class="test">Header 2</td><td colspan="2">Header 3</td></tr></thead><tbody><tr><td>Data 1</td><td>Data 2</td><td>Data 3</td></tr></tbody></table>';
+		// Test comprehensive table: td→th conversion, attributes, empty cells, tbody preservation
+		$input = '<table class="grid" border="0"><thead><tr><td>Header 1</td><td class="test">Header 2</td><td colspan="2">Header 3</td><td></td><th>  </th><th colspan="1" class="existing">Already TH</th></tr></thead><tbody><tr><td>Data 1</td><td>Data 2</td><td>Data 3</td><td></td></tr></tbody></table>';
 		$result = \Pressbooks\Editor\fix_table_header_cells( wp_slash( $input ) );
-
-		// Should convert td to th in thead
-		$this->assertStringContainsString( '<thead><tr><th>Header 1</th>', $result );
+		
+		// Non-empty td should convert to th with attributes preserved
+		$this->assertStringContainsString( '<th>Header 1</th>', $result );
 		$this->assertStringContainsString( '<th class=\"test\">Header 2</th>', $result );
 		$this->assertStringContainsString( '<th colspan=\"2\">Header 3</th>', $result );
+		$this->assertStringContainsString( '<th colspan=\"1\" class=\"existing\">Already TH</th>', $result );
+		// Empty cells should become td
+		$this->assertStringContainsString( '<td></td>', $result );
+		$this->assertStringContainsString( '<td>  </td>', $result );
+		// Table attributes preserved without double-encoding
+		$this->assertStringContainsString( 'class=\"grid\"', $result );
+		$this->assertStringContainsString( 'border=\"0\"', $result );
+		$this->assertStringNotContainsString( '&quot;&quot;', $result );
+		// tbody should remain unchanged
+		$this->assertStringContainsString( '<tbody><tr><td>Data 1</td><td>Data 2</td><td>Data 3</td><td></td></tr></tbody>', $result );
 
-		// Should NOT convert td to th in tbody
-		$this->assertStringContainsString( '<tbody><tr><td>Data 1</td>', $result );
-		$this->assertStringContainsString( '<td>Data 2</td>', $result );
-		$this->assertStringContainsString( '<td>Data 3</td>', $result );
+		// Test edge cases: no thead, no tables, empty content
+		$this->assertEquals( wp_slash( '<table><tbody><tr><td>Data</td></tr></tbody></table>' ), \Pressbooks\Editor\fix_table_header_cells( wp_slash( '<table><tbody><tr><td>Data</td></tr></tbody></table>' ) ) );
+		$this->assertEquals( wp_slash( '<p>Just text</p>' ), \Pressbooks\Editor\fix_table_header_cells( wp_slash( '<p>Just text</p>' ) ) );
+		$this->assertEquals( '', \Pressbooks\Editor\fix_table_header_cells( '' ) );
 
-		// Test thead with empty td elements (should remain as td)
-		$input_empty_cells = '<table><thead><tr><td>Header</td><td></td><td>  </td><td>Another Header</td></tr></thead></table>';
-		$result_empty_cells = \Pressbooks\Editor\fix_table_header_cells( wp_slash( $input_empty_cells ) );
-		$this->assertStringContainsString( '<th>Header</th>', $result_empty_cells );
-		$this->assertStringContainsString( '<td></td>', $result_empty_cells );
-		$this->assertStringContainsString( '<td>  </td>', $result_empty_cells );
-		$this->assertStringContainsString( '<th>Another Header</th>', $result_empty_cells );
-
-		// Test content without thead (should return unchanged)
-		$input_no_thead = '<table><tbody><tr><td>Data 1</td><td>Data 2</td></tr></tbody></table>';
-		$result_no_thead = \Pressbooks\Editor\fix_table_header_cells( wp_slash( $input_no_thead ) );
-		$this->assertEquals( wp_slash( $input_no_thead ), $result_no_thead );
-
-		// Test empty content
-		$result_empty = \Pressbooks\Editor\fix_table_header_cells( '' );
-		$this->assertEquals( '', $result_empty );
-
-		// Test content with no tables
-		$input_no_table = '<p>This is just text</p>';
-		$result_no_table = \Pressbooks\Editor\fix_table_header_cells( wp_slash( $input_no_table ) );
-		$this->assertEquals( wp_slash( $input_no_table ), $result_no_table );
-
-		// Test empty and mixed cell handling in thead
-		$input_mixed_cells = '<table><thead><tr><th>Header</th><th></th><td>Another Header</td><td></td><th>  </th></tr></thead></table>';
-		$result_mixed_cells = \Pressbooks\Editor\fix_table_header_cells( wp_slash( $input_mixed_cells ) );
-		// Non-empty cells should be th
-		$this->assertStringContainsString( '<th>Header</th>', $result_mixed_cells );
-		$this->assertStringContainsString( '<th>Another Header</th>', $result_mixed_cells );
-		// Empty cells (both th and td) should become td
-		$this->assertStringContainsString( '<td></td>', $result_mixed_cells );
-		$this->assertStringContainsString( '<td>  </td>', $result_mixed_cells );
-
-		// Test that attributes are not double-encoded
-		$input_with_attrs = '<table class="grid" border="0"><thead><tr><th colspan="1" class="some-class">This is a Header</th><th colspan="1">This is another Header</th><td colspan="1"></td><td colspan="1"></td></tr></thead><tbody><tr><td>This is a column</td><td>This is another column</td><td>This is another column</td><td></td></tr></tbody></table>';
-		$result_with_attrs = \Pressbooks\Editor\fix_table_header_cells( wp_slash( $input_with_attrs ) );
-
-		// Verify attributes are preserved correctly without double encoding
-		$this->assertStringContainsString( 'class=\"grid\"', $result_with_attrs );
-		$this->assertStringContainsString( 'border=\"0\"', $result_with_attrs );
-		$this->assertStringContainsString( 'colspan=\"1\"', $result_with_attrs );
-		$this->assertStringContainsString( 'class=\"some-class\"', $result_with_attrs );
-
-		// Verify attributes are NOT double-encoded
-		$this->assertStringNotContainsString( '&quot;&quot;grid&quot;&quot;', $result_with_attrs );
-		$this->assertStringNotContainsString( '&quot;&quot;0&quot;&quot;', $result_with_attrs );
-		$this->assertStringNotContainsString( '&quot;&quot;1&quot;&quot;', $result_with_attrs );
-		$this->assertStringNotContainsString( '&quot;&quot;some-class&quot;&quot;', $result_with_attrs );
-
-		// Verify empty td cells remain as td
-		$this->assertStringContainsString( '<td colspan=\"1\"></td>', $result_with_attrs );
-
-		// Test comprehensive content preservation: LaTeX, quotes, mixed HTML, and table transformations
-		$input_complex = '<p>LaTeX: \[ f(x) = \frac{1}{2} \]</p><p>There are "double quotes" and \'single quotes\' here.</p><span class="strong">Bold text</span><table class="grid"><thead><tr><td>\[ x = y \]</td><td>Normal Header</td><td>\sum_{i=1}^{n} i</td></tr></thead><tbody><tr><td>Data</td><td>More data</td></tr></tbody></table><p>Paragraph after</p>';
+		// Test comprehensive content: LaTeX, UTF-8, quotes, mixed HTML
+		$input_complex = '<p>LaTeX: \[ f(x) = \frac{1}{2} \]</p><p>There are "double quotes" and \'single quotes\'.</p><span class="strong">Bold</span><table><thead><tr><td>\[ x = y \]</td><td>Café</td><td>Niño</td><td>"Curly"</td><td>中文</td><td>\sum_{i=1}^{n} i</td></tr></thead><tbody><tr><td>Data</td></tr></tbody></table><p>After</p>';
 		$result_complex = \Pressbooks\Editor\fix_table_header_cells( wp_slash( $input_complex ) );
-		// LaTeX should be preserved with double backslashes (slashed output)
+		// LaTeX preserved with double backslashes (slashed output)
 		$this->assertStringContainsString( '\\\\[ f(x) = \\\\frac{1}{2} \\\\]', $result_complex );
 		$this->assertStringContainsString( '<th>\\\\[ x = y \\\\]</th>', $result_complex );
 		$this->assertStringContainsString( '<th>\\\\sum_{i=1}^{n} i</th>', $result_complex );
-		// Quotes should be preserved
+		// UTF-8 characters preserved as HTML entities
+		$this->assertStringContainsString( '<th>Caf&eacute;</th>', $result_complex );
+		$this->assertStringContainsString( '<th>Ni&ntilde;o</th>', $result_complex );
+		$this->assertStringContainsString( '<th>&#20013;&#25991;</th>', $result_complex );
+		$this->assertStringContainsString( '<th>\"Curly\"</th>', $result_complex );
+		// Quotes and HTML elements preserved
 		$this->assertStringContainsString( '\"double quotes\"', $result_complex );
 		$this->assertStringContainsString( "\\'single quotes\\'", $result_complex );
-		// HTML elements should be preserved
-		$this->assertStringContainsString( '<span class=\"strong\">Bold text</span>', $result_complex );
-		$this->assertStringContainsString( '<p>Paragraph after</p>', $result_complex );
-		// Table headers should be transformed
-		$this->assertStringContainsString( '<th>Normal Header</th>', $result_complex );
-		// Table body should be unchanged
-		$this->assertStringContainsString( '<tbody><tr><td>Data</td><td>More data</td></tr></tbody>', $result_complex );
-
-		// Test UTF-8 special characters (curly quotes, em dash, international characters)
-		$input_utf8 = '<table><thead><tr><td>Café</td><td>Niño</td><td>"Curly" Quotes</td><td>Em—Dash</td><td>中文</td></tr></thead></table>';
-		$result_utf8 = \Pressbooks\Editor\fix_table_header_cells( wp_slash( $input_utf8 ) );
-		// DOMDocument encodes special characters as HTML entities - verify they're preserved
-		$this->assertStringContainsString( '<th>Caf&eacute;</th>', $result_utf8 );
-		$this->assertStringContainsString( '<th>Ni&ntilde;o</th>', $result_utf8 );
-		$this->assertStringContainsString( '<th>\"Curly\" Quotes</th>', $result_utf8 );
-		$this->assertStringContainsString( '<th>Em&mdash;Dash</th>', $result_utf8 );
-		$this->assertStringContainsString( '<th>&#20013;&#25991;</th>', $result_utf8 );
+		$this->assertStringContainsString( '<span class=\"strong\">Bold</span>', $result_complex );
+		$this->assertStringContainsString( '<p>After</p>', $result_complex );
+		// tbody unchanged
+		$this->assertStringContainsString( '<tbody><tr><td>Data</td></tr></tbody>', $result_complex );
 	}
 }

--- a/tests/test-editor.php
+++ b/tests/test-editor.php
@@ -255,5 +255,24 @@ class EditorTest extends \WP_UnitTestCase {
 		$this->assertStringContainsString( '<td></td>', $result_mixed );
 		$this->assertStringContainsString( '<td>  </td>', $result_mixed );
 		$this->assertStringContainsString( '<th>Another Header</th>', $result_mixed );
+
+		// Test that attributes are not double-encoded (regression test for issue #4329)
+		$input_with_attrs = '<table class="grid" border="0"><thead><tr><th colspan="1" class="some-class">This is a Header</th><th colspan="1">This is another Header</th><td colspan="1"></td><td colspan="1"></td></tr></thead><tbody><tr><td>This is a column</td><td>This is another column</td><td>This is another column</td><td></td></tr></tbody></table>';
+		$result_with_attrs = \Pressbooks\Editor\fix_table_header_cells( $input_with_attrs );
+
+		// Verify attributes are preserved correctly without double encoding
+		$this->assertStringContainsString( 'class="grid"', $result_with_attrs );
+		$this->assertStringContainsString( 'border="0"', $result_with_attrs );
+		$this->assertStringContainsString( 'colspan="1"', $result_with_attrs );
+		$this->assertStringContainsString( 'class="some-class"', $result_with_attrs );
+
+		// Verify attributes are NOT double-encoded
+		$this->assertStringNotContainsString( '&quot;&quot;grid&quot;&quot;', $result_with_attrs );
+		$this->assertStringNotContainsString( '&quot;&quot;0&quot;&quot;', $result_with_attrs );
+		$this->assertStringNotContainsString( '&quot;&quot;1&quot;&quot;', $result_with_attrs );
+		$this->assertStringNotContainsString( '&quot;&quot;some-class&quot;&quot;', $result_with_attrs );
+
+		// Verify empty td cells remain as td
+		$this->assertStringContainsString( '<td colspan="1"></td>', $result_with_attrs );
 	}
 }

--- a/tests/test-editor.php
+++ b/tests/test-editor.php
@@ -256,7 +256,7 @@ class EditorTest extends \WP_UnitTestCase {
 		$this->assertStringContainsString( '<td>  </td>', $result_mixed );
 		$this->assertStringContainsString( '<th>Another Header</th>', $result_mixed );
 
-		// Test that attributes are not double-encoded (regression test for issue #4329)
+		// Test that attributes are not double-encoded
 		$input_with_attrs = '<table class="grid" border="0"><thead><tr><th colspan="1" class="some-class">This is a Header</th><th colspan="1">This is another Header</th><td colspan="1"></td><td colspan="1"></td></tr></thead><tbody><tr><td>This is a column</td><td>This is another column</td><td>This is another column</td><td></td></tr></tbody></table>';
 		$result_with_attrs = \Pressbooks\Editor\fix_table_header_cells( $input_with_attrs );
 

--- a/tests/test-editor.php
+++ b/tests/test-editor.php
@@ -240,21 +240,15 @@ class EditorTest extends \WP_UnitTestCase {
 		$result_no_table = \Pressbooks\Editor\fix_table_header_cells( wp_slash( $input_no_table ) );
 		$this->assertEquals( wp_slash( $input_no_table ), $result_no_table );
 
-		// Test thead with empty th elements (should convert to td)
-		$input_empty_th = '<table><thead><tr><th>Header</th><th></th><th>  </th><th>Another Header</th></tr></thead></table>';
-		$result_empty_th = \Pressbooks\Editor\fix_table_header_cells( wp_slash( $input_empty_th ) );
-		$this->assertStringContainsString( '<th>Header</th>', $result_empty_th );
-		$this->assertStringContainsString( '<td></td>', $result_empty_th );
-		$this->assertStringContainsString( '<td>  </td>', $result_empty_th );
-		$this->assertStringContainsString( '<th>Another Header</th>', $result_empty_th );
-
-		// Test thead with mix of empty and non-empty th and td
-		$input_mixed = '<table><thead><tr><td>Header</td><td></td><th></th><td>Another Header</td><th>  </th></tr></thead></table>';
-		$result_mixed = \Pressbooks\Editor\fix_table_header_cells( wp_slash( $input_mixed ) );
-		$this->assertStringContainsString( '<th>Header</th>', $result_mixed );
-		$this->assertStringContainsString( '<td></td>', $result_mixed );
-		$this->assertStringContainsString( '<td>  </td>', $result_mixed );
-		$this->assertStringContainsString( '<th>Another Header</th>', $result_mixed );
+		// Test empty and mixed cell handling in thead
+		$input_mixed_cells = '<table><thead><tr><th>Header</th><th></th><td>Another Header</td><td></td><th>  </th></tr></thead></table>';
+		$result_mixed_cells = \Pressbooks\Editor\fix_table_header_cells( wp_slash( $input_mixed_cells ) );
+		// Non-empty cells should be th
+		$this->assertStringContainsString( '<th>Header</th>', $result_mixed_cells );
+		$this->assertStringContainsString( '<th>Another Header</th>', $result_mixed_cells );
+		// Empty cells (both th and td) should become td
+		$this->assertStringContainsString( '<td></td>', $result_mixed_cells );
+		$this->assertStringContainsString( '<td>  </td>', $result_mixed_cells );
 
 		// Test that attributes are not double-encoded
 		$input_with_attrs = '<table class="grid" border="0"><thead><tr><th colspan="1" class="some-class">This is a Header</th><th colspan="1">This is another Header</th><td colspan="1"></td><td colspan="1"></td></tr></thead><tbody><tr><td>This is a column</td><td>This is another column</td><td>This is another column</td><td></td></tr></tbody></table>';
@@ -275,26 +269,22 @@ class EditorTest extends \WP_UnitTestCase {
 		// Verify empty td cells remain as td
 		$this->assertStringContainsString( '<td colspan=\"1\"></td>', $result_with_attrs );
 
-		// Test that LaTeX backslashes are preserved
-		$input_with_latex = '<p>LaTeX: \[ f(x) = \frac{1}{2} \]</p><table><thead><tr><td>Header</td></tr></thead></table>';
-		$result_with_latex = \Pressbooks\Editor\fix_table_header_cells( wp_slash( $input_with_latex ) );
-		$this->assertStringContainsString( '\\[ f(x) = \\frac{1}{2} \\]', $result_with_latex );
-		$this->assertStringContainsString( '<th>Header</th>', $result_with_latex );
-
-		// Test that quotes are preserved (single and double)
-		$input_with_quotes = '<p>There are "double quotes" and \'single quotes\' here.</p><table><thead><tr><td>Header</td></tr></thead></table>';
-		$result_with_quotes = \Pressbooks\Editor\fix_table_header_cells( wp_slash( $input_with_quotes ) );
-		$this->assertStringContainsString( '\"double quotes\"', $result_with_quotes );
-		$this->assertStringContainsString( "\'single quotes\'", $result_with_quotes );
-		$this->assertStringContainsString( '<th>Header</th>', $result_with_quotes );
-
-		// Test mixed content with tables and other HTML elements
-		$input_mixed = '<p>Paragraph before</p><span class="strong">Bold text</span><table class="grid"><thead><tr><td>Col 1</td><td>Col 2</td></tr></thead><tbody><tr><td>Data</td><td>More data</td></tr></tbody></table><p>Paragraph after</p>';
-		$result_mixed = \Pressbooks\Editor\fix_table_header_cells( wp_slash( $input_mixed ) );
-		$this->assertStringContainsString( '<p>Paragraph before</p>', $result_mixed );
-		$this->assertStringContainsString( '<span class=\"strong\">Bold text</span>', $result_mixed );
-		$this->assertStringContainsString( '<th>Col 1</th>', $result_mixed );
-		$this->assertStringContainsString( '<th>Col 2</th>', $result_mixed );
-		$this->assertStringContainsString( '<p>Paragraph after</p>', $result_mixed );
+		// Test comprehensive content preservation: LaTeX, quotes, mixed HTML, and table transformations
+		$input_complex = '<p>LaTeX: \[ f(x) = \frac{1}{2} \]</p><p>There are "double quotes" and \'single quotes\' here.</p><span class="strong">Bold text</span><table class="grid"><thead><tr><td>\[ x = y \]</td><td>Normal Header</td><td>\sum_{i=1}^{n} i</td></tr></thead><tbody><tr><td>Data</td><td>More data</td></tr></tbody></table><p>Paragraph after</p>';
+		$result_complex = \Pressbooks\Editor\fix_table_header_cells( wp_slash( $input_complex ) );
+		// LaTeX should be preserved both inside and outside table
+		$this->assertStringContainsString( '\\[ f(x) = \\frac{1}{2} \\]', $result_complex );
+		$this->assertStringContainsString( '<th>\\[ x = y \\]</th>', $result_complex );
+		$this->assertStringContainsString( '<th>\\sum_{i=1}^{n} i</th>', $result_complex );
+		// Quotes should be preserved
+		$this->assertStringContainsString( '\"double quotes\"', $result_complex );
+		$this->assertStringContainsString( "\'single quotes\'", $result_complex );
+		// HTML elements should be preserved
+		$this->assertStringContainsString( '<span class=\"strong\">Bold text</span>', $result_complex );
+		$this->assertStringContainsString( '<p>Paragraph after</p>', $result_complex );
+		// Table headers should be transformed
+		$this->assertStringContainsString( '<th>Normal Header</th>', $result_complex );
+		// Table body should be unchanged
+		$this->assertStringContainsString( '<tbody><tr><td>Data</td><td>More data</td></tr></tbody>', $result_complex );
 	}
 }

--- a/tests/test-editor.php
+++ b/tests/test-editor.php
@@ -274,5 +274,27 @@ class EditorTest extends \WP_UnitTestCase {
 
 		// Verify empty td cells remain as td
 		$this->assertStringContainsString( '<td colspan="1"></td>', $result_with_attrs );
+
+		// Test that LaTeX backslashes are preserved
+		$input_with_latex = '<p>LaTeX: \[ f(x) = \frac{1}{2} \]</p><table><thead><tr><td>Header</td></tr></thead></table>';
+		$result_with_latex = \Pressbooks\Editor\fix_table_header_cells( $input_with_latex );
+		$this->assertStringContainsString( '\[ f(x) = \frac{1}{2} \]', $result_with_latex );
+		$this->assertStringContainsString( '<th>Header</th>', $result_with_latex );
+
+		// Test that quotes are preserved (single and double)
+		$input_with_quotes = '<p>There are "double quotes" and \'single quotes\' here.</p><table><thead><tr><td>Header</td></tr></thead></table>';
+		$result_with_quotes = \Pressbooks\Editor\fix_table_header_cells( $input_with_quotes );
+		$this->assertStringContainsString( '"double quotes"', $result_with_quotes );
+		$this->assertStringContainsString( "'single quotes'", $result_with_quotes );
+		$this->assertStringContainsString( '<th>Header</th>', $result_with_quotes );
+
+		// Test mixed content with tables and other HTML elements
+		$input_mixed = '<p>Paragraph before</p><span class="strong">Bold text</span><table class="grid"><thead><tr><td>Col 1</td><td>Col 2</td></tr></thead><tbody><tr><td>Data</td><td>More data</td></tr></tbody></table><p>Paragraph after</p>';
+		$result_mixed = \Pressbooks\Editor\fix_table_header_cells( $input_mixed );
+		$this->assertStringContainsString( '<p>Paragraph before</p>', $result_mixed );
+		$this->assertStringContainsString( '<span class="strong">Bold text</span>', $result_mixed );
+		$this->assertStringContainsString( '<th>Col 1</th>', $result_mixed );
+		$this->assertStringContainsString( '<th>Col 2</th>', $result_mixed );
+		$this->assertStringContainsString( '<p>Paragraph after</p>', $result_mixed );
 	}
 }


### PR DESCRIPTION
Fix for https://github.com/pressbooks/pressbooks/issues/4329. See https://github.com/pressbooks/pressbooks/issues/4329#issuecomment-3789346497

Previously, when users created tables with header rows using the TinyMCE editor, the cells were incorrectly created as <td> elements instead of the semantically correct <th> elements. This PR checks the content before save and safely converts td elements inside of thead rows to the correct th element IF AND ONLY IF they contain content. It also converts emtpy <th> elements to <td> and leaves empty td elements as is (to avoid the problem reported by users after the last fix was released). This will result in accessible markup for thead row content and will remove the Editoria11y checks/flags for malformed thead content upon content save for preexisting and new tables alike.

## How It Works
When a user saves a post with a table that has a header row:

1. TinyMCE creates the table with <thead> but uses <td> elements
2. WordPress fires the content_save_pre filter before saving
3. The newly created function processes the HTML and converts <td> cells within <thead> to <th> elements if they contain content and <th> to <td> if they are empty
4. The corrected HTML is saved to the database

## Changes Made
1. Added a new fix_table_header_cells() function to the Presbooks/Editor namespace
This function processes HTML content using DOMDocument to find all <thead> elements. It converts <td> elements within <thead> to <th> elements IF THEY CONTAIN CONTENT and preserves all attributes (class, colspan, rowspan, etc.). It converts empty <th> elements to <td> elements fixing any problems introduced by the previous release.

It only processes content when <thead> is present. It leaves <tbody> cells untouched.

2. Hooked the function to content_save_pre filter (hooks-admin.php)
This filter runs when content is saved, automatically converting the HTML before it's stored in the database.

3. Added tests.

## To test
1. Add a new table to a book
2. Select a row, click table row properties and choose row type header
3. Add content to one or more of the cells in that row. Leave at least one cell blank
4. Manually convert an empty cell to <th>
5. Save the chapter
6. Observe that cells in the header row with content have been converted to th elements. Observe that cells without content become (or remain) td elements. Observe that there are no Editoria11y warnings after save

https://github.com/user-attachments/assets/61f6f308-30b2-448f-bfdb-87b380823282


