### PR TITLE
feat: add crawler filter and pressbooks_tracking schema changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,8 @@
 		"symfony/process": "^6.0|^7.0",
 		"vanilla/htmlawed": "^2.2",
 		"vlucas/phpdotenv": "^5.4",
-		"h5p/h5p-core": "1.27.0"
+		"h5p/h5p-core": "1.27.0",
+		"jaybizzle/crawler-detect": "^1.4"
 	},
 	"require-dev": {
 		"dms/phpunit-arraysubset-asserts": "^0.5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "769e00b05ecd012cba7a2500caca4483",
+    "content-hash": "3cfce71ea10e8720ccd0fea3278b2d88",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -2307,6 +2307,58 @@
                 }
             ],
             "time": "2022-05-21T17:30:32+00:00"
+        },
+        {
+            "name": "jaybizzle/crawler-detect",
+            "version": "v1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/JayBizzle/Crawler-Detect.git",
+                "reference": "770e00e5bcd35054871a6f790f380123cc3b8b0c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/JayBizzle/Crawler-Detect/zipball/770e00e5bcd35054871a6f790f380123cc3b8b0c",
+                "reference": "770e00e5bcd35054871a6f790f380123cc3b8b0c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5.52|^9.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Jaybizzle\\CrawlerDetect\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Beech",
+                    "email": "m@rkbee.ch",
+                    "role": "Developer"
+                }
+            ],
+            "description": "CrawlerDetect is a PHP class for detecting bots/crawlers/spiders via the user agent",
+            "homepage": "https://github.com/JayBizzle/Crawler-Detect/",
+            "keywords": [
+                "crawler",
+                "crawler detect",
+                "crawler detector",
+                "crawlerdetect",
+                "php crawler detect"
+            ],
+            "support": {
+                "issues": "https://github.com/JayBizzle/Crawler-Detect/issues",
+                "source": "https://github.com/JayBizzle/Crawler-Detect/tree/v1.4.1"
+            },
+            "time": "2026-07-10T14:15:38+00:00"
         },
         {
             "name": "jenssegers/imagehash",
@@ -8577,5 +8629,5 @@
         "php": "^8.3"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/inc/tracking/class-bookdownload.php
+++ b/inc/tracking/class-bookdownload.php
@@ -20,7 +20,7 @@ class BookDownload extends Tracking {
 	 * @param mixed $value
 	 * @return void
 	 */
-	public function store( $value ): void {
+	public function store( $value ) {
 		if ( ! $this->shouldTrack() ) {
 			return;
 		}
@@ -31,8 +31,8 @@ class BookDownload extends Tracking {
 	/**
 	 * Only count GET requests with a non-empty, non-bot user agent.
 	 *
-	 * Files are still served to everyone; this stage changes only what is
-	 * counted, so direct links (including OPDS consumers) keep working.
+	 * The user agent is inspected in-memory to classify the request and
+	 * is never persisted.
 	 *
 	 * @return bool
 	 */
@@ -41,9 +41,9 @@ class BookDownload extends Tracking {
 			return false;
 		}
 
-		$user_agent = $this->getUserAgent();
+		$user_agent = sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ?? '' ) );
 
-		if ( $user_agent === null ) {
+		if ( $user_agent === '' ) {
 			return false;
 		}
 

--- a/inc/tracking/class-bookdownload.php
+++ b/inc/tracking/class-bookdownload.php
@@ -20,7 +20,7 @@ class BookDownload extends Tracking {
 	 * @param mixed $value
 	 * @return void
 	 */
-	public function store( $value ) {
+	public function store( $value ): void {
 		if ( ! $this->shouldTrack() ) {
 			return;
 		}

--- a/inc/tracking/class-bookdownload.php
+++ b/inc/tracking/class-bookdownload.php
@@ -2,12 +2,51 @@
 
 namespace Pressbooks\Tracking;
 
+use Jaybizzle\CrawlerDetect\CrawlerDetect;
+
 class BookDownload extends Tracking {
+
 	protected function __construct() {
 		parent::__construct();
 
 		$this->type = 'book_download';
 
 		add_action( 'store_download_data', [ $this, 'store' ] );
+	}
+
+	/**
+	 * Store the download event, unless the request should not be counted.
+	 *
+	 * @param mixed $value
+	 * @return void
+	 */
+	public function store( $value ) {
+		if ( ! $this->shouldTrack() ) {
+			return;
+		}
+
+		parent::store( $value );
+	}
+
+	/**
+	 * Only count GET requests with a non-empty, non-bot user agent.
+	 *
+	 * Files are still served to everyone; this stage changes only what is
+	 * counted, so direct links (including OPDS consumers) keep working.
+	 *
+	 * @return bool
+	 */
+	protected function shouldTrack(): bool {
+		if ( ( $_SERVER['REQUEST_METHOD'] ?? '' ) !== 'GET' ) {
+			return false;
+		}
+
+		$user_agent = $this->getUserAgent();
+
+		if ( $user_agent === null ) {
+			return false;
+		}
+
+		return ! ( new CrawlerDetect() )->isCrawler( $user_agent );
 	}
 }

--- a/inc/tracking/class-tracking.php
+++ b/inc/tracking/class-tracking.php
@@ -3,13 +3,6 @@
 namespace Pressbooks\Tracking;
 
 abstract class Tracking {
-
-	const DB_VERSION = '1.1';
-
-	const DB_VERSION_OPTION = 'pressbooks_tracking_db_version';
-
-	const IP_SALT_OPTION = 'pressbooks_tracking_ip_salt';
-
 	protected static $instance;
 
 	/**
@@ -45,38 +38,22 @@ abstract class Tracking {
 	/**
 	 * Set up the database table.
 	 *
-	 * Version-gated: dbDelta only runs when DB_VERSION changes. The schema
-	 * string must stay dbDelta-compatible: no IF NOT EXISTS (its table-name
-	 * regex captures IF as the name and skips the ALTER/diff path on existing
-	 * tables), no backticks (they mismatch DESCRIBE output and can re-attempt
-	 * ADDs of existing columns), one definition per line, two spaces after
-	 * PRIMARY KEY.
-	 *
 	 * @return void
 	 */
-	protected function setup(): void {
-		if ( get_site_option( self::DB_VERSION_OPTION ) === self::DB_VERSION ) {
-			return;
-		}
-
+	protected function setup() {
 		require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );
 
-		$sql = "CREATE TABLE {$this->dbTable} (
-				id bigint(20) NOT NULL AUTO_INCREMENT,
-				blog_id bigint(20) NOT NULL,
-				track_type varchar(30) NOT NULL,
-				track_value varchar(255),
-				logged_in boolean NOT NULL default false,
-				created_at datetime NOT NULL,
-				user_agent varchar(500) DEFAULT NULL,
-				referrer varchar(500) DEFAULT NULL,
-				ip_hash char(64) DEFAULT NULL,
+		$sql = "CREATE TABLE IF NOT EXISTS `$this->dbTable` (
+				`id` bigint(20) NOT NULL AUTO_INCREMENT,
+				`blog_id` bigint(20) NOT NULL,
+				`track_type` varchar(30) NOT NULL,
+				`track_value` varchar(255),
+				`logged_in` boolean NOT NULL default false,
+				`created_at` datetime NOT NULL,
 				PRIMARY KEY  (id)
 				);";
 
 		dbDelta( $sql );
-
-		update_site_option( self::DB_VERSION_OPTION, self::DB_VERSION );
 	}
 
 	/**
@@ -85,7 +62,7 @@ abstract class Tracking {
 	 * @param mixed $value
 	 * @return void
 	 */
-	public function store( $value ): void {
+	public function store( $value ) {
 		global $wpdb;
 
 		$date = new \DateTime( 'now', new \DateTimeZone( 'UTC' ) );
@@ -97,75 +74,7 @@ abstract class Tracking {
 				'track_value' => $value,
 				'logged_in' => is_user_logged_in(),
 				'created_at' => $date->format( 'Y-m-d H:i:s' ),
-				'user_agent' => $this->getUserAgent(),
-				'referrer' => $this->getReferrer(),
-				'ip_hash' => $this->getIpHash(),
 			]
 		);
-	}
-
-	/**
-	 * Sanitized, truncated user agent, or null when absent.
-	 *
-	 * @return string|null
-	 */
-	protected function getUserAgent(): ?string {
-		$user_agent = sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ?? '' ) );
-
-		return $user_agent === '' ? null : mb_substr( $user_agent, 0, 500 );
-	}
-
-	/**
-	 * Sanitized, truncated referrer, or null when absent.
-	 *
-	 * @return string|null
-	 */
-	protected function getReferrer(): ?string {
-		$referrer = esc_url_raw( wp_unslash( $_SERVER['HTTP_REFERER'] ?? '' ) );
-
-		return $referrer === '' ? null : mb_substr( $referrer, 0, 500 );
-	}
-
-	/**
-	 * Salted SHA-256 hash of the client IP, or null when unavailable.
-	 * The raw IP is never stored.
-	 *
-	 * @return string|null
-	 */
-	protected function getIpHash(): ?string {
-		/**
-		 * Filter the client IP used for hashed tracking.
-		 *
-		 * Behind a proxy/CDN, REMOTE_ADDR may be the proxy address; ops can
-		 * point this at the sanitized real-client-IP source for the network.
-		 *
-		 * @since 6.43.0
-		 *
-		 * @param string $ip
-		 */
-		$ip = apply_filters( 'pb_tracking_client_ip', isset( $_SERVER['REMOTE_ADDR'] ) ? wp_unslash( $_SERVER['REMOTE_ADDR'] ) : '' );
-
-		if ( ! $ip ) {
-			return null;
-		}
-
-		return hash( 'sha256', $ip . $this->getIpSalt() );
-	}
-
-	/**
-	 * Dedicated persistent salt, independent of wp_salt() so WordPress key
-	 * rotation does not break hash continuity.
-	 *
-	 * @return string
-	 */
-	protected function getIpSalt(): string {
-		$salt = get_site_option( self::IP_SALT_OPTION );
-
-		if ( ! $salt ) {
-			$salt = wp_generate_password( 64, true, true );
-			add_site_option( self::IP_SALT_OPTION, $salt );
-		}
-
-		return $salt;
 	}
 }

--- a/inc/tracking/class-tracking.php
+++ b/inc/tracking/class-tracking.php
@@ -3,6 +3,13 @@
 namespace Pressbooks\Tracking;
 
 abstract class Tracking {
+
+	const DB_VERSION = '1.1';
+
+	const DB_VERSION_OPTION = 'pressbooks_tracking_db_version';
+
+	const IP_SALT_OPTION = 'pressbooks_tracking_ip_salt';
+
 	protected static $instance;
 
 	/**
@@ -38,22 +45,38 @@ abstract class Tracking {
 	/**
 	 * Set up the database table.
 	 *
+	 * Version-gated: dbDelta only runs when DB_VERSION changes. The schema
+	 * string must stay dbDelta-compatible: no IF NOT EXISTS (its table-name
+	 * regex captures IF as the name and skips the ALTER/diff path on existing
+	 * tables), no backticks (they mismatch DESCRIBE output and can re-attempt
+	 * ADDs of existing columns), one definition per line, two spaces after
+	 * PRIMARY KEY.
+	 *
 	 * @return void
 	 */
 	protected function setup() {
+		if ( get_site_option( self::DB_VERSION_OPTION ) === self::DB_VERSION ) {
+			return;
+		}
+
 		require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );
 
-		$sql = "CREATE TABLE IF NOT EXISTS `$this->dbTable` (
-				`id` bigint(20) NOT NULL AUTO_INCREMENT,
-				`blog_id` bigint(20) NOT NULL,
-				`track_type` varchar(30) NOT NULL,
-				`track_value` varchar(255),
-				`logged_in` boolean NOT NULL default false,
-				`created_at` datetime NOT NULL,
+		$sql = "CREATE TABLE {$this->dbTable} (
+				id bigint(20) NOT NULL AUTO_INCREMENT,
+				blog_id bigint(20) NOT NULL,
+				track_type varchar(30) NOT NULL,
+				track_value varchar(255),
+				logged_in boolean NOT NULL default false,
+				created_at datetime NOT NULL,
+				user_agent varchar(500) DEFAULT NULL,
+				referrer varchar(500) DEFAULT NULL,
+				ip_hash char(64) DEFAULT NULL,
 				PRIMARY KEY  (id)
 				);";
 
 		dbDelta( $sql );
+
+		update_site_option( self::DB_VERSION_OPTION, self::DB_VERSION );
 	}
 
 	/**
@@ -74,7 +97,75 @@ abstract class Tracking {
 				'track_value' => $value,
 				'logged_in' => is_user_logged_in(),
 				'created_at' => $date->format( 'Y-m-d H:i:s' ),
+				'user_agent' => $this->getUserAgent(),
+				'referrer' => $this->getReferrer(),
+				'ip_hash' => $this->getIpHash(),
 			]
 		);
+	}
+
+	/**
+	 * Sanitized, truncated user agent, or null when absent.
+	 *
+	 * @return string|null
+	 */
+	protected function getUserAgent() {
+		$user_agent = sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ?? '' ) );
+
+		return $user_agent === '' ? null : mb_substr( $user_agent, 0, 500 );
+	}
+
+	/**
+	 * Sanitized, truncated referrer, or null when absent.
+	 *
+	 * @return string|null
+	 */
+	protected function getReferrer() {
+		$referrer = esc_url_raw( wp_unslash( $_SERVER['HTTP_REFERER'] ?? '' ) );
+
+		return $referrer === '' ? null : mb_substr( $referrer, 0, 500 );
+	}
+
+	/**
+	 * Salted SHA-256 hash of the client IP, or null when unavailable.
+	 * The raw IP is never stored.
+	 *
+	 * @return string|null
+	 */
+	protected function getIpHash() {
+		/**
+		 * Filter the client IP used for hashed tracking.
+		 *
+		 * Behind a proxy/CDN, REMOTE_ADDR may be the proxy address; ops can
+		 * point this at the sanitized real-client-IP source for the network.
+		 *
+		 * @since 6.43.0
+		 *
+		 * @param string $ip
+		 */
+		$ip = apply_filters( 'pb_tracking_client_ip', isset( $_SERVER['REMOTE_ADDR'] ) ? wp_unslash( $_SERVER['REMOTE_ADDR'] ) : '' );
+
+		if ( ! $ip ) {
+			return null;
+		}
+
+		return hash( 'sha256', $ip . $this->getIpSalt() );
+	}
+
+	/**
+	 * Dedicated persistent salt, independent of wp_salt() so WordPress key
+	 * rotation does not break hash continuity.
+	 *
+	 * @return string
+	 */
+	protected function getIpSalt() {
+		$salt = get_site_option( self::IP_SALT_OPTION );
+
+		if ( ! $salt ) {
+			$salt = wp_generate_password( 64, true, true );
+			add_site_option( self::IP_SALT_OPTION, $salt );
+		}
+
+		return $salt;
 	}
 }

