### PR TITLE
feat: allow single dollar delimiters

### DIFF
--- a/inc/class-mathjax.php
+++ b/inc/class-mathjax.php
@@ -30,10 +30,11 @@ class MathJax {
 	private static $instance = null;
 
 	/**
-	 * @var array{fg: string}
+	 * @var array{fg: string, use_single_dollar: bool}
 	 */
 	private $defaultOptions = [
-		'fg' => '000000',
+		'fg'                => '000000',
+		'use_single_dollar' => false,
 	];
 
 	/**
@@ -120,6 +121,7 @@ class MathJax {
 		);
 		add_action( 'wp_enqueue_scripts', [ $obj, 'addScripts' ] );
 		add_action( 'wp_head', [ $obj, 'addHeaders' ] );
+		add_filter( 'the_content', [ $obj, 'replaceSingleDollarDelimiters' ], 8 ); // before wptexturize
 		add_filter( 'pb_pdf_css_override', [ $obj, 'displayMathHandler' ] );
 		add_filter( 'pb_epub_css_override', [ $obj, 'displayMathHandler' ] );
 		add_action( 'pb_pre_export', [ $obj, 'beforeExport' ] );
@@ -177,9 +179,10 @@ class MathJax {
 		echo $blade->render(
 			'admin.mathjax',
 			[
-				'wp_nonce_field' => wp_nonce_field( 'save', 'pb-mathjax-nonce', true, false ),
-				'test_image' => $test_image,
-				'fg' => $options['fg'],
+				'wp_nonce_field'    => wp_nonce_field( 'save', 'pb-mathjax-nonce', true, false ),
+				'test_image'        => $test_image,
+				'fg'                => $options['fg'],
+				'use_single_dollar' => $options['use_single_dollar'],
 			]
 		);
 	}
@@ -201,8 +204,11 @@ class MathJax {
 			$fg .= str_repeat( '0', 6 - $l );
 		}
 
+		$use_single_dollar = isset( $_POST['use_single_dollar'] ) && '1' === $_POST['use_single_dollar'];
+
 		$options = [
-			'fg' => $fg,
+			'fg'                => $fg,
+			'use_single_dollar' => $use_single_dollar,
 		];
 
 		if ( update_option( self::OPTION, $options ) ) {
@@ -252,7 +258,16 @@ class MathJax {
 		}
 
 		// Use regex to check for LaTeX delimiters
-		$has_math = (bool) preg_match( '/(?:\\\\\[|\\\\\]|\\\\\(|\\\\\)|\$\$|\$latex\s+[^$]+\$|\$\s+[^$]+\s+\$)/', $content );
+		$has_math = (bool) preg_match( '/(?:\\\\\[|\\\\\]|\\\\\(|\\\\\)|\$\$|\$latex\s+[^$]+\$)/', $content );
+
+		// Check for single-dollar inline math if opt-in is enabled
+		if ( ! $has_math ) {
+			$options = $this->getOptions();
+			if ( $options['use_single_dollar'] ) {
+				$has_math = (bool) preg_match( '/(?<!\\\\)\$(?!\s|\$).+?(?<!\s)\$(?!\$)/', $content );
+			}
+		}
+
 		$this->sectionHasMath[ $id ] = $has_math;
 		return $has_math;
 	}
@@ -275,8 +290,8 @@ class MathJax {
 	 */
 	public function addHeaders() {
 		if ( ! is_admin() && $this->sectionHasMath() ) {
-			// Color
-			$options = $this->getOptions();
+			$options     = $this->getOptions();
+			$inline_math = "[['\\\\(', '\\\\)'], ['[latex]','[/latex]']]";
 			echo "<script>
 window.MathJax = {
 	versionWarnings: false,
@@ -305,24 +320,25 @@ window.MathJax = {
 			delimiters: [['`','`'],['[asciimath]','[/asciimath]']]
 		},
     tex: {
-        inlineMath: [['\\\\(', '\\\\)'], ['[latex]','[/latex]']],
+        inlineMath: {$inline_math},
         displayMath: [['$$', '$$'], ['\\\\[', '\\\\]']],
         packages: {
             '[+]': [
-                'ams',        // AMS math features
-                'bbox',       // Boxed expressions
-                'boldsymbol', // Bold symbols
-                'braket',     // Quantum mechanics notation
-                'cancel',     // Strike-through notation
-                'color',      // Colored text
-                'enclose',    // Provide notations like rounded boxes and underlining
-                'gensymb',    // General symbols (degrees, angles, etc.)
-                'mathtools',  // Extended math tools
-                'mhchem',     // Chemistry formulas
-                'textmacros', // Text formatting macros
-                'newcommand', // Define custom LaTeX commands useful for macros
-                'noerrors',   // Suppresses errors
-                'unicode'     // Unicode math symbols
+                'ams',
+                'bbox',
+                'boldsymbol',
+                'braket',
+                'cancel',
+                'color',
+                'enclose',
+                'gensymb',
+                'mathtools',
+                'mhchem',
+                'textmacros',
+                'newcommand',
+                'noerrors',
+                'physics',
+                'unicode'
             ]
         },
         tags: 'ams',
@@ -347,14 +363,26 @@ STYLES;
 	}
 
 	/**
-	 * @return array{fg: string}
+	 * @return array{fg: string, use_single_dollar: bool}
 	 * @see    MathJax
 	 */
 	public function getOptions() {
 		$options = get_option( self::OPTION, [] );
 		$fg = trim( $options['fg'] ?? $this->defaultOptions['fg'] );
+		$use_single_dollar = (bool) ( $options['use_single_dollar'] ?? $this->defaultOptions['use_single_dollar'] );
+
+		/**
+		 * Override whether single dollar sign delimiters are enabled.
+		 *
+		 * @since  [next version]
+		 * @param  bool $use_single_dollar
+		 * @return bool
+		 */
+		$use_single_dollar = (bool) apply_filters( 'pb_mathjax_use_single_dollar', $use_single_dollar );
+
 		return [
-			'fg' => $fg,
+			'fg'                => $fg,
+			'use_single_dollar' => $use_single_dollar,
 		];
 	}
 
@@ -453,16 +481,49 @@ STYLES;
 			'%\$\$(.*?)\$\$%s', // $$ ... $$
 		];
 		foreach ( $patterns as $index => $pattern ) {
-			$content = preg_replace_callback($pattern, function ( $matches ) use ( $index ) {
+			$content = preg_replace_callback( $pattern, function ( $matches ) use ( $index ) {
 				$rendered = $this->renderFormula( $matches[1], 'latex' );
 				// Wrap in div if it's display math (\[...\]) or $$...$$
 				if ( $index === 0 || $index === 2 ) {
 					return '<div class="display-math">' . $rendered . '</div>';
 				}
 				return $rendered;
-			}, $content);
+			}, $content );
 		}
+
 		return $content;
+	}
+
+	/**
+	 * Replace single-dollar delimiters ($...$) with \(...\) in webbook content.
+	 *
+	 * MathJax v3 has no built-in heuristic to skip '$' delimiters adjacent to
+	 * whitespace, so adding ['$','$'] to inlineMath greedily matches currency
+	 * like "$ 5,000". Instead, we pre-process content server-side with the same
+	 * no-adjacent-whitespace regex the export pipeline uses, converting $...$
+	 * to \(...\) which MathJax already recognises.
+	 *
+	 * @param string $content
+	 *
+	 * @return string
+	 */
+	public function replaceSingleDollarDelimiters( string $content ): string {
+		$options = $this->getOptions();
+		if ( ! $options['use_single_dollar'] ) {
+			return $content;
+		}
+
+		// Match $...$ where:
+		//   (?<!\\)   - opening $ not preceded by backslash (respects \$ escape)
+		//   (?!\s|\$) - opening $ not followed by whitespace or another $ (avoids $$ and currency)
+		//   ([^$]+?)  - non-greedy capture that cannot contain $ (prevents $$ leaking)
+		//   (?<!\s)   - closing $ not preceded by whitespace
+		//   (?!\$)    - closing $ not followed by $ (avoids $$ collision)
+		return preg_replace(
+			'/(?<!\\\\)\$(?!\s|\$)([^$]+?)(?<!\s)\$(?!\$)/',
+			'\\($1\\)',
+			$content
+		);
 	}
 
 	// ------------------------------------------------------------------------

--- a/templates/admin/mathjax.blade.php
+++ b/templates/admin/mathjax.blade.php
@@ -54,7 +54,10 @@
                     <input type="checkbox" name="use_single_dollar" id="mathjax-use-single-dollar"
                            value="1" @if ( $use_single_dollar ) checked @endif />
                     <p>
-                        {!! sprintf( __( 'When enabled, %s will be treated as inline LaTeX math.', 'pressbooks' ), '<code>$e^{i \pi} + 1 = 0$</code>' ) !!}
+                        {!! sprintf( __( 'When enabled, %1$s will be treated as inline LaTeX math. Use %2$s to display a literal dollar sign.', 'pressbooks'	), '<code>$e^{i \\pi} + 1 = 0$</code>', '<code>\\$</code>' ) !!}
+                    </p>
+                    <p>
+                        {{ __( 'Note: The opening $ must not be followed by a space and the closing $ must not be preceded by a space.', 'pressbooks' ) }}
                     </p>
                     <p>
                         {{ __( 'The opening $ must not be followed by a space and the closing $ must not be preceded by a space, so currency like "$ 5,000" is not affected.', 'pressbooks' ) }}

--- a/templates/admin/mathjax.blade.php
+++ b/templates/admin/mathjax.blade.php
@@ -10,34 +10,56 @@
                 <td class="syntax">
                     <section>
                         <h2>{{ __( 'LaTeX' ,'pressbooks' ) }}</h2>
-						<p>
-							{!! sprintf( __( 'Inline math delimiter: %s', 'pressbooks' ), '<code>\( e^{i \pi} + 1 = 0 \)</code>') !!}
-						</p>
-						<p>
-							{!! sprintf( __( 'Display math delimiter: %s', 'pressbooks' ), '<code>\[ e^{i \pi} + 1 = 0 \]</code>' ) !!}
-						</p>
                         <p>
-							{!! sprintf( __( 'Shortcode syntax: %s', 'pressbooks' ), '<code>[latex]e^{i \pi} + 1 = 0[/latex]</code>' ) !!} </p>
+                            {!! sprintf( __( 'Inline math delimiter: %s', 'pressbooks' ), '<code>\( e^{i \pi} + 1 = 0 \)</code>') !!}
+                        </p>
                         <p>
-							{!! sprintf( __( 'Double dollar sign syntax: %s', 'pressbooks' ), '<code>$$ e^{i \pi} + 1 = 0 $$</code>' ) !!}
-						</p>
+                            {!! sprintf( __( 'Display math delimiter: %s', 'pressbooks' ), '<code>\[ e^{i \pi} + 1 = 0 \]</code>' ) !!}
+                        </p>
+                        <p>
+                            {!! sprintf( __( 'Shortcode syntax: %s', 'pressbooks' ), '<code>[latex]e^{i \pi} + 1 = 0[/latex]</code>' ) !!}
+                        </p>
+                        <p>
+                            {!! sprintf( __( 'Double dollar sign syntax: %s', 'pressbooks' ), '<code>$$ e^{i \pi} + 1 = 0 $$</code>' ) !!}
+                        </p>
+                        @if ( $use_single_dollar )
+                        <p>
+                            {!! sprintf( __( 'Single dollar sign syntax: %s', 'pressbooks' ), '<code>$e^{i \pi} + 1 = 0$</code>' ) !!}
+                        </p>
+                        @endif
                     </section>
                     <section>
                         <h2>{{ __( 'AsciiMath' ,'pressbooks' ) }}</h2>
                         <p>
-							{!! sprintf( __( 'Shortcode syntax: %s', 'pressbooks' ),'<code>[asciimath]e^{i \pi} + 1 = 0[/asciimath]</code>' ) !!}
-						</p>
+                            {!! sprintf( __( 'Shortcode syntax: %s', 'pressbooks' ),'<code>[asciimath]e^{i \pi} + 1 = 0[/asciimath]</code>' ) !!}
+                        </p>
                         <p>
-							{!! sprintf( __( 'Dollar sign syntax: %s', 'pressbooks' ),'<code>$asciimath e^{i \pi} + 1 = 0$</code>' ) !!}
-						</p>
+                            {!! sprintf( __( 'Dollar sign syntax: %s', 'pressbooks' ),'<code>$asciimath e^{i \pi} + 1 = 0$</code>' ) !!}
+                        </p>
                     </section>
                     <section>
                         <h2>{{ __( 'MathML' ,'pressbooks' ) }}</h2>
                         <p>{!! sprintf(
                             __( 'Markup syntax: %s', 'pressbooks' ),
-	                        '<code>&lt;math&gt;&lt;!-- Your math here --&gt;&lt;/math&gt;</code>'
+                            '<code>&lt;math&gt;&lt;!-- Your math here --&gt;&lt;/math&gt;</code>'
                         ) !!} </p>
                     </section>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row">
+                    <label for="mathjax-use-single-dollar">{{ __( 'Single dollar sign delimiter', 'pressbooks' ) }}</label>
+                </th>
+                <td>
+                    <input type="checkbox" name="use_single_dollar" id="mathjax-use-single-dollar"
+                           value="1" @if ( $use_single_dollar ) checked @endif />
+                    <p>
+                        {!! sprintf( __( 'When enabled, %s will be treated as inline LaTeX math.', 'pressbooks' ), '<code>$e^{i \pi} + 1 = 0$</code>' ) !!}
+                    </p>
+                    <p>
+                        {{ __( 'The opening $ must not be followed by a space and the closing $ must not be preceded by a space, so currency like "$ 5,000" is not affected.', 'pressbooks' ) }}
+                        {!! sprintf( __( 'Use %s to display a literal dollar sign.', 'pressbooks' ), '<code>\$</code>' ) !!}
+                    </p>
                 </td>
             </tr>
             <tr>

--- a/tests/test-mathjax.php
+++ b/tests/test-mathjax.php
@@ -53,6 +53,41 @@ class MathjaxTest extends \WP_UnitTestCase {
 		$this->assertEquals( $options['fg'], '000000' );
 	}
 
+	public function testSingleDollarOptionDefault() {
+		$options = $this->mathjax->getOptions();
+		$this->assertFalse( $options['use_single_dollar'] );
+	}
+
+	public function testSingleDollarOptionSave() {
+		$_POST = [
+			'pb-mathjax-nonce'  => wp_create_nonce( 'save' ),
+			'fg'                => '000000',
+			'use_single_dollar' => '1',
+		];
+		$this->mathjax->saveOptions();
+		$options = $this->mathjax->getOptions();
+		$this->assertTrue( $options['use_single_dollar'] );
+	}
+
+	public function testSingleDollarOptionSaveUnchecked() {
+		// First enable it
+		$_POST = [
+			'pb-mathjax-nonce'  => wp_create_nonce( 'save' ),
+			'fg'                => '000000',
+			'use_single_dollar' => '1',
+		];
+		$this->mathjax->saveOptions();
+
+		// Then save without the checkbox (unchecked = absent from POST)
+		$_POST = [
+			'pb-mathjax-nonce' => wp_create_nonce( 'save' ),
+			'fg'               => '000000',
+		];
+		$this->mathjax->saveOptions();
+		$options = $this->mathjax->getOptions();
+		$this->assertFalse( $options['use_single_dollar'] );
+	}
+
 	public function testSectionHasMath() {
 		$new_post = [
 			'post_title' => 'Test Chapter: ' . wp_rand(),
@@ -190,6 +225,155 @@ class MathjaxTest extends \WP_UnitTestCase {
 		$this->assertEquals( '<svg>...</svg>', $content );
 	}
 
+	public function testSectionHasMathSingleDollarEnabled() {
+		// Enable the option
+		update_option( MathJax::OPTION, [ 'fg' => '000000', 'use_single_dollar' => true ] );
+
+		$new_post = [
+			'post_title'   => 'Test Chapter: ' . wp_rand(),
+			'post_type'    => 'chapter',
+			'post_status'  => 'published',
+			'post_content' => 'Euler\'s formula $e^{i\pi}+1=0$ is beautiful.',
+		];
+		$pid             = $this->factory()->post->create_object( $new_post );
+		$GLOBALS['post'] = get_post( $pid );
+		$this->assertTrue( $this->mathjax->sectionHasMath() );
+	}
+
+	public function testSectionHasMathSingleDollarDisabled() {
+		// Explicitly disable the option (default)
+		update_option( MathJax::OPTION, [ 'fg' => '000000', 'use_single_dollar' => false ] );
+
+		$new_post = [
+			'post_title'   => 'Test Chapter: ' . wp_rand(),
+			'post_type'    => 'chapter',
+			'post_status'  => 'published',
+			'post_content' => 'Euler\'s formula $e^{i\pi}+1=0$ is beautiful.',
+		];
+		$pid             = $this->factory()->post->create_object( $new_post );
+		$GLOBALS['post'] = get_post( $pid );
+		$this->assertFalse( $this->mathjax->sectionHasMath() );
+	}
+
+	public function testSectionHasMathCurrencyNotMath() {
+		// Enable the option — currency must NOT trigger detection
+		update_option( MathJax::OPTION, [ 'fg' => '000000', 'use_single_dollar' => true ] );
+
+		$new_post = [
+			'post_title'   => 'Test Chapter: ' . wp_rand(),
+			'post_type'    => 'chapter',
+			'post_status'  => 'published',
+			'post_content' => 'We earned $ 5,000 today and $ 4,000 yesterday.',
+		];
+		$pid             = $this->factory()->post->create_object( $new_post );
+		$GLOBALS['post'] = get_post( $pid );
+		$this->assertFalse( $this->mathjax->sectionHasMath() );
+	}
+
+	public function testAddHeadersSingleDollarEnabled() {
+		update_option( MathJax::OPTION, [ 'fg' => '000000', 'use_single_dollar' => true ] );
+
+		$new_post = [
+			'post_title'   => 'Test Chapter: ' . wp_rand(),
+			'post_type'    => 'chapter',
+			'post_status'  => 'published',
+			'post_content' => '$e^{i\pi}+1=0$',
+		];
+		$pid             = $this->factory()->post->create_object( $new_post );
+		$GLOBALS['post'] = get_post( $pid );
+
+		ob_start();
+		$this->mathjax->addHeaders();
+		$buffer = ob_get_clean();
+
+		// Single-dollar is handled server-side by replaceSingleDollarDelimiters(),
+		// NOT by adding ['$','$'] to MathJax's inlineMath config.
+		$this->assertStringNotContainsString( "['$','$']", $buffer );
+		$this->assertStringContainsString( "['\\\\(', '\\\\)']", $buffer );
+	}
+
+	public function testAddHeadersSingleDollarDisabled() {
+		update_option( MathJax::OPTION, [ 'fg' => '000000', 'use_single_dollar' => false ] );
+
+		$new_post = [
+			'post_title'   => 'Test Chapter: ' . wp_rand(),
+			'post_type'    => 'chapter',
+			'post_status'  => 'published',
+			'post_content' => '[latex]x^2[/latex]',
+		];
+		$pid             = $this->factory()->post->create_object( $new_post );
+		$GLOBALS['post'] = get_post( $pid );
+
+		ob_start();
+		$this->mathjax->addHeaders();
+		$buffer = ob_get_clean();
+
+		$this->assertStringNotContainsString( "['$','$']", $buffer );
+		$this->assertStringContainsString( "['\\\\(', '\\\\)']", $buffer );
+	}
+
+	public function testReplaceSingleDollarDelimiters() {
+		update_option( MathJax::OPTION, [ 'fg' => '000000', 'use_single_dollar' => true ] );
+
+		// Basic inline math
+		$result = $this->mathjax->replaceSingleDollarDelimiters( 'Euler formula $e^{i\pi}+1=0$ is beautiful.' );
+		$this->assertEquals( 'Euler formula \(e^{i\pi}+1=0\) is beautiful.', $result );
+	}
+
+	public function testReplaceSingleDollarDelimitersCurrency() {
+		update_option( MathJax::OPTION, [ 'fg' => '000000', 'use_single_dollar' => true ] );
+
+		// Currency with space after $ must NOT be converted
+		$result = $this->mathjax->replaceSingleDollarDelimiters( 'We earned $ 5,000 today and $ 4,000 yesterday.' );
+		$this->assertEquals( 'We earned $ 5,000 today and $ 4,000 yesterday.', $result );
+	}
+
+	public function testReplaceSingleDollarDelimitersDisabled() {
+		update_option( MathJax::OPTION, [ 'fg' => '000000', 'use_single_dollar' => false ] );
+
+		// When disabled, content passes through unchanged
+		$result = $this->mathjax->replaceSingleDollarDelimiters( '$e^{i\pi}+1=0$' );
+		$this->assertEquals( '$e^{i\pi}+1=0$', $result );
+	}
+
+	public function testReplaceSingleDollarDelimitersEscaped() {
+		update_option( MathJax::OPTION, [ 'fg' => '000000', 'use_single_dollar' => true ] );
+
+		// Escaped dollar sign must NOT be converted
+		$result = $this->mathjax->replaceSingleDollarDelimiters( '\$5,000' );
+		$this->assertEquals( '\$5,000', $result );
+	}
+
+	public function testReplaceSingleDollarDelimitersDisplayMath() {
+		update_option( MathJax::OPTION, [ 'fg' => '000000', 'use_single_dollar' => true ] );
+
+		// Double dollar display math must NOT be affected
+		$result = $this->mathjax->replaceSingleDollarDelimiters( '$$e^{i\pi}+1=0$$' );
+		$this->assertEquals( '$$e^{i\pi}+1=0$$', $result );
+	}
+
+	public function testReplaceSingleDollarDelimitersSpacedFormula() {
+		update_option( MathJax::OPTION, [ 'fg' => '000000', 'use_single_dollar' => true ] );
+
+		// Formula with internal spaces but NOT adjacent to delimiters should work
+		$result = $this->mathjax->replaceSingleDollarDelimiters( '$x + y = z$' );
+		$this->assertEquals( '\(x + y = z\)', $result );
+	}
+
+	public function testReplaceSingleDollarDelimitersMixedContent() {
+		update_option( MathJax::OPTION, [ 'fg' => '000000', 'use_single_dollar' => true ] );
+
+		// Mixed: real math + currency in same content
+		$result = $this->mathjax->replaceSingleDollarDelimiters(
+			'I think $ 5,000 dolares will be enough $ or maybe $4,000$ pesos.'
+		);
+		// Only $4,000$ should be converted (no space adjacent to delimiters)
+		$this->assertEquals(
+			'I think $ 5,000 dolares will be enough $ or maybe \(4,000\) pesos.',
+			$result
+		);
+	}
+
 	public function testReplaceMathML() {
 		$mathml_content = '<math><mrow><mrow><msup><mi>x</mi><mn>2</mn></msup><mo>+</mo><mrow><mn>4</mn><mo>&InvisibleTimes;</mo><mi>x</mi></mrow><mo>+</mo><mn>4</mn></mrow><mo>=</mo><mn>0</mn></mrow></math>';
 
@@ -200,5 +384,61 @@ class MathjaxTest extends \WP_UnitTestCase {
 		$this->mathjax->usePbMathJax = true;
 		$content = $this->mathjax->replaceMathML( $mathml_content );
 		$this->assertStringContainsString( 'http://localhost:3000/mathml', $content );
+	}
+
+	public function testExportDoubleDollarUnaffected() {
+		// Double dollar should still produce display math, unaffected by single-dollar setting
+		update_option( MathJax::OPTION, [ 'fg' => '000000', 'use_single_dollar' => true ] );
+		$this->mathjax->usePbMathJax = true;
+
+		$s = $this->mathjax->replaceLatexDelimitersOnExports( '$$e^{i\pi}+1=0$$' );
+		$this->assertStringContainsString( 'display-math', $s );
+		$this->assertStringStartsWith( '<div class="display-math"><img', $s );
+	}
+
+	/**
+	 * Integration tests: simulate the export filter chain where
+	 * replaceSingleDollarDelimiters() converts $...$ to \(...\)
+	 * then replaceLatexDelimitersOnExports() renders \(...\) via pb-mathjax.
+	 */
+	public function testExportPipelineSingleDollarRendered() {
+		update_option( MathJax::OPTION, [ 'fg' => '000000', 'use_single_dollar' => true ] );
+		$this->mathjax->usePbMathJax = true;
+
+		$content = '$f(x)$';
+		// Step 1: replaceSingleDollarDelimiters converts $...$ to \(...\)
+		$content = $this->mathjax->replaceSingleDollarDelimiters( $content );
+		// Step 2: replaceLatexDelimitersOnExports renders \(...\) as <img>
+		$content = $this->mathjax->replaceLatexDelimitersOnExports( $content );
+
+		$this->assertStringStartsWith( '<img', $content );
+		$this->assertStringContainsString( 'class="latex mathjax"', $content );
+	}
+
+	public function testExportPipelineCurrencyUntouched() {
+		update_option( MathJax::OPTION, [ 'fg' => '000000', 'use_single_dollar' => true ] );
+		$this->mathjax->usePbMathJax = true;
+
+		$content = 'I think $ 5,000 dolares will be enough $ or maybe $4,000$ pesos.';
+		$content = $this->mathjax->replaceSingleDollarDelimiters( $content );
+		$content = $this->mathjax->replaceLatexDelimitersOnExports( $content );
+
+		// Currency with spaces must remain as plain text
+		$this->assertStringContainsString( '$ 5,000 dolares will be enough $', $content );
+		// $4,000$ should be rendered (no spaces adjacent to delimiters)
+		$this->assertStringContainsString( '<img', $content );
+		$this->assertStringContainsString( 'pesos.', $content );
+	}
+
+	public function testExportPipelineDoubleDollarNotCorrupted() {
+		update_option( MathJax::OPTION, [ 'fg' => '000000', 'use_single_dollar' => true ] );
+		$this->mathjax->usePbMathJax = true;
+
+		$content = '$$e^{i\pi}+1=0$$';
+		$content = $this->mathjax->replaceSingleDollarDelimiters( $content );
+		$content = $this->mathjax->replaceLatexDelimitersOnExports( $content );
+
+		// Must produce display-math, not get mangled by single-dollar processing
+		$this->assertStringStartsWith( '<div class="display-math"><img', $content );
 	}
 }


### PR DESCRIPTION
Address https://github.com/pressbooks/pb-mathjax/issues/124

Add user-facing option to support single dollar sign delimiters (`$...) for inline LaTeX math, with careful handling to avoid false positives (such as currency). Update backend logic and MathJax integration, and add tests.

**Single Dollar Delimiter Support**

* Add a new `use_single_dollar` option for MathJax, allowing users to enable or disable `$... as inline math delimiters. This option is exposed in the admin interface with clear documentation and is off by default. [[1]](diffhunk://#diff-75471e261b56521dd46690fedb88783fbf2ce63be3148866d236767dfe25fde2L33-R37) [[2]](diffhunk://#diff-75471e261b56521dd46690fedb88783fbf2ce63be3148866d236767dfe25fde2R185) [[3]](diffhunk://#diff-75471e261b56521dd46690fedb88783fbf2ce63be3148866d236767dfe25fde2R207-R211) [[4]](diffhunk://#diff-183101177c03e8c9991d2f31dada2f1add4f4a66a9f461647b5bad5c4fe1cbb4R49-R64)
* When enabled, server-side processing (not MathJax config) converts `$...` to `\(...\)` using a regex that avoids matching currency or escaped dollar signs, ensuring only intended math expressions are affected.
* The `sectionHasMath` method now detects inline math using single dollar delimiters only if the option is enabled, with logic to avoid currency and similar patterns.
* The MathJax configuration is unchanged for single dollar delimiters—processing is handled server-side to avoid MathJax's greedy matching issues. [[1]](diffhunk://#diff-75471e261b56521dd46690fedb88783fbf2ce63be3148866d236767dfe25fde2L278-R294) [[2]](diffhunk://#diff-75471e261b56521dd46690fedb88783fbf2ce63be3148866d236767dfe25fde2L308-R341)
* Add a filter hook (`pb_mathjax_use_single_dollar`) for programmatic override of this setting.

**Admin Interface Improvements**

* The MathJax settings page now includes a checkbox to enable/disable single dollar delimiter support, with user guidance and examples. The feature is also documented in the "Allowed Syntax" section, which conditionally displays the `$... syntax when enabled. [[1]](diffhunk://#diff-183101177c03e8c9991d2f31dada2f1add4f4a66a9f461647b5bad5c4fe1cbb4L20-R29) [[2]](diffhunk://#diff-183101177c03e8c9991d2f31dada2f1add4f4a66a9f461647b5bad5c4fe1cbb4R49-R64)

<img width="1440" height="817" alt="Pasted_Image_2026-04-02__9_04 PM" src="https://github.com/user-attachments/assets/eba47b5e-bd98-4b2f-8fa6-e66a26eff774" />


**Testing and Quality Assurance**

* Add tests to verify default behavior, option toggling, correct detection of math and currency, export pipeline integration, and edge cases (e.g., escaped dollars, display math, mixed content). [[1]](diffhunk://#diff-75c656a671caff55ad7a4836ccb66dd2b86b860241349385d5c8978feeb65006R56-R90) [[2]](diffhunk://#diff-75c656a671caff55ad7a4836ccb66dd2b86b860241349385d5c8978feeb65006R228-R376) [[3]](diffhunk://#diff-75c656a671caff55ad7a4836ccb66dd2b86b860241349385d5c8978feeb65006R388-R443)