### PR TITLE
fix: fall back to editors for copyright when book has no authors

### DIFF
--- a/inc/class-licensing.php
+++ b/inc/class-licensing.php
@@ -8,7 +8,7 @@ namespace Pressbooks;
 
 use function \Pressbooks\Utility\debug_error_log;
 use function \Pressbooks\Utility\explode_remove_and;
-use function \Pressbooks\Utility\implode_add_and;
+use function \Pressbooks\Utility\get_contributors_name_imploded;
 
 /**
  * TODO: Refactor
@@ -303,17 +303,7 @@ class Licensing {
 			return $contributors;
 		}
 
-		$names = [];
-
-		foreach ( $contributors as $contributor ) {
-			if ( empty( $contributor['name'] ) ) {
-				continue;
-			}
-
-			$names[] = $contributor['name'];
-		}
-
-		return implode_add_and( ';', $names );
+		return get_contributors_name_imploded( $contributors );
 	}
 
 	/**

--- a/inc/class-licensing.php
+++ b/inc/class-licensing.php
@@ -252,20 +252,15 @@ class Licensing {
 		if ( ! empty( $section_author ) && ! empty( $section_license ) ) {
 			// section author higher priority than book author when there's a custom license
 			$copyright_holder = $section_author;
-		} elseif ( isset( $metadata['pb_copyright_holder'] ) ) {
+		} elseif ( ! empty( $metadata['pb_copyright_holder'] ) ) {
 			// book copyright holder higher priority than book author
 			$copyright_holder = $metadata['pb_copyright_holder'];
-		} elseif ( isset( $metadata['pb_authors'] ) ) {
+		} elseif ( ! empty( $metadata['pb_authors'] ) ) {
 			// book author is the fallback, default
-			if ( is_array( $metadata['pb_authors'] ) ) {
-				$authors = [];
-				foreach ( $metadata['pb_authors'] as $author ) {
-					$authors[] = $author['name'];
-				}
-				$copyright_holder = implode_add_and( ';', $authors );
-			} else {
-				$copyright_holder = $metadata['pb_authors'];
-			}
+			$copyright_holder = $this->contributorsToString( $metadata['pb_authors'] );
+		} elseif ( ! empty( $metadata['pb_editors'] ) ) {
+			// book editors are used as copyright holder when there are no authors
+			$copyright_holder = $this->contributorsToString( $metadata['pb_editors'] );
 		} else {
 			$copyright_holder = '';
 		}
@@ -291,6 +286,34 @@ class Licensing {
 		$html = $this->getLicense( $license, $copyright_holder, $link, $title, $copyright_year );
 
 		return $html;
+	}
+
+	/**
+	 * Normalize a contributor metadata value into a display string.
+	 *
+	 * Contributor metadata can be either a pre-formatted string or an array of
+	 * entries, depending on how the book information was loaded.
+	 *
+	 * @param string|array{name: string} $contributors
+	 *
+	 * @return string
+	 */
+	private function contributorsToString( string|array $contributors ): string {
+		if ( ! is_array( $contributors ) ) {
+			return $contributors;
+		}
+
+		$names = [];
+
+		foreach ( $contributors as $contributor ) {
+			if ( empty( $contributor['name'] ) ) {
+				continue;
+			}
+
+			$names[] = $contributor['name'];
+		}
+
+		return implode_add_and( ';', $names );
 	}
 
 	/**

--- a/tests/test-licensing.php
+++ b/tests/test-licensing.php
@@ -120,6 +120,34 @@ class LicensingTest extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * @group licensing
+	 */
+	public function test_doLicenseFallsBackToEditors() {
+		$new_post = [
+			'post_title' => 'Test Chapter',
+			'post_type' => 'chapter',
+			'post_status' => 'publish',
+			'post_content' => 'My test chapter.',
+		];
+		$post_id = $this->factory()->post->create_object( $new_post );
+
+		// No copyright holder and no authors, but editors are present (as string).
+		$result = $this->licensing->doLicense( [ 'pb_book_license' => 'cc-by', 'pb_editors' => 'Edith Editor' ], $post_id );
+		$this->assertStringContainsString( 'by', $result );
+		$this->assertStringContainsString( 'Edith Editor', $result );
+
+		// Editors provided as an array of contributors.
+		$result = $this->licensing->doLicense( [ 'pb_book_license' => 'cc-by', 'pb_editors' => [ [ 'name' => 'Edith Editor' ], [ 'name' => 'Edmund Editor' ] ] ], $post_id );
+		$this->assertStringContainsString( 'Edith Editor', $result );
+		$this->assertStringContainsString( 'Edmund Editor', $result );
+
+		// Authors take precedence over editors.
+		$result = $this->licensing->doLicense( [ 'pb_book_license' => 'cc-by', 'pb_authors' => 'Anne Author', 'pb_editors' => 'Edith Editor' ], $post_id );
+		$this->assertStringContainsString( 'Anne Author', $result );
+		$this->assertStringNotContainsString( 'Edith Editor', $result );
+	}
+
+	/**
 	 * @expectedIncorrectUsage Pressbooks\Licensing::doLicense
 	 * @group licensing
 	 */


### PR DESCRIPTION
Resolves #4324 

## Fall back to editors for copyright holder when a book has no authors

### Problem

When a book has authors, their names are automatically used as the copyright holder in the copyright notice. But when a book has **only editors** and the copyright-holder field is left blank, no holder name appears in the notice — while the "by" still renders, leaving a dangling "by" with no name.

### Steps to reproduce

1. Remove all contributors from the **Authors** field of a book
2. Leave the **Copyright holder** field in Book Info blank
3. View the book's homepage

**Before:** `… Copyright © by  is licensed under …` — empty holder, dangling "by".
**After:** the editor's name is used as the copyright holder.

### Changes

- **`inc/class-licensing.php`** — `doLicense()` now adds `pb_editors` as the next fallback in the copyright-holder precedence chain:
  *section author → `pb_copyright_holder` → `pb_authors` → `pb_editors`*.
  The `pb_copyright_holder`/`pb_authors` checks were switched from `isset()` to `! empty()` so a blank-but-present field correctly falls through to the next source.
- Extracted contributor normalization into a new private `contributorsToString()` helper, reused for both authors and editors.

### Tests

Added `test_doLicenseFallsBackToEditors` covering:
- editors used as the holder when there's no author/copyright holder (string and array forms)
- multiple editors rendered together
- authors still taking precedence over editors