### PR TITLE
fix: language attributes display on PDF

### DIFF
--- a/inc/modules/export/epub/class-epub.php
+++ b/inc/modules/export/epub/class-epub.php
@@ -737,6 +737,7 @@ class Epub extends Export {
 
 		$config = [
 			'valid_xhtml' => 1,
+			'xml:lang' => 1,
 			'no_deprecated_attr' => 2,
 			'unique_ids' => 'fixme-',
 			'hook' => '\Pressbooks\Sanitize\html5_to_epub3',
@@ -866,6 +867,7 @@ class Epub extends Export {
 	protected function html5ToXhtml( string $html ): string {
 		$config = [
 			'valid_xhtml' => 1,
+			'xml:lang' => 1,
 			'unique_ids' => 0,
 		];
 

--- a/inc/modules/export/xhtml/class-xhtml11.php
+++ b/inc/modules/export/xhtml/class-xhtml11.php
@@ -1148,6 +1148,7 @@ class Xhtml11 extends Export {
 
 		$config = [
 			'valid_xhtml' => 1,
+			'xml:lang' => 1,
 			'no_deprecated_attr' => 2,
 			'unique_ids' => 'fixme-',
 			'hook' => '\Pressbooks\Sanitize\html5_to_xhtml11',
@@ -1170,6 +1171,7 @@ class Xhtml11 extends Export {
 	protected function html5ToXhtml( $html ) {
 		$config = [
 			'valid_xhtml' => 1,
+			'xml:lang' => 1,
 			'unique_ids' => 0,
 		];
 		return HtmLawed::filter( $html, $config );
@@ -1187,7 +1189,7 @@ class Xhtml11 extends Export {
 
 		echo '<?xml version="1.0" encoding="UTF-8"?>' . "\n";
 		echo '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">' . "\n";
-		echo '<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="' . $this->lang . '">' . "\n";
+		echo '<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="' . $this->lang . '" lang="' . $this->lang . '">' . "\n";
 	}
 
 	/**

--- a/inc/sanitize/namespace.php
+++ b/inc/sanitize/namespace.php
@@ -210,7 +210,7 @@ function force_ascii( $slug ) {
  */
 function decode( string $slug, bool $exclude_ampersands = true ): string {
 
-	$slug = html_entity_decode( $slug, ENT_NOQUOTES | ENT_XHTML, 'UTF-8' );
+	$slug = html_entity_decode( $slug, ENT_COMPAT | ENT_XHTML, 'UTF-8' );
 
 	return $exclude_ampersands ? encode_ampersand( $slug ) : $slug;
 }

--- a/tests/test-sanitize.php
+++ b/tests/test-sanitize.php
@@ -141,6 +141,20 @@ class SanitizeTest extends \WP_UnitTestCase {
 	 * @group sanitize
 	 * @test
 	 */
+	public function decode_handles_double_quotes_from_sanitize_xml_attribute(): void {
+		// Simulate the encode/decode roundtrip for titles with lang spans
+		$title = 'A Title: <span lang="de">Vunderkind</span>';
+		$encoded = \Pressbooks\Sanitize\sanitize_xml_attribute( $title );
+		$decoded = \Pressbooks\Sanitize\decode( $encoded );
+
+		$this->assertStringNotContainsString( '&quot;', $decoded );
+		$this->assertStringContainsString( '<span lang="de">', $decoded );
+	}
+
+	/**
+	 * @group sanitize
+	 * @test
+	 */
 	public function sanitize_excluding_ampersand(): void {
 		$string = 'Hello & World';
 		$this->assertEquals( 'Hello &#038; World', \Pressbooks\Sanitize\decode( $string ) );


### PR DESCRIPTION
This pull request focuses on improving XHTML and XML language attribute handling, as well as refining entity decoding in the sanitization process. It also adds a unit test to ensure correct decoding of double quotes in XML attributes. The most important changes are grouped below:

**Language Attribute Handling Improvements:**

* Added the `xml:lang` attribute to the configuration arrays in both the EPUB and XHTML export modules to ensure proper language tagging in generated files. [[1]](diffhunk://#diff-4d36e712f4455de8592afc2af3953c30f7cf23921703a5c4ce5980930b1ed895R740) [[2]](diffhunk://#diff-4d36e712f4455de8592afc2af3953c30f7cf23921703a5c4ce5980930b1ed895R870) [[3]](diffhunk://#diff-d114cd98af204df5d88c00b9c9e8cede1cb667d34a520b04a3016b1869717e46R1151) [[4]](diffhunk://#diff-d114cd98af204df5d88c00b9c9e8cede1cb667d34a520b04a3016b1869717e46R1174)
* Updated the XHTML export's `echoDocType` method to include both `xml:lang` and `lang` attributes on the root `<html>` element for better standards compliance and compatibility.

**Sanitization and Decoding Enhancements:**

* Changed the `decode` function in `namespace.php` to use `ENT_COMPAT` instead of `ENT_NOQUOTES` for `html_entity_decode`, ensuring that double quotes are correctly decoded and improving round-trip handling of XML attributes.
* Added a new unit test to verify that double quotes are handled correctly when decoding sanitized XML attributes, specifically checking that `&quot;` does not appear in the decoded output and that language spans are preserved.

### How to test

1. Checkout this branch
2. Add some chapter titles or texts with language attributes for instance

```
<span lang="fr">en français</span>
<span lang="es">Ejemplo</span>
```

3. Titles should have the attribute with `lang="es"` single doubles quote not double.
4. PDF accessibility sidebar should display the expected language in the node was applied

![Pasted_Image_2026-03-31__8_41 PM](https://github.com/user-attachments/assets/d475fd21-64ca-416c-90e0-7c6c5337639f)
