### PR TITLE
feat: bot crawling endpoints

### DIFF
--- a/hooks.php
+++ b/hooks.php
@@ -252,6 +252,7 @@ add_filter( 'login_redirect', '\Pressbooks\Redirect\handle_dashboard_redirect', 
 add_action( 'init', '\Pressbooks\Redirect\rewrite_rules_for_sitemap', 1 );
 add_action( 'do_robotstxt', '\Pressbooks\Utility\add_sitemap_to_robots_txt' );
 add_filter( 'wp_robots', '\Pressbooks\Utility\handle_book_indexing' );
+add_filter( 'robots_txt', '\Pressbooks\Utility\add_disallow_rules_to_robots_txt', 10, 2 );
 
 // -------------------------------------------------------------------------------------------------------------------
 // Shortcodes

--- a/inc/utility/namespace.php
+++ b/inc/utility/namespace.php
@@ -253,6 +253,66 @@ function handle_book_indexing( array $robots ) {
 }
 
 /**
+ * Append Disallow rules to robots.txt for high-cost, zero-index-value endpoints
+ * (exports, on-the-fly renders, REST API, in-book search, faceted catalog search, misc WP).
+ *
+ * Hooked on `robots_txt` (not `do_robotstxt`) so the rules attach to the `User-agent: *`
+ * group that WordPress core builds; `do_robotstxt` fires before that group exists and is
+ * only valid for group-independent directives such as `Sitemap:`.
+ *
+ * robots.txt is only ever fetched by crawlers at the host root, so the rules emitted depend
+ * on the site role and the multisite install mode:
+ *
+ * - Main site, subdirectory install: a single root robots.txt must cover every book, so book
+ *   endpoints are emitted as wildcard paths (e.g. `/*​/open/`).
+ * - Main site, subdomain install: the root robots.txt is just the network homepage.
+ * - Book site (only crawler-reachable in a subdomain install): plain book endpoint paths.
+ *
+ * `/wp-admin/` is intentionally omitted because WordPress core already emits it.
+ *
+ * @param string $output The robots.txt output built by WordPress.
+ * @param bool $public Whether the site is considered "public".
+ *
+ * @return string
+ */
+function add_disallow_rules_to_robots_txt( $output, $public ) {
+	$rules = [ '/feed/', '/comments/feed/' ];
+
+	if ( is_main_site() ) {
+		$rules = array_merge( $rules, [ '/wp-signup.php', '/wp-activate.php', '/xmlrpc.php', '/wp-json/oembed/' ] );
+
+		if ( is_subdomain_install() ) {
+			$rules[] = '/wp-json/';
+		} else {
+			// Subdirectory install: one root robots.txt must cover every book.
+			$rules = array_merge( $rules, [ '/*/open/', '/*/format/', '/*/wp-json/', '/*/?s=' ] );
+		}
+	} else {
+		// Book site: only crawler-reachable in a subdomain install.
+		$rules = array_merge( $rules, [ '/open/', '/format/', '/wp-json/', '/?s=' ] );
+	}
+
+	/**
+	 * Filter the list of paths disallowed in robots.txt.
+	 *
+	 * Allows other Pressbooks plugins (e.g. pressbooks-network-catalog) to register their own
+	 * high-cost endpoints without coupling core to their implementation.
+	 *
+	 * @since 6.x.x
+	 *
+	 * @param string[] $rules Array of paths to disallow (each becomes a `Disallow:` line).
+	 * @param bool $public Whether the site is considered "public".
+	 */
+	$rules = apply_filters( 'pb_robots_txt_disallow', $rules, $public );
+
+	foreach ( array_unique( $rules ) as $rule ) {
+		$output .= "Disallow: {$rule}\n";
+	}
+
+	return $output;
+}
+
+/**
  * Echo a sitemap
  */
 function do_sitemap() {

--- a/tests/test-utility.php
+++ b/tests/test-utility.php
@@ -1,6 +1,7 @@
 <?php
 
 use Pressbooks\Modules\Export\Export;
+use function Pressbooks\Utility\add_disallow_rules_to_robots_txt;
 use function Pressbooks\Utility\add_sitemap_to_robots_txt;
 use function Pressbooks\Utility\do_shortcode_by_tags;
 use function Pressbooks\Utility\latest_exports;
@@ -972,6 +973,68 @@ class UtilityTest extends \WP_UnitTestCase {
 			[ 'max-image-preview' => 'large', 'noindex' => 1, 'nofollow' => 1, 'noai' => 1, 'noimageai' => 1 ],
 			\Pressbooks\Utility\handle_book_indexing( [ 'max-image-preview' => 'large'] )
 		);
+	}
+
+	/**
+	 * @group utility
+	 */
+	public function test_add_disallow_rules_to_robots_txt_main_site(): void {
+		// Default test environment is a subdirectory multisite install.
+		$output = add_disallow_rules_to_robots_txt( "User-agent: *\n", true );
+
+		// Network-root and shared WordPress rules.
+		$this->assertStringContainsString( "Disallow: /wp-signup.php\n", $output );
+		$this->assertStringContainsString( "Disallow: /wp-activate.php\n", $output );
+		$this->assertStringContainsString( "Disallow: /xmlrpc.php\n", $output );
+		$this->assertStringContainsString( "Disallow: /feed/\n", $output );
+
+		// Subdirectory install: book endpoints are covered by wildcard paths.
+		$this->assertStringContainsString( "Disallow: /*/open/\n", $output );
+		$this->assertStringContainsString( "Disallow: /*/format/\n", $output );
+		$this->assertStringContainsString( "Disallow: /*/wp-json/\n", $output );
+
+		// Plain book rules must not appear on the main site.
+		$this->assertStringNotContainsString( "Disallow: /open/\n", $output );
+
+		// WordPress core already emits the wp-admin rules; our callback must not duplicate them.
+		$this->assertStringNotContainsString( 'wp-admin', $output );
+	}
+
+	/**
+	 * @group utility
+	 */
+	public function test_add_disallow_rules_to_robots_txt_book(): void {
+		$this->_book();
+
+		$output = add_disallow_rules_to_robots_txt( "User-agent: *\n", true );
+
+		// Plain book endpoint rules.
+		$this->assertStringContainsString( "Disallow: /open/\n", $output );
+		$this->assertStringContainsString( "Disallow: /format/\n", $output );
+		$this->assertStringContainsString( "Disallow: /wp-json/\n", $output );
+		$this->assertStringContainsString( "Disallow: /?s=\n", $output );
+		$this->assertStringContainsString( "Disallow: /feed/\n", $output );
+
+		// Network-root-only rules must not appear on a book site.
+		$this->assertStringNotContainsString( 'wp-signup.php', $output );
+		$this->assertStringNotContainsString( '/*/open/', $output );
+	}
+
+	/**
+	 * @group utility
+	 */
+	public function test_add_disallow_rules_to_robots_txt_filter(): void {
+		$callback = function ( $rules ) {
+			$rules[] = '/custom-endpoint/';
+
+			return $rules;
+		};
+
+		add_filter( 'pb_robots_txt_disallow', $callback );
+		$output = add_disallow_rules_to_robots_txt( "User-agent: *\n", true );
+		remove_filter( 'pb_robots_txt_disallow', $callback );
+
+		$this->assertStringContainsString( "Disallow: /custom-endpoint/\n", $output );
 	}
 
 	/**


### PR DESCRIPTION
Issue: https://github.com/pressbooks/private/issues/2601

Bots crawling export, REST, and on-the-fly render endpoints burn server resources for zero index value and inflate the download counts Koko Analytics reports — every hit on `/open/download` fires `store_download_data` whether the requester is human or not. This adds `Disallow` rules to the network's robots.txt for those endpoints, branches them correctly for subdirectory vs subdomain installs, and exposes a filter so companion plugins can register their own high-cost endpoints without editing core.

 The companion https://github.com/pressbooks/pressbooks-network-catalog/pull/533 should land after this one so its `pb_robots_txt_disallow` callback has a filter to hook.

### What changed
- New robots.txt rules disallow `/open/`, `/format/`, `/wp-json/`, in-book search (`/?s=`), WP signup/activate, xmlrpc, and comment feeds from crawlers.
- Install-mode aware: in a subdirectory multisite the single root robots.txt covers every book with wildcard paths (`/*/open/` etc.); in a subdomain install each book site gets plain paths. `/wp-admin/` is left to WordPress
  core, which already emits it.
- New `pb_robots_txt_disallow` filter lets other plugins (e.g. pressbooks-network-catalog) append their own disallowed paths without coupling core to their implementation.
- Rules are emitted through the `robots_txt` filter rather than `do_robotstxt` so they attach to the `User-agent: *` group WordPress core builds.

### How to test
1. Visit `/robots.txt` on the network root of a subdirectory install and confirm the wildcard book rules (`/*/open/`, `/*/format/`, `/*/wp-json/`) and the network-root rules (`/wp-signup.php`, `/xmlrpc.php`, etc.) are present.
2. Visit `/robots.txt` on a book subsite (subdomain install) and confirm the plain book rules (`/open/`, `/format/`, `/wp-json/`) are present and the network-root rules are absent. You will need to set up subdomain installation to test it if you want.
5. Drop a sample export URL (`/<book>/open/download?type=epub`) into Google's robots.txt tester and confirm it's flagged as blocked. You can use also, for example: https://technicalseo.com/tools/robots-txt/

For lando environments:
I had to change `config_services/nginx.conf` file:
```
location = /robots.txt {
  try_files $uri /index.php?$args;
  ...
}
```
to avoid 404 on `<network_url>/robots.txt`