### PR TITLE
chore: improved release artifact to include required files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,7 +7,6 @@
 /.stylelintrc export-ignore
 /.travis.yml export-ignore
 /.tx export-ignore
-/assets/src export-ignore
 /bin export-ignore
 /codecov.yml export-ignore
 /phpcs.ruleset.xml export-ignore

--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,6 @@
 			".gitignore",
 			".phpstorm.meta.php",
 			".tx",
-			"assets/src",
 			"bin",
 			"codecov.yml",
 			"phpcs.ruleset.xml",


### PR DESCRIPTION
Summary
- Include assets/src directory in release artifacts by removing it from exclusion lists
- Ensures downstream packages have access to source files required for builds

Changes
- Removed /assets/src export-ignore from .gitattributes
- Removed "assets/src" from composer.json archive exclude list

Why

The assets/src directory contains source files (SCSS, JS) that downstream packages require for development and custom builds. Previously, these files were excluded from release artifacts, causing dependency issues for packages that need them.