--- a/inc/tracking/class-tracking.php
+++ b/inc/tracking/class-tracking.php
@@ -54,7 +54,7 @@ abstract class Tracking {
 	 *
 	 * @return void
 	 */
-	protected function setup() {
+	protected function setup(): void {
 		if ( get_site_option( self::DB_VERSION_OPTION ) === self::DB_VERSION ) {
 			return;
 		}
@@ -85,7 +85,7 @@ abstract class Tracking {
 	 * @param mixed $value
 	 * @return void
 	 */
-	public function store( $value ) {
+	public function store( $value ): void {
 		global $wpdb;
 
 		$date = new \DateTime( 'now', new \DateTimeZone( 'UTC' ) );
@@ -109,7 +109,7 @@ abstract class Tracking {
 	 *
 	 * @return string|null
 	 */
-	protected function getUserAgent() {
+	protected function getUserAgent(): ?string {
 		$user_agent = sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ?? '' ) );
 
 		return $user_agent === '' ? null : mb_substr( $user_agent, 0, 500 );
@@ -120,7 +120,7 @@ abstract class Tracking {
 	 *
 	 * @return string|null
 	 */
-	protected function getReferrer() {
+	protected function getReferrer(): ?string {
 		$referrer = esc_url_raw( wp_unslash( $_SERVER['HTTP_REFERER'] ?? '' ) );
 
 		return $referrer === '' ? null : mb_substr( $referrer, 0, 500 );
@@ -132,7 +132,7 @@ abstract class Tracking {
 	 *
 	 * @return string|null
 	 */
-	protected function getIpHash() {
+	protected function getIpHash(): ?string {
 		/**
 		 * Filter the client IP used for hashed tracking.
 		 *
@@ -158,7 +158,7 @@ abstract class Tracking {
 	 *
 	 * @return string
 	 */
-	protected function getIpSalt() {
+	protected function getIpSalt(): string {
 		$salt = get_site_option( self::IP_SALT_OPTION );
 
 		if ( ! $salt ) {

--- a/tests/test-track-bookdownload.php
+++ b/tests/test-track-bookdownload.php
@@ -1,26 +1,65 @@
 <?php
 
 use Pressbooks\Tracking\BookDownload;
+use Pressbooks\Tracking\Tracking;
 
 class Track_BookDownloadTest extends \WP_UnitTestCase {
 	use utilsTrait;
 
 	protected $table;
 
+	/**
+	 * @var array Preserved $_SERVER for restoration in tear_down.
+	 */
+	protected $originalServer;
+
+	/**
+	 * Browser-likewise default request environment so the existing assertions
+	 * keep working once BookDownload::store() filters bots/non-GET requests.
+	 */
+	private $browserUa = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36';
+
 	public function set_up() {
 		parent::set_up();
 
-		global $wpdb;
+		// Reset the BookDownload singleton so init() re-runs per test.
+		$reflection = new ReflectionClass( BookDownload::class );
+		$instance = $reflection->getProperty( 'instance' );
+		$instance->setAccessible( true );
+		$instance->setValue( null, null );
 
-		$reflection = new ReflectionClass(BookDownload::class);
-		$instance = $reflection->getProperty('instance');
-		$instance->setAccessible(true);
-		$instance->setValue(null);
-		$instance->setAccessible(false);
+		remove_all_actions( 'store_download_data' );
+
+		// Default to a real browser GET request.
+		$this->originalServer = $_SERVER;
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$_SERVER['HTTP_USER_AGENT'] = $this->browserUa;
+		$_SERVER['HTTP_REFERER'] = 'http://example.org/';
+		$_SERVER['REMOTE_ADDR'] = '192.0.2.10';
+
+		// Reset tracking state so each test is isolated.
+		delete_site_option( Tracking::IP_SALT_OPTION );
 
 		$this->_book();
 
+		global $wpdb;
 		$this->table = $wpdb->base_prefix . 'pressbooks_tracking';
+		$wpdb->query( "DELETE FROM {$this->table}" );
+	}
+
+	public function tear_down() {
+		$_SERVER = $this->originalServer;
+		parent::tear_down();
+	}
+
+	/**
+	 * Triggers the tracking code path by firing the store_download_data action.
+	 *
+	 * @return void
+	 */
+	private function fireDownloadAction( $value = 'pdf' ) {
+		BookDownload::init();
+		do_action( 'store_download_data', $value );
 	}
 
 	/**
@@ -43,9 +82,7 @@ class Track_BookDownloadTest extends \WP_UnitTestCase {
 	public function test_store_download_action() {
 		global $wpdb;
 
-		BookDownload::init();
-
-		do_action( 'store_download_data', 'epub' );
+		$this->fireDownloadAction( 'epub' );
 
 		$record = $wpdb->get_row( "SELECT * FROM $this->table" );
 
@@ -60,9 +97,10 @@ class Track_BookDownloadTest extends \WP_UnitTestCase {
 		$_GET['type'] = 'epub';
 		$GLOBALS['wp_query']->query_vars = array_merge( $GLOBALS['wp_query']->query_vars, [ 'open' => 'download' ] );
 
-		try{
+		$message = '';
+		try {
 			\Pressbooks\Redirect\do_open();
-		} catch (\WPDieException $e) {
+		} catch ( \WPDieException $e ) {
 			$message = $e->getMessage();
 		}
 
@@ -75,17 +113,278 @@ class Track_BookDownloadTest extends \WP_UnitTestCase {
 	public function test_download_book_call() {
 		global $wpdb;
 
+		BookDownload::init();
+
 		$_GET['type'] = 'pdf';
 		$GLOBALS['wp_query']->query_vars = array_merge( $GLOBALS['wp_query']->query_vars, [ 'open' => 'download' ] );
 
 		$filepath = \Pressbooks\Modules\Export\Export::getExportFolder() . 'test-1623077888.pdf';
 		copy( __DIR__ . '/data/test.pdf', $filepath );
 
-		\Pressbooks\Redirect\do_open( static function( $param ) {} );
+		\Pressbooks\Redirect\do_open( static function ( $param ) {} );
 
 		$record = $wpdb->get_row( "SELECT * FROM $this->table" );
 
 		$this->assertSame( 'pdf', $record->track_value );
 		$this->assertSame( 'book_download', $record->track_type );
+	}
+
+	// -----------------------------------------------------------------------------------------------------------------
+	// Migration
+	// -----------------------------------------------------------------------------------------------------------------
+
+	/**
+	 * @group book_download
+	 */
+	public function test_migration_creates_evidence_columns_on_fresh_install() {
+		global $wpdb;
+
+		// Force a clean slate.
+		delete_site_option( Tracking::DB_VERSION_OPTION );
+		$wpdb->query( "DROP TABLE IF EXISTS {$this->table}" );
+
+		BookDownload::init();
+
+		$columns = $wpdb->get_col( "SHOW COLUMNS FROM {$this->table}" );
+		$this->assertContains( 'user_agent', $columns );
+		$this->assertContains( 'referrer', $columns );
+		$this->assertContains( 'ip_hash', $columns );
+		$this->assertSame( Tracking::DB_VERSION, get_site_option( Tracking::DB_VERSION_OPTION ) );
+	}
+
+	/**
+	 * Reproduces the dbDelta trap (IF NOT EXISTS + backticks would silently skip
+	 * the ALTER on a pre-existing table). Drops the table, recreates it with the
+	 * old six-column schema, deletes the version option, then runs setup().
+	 *
+	 * @group book_download
+	 */
+	public function test_migration_upgrades_existing_table_from_old_schema() {
+		global $wpdb;
+
+		$wpdb->query( "DROP TABLE IF EXISTS {$this->table}" );
+		$wpdb->query(
+			"CREATE TABLE {$this->table} (
+				`id` bigint(20) NOT NULL AUTO_INCREMENT,
+				`blog_id` bigint(20) NOT NULL,
+				`track_type` varchar(30) NOT NULL,
+				`track_value` varchar(255),
+				`logged_in` boolean NOT NULL default false,
+				`created_at` datetime NOT NULL,
+				PRIMARY KEY  (id)
+			);"
+		);
+		delete_site_option( Tracking::DB_VERSION_OPTION );
+
+		// Invoke setup() directly to force the migration path.
+		$reflection = new ReflectionClass( Tracking::class );
+		$method = $reflection->getMethod( 'setup' );
+		$method->setAccessible( true );
+		$instance = BookDownload::init();
+		$method->invoke( $instance );
+
+		$columns = $wpdb->get_col( "SHOW COLUMNS FROM {$this->table}" );
+		$this->assertContains( 'user_agent', $columns );
+		$this->assertContains( 'referrer', $columns );
+		$this->assertContains( 'ip_hash', $columns );
+		$this->assertSame( Tracking::DB_VERSION, get_site_option( Tracking::DB_VERSION_OPTION ) );
+	}
+
+	/**
+	 * @group book_download
+	 */
+	public function test_setup_is_version_gated() {
+		global $wpdb;
+
+		update_site_option( Tracking::DB_VERSION_OPTION, Tracking::DB_VERSION );
+		BookDownload::init();
+
+		$reflection = new ReflectionClass( Tracking::class );
+		$method = $reflection->getMethod( 'setup' );
+		$method->setAccessible( true );
+
+		$before = $wpdb->num_queries;
+		$method->invoke( BookDownload::init() );
+
+		$this->assertSame( 0, $wpdb->num_queries - $before, 'setup() queried the DB despite the version match.' );
+	}
+
+	// -----------------------------------------------------------------------------------------------------------------
+	// Capture
+	// -----------------------------------------------------------------------------------------------------------------
+
+	/**
+	 * @group book_download
+	 */
+	public function test_store_captures_evidence_columns() {
+		global $wpdb;
+
+		$this->fireDownloadAction( 'pdf' );
+
+		$record = $wpdb->get_row( "SELECT * FROM $this->table" );
+
+		$this->assertSame( $this->browserUa, $record->user_agent );
+		$this->assertSame( 'http://example.org/', $record->referrer );
+		$this->assertSame( 64, strlen( $record->ip_hash ) );
+		$this->assertMatchesRegularExpression( '/^[0-9a-f]{64}$/', $record->ip_hash );
+		// Raw IP must never appear in any stored value.
+		$this->assertStringNotContainsString( '192.0.2.10', implode( ' ', (array) $record ) );
+	}
+
+	/**
+	 * @group book_download
+	 */
+	public function test_store_persists_nulls_when_evidence_headers_missing() {
+		global $wpdb;
+
+		unset( $_SERVER['HTTP_REFERER'], $_SERVER['REMOTE_ADDR'] );
+
+		$this->fireDownloadAction( 'pdf' );
+
+		$record = $wpdb->get_row( "SELECT * FROM $this->table" );
+
+		$this->assertNull( $record->referrer );
+		$this->assertNull( $record->ip_hash );
+		// UA still set in set_up(), so the row is counted.
+		$this->assertSame( $this->browserUa, $record->user_agent );
+	}
+
+	/**
+	 * @group book_download
+	 */
+	public function test_store_truncates_long_user_agent_and_referrer() {
+		global $wpdb;
+
+		$long_ua = str_repeat( 'a', 600 );
+		$long_referrer = 'http://example.org/' . str_repeat( 'b', 600 );
+		$_SERVER['HTTP_USER_AGENT'] = $long_ua;
+		$_SERVER['HTTP_REFERER'] = $long_referrer;
+
+		$this->fireDownloadAction( 'pdf' );
+
+		$record = $wpdb->get_row( "SELECT * FROM $this->table" );
+
+		$this->assertSame( 500, strlen( $record->user_agent ) );
+		// Referrer is sanitized as a URL; the scheme+host survive, then trimmed to 500 chars total.
+		$this->assertLessThanOrEqual( 500, strlen( $record->referrer ) );
+	}
+
+	/**
+	 * @group book_download
+	 */
+	public function test_ip_hash_is_stable_for_same_ip_and_salt() {
+		global $wpdb;
+
+		$this->fireDownloadAction( 'pdf' );
+		$first = $wpdb->get_var( "SELECT ip_hash FROM {$this->table} ORDER BY id DESC LIMIT 1" );
+		$wpdb->query( "DELETE FROM {$this->table}" );
+
+		$this->fireDownloadAction( 'pdf' );
+		$second = $wpdb->get_var( "SELECT ip_hash FROM {$this->table} ORDER BY id DESC LIMIT 1" );
+
+		$this->assertSame( $first, $second, 'ip_hash must be deterministic for the same IP + salt.' );
+
+		// And the salt option must have been persisted.
+		$this->assertNotEmpty( get_site_option( Tracking::IP_SALT_OPTION ) );
+	}
+
+	/**
+	 * @group book_download
+	 */
+	public function test_pb_tracking_client_ip_filter_overrides_ip_source() {
+		global $wpdb;
+
+		add_filter( 'pb_tracking_client_ip', $cb = function () {
+			return '198.51.100.42';
+		} );
+
+		$this->fireDownloadAction( 'pdf' );
+
+		remove_filter( 'pb_tracking_client_ip', $cb );
+
+		$record = $wpdb->get_row( "SELECT * FROM $this->table" );
+
+		$salt = get_site_option( Tracking::IP_SALT_OPTION );
+		$expected = hash( 'sha256', '198.51.100.42' . $salt );
+
+		$this->assertSame( $expected, $record->ip_hash );
+	}
+
+	// -----------------------------------------------------------------------------------------------------------------
+	// Filters
+	// -----------------------------------------------------------------------------------------------------------------
+
+	/**
+	 * @group book_download
+	 */
+	public function test_filter_skips_non_get_requests() {
+		global $wpdb;
+
+		foreach ( [ 'HEAD', 'POST' ] as $method ) {
+			$_SERVER['REQUEST_METHOD'] = $method;
+			$this->fireDownloadAction( 'pdf' );
+		}
+
+		$this->assertSame( '0', $wpdb->get_var( "SELECT COUNT(*) FROM {$this->table}" ) );
+	}
+
+	/**
+	 * @group book_download
+	 */
+	public function test_filter_skips_empty_user_agent() {
+		global $wpdb;
+
+		unset( $_SERVER['HTTP_USER_AGENT'] );
+
+		$this->fireDownloadAction( 'pdf' );
+
+		$this->assertSame( '0', $wpdb->get_var( "SELECT COUNT(*) FROM {$this->table}" ) );
+	}
+
+	/**
+	 * @group book_download
+	 * @dataProvider botUserAgents
+	 */
+	public function test_filter_skips_known_bots( $ua ) {
+		global $wpdb;
+
+		$_SERVER['HTTP_USER_AGENT'] = $ua;
+
+		$this->fireDownloadAction( 'pdf' );
+
+		$this->assertSame( '0', $wpdb->get_var( "SELECT COUNT(*) FROM {$this->table}" ), "Bot UA not filtered: {$ua}" );
+	}
+
+	public function botUserAgents() {
+		return [
+			'Googlebot' => [ 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)' ],
+			'Bingbot' => [ 'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)' ],
+			'python-requests' => [ 'python-requests/2.31.0' ],
+			'curl' => [ 'curl/8.4.0' ],
+			'Bytespider' => [ 'Mozilla/5.0 (compatible; Bytespider; spider-feedback@bytedance.com)' ],
+		];
+	}
+
+	/**
+	 * @group book_download
+	 * @dataProvider humanUserAgents
+	 */
+	public function test_filter_counts_real_browsers( $ua ) {
+		global $wpdb;
+
+		$_SERVER['HTTP_USER_AGENT'] = $ua;
+
+		$this->fireDownloadAction( 'pdf' );
+
+		$this->assertSame( '1', $wpdb->get_var( "SELECT COUNT(*) FROM {$this->table}" ), "Human UA filtered out: {$ua}" );
+	}
+
+	public function humanUserAgents() {
+		return [
+			'Chrome desktop' => [ 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36' ],
+			'Firefox desktop' => [ 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:127.0) Gecko/20100101 Firefox/127.0' ],
+			'Safari desktop' => [ 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15' ],
+			'Safari mobile' => [ 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1' ],
+		];
 	}
 }

--- a/tests/test-track-bookdownload.php
+++ b/tests/test-track-bookdownload.php
@@ -30,15 +30,11 @@ class Track_BookDownloadTest extends \WP_UnitTestCase {
 
 		remove_all_actions( 'store_download_data' );
 
-		// Default to a real browser GET request.
+		// Default to a real browser GET request so the existing assertions
+		// keep working once the filter is in place.
 		$this->originalServer = $_SERVER;
 		$_SERVER['REQUEST_METHOD'] = 'GET';
 		$_SERVER['HTTP_USER_AGENT'] = $this->browserUa;
-		$_SERVER['HTTP_REFERER'] = 'http://example.org/';
-		$_SERVER['REMOTE_ADDR'] = '192.0.2.10';
-
-		// Reset tracking state so each test is isolated.
-		delete_site_option( Tracking::IP_SALT_OPTION );
 
 		$this->_book();
 
@@ -129,185 +125,18 @@ class Track_BookDownloadTest extends \WP_UnitTestCase {
 		$this->assertSame( 'book_download', $record->track_type );
 	}
 
-	// -----------------------------------------------------------------------------------------------------------------
-	// Migration
-	// -----------------------------------------------------------------------------------------------------------------
-
 	/**
 	 * @group book_download
 	 */
-	public function test_migration_creates_evidence_columns_on_fresh_install() {
+	public function test_inserted_row_has_only_original_columns() {
 		global $wpdb;
 
-		// Force a clean slate.
-		delete_site_option( Tracking::DB_VERSION_OPTION );
-		$wpdb->query( "DROP TABLE IF EXISTS {$this->table}" );
-
-		BookDownload::init();
+		$this->fireDownloadAction( 'pdf' );
 
 		$columns = $wpdb->get_col( "SHOW COLUMNS FROM {$this->table}" );
-		$this->assertContains( 'user_agent', $columns );
-		$this->assertContains( 'referrer', $columns );
-		$this->assertContains( 'ip_hash', $columns );
-		$this->assertSame( Tracking::DB_VERSION, get_site_option( Tracking::DB_VERSION_OPTION ) );
-	}
+		$expected = [ 'id', 'blog_id', 'track_type', 'track_value', 'logged_in', 'created_at' ];
 
-	/**
-	 * Reproduces the dbDelta trap (IF NOT EXISTS + backticks would silently skip
-	 * the ALTER on a pre-existing table). Drops the table, recreates it with the
-	 * old six-column schema, deletes the version option, then runs setup().
-	 *
-	 * @group book_download
-	 */
-	public function test_migration_upgrades_existing_table_from_old_schema() {
-		global $wpdb;
-
-		$wpdb->query( "DROP TABLE IF EXISTS {$this->table}" );
-		$wpdb->query(
-			"CREATE TABLE {$this->table} (
-				`id` bigint(20) NOT NULL AUTO_INCREMENT,
-				`blog_id` bigint(20) NOT NULL,
-				`track_type` varchar(30) NOT NULL,
-				`track_value` varchar(255),
-				`logged_in` boolean NOT NULL default false,
-				`created_at` datetime NOT NULL,
-				PRIMARY KEY  (id)
-			);"
-		);
-		delete_site_option( Tracking::DB_VERSION_OPTION );
-
-		// Invoke setup() directly to force the migration path.
-		$reflection = new ReflectionClass( Tracking::class );
-		$method = $reflection->getMethod( 'setup' );
-		$method->setAccessible( true );
-		$instance = BookDownload::init();
-		$method->invoke( $instance );
-
-		$columns = $wpdb->get_col( "SHOW COLUMNS FROM {$this->table}" );
-		$this->assertContains( 'user_agent', $columns );
-		$this->assertContains( 'referrer', $columns );
-		$this->assertContains( 'ip_hash', $columns );
-		$this->assertSame( Tracking::DB_VERSION, get_site_option( Tracking::DB_VERSION_OPTION ) );
-	}
-
-	/**
-	 * @group book_download
-	 */
-	public function test_setup_is_version_gated() {
-		global $wpdb;
-
-		update_site_option( Tracking::DB_VERSION_OPTION, Tracking::DB_VERSION );
-		BookDownload::init();
-
-		$reflection = new ReflectionClass( Tracking::class );
-		$method = $reflection->getMethod( 'setup' );
-		$method->setAccessible( true );
-
-		$before = $wpdb->num_queries;
-		$method->invoke( BookDownload::init() );
-
-		$this->assertSame( 0, $wpdb->num_queries - $before, 'setup() queried the DB despite the version match.' );
-	}
-
-	// -----------------------------------------------------------------------------------------------------------------
-	// Capture
-	// -----------------------------------------------------------------------------------------------------------------
-
-	/**
-	 * @group book_download
-	 */
-	public function test_store_captures_evidence_columns() {
-		global $wpdb;
-
-		$this->fireDownloadAction( 'pdf' );
-
-		$record = $wpdb->get_row( "SELECT * FROM $this->table" );
-
-		$this->assertSame( $this->browserUa, $record->user_agent );
-		$this->assertSame( 'http://example.org/', $record->referrer );
-		$this->assertSame( 64, strlen( $record->ip_hash ) );
-		$this->assertMatchesRegularExpression( '/^[0-9a-f]{64}$/', $record->ip_hash );
-		// Raw IP must never appear in any stored value.
-		$this->assertStringNotContainsString( '192.0.2.10', implode( ' ', (array) $record ) );
-	}
-
-	/**
-	 * @group book_download
-	 */
-	public function test_store_persists_nulls_when_evidence_headers_missing() {
-		global $wpdb;
-
-		unset( $_SERVER['HTTP_REFERER'], $_SERVER['REMOTE_ADDR'] );
-
-		$this->fireDownloadAction( 'pdf' );
-
-		$record = $wpdb->get_row( "SELECT * FROM $this->table" );
-
-		$this->assertNull( $record->referrer );
-		$this->assertNull( $record->ip_hash );
-		// UA still set in set_up(), so the row is counted.
-		$this->assertSame( $this->browserUa, $record->user_agent );
-	}
-
-	/**
-	 * @group book_download
-	 */
-	public function test_store_truncates_long_user_agent_and_referrer() {
-		global $wpdb;
-
-		$long_ua = str_repeat( 'a', 600 );
-		$long_referrer = 'http://example.org/' . str_repeat( 'b', 600 );
-		$_SERVER['HTTP_USER_AGENT'] = $long_ua;
-		$_SERVER['HTTP_REFERER'] = $long_referrer;
-
-		$this->fireDownloadAction( 'pdf' );
-
-		$record = $wpdb->get_row( "SELECT * FROM $this->table" );
-
-		$this->assertSame( 500, strlen( $record->user_agent ) );
-		// Referrer is sanitized as a URL; the scheme+host survive, then trimmed to 500 chars total.
-		$this->assertLessThanOrEqual( 500, strlen( $record->referrer ) );
-	}
-
-	/**
-	 * @group book_download
-	 */
-	public function test_ip_hash_is_stable_for_same_ip_and_salt() {
-		global $wpdb;
-
-		$this->fireDownloadAction( 'pdf' );
-		$first = $wpdb->get_var( "SELECT ip_hash FROM {$this->table} ORDER BY id DESC LIMIT 1" );
-		$wpdb->query( "DELETE FROM {$this->table}" );
-
-		$this->fireDownloadAction( 'pdf' );
-		$second = $wpdb->get_var( "SELECT ip_hash FROM {$this->table} ORDER BY id DESC LIMIT 1" );
-
-		$this->assertSame( $first, $second, 'ip_hash must be deterministic for the same IP + salt.' );
-
-		// And the salt option must have been persisted.
-		$this->assertNotEmpty( get_site_option( Tracking::IP_SALT_OPTION ) );
-	}
-
-	/**
-	 * @group book_download
-	 */
-	public function test_pb_tracking_client_ip_filter_overrides_ip_source() {
-		global $wpdb;
-
-		add_filter( 'pb_tracking_client_ip', $cb = function () {
-			return '198.51.100.42';
-		} );
-
-		$this->fireDownloadAction( 'pdf' );
-
-		remove_filter( 'pb_tracking_client_ip', $cb );
-
-		$record = $wpdb->get_row( "SELECT * FROM $this->table" );
-
-		$salt = get_site_option( Tracking::IP_SALT_OPTION );
-		$expected = hash( 'sha256', '198.51.100.42' . $salt );
-
-		$this->assertSame( $expected, $record->ip_hash );
+		$this->assertSame( $expected, $columns, 'pressbooks_tracking schema must be unchanged — no UA/IP/referrer stored.' );
 	}
 
 	// -----------------------------------------------------------------------------------------------------------------
@@ -356,12 +185,16 @@ class Track_BookDownloadTest extends \WP_UnitTestCase {
 	}
 
 	public function botUserAgents() {
+		// Crawler-Detect catches named crawlers AND generic HTTP libraries
+		// (python-requests, curl, Wget) — the latter are missed by
+		// matomo/device-detector, which is why we use Crawler-Detect here.
 		return [
 			'Googlebot' => [ 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)' ],
 			'Bingbot' => [ 'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)' ],
+			'Bytespider' => [ 'Mozilla/5.0 (compatible; Bytespider; spider-feedback@bytedance.com)' ],
 			'python-requests' => [ 'python-requests/2.31.0' ],
 			'curl' => [ 'curl/8.4.0' ],
-			'Bytespider' => [ 'Mozilla/5.0 (compatible; Bytespider; spider-feedback@bytedance.com)' ],
+			'Wget' => [ 'Wget/1.21' ],
 		];
 	}
 


### PR DESCRIPTION
Issue: https://github.com/pressbooks/private/issues/2629

Download counts in `pressbooks_tracking` include HEAD probes, scripts, and self-announced crawlers — anyone who hits `/open/download?type=…` increments a row. This first step toward https://github.com/pressbooks/private/issues/2596 filters those out at insert time so the numbers reflect actual human-driven downloads. No data is stored about who downloaded what: the user agent is read only to classify the request and is never persisted. Token-gating, dedup, and edge blocking stay out of scope — those land with the homepage-origin/token discussion.

### What changed
- **Insert-time filters in `BookDownload`** — requests are skipped unless they are GET with a non-empty, non-bot user agent. Files still get served to everyone, so only the counting changes and direct links (including OPDS consumers) keep working unchanged.
- **Bot detection via Crawler-Detect** (`jaybizzle/crawler-detect:^1.4`). The original plan proposed `matomo/device-detector` (already in core), but tests proved its bot list misses `python-requests`, `curl`, `Wget`, and other HTTP libraries — the self-announcing scrapers showing up in the access-log evidence. Crawler-Detect covers both named crawlers and HTTP libraries. device-detector stays for the diagnostics page (different purpose).

### How to test
1. `curl -I '<book-url>/open/download?type=pdf'` (HEAD): file headers OK, no row inserted.
2. `curl '<book-url>/open/download?type=pdf' -o /dev/null` (default curl UA): file serves, no row inserted.
3. `curl -A 'Mozilla/5.0 (KHTML, like Gecko) Chrome/126.0' '<book-url>/open/download?type=pdf'`: file serves, row inserted — faked-browser UAs pass the filter; this is a known limitation. 
4. Go to a book home page and download any book format. It should also insert a row.