### PR TITLE
chore: improve single delimiter settings page instructions

### DIFF
--- a/templates/admin/mathjax.blade.php
+++ b/templates/admin/mathjax.blade.php
@@ -57,10 +57,7 @@
                         {!! sprintf( __( 'When enabled, %1$s will be treated as inline LaTeX math. Use %2$s to display a literal dollar sign.', 'pressbooks'	), '<code>$e^{i \\pi} + 1 = 0$</code>', '<code>\\$</code>' ) !!}
                     </p>
                     <p>
-                        {{ __( 'Note: The opening $ must not be followed by a space and the closing $ must not be preceded by a space.', 'pressbooks' ) }}
-                    </p>
-                    <p>
-                        {{ __( 'The opening $ must not be followed by a space and the closing $ must not be preceded by a space, so currency like "$ 5,000" is not affected.', 'pressbooks' ) }}
+                        {{ __( 'Note: The opening $ must not be followed by a space and the closing $ must not be preceded by a space, so currency like "$ 5,000" is not affected.', 'pressbooks' ) }}
                         {!! sprintf( __( 'Use %s to display a literal dollar sign.', 'pressbooks' ), '<code>\$</code>' ) !!}
                     </p>
                 </td>


### PR DESCRIPTION
This pull request makes a small improvement to the MathJax admin template by clarifying the note about how dollar signs are interpreted in LaTeX math mode.

* Updated the instructional text in `templates/admin/mathjax.blade.php` to combine and clarify the explanation about spaces around dollar signs, ensuring users understand how to avoid unintended math formatting for currency values like "$ 5,000".