### PR TITLE
fix: use correct sitemap url

### DIFF
--- a/hooks.php
+++ b/hooks.php
@@ -249,6 +249,7 @@ add_filter( 'login_redirect', '\Pressbooks\Redirect\handle_dashboard_redirect', 
 // Sitemap
 // -------------------------------------------------------------------------------------------------------------------
 
+add_filter( 'wp_sitemaps_enabled', '__return_false' );
 add_action( 'init', '\Pressbooks\Redirect\rewrite_rules_for_sitemap', 1 );
 add_action( 'do_robotstxt', '\Pressbooks\Utility\add_sitemap_to_robots_txt' );
 add_filter( 'wp_robots', '\Pressbooks\Utility\handle_book_indexing' );

--- a/inc/utility/namespace.php
+++ b/inc/utility/namespace.php
@@ -226,7 +226,7 @@ function latest_exports() {
 function add_sitemap_to_robots_txt() {
 
 	if ( 1 === absint( get_option( 'blog_public' ) ) ) {
-		echo 'Sitemap: ' . get_option( 'siteurl' ) . "/?feed=sitemap.xml\n\n";
+		echo 'Sitemap: ' . home_url() . "/?feed=sitemap.xml\n\n";
 	}
 }
 


### PR DESCRIPTION
using home_url() instead of get_option('siteurl') and removing core WP sitemap functionality so it doesn't put the wrong URL in robots.txt