### PR TITLE
chore: change institution name Adelaide

### DIFF
--- a/symbionts/institutions/institutions.json
+++ b/symbionts/institutions/institutions.json
@@ -172,7 +172,7 @@
           },
           {
             "code": "AU-SA-002",
-            "name": "University of Adelaide",
+            "name": "Adelaide University",
             "url": "https:\/\/www.adelaide.edu.au\/"
           },
           {


### PR DESCRIPTION
change institution name 'University of Adelaide' to 'Adelaide University' upon request from network manager

addresses https://github.com/pressbooks/private/issues/2376
(Zendesk ticket 28152)