### PR TITLE
fix: esc_html() site name in XHTML export title element

### DIFF
--- a/inc/modules/export/xhtml/class-xhtml11.php
+++ b/inc/modules/export/xhtml/class-xhtml11.php
@@ -372,7 +372,7 @@ class Xhtml11 extends Export {
 
 		$this->echoMetaData( $_unused, $metadata );
 
-		echo '<title>' . get_bloginfo( 'name' ) . "</title>\n";
+		echo '<title>' . esc_html( get_bloginfo( 'name' ) ) . "</title>\n";
 
 		if ( current_user_can( 'edit_posts' ) ) {
 			if ( ! empty( $_GET['debug'] ) ) {


### PR DESCRIPTION
## What

`get_bloginfo('name')` was echoed directly into the XHTML `<title>` element without HTML entity encoding.

A site name containing an ampersand — e.g. **Arts & Sciences** — produces a raw `&` in the output. That makes the document invalid XML, and XML parsers (including Prince, which Pressbooks uses for PDF generation) throw a parse error on export.

**Before:**
```php
echo '<title>' . get_bloginfo( 'name' ) . "</title>\n";
```

**After:**
```php
echo '<title>' . esc_html( get_bloginfo( 'name' ) ) . "</title>\n";
```

## Why this line specifically

The `echoMetaData()` call immediately above this line already routes all metadata through `sanitize_xml_attribute()`. The title line was the one spot that skipped that discipline. The fix uses `esc_html()` to stay consistent with the escaping pattern used throughout the class.

## Testing

1. Set site name to something containing `&` (e.g. `Arts & Sciences`) in Network Settings.
2. Export a book as PDF using Prince.
3. Confirm the export succeeds and the title renders correctly.

Closes #4264

---
*Development and testing assisted by AI. All code reviewed and verified manually.*