### PR TITLE
fix: missing jquery dependency in import

### DIFF
--- a/inc/admin/laf/namespace.php
+++ b/inc/admin/laf/namespace.php
@@ -392,7 +392,12 @@ function replace_book_admin_menu() {
 	add_action(
 		'admin_enqueue_scripts', function ( $hook ) use ( $import_page, $assets ) {
 			if ( $hook === $import_page ) {
-				$assets->enqueue( 'assets/src/scripts/import.js', 'pb-import' );
+				$assets->enqueue( 'assets/src/scripts/import.js', 'pb-import', [
+					'dependencies' => [
+						'jquery',
+						'jquery-form',
+					],
+				] );
 				wp_localize_script(
 					'pb-import', 'PB_ImportToken', [
 						'ajaxUrl' => wp_nonce_url( admin_url( 'admin-ajax.php?action=import-book' ), 'pb-import' ),


### PR DESCRIPTION
Issue https://github.com/pressbooks/pressbooks/issues/4390

This pull request makes a minor update to the script enqueuing logic for the import page in the admin interface. The change ensures that the `pb-import` script explicitly lists its dependencies, which helps guarantee that required scripts like `jquery` and `jquery-form` are loaded beforehand.

* Added explicit `dependencies` (`jquery`, `jquery-form`) to the `pb-import` script when enqueuing it in `replace_book_admin_menu()` in `inc/admin/laf/namespace.php`