### PR TITLE
fix: stored XSS in built-in shortcodes

### DIFF
--- a/inc/shortcodes/attributions/class-attachments.php
+++ b/inc/shortcodes/attributions/class-attachments.php
@@ -210,15 +210,15 @@ class Attachments {
 						( isset( $attribution['title_url'] ) ) ?
 							sprintf(
 								'about="%s"',
-								$attribution['title_url']
+								esc_url( $attribution['title_url'] )
 							) : '',
 						// title attribution
 						( isset( $attribution['title_url'] ) ) ?
 							sprintf(
 								'<a rel="cc:attributionURL" href="%1$s" property="dc:title">%2$s</a>',
-								$attribution['title_url'],
-								$title
-							) : $title,
+								esc_url( $attribution['title_url'] ),
+								esc_html( $title )
+							) : esc_html( $title ),
 						// author attribution
 						sprintf(
 							'%1$s %2$s',
@@ -226,9 +226,9 @@ class Attachments {
 							( isset( $attribution['author_url'] ) ) ?
 								sprintf(
 									'<a rel="dc:creator" href="%1$s" property="cc:attributionName">%2$s</a>',
-									$attribution['author_url'],
-									$author
-								) : $author
+									esc_url( $attribution['author_url'] ),
+									esc_html( $author )
+								) : esc_html( $author )
 						),
 						// adapted attribution
 						sprintf(
@@ -237,9 +237,9 @@ class Attachments {
 							( isset( $attribution['adapted_url'] ) ) ?
 								sprintf(
 									'<a rel="dc:source" href="%1$s">%2$s</a>',
-									$attribution['adapted_url'],
-									$adapted_author
-								) : $adapted_author
+									esc_url( $attribution['adapted_url'] ),
+									esc_html( $adapted_author )
+								) : esc_html( $adapted_author )
 						),
 						// license attribution
 						sprintf(

--- a/inc/shortcodes/complex/class-complex.php
+++ b/inc/shortcodes/complex/class-complex.php
@@ -72,8 +72,8 @@ class Complex {
 		return sprintf(
 			'<a id="%1$s"%2$s%3$s></a>',
 			sanitize_title( $atts['id'] ),
-			( isset( $atts['class'] ) ) ? sprintf( ' class="%s"', $atts['class'] ) : '',
-			( $content ) ? sprintf( ' title="%s"', $content ) : ''
+			( isset( $atts['class'] ) ) ? sprintf( ' class="%s"', esc_attr( $atts['class'] ) ) : '',
+			( $content ) ? sprintf( ' title="%s"', esc_attr( $content ) ) : ''
 		);
 	}
 
@@ -115,7 +115,7 @@ class Complex {
 
 		return sprintf(
 			'<div class="%1$s">%2$s</div>',
-			trim( $classes ),
+			esc_attr( trim( $classes ) ),
 			wpautop( trim( $content ) )
 		);
 	}
@@ -149,13 +149,13 @@ class Complex {
 			return sprintf(
 				'<a href="mailto:%1$s"%2$s>%1$s</a>',
 				antispambot( $address ),
-				( isset( $atts['class'] ) ) ? sprintf( ' class="%s"', $atts['class'] ) : ''
+				( isset( $atts['class'] ) ) ? sprintf( ' class="%s"', esc_attr( $atts['class'] ) ) : ''
 			);
 		} else {
 			return sprintf(
 				'<a href="mailto:%1$s"%2$s>%3$s</a>',
 				antispambot( $address ),
-				( isset( $atts['class'] ) ) ? sprintf( ' class="%s"', $atts['class'] ) : '',
+				( isset( $atts['class'] ) ) ? sprintf( ' class="%s"', esc_attr( $atts['class'] ) ) : '',
 				( $content ) ? $content : antispambot( $address )
 			);
 		}

--- a/inc/shortcodes/generics/class-generics.php
+++ b/inc/shortcodes/generics/class-generics.php
@@ -91,7 +91,7 @@ class Generics {
 			if ( is_array( $atts ) && array_key_exists( 'class', $atts ) ) {
 				$classnames[] = $atts['class'];
 			}
-			$class = ' class="' . implode( ' ', $classnames ) . '"';
+			$class = ' class="' . esc_attr( implode( ' ', $classnames ) ) . '"';
 		}
 		$content = trim( $content );
 		return '<' . $tag . $class . '>' . do_shortcode( $content ) . '</' . $tag . '>';
@@ -113,7 +113,7 @@ class Generics {
 			if ( is_array( $atts ) && array_key_exists( 'class', $atts ) ) {
 				$classnames[] = $atts['class'];
 			}
-			$class = ' class="' . implode( ' ', $classnames ) . '"';
+			$class = ' class="' . esc_attr( implode( ' ', $classnames ) ) . '"';
 		}
 		$content = wpautop( trim( $content ) );
 		return '<' . $tag . $class . '>' . do_shortcode( $content ) . '</' . $tag . '>';
@@ -131,7 +131,7 @@ class Generics {
 			if ( is_array( $atts ) && array_key_exists( 'class', $atts ) ) {
 				$classnames[] = $atts['class'];
 			}
-			$class = ' class="' . implode( ' ', $classnames ) . '"';
+			$class = ' class="' . esc_attr( implode( ' ', $classnames ) ) . '"';
 		}
 		return '<' . $tag . $class . '>' . do_shortcode( $content ) . '</' . $tag . '>';
 	}

