### PR TITLE
fix: consider parts post content for word counting

### DIFF
--- a/inc/class-book.php
+++ b/inc/class-book.php
@@ -555,26 +555,25 @@ class Book {
 	 * @return int
 	 */
 	static function wordCount( $selected_for_export = false ) {
-		$wc = 0;
-		$wc_selected_for_export = 0;
+		$items = [];
 		foreach ( static::getBookStructure() as $key => $section ) {
 			if ( $key === 'front-matter' || $key === 'back-matter' ) {
-				foreach ( $section as $val ) {
-					$wc += $val['word_count'];
-					if ( $val['export'] ) {
-						$wc_selected_for_export += $val['word_count'];
-					}
-				}
+				array_push( $items, ...$section );
 			}
 			if ( $key === 'part' ) {
 				foreach ( $section as $part ) {
-					foreach ( $part['chapters'] as $val ) {
-						$wc += $val['word_count'];
-						if ( $val['export'] ) {
-							$wc_selected_for_export += $val['word_count'];
-						}
-					}
+					$items[] = $part;
+					array_push( $items, ...$part['chapters'] );
 				}
+			}
+		}
+
+		$wc = 0;
+		$wc_selected_for_export = 0;
+		foreach ( $items as $item ) {
+			$wc += $item['word_count'];
+			if ( $item['export'] ) {
+				$wc_selected_for_export += $item['word_count'];
 			}
 		}
 

--- a/tests/test-book.php
+++ b/tests/test-book.php
@@ -168,11 +168,21 @@ class BookTest extends \WP_UnitTestCase {
 		$book = \Pressbooks\Book::getInstance();
 
 		$this->_book();
+
 		$wc = $book::wordCount();
 		$wc_selected_for_export = $book::wordCount( true );
 
-		$this->assertEquals( 166, $wc );
-		$this->assertEquals( 166, $wc_selected_for_export );
+		$this->assertEquals( 170, $wc );
+		$this->assertEquals( 170, $wc_selected_for_export );
+
+		$part_id = $book::getBookStructure()['part'][0]['ID'];
+		$this->factory()->post->update_object( $part_id, [ 'post_content' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.' ] );
+		$book::deleteBookObjectCache();
+		$wc = $book::wordCount();
+		$wc_selected_for_export = $book::wordCount( true );
+
+		$this->assertEquals( 176, $wc );
+		$this->assertEquals( 176, $wc_selected_for_export );
 	}
 
 	/**


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks/issues/4320

This pull request refactors the `wordCount` method in `class-book.php` to simplify how word counts are aggregated from the book structure. Instead of accumulating word counts directly during iteration, it first flattens all relevant items into a single array and then processes them in a separate loop. Additionally, it also considers the parts' post content.

Refactoring and code simplification:

* Refactored the `wordCount` method to first collect all relevant items (`front-matter`, `back-matter`, and `part` chapters) into a single `items` array, and then aggregate word counts in a separate loop for improved readability and maintainability.

### Testing notes
- Go go to Book list (super admin area) and check a word count for a book
- Add content to a part of that book
- update the Book Info (just click save button to trigger the data collector update)
- you should see now the word counts updated considerding the new content added to the part.