### PR TITLE
fix: display custom fonts for network managers

### DIFF
--- a/inc/admin/networkmanagers/namespace.php
+++ b/inc/admin/networkmanagers/namespace.php
@@ -139,6 +139,7 @@ function is_restricted() {
 function permitted_setting_menus() {
 	return [
 		'pb_analytics',
+		'pb_custom_fonts',
 		'pb_network_analytics_options',
 		'pb_whitelabel_settings',
 		'pressbooks_sharingandprivacy_options',

--- a/tests/test-admin-networkmanagers.php
+++ b/tests/test-admin-networkmanagers.php
@@ -132,6 +132,7 @@ class Admin_NetworkManagers extends \WP_UnitTestCase {
 		$allowed = \Pressbooks\Admin\NetworkManagers\permitted_setting_menus();
 		$this->assertTrue( is_array( $allowed ) );
 		$this->assertContains( 'pb_analytics', $allowed );
+		$this->assertContains( 'pb_custom_fonts', $allowed );
 		$this->assertContains( 'pb_whitelabel_settings', $allowed );
 		$this->assertContains( 'pressbooks_sharingandprivacy_options', $allowed );
 		$this->assertContains( 'pb_network_analytics_options', $allowed );


### PR DESCRIPTION
The new custom fonts menu page wasn't being displayed to network managers previously. Now it is. Addresses https://github.com/pressbooks/ideas/issues/523#issuecomment-4128684402. Thanks for catching @tw77 

<img width="709" height="683" alt="Screenshot 2026-03-25 132331" src="https://github.com/user-attachments/assets/67da60d5-5536-4eff-bb89-90f7a85fa4b5" />