--- a/inc/shortcodes/glossary/class-glossary.php
+++ b/inc/shortcodes/glossary/class-glossary.php
@@ -254,6 +254,8 @@ class Glossary implements FrontOrBackMatter {
 			], $atts
 		);
 
+		$a['id'] = absint( $a['id'] );
+
 		if ( ! empty( $content ) ) {
 			// This is a tooltip
 			if ( $a['id'] ) {

--- a/inc/shortcodes/glossary/class-glossary.php
+++ b/inc/shortcodes/glossary/class-glossary.php
@@ -195,7 +195,7 @@ class Glossary implements FrontOrBackMatter {
 						'dfn-%s',
 						\Pressbooks\Sanitize\sanitize_xml_id( \Pressbooks\Utility\str_lowercase_dash( $glossary_term_id ) )
 					),
-					$glossary_term_id,
+					esc_html( $glossary_term_id ),
 					wpautop( $g_content )
 				);
 			}

--- a/tests/test-shortcodes-attributions-attachments.php
+++ b/tests/test-shortcodes-attributions-attachments.php
@@ -112,6 +112,39 @@ class Shortcodes_Attributions_Attachments extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * A malicious attribution value (e.g. set via the REST meta write path, which
+	 * bypasses validate_attachment_metadata()) must not break out of the HTML it is
+	 * rendered into. URLs are escaped with esc_url(), text with esc_html().
+	 *
+	 * @group attributions
+	 */
+	public function test_attributionsContentEscapesXss() {
+		$attributions = [
+			42 => [
+				'title'       => '<script>alert(1)</script>',
+				'title_url'   => 'https://example.com/" onmouseover="alert(1)',
+				'author'      => '"><img src=x onerror=alert(1)>',
+				'author_url'  => 'javascript:alert(document.cookie)',
+				'adapted'     => '',
+				'adapted_url' => '',
+				'license'     => 'cc-by',
+			],
+		];
+
+		$html = $this->att->attributionsContent( $attributions );
+
+		// URL attribute breakout is neutralized: no live event handler in the markup.
+		$this->assertStringNotContainsString( 'onmouseover="alert(1)"', $html );
+		// The javascript: scheme is stripped by esc_url().
+		$this->assertStringNotContainsString( 'javascript:alert', $html );
+		// Text-node payloads are escaped, not rendered as tags.
+		$this->assertStringNotContainsString( '<script>alert(1)</script>', $html );
+		$this->assertStringNotContainsString( '<img src=x onerror=alert(1)>', $html );
+		$this->assertStringContainsString( '&lt;script&gt;', $html );
+		$this->assertStringContainsString( '&lt;img', $html );
+	}
+
+	/**
 	 * @group attributions
 	 */
 	public function test_getBookMedia() {

--- a/tests/test-shortcodes-complex.php
+++ b/tests/test-shortcodes-complex.php
@@ -160,4 +160,27 @@ class Shortcodes_Complex extends \WP_UnitTestCase {
 		$this->assertStringContainsString( '<iframe', $content );
 		$this->assertStringContainsString( '<figcaption>Deploy day!</figcaption>', $content );
 	}
+
+	/**
+	 * Attribute values supplied by the shortcode must be escaped so they cannot
+	 * break out of the attribute and inject an event handler (stored XSS).
+	 *
+	 * @group shortcodes
+	 */
+	public function test_shortcodeHandlersEscapeAttributes() {
+		$payload = 'x" onmouseover="alert(1)"';
+
+		// Anchor: class + title.
+		$anchor = $this->complex->anchorShortCodeHandler( [ 'id' => 'a', 'class' => $payload ], $payload, 'anchor' );
+		$this->assertStringNotContainsString( 'onmouseover="', $anchor );
+		$this->assertStringContainsString( '&quot;', $anchor );
+
+		// Columns: class.
+		$columns = $this->complex->columnsShortCodeHandler( [ 'class' => $payload ], 'Test', 'columns' );
+		$this->assertStringNotContainsString( 'onmouseover="', $columns );
+
+		// Email: class.
+		$email = $this->complex->emailShortCodeHandler( [ 'address' => 'me@here.com', 'class' => $payload ], '', 'email' );
+		$this->assertStringNotContainsString( 'onmouseover="', $email );
+	}
 }

