### PR TITLE
fix: orphan http_import url handler and cleanup

### DIFF
--- a/inc/modules/import/class-import.php
+++ b/inc/modules/import/class-import.php
@@ -531,11 +531,10 @@ abstract class Import {
 	 * @return bool
 	 */
 	static protected function setGoogleDocsImportOptions(): bool {
-		$url = sanitize_text_field( getset( '_POST', 'import_http' ) );
-		$doc_id = GoogleDocs\OAuthClient::extractDocId( $url );
+		$doc_id = sanitize_text_field( getset( '_POST', 'import_gdoc_id' ) );
 
-		if ( ! $doc_id ) {
-			$_SESSION['pb_errors'][] = __( 'Please enter a valid Google Docs URL.', 'pressbooks' );
+		if ( ! $doc_id || ! preg_match( '/^[a-zA-Z0-9_-]+$/', $doc_id ) ) {
+			$_SESSION['pb_errors'][] = __( 'Please select a Google Doc to import.', 'pressbooks' );
 			return false;
 		}
 
@@ -588,7 +587,6 @@ abstract class Import {
 
 		$upload = [
 			'file' => $cached_path,
-			'url'  => $url,
 			'type' => 'application/json',
 		];
 

--- a/inc/modules/import/googledocs/assets/picker.js
+++ b/inc/modules/import/googledocs/assets/picker.js
@@ -1,15 +1,8 @@
 /**
  * Google Picker integration for the Google Docs importer.
  *
- * With the drive.file OAuth scope the app can only read files the user
- * explicitly selects through the Google Picker, so the URL input is hidden
- * and replaced with a "Select from Google Drive" button. Picking a document
- * (a) grants this app per-file access to it, (b) stores the document URL in
- * the hidden input so the existing server-side import flow works unchanged,
- * and (c) shows the picked document as a link for confirmation.
- *
- * If this script does not load (Picker not configured), the URL input stays
- * visible as a graceful fallback.
+ * Replaces the URL field with a picker button and stores the picked document
+ * id in a hidden input (#import_gdoc_id) for the server to fetch.
  *
  * @package Pressbooks
  * @license GPLv3 (or any later version)
@@ -22,33 +15,16 @@
 	var strings = cfg.strings || {};
 	var pickerReady = false;
 
-	function findUrlField() {
-		// The import form has a generic URL field (#import_http) and a Google
-		// Docs-specific one (#import_http_gdocs); prefer the gdocs field.
-		var selectors = [
-			cfg.urlSelector || '#import_http_gdocs',
-			'input[placeholder*="docs.google.com"]',
-			'#import_http',
-			'input[name="import_http"]',
-		];
-		for ( var i = 0; i < selectors.length; i++ ) {
-			var el = document.querySelector( selectors[ i ] );
-			if ( el ) {
-				return el;
-			}
-		}
-		return null;
+	function findIdField() {
+		return document.querySelector( cfg.fieldSelector || '#import_gdoc_id' );
 	}
 
 	function init() {
-		var urlField = findUrlField();
-		if ( ! urlField ) {
+		var idField = findIdField();
+		if ( ! idField ) {
 			return;
 		}
 		var typeSelect = document.querySelector( cfg.typeSelector || '#type_of' );
-
-		// Picker-only UX: the input becomes a hidden value carrier.
-		urlField.style.display = 'none';
 
 		var container = document.createElement( 'span' );
 		container.className = 'pb-gdocs-picker';
@@ -67,7 +43,7 @@
 		docLink.style.display = 'none';
 		container.appendChild( docLink );
 
-		urlField.insertAdjacentElement( 'afterend', container );
+		idField.insertAdjacentElement( 'afterend', container );
 
 		function toggle() {
 			var show = ! typeSelect || typeSelect.value === 'google-docs';
@@ -79,7 +55,7 @@
 		}
 
 		btn.addEventListener( 'click', function () {
-			openPicker( urlField, btn, docLink );
+			openPicker( idField, btn, docLink );
 		} );
 	}
 
@@ -131,7 +107,7 @@
 			} );
 	}
 
-	function openPicker( urlField, btn, docLink ) {
+	function openPicker( idField, btn, docLink ) {
 		btn.disabled = true;
 		Promise.all( [ loadPickerApi(), fetchToken() ] )
 			.then( function ( results ) {
@@ -150,15 +126,15 @@
 					.setCallback( function ( data ) {
 						if ( data[ google.picker.Response.ACTION ] === google.picker.Action.PICKED ) {
 							var doc = data[ google.picker.Response.DOCUMENTS ][ 0 ];
-							var url =
+							var docId = doc[ google.picker.Document.ID ];
+
+							idField.value = docId;
+							idField.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+
+							docLink.href =
 								doc[ google.picker.Document.URL ] ||
-								'https://docs.google.com/document/d/' + doc[ google.picker.Document.ID ] + '/edit';
-
-							urlField.value = url;
-							urlField.dispatchEvent( new Event( 'change', { bubbles: true } ) );
-
-							docLink.href = url;
-							docLink.textContent = doc[ google.picker.Document.NAME ] || url;
+								'https://docs.google.com/document/d/' + docId + '/edit';
+							docLink.textContent = doc[ google.picker.Document.NAME ] || docId;
 							docLink.style.display = '';
 							btn.textContent = strings.changeLabel || 'Change document';
 						}

--- a/inc/modules/import/googledocs/class-bootstrap.php
+++ b/inc/modules/import/googledocs/class-bootstrap.php
@@ -159,8 +159,8 @@ class Bootstrap {
 				/**
 				 * Selectors for the import form; filter if the import page markup changes.
 				 */
-				'typeSelector' => apply_filters( 'pb_gdocs_picker_type_selector', '#type_of' ),
-				'urlSelector'  => apply_filters( 'pb_gdocs_picker_url_selector', '#import_http_gdocs' ),
+				'typeSelector'  => apply_filters( 'pb_gdocs_picker_type_selector', '#type_of' ),
+				'fieldSelector' => apply_filters( 'pb_gdocs_picker_field_selector', '#import_gdoc_id' ),
 				'strings'      => [
 					'buttonLabel' => __( 'Select from Google Drive', 'pressbooks' ),
 					'changeLabel' => __( 'Change document', 'pressbooks' ),

--- a/inc/modules/import/googledocs/class-oauthclient.php
+++ b/inc/modules/import/googledocs/class-oauthclient.php
@@ -218,14 +218,6 @@ class OAuthClient {
 		$this->token_storage->delete( $user_id );
 	}
 
-	public static function extractDocId( string $url ): ?string {
-		if ( preg_match( '#docs\.google\.com/document/d/([a-zA-Z0-9_-]+)#', $url, $matches ) ) {
-			return $matches[1];
-		}
-
-		return null;
-	}
-
 	public function getRedirectUri(): string {
 		return network_home_url( 'wp-admin/admin-post.php?action=pb_gdocs_callback' );
 	}

--- a/templates/admin/import.php
+++ b/templates/admin/import.php
@@ -230,10 +230,11 @@ $import_option_types = apply_filters( 'pb_select_import_type', [
 			?>
 			<tr x-show="typeOf === 'google-docs' && <?php echo $gdocs_is_connected ? 'true' : 'false'; ?>" x-cloak>
 				<th scope="row">
-					<label for="import_http_gdocs"><?php _e( 'Google Docs URL', 'pressbooks' ); ?></label>
+					<?php _e( 'Google Docs Document', 'pressbooks' ); ?>
 				</th>
 				<td>
-					<input type="url" class="widefat" name="import_http" id="import_http_gdocs" placeholder="https://docs.google.com/document/d/..." style="display:block;" aria-label="<?php _e( 'Google Docs URL', 'pressbooks' ); ?>" />
+					<?php // Populated by the Google Picker; see googledocs/assets/picker.js. ?>
+					<input type="hidden" name="import_gdoc_id" id="import_gdoc_id" />
 				</td>
 			</tr>
 

--- a/tests/test-modules-import-google-docs-oauth.php
+++ b/tests/test-modules-import-google-docs-oauth.php
@@ -104,22 +104,6 @@ class Modules_ImportGoogleDocsOAuthTest extends \WP_UnitTestCase {
 	/**
 	 * @group import
 	 */
-	public function test_extract_doc_id_from_url(): void {
-		$this->assertSame(
-			'1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms',
-			OAuthClient::extractDocId( 'https://docs.google.com/document/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/edit' )
-		);
-		$this->assertSame(
-			'1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms',
-			OAuthClient::extractDocId( 'https://docs.google.com/document/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/edit#heading=h.abc' )
-		);
-		$this->assertNull( OAuthClient::extractDocId( 'https://docs.google.com/spreadsheets/d/abc/edit' ) );
-		$this->assertNull( OAuthClient::extractDocId( 'not-a-url' ) );
-	}
-
-	/**
-	 * @group import
-	 */
 	public function test_get_authed_client_throws_when_no_token(): void {
 		$this->expectException( \Pressbooks\Modules\Import\GoogleDocs\ReauthorizationRequiredException::class );
 		$oauth = $this->make_oauth_client( false );


### PR DESCRIPTION
Connecting a Google account broke every "Import from URL" flow: the Google Docs field reused `name="import_http"`, so its empty value clobbered the real URL on submit and WXR/EPUB/HTML imports failed. This fixes the collision and drops the URL-handling code left over now that Google Docs imports via the Picker.

### What changed

- Google Docs now uses a dedicated hidden `import_gdoc_id` field instead of sharing `import_http`, so URL imports work again.
- The Picker stores the doc id directly and the server fetches by id; removed the URL round-trip (`OAuthClient::extractDocId` and its test).

### How to test

1. With Google **connected**, import an EPUB/WXR by URL — it should succeed (previously failed).
2. Pick a doc via **Select from Google Drive** and confirm the import runs.
3. Submit Google Docs with no doc picked — expect "Please select a Google Doc to import."