### PR TITLE
fix: wp 6.9 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         include:
           - php: 8.3
-            wordpress: 6.8.3
+            wordpress: 6.9.1
             prince: 15.4-1
             epubcheck: 4.2.6
             experimental: false
@@ -24,7 +24,7 @@ jobs:
             epubcheck: 4.2.6
             experimental: true
           - php: 8.4
-            wordpress: 6.8.3
+            wordpress: 6.9.1
             prince: 15.4-1
             epubcheck: 4.2.6
             experimental: true

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Pressbooks
 Contributors: Pressbooks <code@pressbooks.com>
 Tags: ebooks, publishing, webbooks
-Requires at least: 6.8.3
-Tested up to: 6.8.3
+Requires at least: 6.9.1
+Tested up to: 6.9.1
 <!-- x-release-please-start-version -->
 Stable tag: 6.36.1
 <!-- x-release-please-end -->
@@ -30,7 +30,7 @@ Our webbooks and EPUB/[PDF][pdf] exports are all driven by HTML + CSS. XML outpu
 
 ## Requirements
 
-Pressbooks works with PHP 8.3 and WordPress 6.8.3. Lower versions are not supported.
+Pressbooks works with PHP 8.3 and WordPress 6.9.1. Lower versions are not supported.
 
 ## Installing the Plugin
 