--- a/tests/test-shortcodes-generics.php
+++ b/tests/test-shortcodes-generics.php
@@ -86,4 +86,23 @@ class Shortcodes_Generics extends \WP_UnitTestCase {
 
 		$this->assertEmpty( $this->generics->inlineShortcodeHandler( [], '', 'strong' ) );
 	}
+
+	/**
+	 * A malicious class attribute must not be able to break out of the attribute
+	 * and inject an event handler (stored XSS).
+	 *
+	 * @group shortcodes
+	 */
+	public function test_shortcodeHandlersEscapeClassAttribute() {
+		$payload = 'x" onmouseover="alert(1)"';
+
+		$block = $this->generics->blockShortcodeHandler( [ 'class' => $payload ], 'Test', 'heading' );
+		$multiline = $this->generics->multilineBlockShortcodeHandler( [ 'class' => $payload ], 'Test', 'textbox' );
+		$inline = $this->generics->inlineShortcodeHandler( [ 'class' => $payload ], 'Test', 'strong' );
+
+		foreach ( [ $block, $multiline, $inline ] as $html ) {
+			$this->assertStringNotContainsString( 'onmouseover="', $html );
+			$this->assertStringContainsString( '&quot;', $html );
+		}
+	}
 }

--- a/tests/test-shortcodes-glossary.php
+++ b/tests/test-shortcodes-glossary.php
@@ -131,6 +131,23 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * A malicious id attribute must be reduced to its integer post ID (absint),
+	 * preventing attribute breakout in the tooltip href (stored XSS).
+	 *
+	 * @group glossary
+	 */
+	public function test_webShortcodeHandlerSanitizesId() {
+		global $id;
+		$id = 42;
+		$pid = $this->_createGlossaryPost();
+
+		$result = $this->gl->webShortCodeHandler( [ 'id' => $pid . '" onmouseover="alert(1)"' ], 'PHP' );
+
+		$this->assertStringNotContainsString( 'onmouseover="', $result );
+		$this->assertStringContainsString( 'href="#term_' . $id . '_' . $pid . '"', $result );
+	}
+
+	/**
 	 * @group glossary
 	 */
 	public function test_getGlossaryTerms() {

--- a/tests/test-shortcodes-glossary.php
+++ b/tests/test-shortcodes-glossary.php
@@ -294,4 +294,29 @@ class Shortcodes_Glossary extends \WP_UnitTestCase {
 		$post = get_post( $pid );
 		$this->assertStringContainsString( '<dl data-type="glossary">', $this->gl->overrideDisplay( $post->post_content ) );
 	}
+
+	/**
+	 * A glossary term title is emitted into the <dfn> text node and must be escaped
+	 * with esc_html(), so a title containing markup (storable by a user with the
+	 * unfiltered_html capability) is not rendered as live HTML.
+	 *
+	 * @group glossary
+	 */
+	public function test_glossaryTermsEscapesTitle() {
+		$args = [
+			'post_type'    => 'glossary',
+			'post_title'   => 'Alpha <b>Beta</b>',
+			'post_content' => 'Content.',
+			'post_status'  => 'publish',
+		];
+		$pid = $this->factory()->post->create_object( $args );
+		wp_set_object_terms( $pid, 'definitions', 'glossary-type' );
+		$this->gl->getGlossaryTerms( true ); // Reset cache
+
+		$html = $this->gl->glossaryTerms();
+
+		// The title's markup is encoded, not rendered.
+		$this->assertStringContainsString( '&lt;b&gt;Beta&lt;/b&gt;', $html );
+		$this->assertStringNotContainsString( 'Alpha <b>Beta</b>', $html );
+	}
 }


