### PR TITLE
feat: add hooks when network managers are added or removed

### DIFF
--- a/inc/admin/networkmanagers/namespace.php
+++ b/inc/admin/networkmanagers/namespace.php
@@ -95,7 +95,7 @@ function update_admin_status() {
 		} else {
 			delete_site_option( 'pressbooks_network_managers' );
 		}
-		
+
 		// Fire hooks after successful manager changes
 		if ( isset( $was_added ) && $was_added ) {
 			do_action( 'pressbooks_network_manager_added', $id );
@@ -103,7 +103,7 @@ function update_admin_status() {
 		if ( isset( $was_removed ) && $was_removed ) {
 			do_action( 'pressbooks_network_manager_removed', $id );
 		}
-		
+
 		// Reset the cheap cache after updating the option
 		_restricted_users();
 	}

--- a/inc/admin/networkmanagers/namespace.php
+++ b/inc/admin/networkmanagers/namespace.php
@@ -80,11 +80,13 @@ function update_admin_status() {
 		if ( 1 === absint( $_POST['status'] ) ) {
 			if ( ! in_array( absint( $id ), $restricted, true ) ) {
 				$restricted[] = $id;
+				$was_added = true;
 			}
 		} elseif ( 0 === absint( $_POST['status'] ) ) {
 			$key = array_search( absint( $id ), $restricted, true );
 			if ( $key !== false ) {
 				unset( $restricted[ $key ] );
+				$was_removed = true;
 			}
 		}
 
@@ -93,6 +95,15 @@ function update_admin_status() {
 		} else {
 			delete_site_option( 'pressbooks_network_managers' );
 		}
+		
+		// Fire hooks after successful manager changes
+		if ( isset( $was_added ) && $was_added ) {
+			do_action( 'pressbooks_network_manager_added', $id );
+		}
+		if ( isset( $was_removed ) && $was_removed ) {
+			do_action( 'pressbooks_network_manager_removed', $id );
+		}
+		
 		// Reset the cheap cache after updating the option
 		_restricted_users();
 	}


### PR DESCRIPTION
Add action hooks which are fired when network managers are added or removed, allowing for more granular event handling. Partial fix for https://github.com/pressbooks/private/issues/1516. Accompanies https://github.com/pressbooks/pressbooks-multi-institution/pull/298 and https://github.com/pressbooks/pressbooks-plugins-config/pull/148.

* Add tracking variables (`$was_added`, `$was_removed`) to determine if a network manager was added or removed during the function execution.
* Introduce new action hooks: `pressbooks_network_manager_added` and `pressbooks_network_manager_removed`, fired after a manager is added or removed.