### PR TITLE
fix: correct activation page login URL

### DIFF
--- a/hooks.php
+++ b/hooks.php
@@ -371,6 +371,7 @@ add_filter( 'wpmu_validate_user_signup', '\Pressbooks\Registration\validate_pass
 add_filter( 'add_signup_meta', '\Pressbooks\Registration\add_temporary_password', 99 );
 add_action( 'signup_blogform', '\Pressbooks\Registration\add_hidden_password_field' );
 add_filter( 'random_password', '\Pressbooks\Registration\override_password_generation' );
+add_filter( 'login_url', '\Pressbooks\Registration\remove_wp_prefix', 12 );
 add_filter( 'lostpassword_url', '\Pressbooks\Registration\remove_wp_prefix', 12 );
 // Hooks to have pending invitation information
 add_action( 'invite_user', '\Pressbooks\Registration\save_invitation_data', 10, 3 );

--- a/inc/registration/namespace.php
+++ b/inc/registration/namespace.php
@@ -357,7 +357,7 @@ function check_for_strong_password( $pwd ) {
 }
 
 /**
- * Remove unwanted and unnecessary Bedrock's prefix in Lost Url link
+ * Remove unwanted and unnecessary Bedrock's prefix in login-related URLs
  * only if the book name is not wp
  */
 function remove_wp_prefix( $lostpassword_url ) {

--- a/inc/registration/namespace.php
+++ b/inc/registration/namespace.php
@@ -360,8 +360,8 @@ function check_for_strong_password( $pwd ) {
  * Remove unwanted and unnecessary Bedrock's prefix in login-related URLs
  * only if the book name is not wp
  */
-function remove_wp_prefix( $lostpassword_url ) {
-	return preg_replace( '/(.*[^\/])\/wp\/(.*)(\/wp-login.php)(.*)/i', '$1/$2$3$4', $lostpassword_url );
+function remove_wp_prefix( $url ) {
+	return preg_replace( '/(.*[^\/])\/wp\/(.*)(\/wp-login.php)(.*)/i', '$1/$2$3$4', $url );
 }
 
 /**

--- a/tests/test-login.php
+++ b/tests/test-login.php
@@ -20,4 +20,19 @@ class Login extends \WP_UnitTestCase {
 			\Pressbooks\Registration\remove_wp_prefix( 'https://network.pressbooks.pub/wp-login.php?action=lostpassword' )
 		);
 	}
+
+	/**
+	 * @group Login
+	 */
+	public function test_if_wp_prefix_is_removed_from_login_url_filter() {
+		$this->assertSame(
+			'https://network.pressbooks.pub/booktitle/wp-login.php',
+			apply_filters(
+				'login_url',
+				'https://network.pressbooks.pub/wp/booktitle/wp-login.php',
+				'',
+				false
+			)
+		);
+	}
 }


### PR DESCRIPTION
## Summary

- apply the existing Bedrock login URL normalization to WordPress's `login_url` filter
- add regression coverage for the activation-page login link
- update the callback comment to reflect both login and lost-password URLs

## Root cause

Pressbooks already removes the extra `/wp/` prefix from lost-password URLs, but the callback was registered only on `lostpassword_url`. WordPress's activation page switches to the new book and calls `wp_login_url()`, which uses the separate `login_url` filter.

## User impact

After activating an invited user account, the `Log in` link now points to the book's actual `wp-login.php` URL instead of the broken `/wp/<book>/wp-login.php` path.

## Testing

- `vendor/bin/phpunit --configuration phpunit.xml --group Login` — 2 tests, 4 assertions
- repository PHPCS ruleset across `inc/` and `bin/`, plus the changed top-level hook file
- PHP syntax checks for all three changed files
- `git diff --check`

The non-integration suite was also started locally; its first 136 of 1,053 tests passed before the run was stopped because PHP 8.4 produced extensive deprecation output from existing dependencies. The pull request CI can run the complete supported matrix.

Fixes #4504
