### PR TITLE
chore: remove user activation keys menu (plugin deprecation)

### DIFF
--- a/inc/admin/menus/class-sidebar.php
+++ b/inc/admin/menus/class-sidebar.php
@@ -393,19 +393,6 @@ class SideBar {
 			$this->getContextSlug( 'users.php', true )
 		);
 
-		if ( is_plugin_active( 'user-activation-keys/ds_wp3_user_activation_keys.php' ) ) {
-			require_once WP_PLUGIN_DIR . '/user-activation-keys/ds_wp3_user_activation_keys.php';
-			$ds_wp3_user_activation_keys = new \DS_User_Activation_Keys();
-			add_submenu_page(
-				'pb-null',
-				__( 'User Activation Keys', 'pressbooks' ),
-				__( 'User Activation Keys', 'pressbooks' ),
-				'edit_users',
-				'act_keys',
-				is_network_admin() ? '' : [ $ds_wp3_user_activation_keys, 'ds_delete_stale' ]
-			);
-		}
-
 		// Appearance
 		add_submenu_page(
 			$this->getContextSlug( 'customize.php', true ),


### PR DESCRIPTION
This pull request removes the integration of the "User Activation Keys" plugin from the super admin menu in the admin sidebar. The code that conditionally added the "User Activation Keys" submenu item has been deleted.

Menu cleanup:

* Removed the check for the activation of the `user-activation-keys/ds_wp3_user_activation_keys.php` plugin and the related submenu page for "User Activation Keys" in the `addSuperAdminMenuItems` method of `class-sidebar.php`.