### PR TITLE
fix: clarify target book URL description

### DIFF
--- a/templates/admin/cloner/page.blade.php
+++ b/templates/admin/cloner/page.blade.php
@@ -1,4 +1,4 @@
-<div class="pb-cloner wrap">
+ <div class="pb-cloner wrap">
 	<div class="pb-cloner-section main">
 		<h1 class="page-title">{{ __( 'Clone a Book', 'pressbooks' ) }}</h1>
 		<p>{{ __( 'This tool allows you to clone openly licensed books from one Pressbooks network to another. The cloning process makes a copy of the original book for you to revise and redistribute as desired. You can enter the source book URL if you already know it, or find and select a suitable book from the Pressbooks Directory.', 'pressbooks' ) }}</p>
@@ -14,7 +14,7 @@
 			@else
 				<span class="subdir-target-url">{{ $base_url }}</span><span class="url-input"><input class="regular-text code" id="target-book-url" name="target_book_url" type="text" aria-describedby="target_book_url_description" required aria-required="true"/></span>
 			@endif
-			<p class="description" id="target_book_url_description">{{ __( 'Enter the URL where you want this book to be cloned. This URL cannot be changed later, so choose carefully.', 'pressbooks' ) }}</p>
+			<p class="description" id="target_book_url_description">{{ __( 'Enter the URL where you want this book to be cloned. This URL can only be changed later by a network administrator, so choose carefully.', 'pressbooks' ) }}</p>
 			<input id="pb-cloner-button" class="button button-hero button-primary" type="submit" value="{{ __( 'Clone book', 'pressbooks' ) }}">
 			<progress id="pb-sse-progressbar" max="100" aria-label="{{ __( 'Cloning progress', 'pressbooks' ) }}"></progress>
 			<strong><span id="pb-sse-minutes"></span><span id="pb-sse-seconds"></span></strong> <span id="pb-sse-info" aria-live="polite"></span> <span id="pb-sse-status" class="screen-reader-text" aria-live="polite">0%</span>

--- a/templates/admin/cloner/page.blade.php
+++ b/templates/admin/cloner/page.blade.php
@@ -1,4 +1,4 @@
- <div class="pb-cloner wrap">
+<div class="pb-cloner wrap">
 	<div class="pb-cloner-section main">
 		<h1 class="page-title">{{ __( 'Clone a Book', 'pressbooks' ) }}</h1>
 		<p>{{ __( 'This tool allows you to clone openly licensed books from one Pressbooks network to another. The cloning process makes a copy of the original book for you to revise and redistribute as desired. You can enter the source book URL if you already know it, or find and select a suitable book from the Pressbooks Directory.', 'pressbooks' ) }}</p>


### PR DESCRIPTION
Update the description for the target book URL input to clarify that changes can only be made later by a network administrator. Fix for https://github.com/pressbooks/pressbooks/issues/4533