### PR TITLE
fix: replace h3 for h2 for footnotes title

### DIFF
--- a/inc/modules/export/xhtml/class-xhtml11.php
+++ b/inc/modules/export/xhtml/class-xhtml11.php
@@ -584,7 +584,7 @@ class Xhtml11 extends Export {
 
 		$e = '<div class="endnotes">';
 		$e .= '<hr />';
-		$e .= '<h3>' . __( 'Notes', 'pressbooks' ) . '</h3>';
+		$e .= '<h2>' . __( 'Notes', 'pressbooks' ) . '</h2>';
 		$e .= '<ol>';
 		foreach ( $this->endnotes[ $id ] as $endnote ) {
 			$e .= "<li><span>$endnote</span></li>";


### PR DESCRIPTION
This pull request makes a minor update to the endnotes section in the XHTML export module. The heading for the "Notes" section has been changed from a level 3 heading (`<h3>`) to a level 2 heading (`<h2>`), improving the document structure and accessibility.

- Changed the "Notes" heading in the endnotes section from `<h3>` to `<h2>` in `class-xhtml11.php` to enhance semantic HTML and accessibility.