### PR TITLE
feat: announce progress bar progress (resolves #3718)

### DIFF
--- a/assets/src/scripts/cloner.js
+++ b/assets/src/scripts/cloner.js
@@ -14,6 +14,7 @@ jQuery( function ( $ ) {
 		const button = $( '#pb-cloner-button' );
 		const bar = $( '#pb-sse-progressbar' );
 		const info = $( '#pb-sse-info' );
+		const status = $( '#pb-sse-status' );
 		const notices = $( '.notice' );
 
 		// Init clock
@@ -53,11 +54,12 @@ jQuery( function ( $ ) {
 			switch ( data.action ) {
 				case 'updateStatusBar':
 					bar.val( parseInt( data.percentage, 10 ) );
+					status.html( `${ data.percentage }%` );
 					info.html( data.info );
 					break;
 				case 'complete':
 					evtSource.close();
-					$( window ).unbind( 'beforeunload' );
+					$( window ).off( 'beforeunload' );
 					if ( data.error ) {
 						bar.val( 0 ).hide();
 						button.attr( 'disabled', false ).show();
@@ -83,7 +85,7 @@ jQuery( function ( $ ) {
 			evtSource.close();
 			$( '#pb-sse-progressbar' ).removeAttr( 'value' );
 			$( '#pb-sse-info' ).html( 'EventStream Connection Error ' + PB_ClonerToken.reloadSnippet );
-			$( window ).unbind( 'beforeunload' );
+			$( window ).off( 'beforeunload' );
 			if ( clock ) {
 				resetClock( clock );
 			}

--- a/assets/src/scripts/covergenerator.js
+++ b/assets/src/scripts/covergenerator.js
@@ -93,7 +93,7 @@ $( function () {
 			let data = JSON.parse( message.data );
 			switch ( data.action ) {
 				case 'updateStatusBar':
-					bar.val(parseInt(data.percentage, 10));
+					bar.val( parseInt( data.percentage, 10 ) );
 					status.html( `${ data.percentage }%` );
 					info.html( data.info );
 					break;

--- a/assets/src/scripts/covergenerator.js
+++ b/assets/src/scripts/covergenerator.js
@@ -56,6 +56,7 @@ $( function () {
 	const makeEbookButton = $( '#generate-jpg' );
 	const bar = $( '#pb-sse-progressbar' );
 	const info = $( '#pb-sse-info' );
+	const status = $( '#pb-sse-status' );
 	const notices = $( '.notice' );
 
 	// Initialize clock
@@ -92,12 +93,13 @@ $( function () {
 			let data = JSON.parse( message.data );
 			switch ( data.action ) {
 				case 'updateStatusBar':
-					bar.val( parseInt( data.percentage, 10 ) );
+					bar.val(parseInt(data.percentage, 10));
+					status.html( `${ data.percentage }%` );
 					info.html( data.info );
 					break;
 				case 'complete':
 					evtSource.close();
-					$( window ).unbind( 'beforeunload' );
+					$( window ).off( 'beforeunload' );
 					if ( data.error ) {
 						bar.val( 0 ).hide();
 						makePdfButton.attr( 'disabled', false ).show();
@@ -123,7 +125,7 @@ $( function () {
 			evtSource.close();
 			bar.removeAttr( 'value' );
 			info.html( 'EventStream Connection Error ' + PB_CG.reloadSnippet );
-			$( window ).unbind( 'beforeunload' );
+			$( window ).off( 'beforeunload' );
 			if ( clock ) {
 				resetClock( clock );
 			}

--- a/assets/src/scripts/export.js
+++ b/assets/src/scripts/export.js
@@ -133,9 +133,9 @@ function createJobRow( jobData ) {
                 </div>
                 <div class="export-progress">
                     <div class="progress-bar-container">
-                        <div class="progress-bar" style="width: ${ jobData.progress_percentage || 0 }%" aria-valuenow="${ jobData.progress_percentage || 0 }"></div>
+                        <div class="progress-bar" role="progress" style="width: ${ jobData.progress_percentage || 0 }%" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${ jobData.progress_percentage || 0 }"></div>
                     </div>
-                    <span class="progress-text">${ jobData.progress_percentage || 0 }%</span>
+                    <span class="progress-text" aria-live="polite">${ jobData.progress_percentage || 0 }%</span>
                 </div>
                 <div class="export-actions">
                	  <button class="button button-secondary cancel-job" data-job-id="${ jobData.job_id }" type="button">${ PB_ExportToken?.text?.cancel_button || 'Cancel' }</button>

--- a/assets/src/scripts/import.js
+++ b/assets/src/scripts/import.js
@@ -8,7 +8,8 @@ jQuery( function ( $ ) {
 	// Set element variables
 	const button = $( 'input[type=submit]' );
 	const bar = $( '#pb-sse-progressbar' );
-	const info = $( '#pb-sse-info' );
+	const info = $('#pb-sse-info');
+	const status = $( '#pb-sse-status' );
 	const notices = $( '.notice' );
 
 	// Init clock
@@ -45,11 +46,12 @@ jQuery( function ( $ ) {
 			switch ( data.action ) {
 				case 'updateStatusBar':
 					bar.val( parseInt( data.percentage, 10 ) );
+					status.html( `${ data.percentage }%` );
 					info.html( data.info );
 					break;
 				case 'complete':
 					evtSource.close();
-					$( window ).unbind( 'beforeunload' );
+					$( window ).off( 'beforeunload' );
 					if ( data.error ) {
 						bar.val( 0 ).hide();
 						button.attr( 'disabled', false ).show();
@@ -74,7 +76,7 @@ jQuery( function ( $ ) {
 			evtSource.close();
 			bar.removeAttr( 'value' );
 			info.html( 'EventStream Connection Error ' + PB_ImportToken.reloadSnippet );
-			$( window ).unbind( 'beforeunload' );
+			$( window ).off( 'beforeunload' );
 			if ( clock ) {
 				resetClock( clock );
 			}

--- a/assets/src/scripts/import.js
+++ b/assets/src/scripts/import.js
@@ -8,7 +8,7 @@ jQuery( function ( $ ) {
 	// Set element variables
 	const button = $( 'input[type=submit]' );
 	const bar = $( '#pb-sse-progressbar' );
-	const info = $('#pb-sse-info');
+	const info = $( '#pb-sse-info' );
 	const status = $( '#pb-sse-status' );
 	const notices = $( '.notice' );
 

--- a/templates/admin/cloner/page.blade.php
+++ b/templates/admin/cloner/page.blade.php
@@ -17,7 +17,7 @@
 			<p class="description" id="target_book_url_description">{{ __( 'Enter the URL where you want this book to be cloned. This URL cannot be changed later, so choose carefully.', 'pressbooks' ) }}</p>
 			<input id="pb-cloner-button" class="button button-hero button-primary" type="submit" value="{{ __( 'Clone book', 'pressbooks' ) }}">
 			<progress id="pb-sse-progressbar" max="100" aria-label="{{ __( 'Cloning progress', 'pressbooks' ) }}"></progress>
-			<strong><span id="pb-sse-minutes"></span><span id="pb-sse-seconds"></span></strong> <span id="pb-sse-info" aria-live="polite"></span>
+			<strong><span id="pb-sse-minutes"></span><span id="pb-sse-seconds"></span></strong> <span id="pb-sse-info" aria-live="polite"></span> <span id="pb-sse-status" class="screen-reader-text" aria-live="polite">0%</span>
 		</form>
 	</div>
 	@if( \Pressbooks\Utility\is_algolia_search_enabled() )

--- a/templates/admin/covergenerator.php
+++ b/templates/admin/covergenerator.php
@@ -79,7 +79,7 @@ if ( $dependency_errors ) {
 	<h3><?php _e( 'Make Your Cover', 'pressbooks' ); ?></h3>
 
 	<progress id="pb-sse-progressbar" max="100"></progress>
-	<p><b><span id="pb-sse-minutes"></span><span id="pb-sse-seconds"></span></b> <span id="pb-sse-info" aria-live="polite"></span></p>
+	<p><b><span id="pb-sse-minutes"></span><span id="pb-sse-seconds"></span></b> <span id="pb-sse-info" aria-live="polite"></span> <span id="pb-sse-status" class="screen-reader-text" aria-live="polite">0%</span></p>
 
 	<?php if ( $is_custom_css ) { ?>
 		<?php printf( '<p><em>%s</em></p>', __( 'You are currently using the Custom CSS theme. To generate a cover, you will need to switch back to a base theme temporarily. You can then reapply your Custom CSS theme.', 'pressbooks' ) ); ?>

--- a/templates/admin/import.php
+++ b/templates/admin/import.php
@@ -149,7 +149,7 @@ $import_option_types = apply_filters( 'pb_select_import_type', [
 		<p><input type='checkbox' id='show_imports_in_web' name='show_imports_in_web' value='1'><label for="show_imports_in_web"> <?php _e( 'Show imported content in web', 'pressbooks' ); ?></label></p>
 
 		<progress id="pb-sse-progressbar" max="100"></progress>
-		<p><b><span id="pb-sse-minutes"></span><span id="pb-sse-seconds"></span></b> <span id="pb-sse-info" aria-live="polite"></span></p>
+		<p><b><span id="pb-sse-minutes"></span><span id="pb-sse-seconds"></span></b> <span id="pb-sse-info" aria-live="polite"></span> <span id="pb-sse-status" class="screen-reader-text" aria-live="polite">0%</span></p>
 		<p><?php
 			submit_button( __( 'Import Selection', 'pressbooks' ), 'primary', 'submit', false );
 			echo ' &nbsp; ';


### PR DESCRIPTION
Resolves #3718 by injecting percentage of progress bars for import, export, clone and cover generator operations into a live region.

As per https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA25:

> The following example uses an element with a `role="progressbar"` attribute. The `aria-valuemin`, `aria-valuemax`, and `aria-valuenow` values on the `progressbar` component programmatically communicate the progress of the upload, but because the `progressbar` role is not a live region, screen readers won't announce updates to those values as they change. The use of an ARIA progress bar is not actually important for this technique – what matters is the progress being conveyed with a status message.

The initial implementation of these progress bars were semantically correct but extra work is required to announce the progress.

## Definition of Done

Enable VoiceOver or JAWS. Import a file or clone a book (the larger the better), generate a cover, or export a book. Percentages should be announced periodically.

**NOTE:** I had to set throttling to 3G in the Network tab of Chrome Developer Tools in order to hear more than one announcement for most of these as the operations on my local dev instance are quite fast.