### PR DESCRIPTION
Issue: https://github.com/pressbooks/private/issues/2666

Several built-in shortcodes (and the media-attribution renderer) wrote user-supplied values into HTML without escaping them. An Author (or higher) could put a payload like `class='x" onmouseover="alert(1)"'` into a shortcode; the value broke out of the attribute and injected an event handler that ran for every reader of the book, with no click required. This escapes those values at output, casts the glossary id to an integer, and hardens the media-attribution URLs and link text. Reported by Ashok Chapagai.
### Why it happened
htmLawed / wp_kses sanitizes `the_content` at priority 10; `do_shortcode` expands shortcodes at priority 11. The payloads use only quotes (no angle brackets), so nothing is stripped at save time, and the shortcode output is generated after the HTML filter has already run. The fix has to happen at output, in the handlers. The media-attribution case is worse: those fields are registered with `show_in_rest` but no sanitize callback, so a payload written via the REST API (bypassing the admin media-modal sanitizer) was stored verbatim and rendered raw.
### What changed
- Generic shortcodes (`[heading]`, `[subheading]`, `[textbox]`, `[blockquote]`, inline `[bold]`/`[code]`/`[em]`/`[italics]`/`[strong]`) — class attribute is now escaped with `esc_attr()`.
- `[anchor]`, `[columns]`, `[email]` — class (and `[anchor]` title) now escaped with `esc_attr()`.
- `[pb_glossary]` — `id` is now reduced to an integer with `absint()`. Since the value is always a post ID, this drops the payload entirely while preserving the real term id for both the tooltip `href` and the `<template id>`.
- Media attributions (`[media_attributions]` / `attributionsContent`) — source/author/adapted URLs are escaped with `esc_url()` and their link text with `esc_html()`, closing a vector reachable via the unsanitized REST meta write path. (Admin media-modal saves were already sanitized via `wp_http_validate_url`; the REST path was not.)
- Glossary listing — the term title emitted inside `<dfn>` is now escaped with `esc_html()`.
- Tests — regression coverage in the shortcode and attribution test files asserting the payloads no longer produce a literal `onmouseover="` attribute or render as live tags.
### How to test
On an environment without a WAF (local / self-hosted):
1. As an Author+, in the Text editor of a chapter, add each payload and view on the front end:
   - `[textbox class='x" onmouseover="alert(1)"']Test[/textbox]`
   - `[anchor id="xss" class='x" onmouseover="alert(document.cookie)"']Hover here[/anchor]`
   - `[pb_glossary id='<validGlossaryId>" onmouseover="alert(1)"']Test[/pb_glossary]`
   No alert fires on hover; the quote renders as `"` inside the attribute (the glossary id collapses to the integer post id, so the tooltip still resolves).
2. Media attributions — upload an attachment and set its Source URL (or author/adapted URL) via a REST `PATCH /wp/v2/media/<id>` to `https://example.com/" onmouseover="alert(1)`. Insert the attachment's attribution into a chapter; the event handler must not appear in the rendered markup, and the URL must render as a safe `href`.
In order to test this, use cURL (or a REST client):
    a. Upload the image:
    ```bash
     curl -i -X POST \
    -H "Content-Type: image/jpeg" \
    -H "Authorization: Basic <BASE 64 of (USER:APPLICATION PASSWORD)" \
    -H 'Content-Disposition: attachment; filename="<FILE_NAME>.jpeg"' \
    -T "<FILE_PATH>" \
    '<BOOK_URL>/wp-json/wp/v2/media'
    ```
    b. grab the ID of the new image uploaded
    c. Inject the metadata:
    ``` bash
    curl -s -X POST "<BOOK_URL>/wp-json/wp/v2/media/<ID_GRABBED>" \
    -H "Authorization: Basic <BASE 64 of (USER:APPLICATION PASSWORD)" \
    -H "Content-Type: application/json" \
    -d '{
      "meta": {
        "pb_media_attribution_title_url": "https://example.com/\" onmouseover=\"alert(1)",
        "pb_media_attribution_author": "<img src=x onerror=alert(1)>",
        "pb_media_attribution_author_url": "javascript:alert(document.cookie)"
      }
    }' | grep -o '{.*}' | jq '.meta'
    ```
    d. Insert the new image into the chapter
    e. Right now in dev, it will show the alert. Using this branch, it should be sanitized.
3. Confirm legitimate usage still works: `class="foo bar"`, multi-class textboxes, valid glossary tooltips, and normal attribution links all render unchanged.