### PR TITLE
fix: include src/js assets for distribution

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,7 +1,8 @@
 .git
 .idea
 crowdin.yml
-assets/src
+assets/src/*
+!assets/src/scripts
 bin
 node_modules
 tests


### PR DESCRIPTION
This pull request makes a small update to the `.distignore` file. The change refines how files in the `assets/src` directory are ignored during distribution, now ignoring all files except the `assets/src/scripts` directory.