--- a/compatibility.php
+++ b/compatibility.php
@@ -35,7 +35,7 @@ function pb_meets_minimum_requirements() {
 
 	// WordPress Version
 	global $pb_minimum_wp;
-	$pb_minimum_wp = '6.8.3';
+	$pb_minimum_wp = '6.9.1';
 
 	include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 	$is_compatible = true;

--- a/hooks-admin.php
+++ b/hooks-admin.php
@@ -91,6 +91,8 @@ if ( is_main_site() && is_network_admin() ) {
 
 // Replace strings
 add_action( 'gettext', '\Pressbooks\Admin\Laf\sites_to_books', 3, 20 );
+add_filter( 'gettext_with_context', '\Pressbooks\Admin\Laf\sites_to_books_with_context', 3, 4 );
+add_filter( 'ngettext', '\Pressbooks\Admin\Laf\sites_to_books_ngettext', 3, 5 );
 
 // Javascript, Css
 add_action( 'admin_init', '\Pressbooks\Admin\Laf\init_css_js' );

--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -1631,6 +1631,30 @@ function sites_to_books( $translated_text, $untranslated_text, $domain ) {
 			case 'Search Sites':
 				$translated_text = esc_html__( 'Search Books', 'pressbooks' );
 				break;
+			case 'You are about to flag the site %s for deletion.':
+				$translated_text = esc_html__( 'You are about to deactivate the site %s.', 'pressbooks' );
+				break;
+			case 'You are about to remove the deletion flag from the site %s.':
+				$translated_text = esc_html__( 'You are about to activate the site %s.', 'pressbooks' );
+				break;
+			case 'Flagging a site for deletion makes the site unavailable to its users and visitors. This is a reversible action. A super admin can permanently delete the site at a later date.':
+				$translated_text = esc_html__( 'Deactivating a site makes it unavailable to its users and visitors. This is a reversible action.', 'pressbooks' );
+				break;
+			case 'Site flagged for deletion.':
+				$translated_text = esc_html__( 'Site deactivated.', 'pressbooks' );
+				break;
+			case 'Site deletion flag removed.':
+				$translated_text = esc_html__( 'Site activated.', 'pressbooks' );
+				break;
+			case 'Flag for Deletion':
+				$translated_text = esc_html__( 'Deactivate', 'pressbooks' );
+				break;
+			case 'Flagged for Deletion':
+				$translated_text = esc_html__( 'Deactivated', 'pressbooks' );
+				break;
+			case 'Flag for Deletion, Archive, and Spam which lead to confirmation screens. These actions can be reversed later.':
+				$translated_text = esc_html__( 'Deactivate, Archive, and Spam which lead to confirmation screens. These actions can be reversed later.', 'pressbooks' );
+				break;
 		}
 	} elseif ( $pagenow === 'site-info.php' ) {
 		switch ( $untranslated_text ) {
@@ -1639,6 +1663,9 @@ function sites_to_books( $translated_text, $untranslated_text, $domain ) {
 				break;
 			case 'Site Address (URL)':
 				$translated_text = esc_html__( 'Book Address (URL)', 'pressbooks' );
+				break;
+			case 'Flagged for Deletion':
+				$translated_text = esc_html__( 'Deactivated', 'pressbooks' );
 				break;
 		}
 	} elseif ( $pagenow === 'site-new.php' ) {
@@ -1659,6 +1686,66 @@ function sites_to_books( $translated_text, $untranslated_text, $domain ) {
 				$translated_text = esc_html__( 'Add Book', 'pressbooks' );
 				break;
 		}
+	}
+
+	return $translated_text;
+}
+
+/**
+ * Override WP 6.9 "flag for deletion" language in context-aware translations on network book pages.
+ *
+ * Handles strings translated with _x() which pass through the gettext_with_context filter.
+ *
+ * @since 6.23.0
+ *
+ * @param string $translated_text The translated string.
+ * @param string $untranslated_text The original string.
+ * @param string $context The translation context.
+ * @param string $domain The textdomain.
+ *
+ * @return string The modified translated string.
+ */
+function sites_to_books_with_context( $translated_text, $untranslated_text, $context, $domain ) {
+	global $pagenow;
+
+	if ( $pagenow !== 'sites.php' || $context !== 'site' ) {
+		return $translated_text;
+	}
+
+	switch ( $untranslated_text ) {
+		case 'Remove Deletion Flag':
+			$translated_text = esc_html__( 'Activate', 'pressbooks' );
+			break;
+	}
+
+	return $translated_text;
+}
+
+/**
+ * Override WP 6.9 "Flagged for Deletion" plural label in the network book list views filter.
+ *
+ * Handles strings translated with _n() which pass through the ngettext filter.
+ *
+ * @since 6.23.0
+ *
+ * @param string $translated_text The translated string.
+ * @param string $single The singular form.
+ * @param string $plural The plural form.
+ * @param int    $number The number used to determine singular/plural.
+ * @param string $domain The textdomain.
+ *
+ * @return string The modified translated string.
+ */
+function sites_to_books_ngettext( $translated_text, $single, $plural, $number, $domain ) {
+	global $pagenow;
+
+	if ( $pagenow !== 'sites.php' ) {
+		return $translated_text;
+	}
+
+	if ( $single === 'Flagged for Deletion <span class="count">(%s)</span>' ) {
+		/* translators: %s: Number of books. */
+		$translated_text = esc_html__( 'Deactivated', 'pressbooks' ) . ' <span class="count">(%s)</span>';
 	}
 
 	return $translated_text;

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -33,5 +33,5 @@
     <exclude-pattern>*.blade.php</exclude-pattern>
 	<!-- Run against the PHPCompatibility ruleset -->
 	<rule ref="PHPCompatibility"/>
-	<config name="testVersion" value="8.3"/>
+	<config name="testVersion" value="8.3-8.4"/>
 </ruleset>

--- a/tests/test-admin-laf.php
+++ b/tests/test-admin-laf.php
@@ -310,6 +310,164 @@ class Admin_LafTest extends \WP_UnitTestCase {
 	/**
 	 * @group branding
 	 */
+	function test_sites_to_books_deactivation_overrides() {
+		global $pagenow;
+		$pagenow = 'sites.php';
+
+		// Confirmation text
+		$result = \Pressbooks\Admin\Laf\sites_to_books(
+			'You are about to flag the site %s for deletion.',
+			'You are about to flag the site %s for deletion.',
+			'default'
+		);
+		$this->assertEquals( 'You are about to deactivate the site %s.', $result );
+
+		// Reactivation confirmation text
+		$result = \Pressbooks\Admin\Laf\sites_to_books(
+			'You are about to remove the deletion flag from the site %s.',
+			'You are about to remove the deletion flag from the site %s.',
+			'default'
+		);
+		$this->assertEquals( 'You are about to activate the site %s.', $result );
+
+		// Deactivation warning
+		$result = \Pressbooks\Admin\Laf\sites_to_books(
+			'Flagging a site for deletion makes the site unavailable to its users and visitors. This is a reversible action. A super admin can permanently delete the site at a later date.',
+			'Flagging a site for deletion makes the site unavailable to its users and visitors. This is a reversible action. A super admin can permanently delete the site at a later date.',
+			'default'
+		);
+		$this->assertEquals( 'Deactivating a site makes it unavailable to its users and visitors. This is a reversible action.', $result );
+
+		// Success messages
+		$result = \Pressbooks\Admin\Laf\sites_to_books(
+			'Site flagged for deletion.',
+			'Site flagged for deletion.',
+			'default'
+		);
+		$this->assertEquals( 'Site deactivated.', $result );
+
+		$result = \Pressbooks\Admin\Laf\sites_to_books(
+			'Site deletion flag removed.',
+			'Site deletion flag removed.',
+			'default'
+		);
+		$this->assertEquals( 'Site activated.', $result );
+
+		// Row action link
+		$result = \Pressbooks\Admin\Laf\sites_to_books(
+			'Flag for Deletion',
+			'Flag for Deletion',
+			'default'
+		);
+		$this->assertEquals( 'Deactivate', $result );
+
+		// Status label
+		$result = \Pressbooks\Admin\Laf\sites_to_books(
+			'Flagged for Deletion',
+			'Flagged for Deletion',
+			'default'
+		);
+		$this->assertEquals( 'Deactivated', $result );
+
+		// Help tab text
+		$result = \Pressbooks\Admin\Laf\sites_to_books(
+			'Flag for Deletion, Archive, and Spam which lead to confirmation screens. These actions can be reversed later.',
+			'Flag for Deletion, Archive, and Spam which lead to confirmation screens. These actions can be reversed later.',
+			'default'
+		);
+		$this->assertEquals( 'Deactivate, Archive, and Spam which lead to confirmation screens. These actions can be reversed later.', $result );
+
+		$pagenow = null;
+	}
+
+	/**
+	 * @group branding
+	 */
+	function test_sites_to_books_site_info_deactivated_label() {
+		global $pagenow;
+		$pagenow = 'site-info.php';
+
+		$result = \Pressbooks\Admin\Laf\sites_to_books(
+			'Flagged for Deletion',
+			'Flagged for Deletion',
+			'default'
+		);
+		$this->assertEquals( 'Deactivated', $result );
+
+		$pagenow = null;
+	}
+
+	/**
+	 * @group branding
+	 */
+	function test_sites_to_books_with_context() {
+		global $pagenow;
+		$pagenow = 'sites.php';
+
+		$result = \Pressbooks\Admin\Laf\sites_to_books_with_context(
+			'Remove Deletion Flag',
+			'Remove Deletion Flag',
+			'site',
+			'default'
+		);
+		$this->assertEquals( 'Activate', $result );
+
+		// Should not modify strings with different context
+		$result = \Pressbooks\Admin\Laf\sites_to_books_with_context(
+			'Remove Deletion Flag',
+			'Remove Deletion Flag',
+			'other',
+			'default'
+		);
+		$this->assertEquals( 'Remove Deletion Flag', $result );
+
+		// Should not modify strings on other pages
+		$pagenow = 'edit.php';
+		$result = \Pressbooks\Admin\Laf\sites_to_books_with_context(
+			'Remove Deletion Flag',
+			'Remove Deletion Flag',
+			'site',
+			'default'
+		);
+		$this->assertEquals( 'Remove Deletion Flag', $result );
+
+		$pagenow = null;
+	}
+
+	/**
+	 * @group branding
+	 */
+	function test_sites_to_books_ngettext() {
+		global $pagenow;
+		$pagenow = 'sites.php';
+
+		$result = \Pressbooks\Admin\Laf\sites_to_books_ngettext(
+			'Flagged for Deletion <span class="count">(5)</span>',
+			'Flagged for Deletion <span class="count">(%s)</span>',
+			'Flagged for Deletion <span class="count">(%s)</span>',
+			5,
+			'default'
+		);
+		$this->assertStringContainsString( 'Deactivated', $result );
+		$this->assertStringNotContainsString( 'Flagged', $result );
+
+		// Should not modify strings on other pages
+		$pagenow = 'edit.php';
+		$result = \Pressbooks\Admin\Laf\sites_to_books_ngettext(
+			'Flagged for Deletion <span class="count">(5)</span>',
+			'Flagged for Deletion <span class="count">(%s)</span>',
+			'Flagged for Deletion <span class="count">(%s)</span>',
+			5,
+			'default'
+		);
+		$this->assertStringContainsString( 'Flagged', $result );
+
+		$pagenow = null;
+	}
+
+	/**
+	 * @group branding
+	 */
 	function test_edit_screen_navigation() {
 		$this->_book();
 


### PR DESCRIPTION
This pull request introduces a comprehensive override of WordPress 6.9 "flag for deletion" language in the network book admin pages, replacing it with "deactivate" terminology to align with Pressbooks branding. The changes cover context-aware translations, plural labels, and add extensive unit tests to verify the new language. Additionally, the test matrix in the GitHub Actions workflow is updated to use WordPress 6.9.1.

Branding and language overrides for network book admin pages:

* Added new filters (`gettext_with_context`, `ngettext`) and their corresponding handler functions (`sites_to_books_with_context`, `sites_to_books_ngettext`) to override WP 6.9 "flag for deletion" language with "deactivate" terminology throughout network book pages. [[1]](diffhunk://#diff-22bd10ffa96e759d116f39767554f68c8559aa9f379e8b6dc6f132854e6a0729R94-R95) [[2]](diffhunk://#diff-f22cdc03da7e566f78087bda7488a4de9313b2fd11f2045771ebaf381ad8283eR1694-R1753)
* Updated the `sites_to_books` function to replace various "flag for deletion" strings and related messaging with "deactivate" language, including confirmation texts, warnings, success messages, row actions, and help tab text. [[1]](diffhunk://#diff-f22cdc03da7e566f78087bda7488a4de9313b2fd11f2045771ebaf381ad8283eR1634-R1657) [[2]](diffhunk://#diff-f22cdc03da7e566f78087bda7488a4de9313b2fd11f2045771ebaf381ad8283eR1667-R1669)

Testing:

* Added comprehensive unit tests in `tests/test-admin-laf.php` to verify all overrides for confirmation texts, labels, context-aware translations, and plural forms, ensuring the new branding is applied correctly in all relevant scenarios.

CI workflow update:

* Updated the GitHub Actions test matrix in `.github/workflows/tests.yml` to use WordPress version 6.9.1 for PHP 8.3 and 8.4 jobs, ensuring tests run against the latest supported WordPress version. [[1]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL17-R17) [[2]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL27-R27)