### PR TITLE
fix: language mapping

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -32,7 +32,6 @@
         "ru": "ru_RU",
         "sv-SE": "sv_SE",
         "ta": "ta_LK",
-        "ta-IN": "ta_IN",
         "tr": "tr_TR",
         "uk": "uk",
         "zh-CN": "zh_CN",


### PR DESCRIPTION
This pull request makes a small change to the `crowdin.yml` configuration file, removing the `ta-IN` language mapping.