### PR TITLE
chore: add institution HfH in Switzerland

### DIFF
--- a/symbionts/institutions/institutions.json
+++ b/symbionts/institutions/institutions.json
@@ -3232,6 +3232,16 @@
             "url": "https:\/\/www.uhu.es\/"
           }
         ]
+      },
+      {
+        "name": "Switzerland",
+        "institutions": [
+          {
+            "code": "EU-SUI-001",
+            "name": "HfH Interkantonale Hochschule für Heilpädagogik",
+            "url": "https:\/\/www.hfh.ch\/"
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
add Switzerland as a new region and add 'HfH Interkantonale Hochschule für Heilpädagogik' upon [request in the forum](https://pressbooks.community/t/institutions-list-how-to-add-to-it/2174/20)

addresses https://github.com/pressbooks/pressbooks/issues/4509