### PR TITLE
fix: image and attachment id consistency during cloning

### DIFF
--- a/inc/cloner/class-downloads.php
+++ b/inc/cloner/class-downloads.php
@@ -284,26 +284,14 @@ class Downloads {
 			if ( $attachment_id === attachment_id_from_url( $maybe_src_new ) ) {
 				// Our best guess is that this is a cloned image, use old filename to preserve WP resizing
 				$src_new = $maybe_src_new;
-				// Update image class to new id to preserve WP Size dropdown
-				if ( $image->hasAttribute( 'class' ) ) {
-					$image->setAttribute( 'class', preg_replace( '/wp-image-\d+/', "wp-image-{$attachment_id}", $image->getAttribute( 'class' ) ) );
-				}
-				// Update wrapper IDs
-				if ( $image->parentNode->tagName === 'div' && strpos( $image->parentNode->getAttribute( 'id' ), 'attachment_' ) !== false ) {
-					// <div> id
-					$image->parentNode->setAttribute( 'id', preg_replace( '/attachment_\d+/', "attachment_{$attachment_id}", $image->parentNode->getAttribute( 'id' ) ) );
-				}
-				foreach ( $image->parentNode->childNodes as $child ) {
-					if ( $child instanceof \DOMText &&
-						strpos( $child->nodeValue, '[caption ' ) !== false &&
-						strpos( $child->nodeValue, 'attachment_' ) !== false
-					) {
-						// [caption] id
-						$child->nodeValue = preg_replace( '/attachment_\d+/', "attachment_{$attachment_id}", $child->nodeValue );
-					}
-				}
 			}
 		}
+
+		// Update the attachment ID references (wp-image-{id} class, attachment_{id} wrapper) to the
+		// newly sideloaded attachment. This runs regardless of the filename heuristic above: at this
+		// point $attachment_id is the new attachment for this exact <img>, so leaving the source book's
+		// IDs in place would make WordPress load the wrong attachment in the editor.
+		$this->replaceImageIds( $attachment_id, $image );
 
 		// Update srcset URLs
 		if ( $image->hasAttribute( 'srcset' ) ) {
@@ -311,6 +299,52 @@ class Downloads {
 		}
 
 		return $src_new;
+	}
+
+	/**
+	 * Rewrite the source book's attachment ID references on a cloned image so they point to the
+	 * newly sideloaded attachment: the `wp-image-{id}` class on the <img>, the `attachment_{id}` id
+	 * on a caption wrapper <div>, and the id in a `[caption id="attachment_{id}"]` shortcode.
+	 *
+	 * Handles images wrapped in a link (e.g. `[caption]<a><img></a>[/caption]`), where the caption
+	 * shortcode text node and wrapper <div> are relatives of the <a>, not of the <img>.
+	 *
+	 * @param int $attachment_id
+	 * @param \DOMElement $image
+	 *
+	 * @return void
+	 */
+	protected function replaceImageIds( $attachment_id, $image ) {
+		// Update image class to new id to preserve WP Size dropdown
+		if ( $image->hasAttribute( 'class' ) ) {
+			$image->setAttribute( 'class', preg_replace( '/wp-image-\d+/', "wp-image-{$attachment_id}", $image->getAttribute( 'class' ) ) );
+		}
+
+		// The caption shortcode / wrapper <div> may sit above a link that wraps the image, so climb
+		// past any <a> ancestors to find the node that contains them.
+		$node = $image;
+		while ( $node->parentNode instanceof \DOMElement && $node->parentNode->tagName === 'a' ) {
+			$node = $node->parentNode;
+		}
+		$container = $node->parentNode;
+
+		// Update wrapper <div id="attachment_{id}">. The legacy rendered caption markup wraps each
+		// image in its own <div>, so this is already scoped to the current image.
+		if ( $container instanceof \DOMElement && $container->tagName === 'div' && strpos( $container->getAttribute( 'id' ), 'attachment_' ) !== false ) {
+			$container->setAttribute( 'id', preg_replace( '/attachment_\d+/', "attachment_{$attachment_id}", $container->getAttribute( 'id' ) ) );
+		}
+
+		// Update the [caption id="attachment_{id}"] shortcode that opens this image's caption. The
+		// opening tag lives in the text node immediately before the image (or its <a> wrapper), so
+		// scope the rewrite to that node's caption id and leave sibling captions untouched.
+		$prev = $node->previousSibling;
+		if ( $prev instanceof \DOMText && strpos( $prev->nodeValue, '[caption ' ) !== false ) {
+			$prev->nodeValue = preg_replace(
+				'/(\[caption[^\]]*\bid=["\']?)attachment_\d+/',
+				sprintf( '${1}attachment_%d', $attachment_id ),
+				$prev->nodeValue
+			);
+		}
 	}
 
 	/**

--- a/inc/cloner/class-downloads.php
+++ b/inc/cloner/class-downloads.php
@@ -287,10 +287,6 @@ class Downloads {
 			}
 		}
 
-		// Update the attachment ID references (wp-image-{id} class, attachment_{id} wrapper) to the
-		// newly sideloaded attachment. This runs regardless of the filename heuristic above: at this
-		// point $attachment_id is the new attachment for this exact <img>, so leaving the source book's
-		// IDs in place would make WordPress load the wrong attachment in the editor.
 		$this->replaceImageIds( $attachment_id, $image );
 
 		// Update srcset URLs
@@ -320,23 +316,16 @@ class Downloads {
 			$image->setAttribute( 'class', preg_replace( '/wp-image-\d+/', "wp-image-{$attachment_id}", $image->getAttribute( 'class' ) ) );
 		}
 
-		// The caption shortcode / wrapper <div> may sit above a link that wraps the image, so climb
-		// past any <a> ancestors to find the node that contains them.
 		$node = $image;
 		while ( $node->parentNode instanceof \DOMElement && $node->parentNode->tagName === 'a' ) {
 			$node = $node->parentNode;
 		}
 		$container = $node->parentNode;
 
-		// Update wrapper <div id="attachment_{id}">. The legacy rendered caption markup wraps each
-		// image in its own <div>, so this is already scoped to the current image.
 		if ( $container instanceof \DOMElement && $container->tagName === 'div' && strpos( $container->getAttribute( 'id' ), 'attachment_' ) !== false ) {
 			$container->setAttribute( 'id', preg_replace( '/attachment_\d+/', "attachment_{$attachment_id}", $container->getAttribute( 'id' ) ) );
 		}
 
-		// Update the [caption id="attachment_{id}"] shortcode that opens this image's caption. The
-		// opening tag lives in the text node immediately before the image (or its <a> wrapper), so
-		// scope the rewrite to that node's caption id and leave sibling captions untouched.
 		$prev = $node->previousSibling;
 		if ( $prev instanceof \DOMText && strpos( $prev->nodeValue, '[caption ' ) !== false ) {
 			$prev->nodeValue = preg_replace(

--- a/inc/image/namespace.php
+++ b/inc/image/namespace.php
@@ -197,7 +197,7 @@ function attachment_id_from_url( $url ) {
 	global $wpdb;
 
 	// If this is the URL of an auto-generated thumbnail, get the URL of the original image
-	$url = preg_replace( '/-\d+x\d+(?=\.(jp?g|png|gif)$)/i', '', $url );
+	$url = preg_replace( '/-\d+x\d+(?=\.(jpe?g|png|gif)$)/i', '', $url );
 
 	$attached_file = strip_baseurl( $url );
 

--- a/inc/modules/import/wordpress/class-downloads.php
+++ b/inc/modules/import/wordpress/class-downloads.php
@@ -206,26 +206,14 @@ class Downloads {
 			if ( $attachment_id === attachment_id_from_url( $maybe_src_new ) ) {
 				// Our best guess is that this is a cloned image, use old filename to preserve WP resizing
 				$src_new = $maybe_src_new;
-				// Update image class to new id to preserve WP Size dropdown
-				if ( $image->hasAttribute( 'class' ) ) {
-					$image->setAttribute( 'class', preg_replace( '/wp-image-\d+/', "wp-image-{$attachment_id}", $image->getAttribute( 'class' ) ) );
-				}
-				// Update wrapper IDs
-				if ( $image->parentNode->tagName === 'div' && strpos( $image->parentNode->getAttribute( 'id' ), 'attachment_' ) !== false ) {
-					// <div> id
-					$image->parentNode->setAttribute( 'id', preg_replace( '/attachment_\d+/', "attachment_{$attachment_id}", $image->parentNode->getAttribute( 'id' ) ) );
-				}
-				foreach ( $image->parentNode->childNodes as $child ) {
-					if ( $child instanceof \DOMText &&
-						strpos( $child->nodeValue, '[caption ' ) !== false &&
-						strpos( $child->nodeValue, 'attachment_' ) !== false
-					) {
-						// [caption] id
-						$child->nodeValue = preg_replace( '/attachment_\d+/', "attachment_{$attachment_id}", $child->nodeValue );
-					}
-				}
 			}
 		}
+
+		// Update the attachment ID references (wp-image-{id} class, attachment_{id} wrapper) to the
+		// newly sideloaded attachment. This runs regardless of the filename heuristic above: at this
+		// point $attachment_id is the new attachment for this exact <img>, so leaving the source book's
+		// IDs in place would make WordPress load the wrong attachment in the editor.
+		$this->replaceImageIds( $attachment_id, $image );
 
 		// Update srcset URLs
 		if ( $image->hasAttribute( 'srcset' ) ) {
@@ -233,6 +221,52 @@ class Downloads {
 		}
 
 		return $src_new;
+	}
+
+	/**
+	 * Rewrite the source book's attachment ID references on an imported image so they point to the
+	 * newly sideloaded attachment: the `wp-image-{id}` class on the <img>, the `attachment_{id}` id
+	 * on a caption wrapper <div>, and the id in a `[caption id="attachment_{id}"]` shortcode.
+	 *
+	 * Handles images wrapped in a link (e.g. `[caption]<a><img></a>[/caption]`), where the caption
+	 * shortcode text node and wrapper <div> are relatives of the <a>, not of the <img>.
+	 *
+	 * @param int $attachment_id
+	 * @param \DOMElement $image
+	 *
+	 * @return void
+	 */
+	protected function replaceImageIds( $attachment_id, $image ) {
+		// Update image class to new id to preserve WP Size dropdown
+		if ( $image->hasAttribute( 'class' ) ) {
+			$image->setAttribute( 'class', preg_replace( '/wp-image-\d+/', "wp-image-{$attachment_id}", $image->getAttribute( 'class' ) ) );
+		}
+
+		// The caption shortcode / wrapper <div> may sit above a link that wraps the image, so climb
+		// past any <a> ancestors to find the node that contains them.
+		$node = $image;
+		while ( $node->parentNode instanceof \DOMElement && $node->parentNode->tagName === 'a' ) {
+			$node = $node->parentNode;
+		}
+		$container = $node->parentNode;
+
+		// Update wrapper <div id="attachment_{id}">. The legacy rendered caption markup wraps each
+		// image in its own <div>, so this is already scoped to the current image.
+		if ( $container instanceof \DOMElement && $container->tagName === 'div' && strpos( $container->getAttribute( 'id' ), 'attachment_' ) !== false ) {
+			$container->setAttribute( 'id', preg_replace( '/attachment_\d+/', "attachment_{$attachment_id}", $container->getAttribute( 'id' ) ) );
+		}
+
+		// Update the [caption id="attachment_{id}"] shortcode that opens this image's caption. The
+		// opening tag lives in the text node immediately before the image (or its <a> wrapper), so
+		// scope the rewrite to that node's caption id and leave sibling captions untouched.
+		$prev = $node->previousSibling;
+		if ( $prev instanceof \DOMText && strpos( $prev->nodeValue, '[caption ' ) !== false ) {
+			$prev->nodeValue = preg_replace(
+				'/(\[caption[^\]]*\bid=["\']?)attachment_\d+/',
+				sprintf( '${1}attachment_%d', $attachment_id ),
+				$prev->nodeValue
+			);
+		}
 	}
 
 	/**

--- a/inc/modules/import/wordpress/class-downloads.php
+++ b/inc/modules/import/wordpress/class-downloads.php
@@ -209,10 +209,6 @@ class Downloads {
 			}
 		}
 
-		// Update the attachment ID references (wp-image-{id} class, attachment_{id} wrapper) to the
-		// newly sideloaded attachment. This runs regardless of the filename heuristic above: at this
-		// point $attachment_id is the new attachment for this exact <img>, so leaving the source book's
-		// IDs in place would make WordPress load the wrong attachment in the editor.
 		$this->replaceImageIds( $attachment_id, $image );
 
 		// Update srcset URLs
@@ -237,28 +233,20 @@ class Downloads {
 	 * @return void
 	 */
 	protected function replaceImageIds( $attachment_id, $image ) {
-		// Update image class to new id to preserve WP Size dropdown
 		if ( $image->hasAttribute( 'class' ) ) {
 			$image->setAttribute( 'class', preg_replace( '/wp-image-\d+/', "wp-image-{$attachment_id}", $image->getAttribute( 'class' ) ) );
 		}
 
-		// The caption shortcode / wrapper <div> may sit above a link that wraps the image, so climb
-		// past any <a> ancestors to find the node that contains them.
 		$node = $image;
 		while ( $node->parentNode instanceof \DOMElement && $node->parentNode->tagName === 'a' ) {
 			$node = $node->parentNode;
 		}
 		$container = $node->parentNode;
 
-		// Update wrapper <div id="attachment_{id}">. The legacy rendered caption markup wraps each
-		// image in its own <div>, so this is already scoped to the current image.
 		if ( $container instanceof \DOMElement && $container->tagName === 'div' && strpos( $container->getAttribute( 'id' ), 'attachment_' ) !== false ) {
 			$container->setAttribute( 'id', preg_replace( '/attachment_\d+/', "attachment_{$attachment_id}", $container->getAttribute( 'id' ) ) );
 		}
 
-		// Update the [caption id="attachment_{id}"] shortcode that opens this image's caption. The
-		// opening tag lives in the text node immediately before the image (or its <a> wrapper), so
-		// scope the rewrite to that node's caption id and leave sibling captions untouched.
 		$prev = $node->previousSibling;
 		if ( $prev instanceof \DOMText && strpos( $prev->nodeValue, '[caption ' ) !== false ) {
 			$prev->nodeValue = preg_replace(

--- a/tests/test-cloner.php
+++ b/tests/test-cloner.php
@@ -699,4 +699,110 @@ class ClonerTest extends \WP_UnitTestCase {
 
 		remove_all_filters( 'rest_pre_dispatch' );
 	}
+
+	/**
+	 * The wp-image-{id} class must be rewritten to the new attachment id even when the image's
+	 * src is not found in the source book's known media (the filename-preservation guard fails).
+	 * A stale source id here is what makes the editor load the wrong image on a clone.
+	 *
+	 * @group cloner
+	 */
+	public function test_replaceImage_rewrites_stale_wp_image_class_outside_known_media() {
+		$downloads = new Downloads( $this->cloner, null );
+
+		// External host => sameAsSource() is false => the known-media guard is skipped, which is
+		// exactly the failure path where the id used to be left pointing at the source book.
+		$src = 'https://external-source.test/app/uploads/sites/2/2023/01/photo.jpeg';
+		$html5 = new \Pressbooks\HtmlParser();
+		$dom = $html5->loadHTML( '<p><img class="size-medium wp-image-18" src="' . $src . '" alt="" /></p>' );
+		$img = $dom->getElementsByTagName( 'img' )->item( 0 );
+
+		$downloads->replaceImage( 4242, $src, $img );
+
+		$this->assertStringContainsString( 'wp-image-4242', $img->getAttribute( 'class' ) );
+		$this->assertStringNotContainsString( 'wp-image-18', $img->getAttribute( 'class' ) );
+	}
+
+	/**
+	 * When the image is wrapped in a link, the [caption id="attachment_{id}"] shortcode is a sibling
+	 * of the <a>, not of the <img>. The rewrite must climb past the <a> to reach it.
+	 *
+	 * @group cloner
+	 */
+	public function test_replaceImage_rewrites_linked_caption_attachment_id() {
+		$downloads = new Downloads( $this->cloner, null );
+
+		$src = 'https://external-source.test/app/uploads/sites/2/2023/01/photo.jpeg';
+		$content = '<p>[caption id="attachment_18" align="alignnone" width="300"]' .
+			'<a href="https://external-source.test/full.jpeg"><img class="wp-image-18 size-medium" src="' . $src . '" alt="" width="300" height="200" /></a>' .
+			' This is the caption[/caption]</p>';
+		$html5 = new \Pressbooks\HtmlParser();
+		$dom = $html5->loadHTML( $content );
+		$img = $dom->getElementsByTagName( 'img' )->item( 0 );
+
+		$downloads->replaceImage( 4242, $src, $img );
+
+		$out = $html5->saveHTML( $dom );
+		$this->assertStringContainsString( 'wp-image-4242', $out );
+		$this->assertStringContainsString( 'attachment_4242', $out );
+		$this->assertStringNotContainsString( 'attachment_18', $out );
+		$this->assertStringNotContainsString( 'wp-image-18', $out );
+	}
+
+	/**
+	 * The legacy rendered caption markup wraps the image in <div id="attachment_{id}">. That id must
+	 * also be rewritten to the new attachment id.
+	 *
+	 * @group cloner
+	 */
+	public function test_replaceImage_rewrites_caption_div_attachment_id() {
+		$downloads = new Downloads( $this->cloner, null );
+
+		$src = 'https://external-source.test/app/uploads/sites/2/2023/01/photo.jpeg';
+		$content = '<div id="attachment_18" class="wp-caption alignnone" style="width: 310px">' .
+			'<img class="size-medium wp-image-18" src="' . $src . '" alt="" width="300" height="200" />' .
+			'<p class="wp-caption-text">A caption</p></div>';
+		$html5 = new \Pressbooks\HtmlParser();
+		$dom = $html5->loadHTML( $content );
+		$img = $dom->getElementsByTagName( 'img' )->item( 0 );
+
+		$downloads->replaceImage( 4242, $src, $img );
+
+		$out = $html5->saveHTML( $dom );
+		$this->assertStringContainsString( 'id="attachment_4242"', $out );
+		$this->assertStringContainsString( 'wp-image-4242', $out );
+		$this->assertStringNotContainsString( 'attachment_18', $out );
+	}
+
+	/**
+	 * When several captioned images live in the same content, each [caption id="attachment_{id}"]
+	 * must be rewritten to its OWN image's new id. A previous implementation rewrote every caption
+	 * in the container on each image, so they all collapsed to the last processed id.
+	 *
+	 * @group cloner
+	 */
+	public function test_replaceImage_scopes_caption_id_to_its_own_image() {
+		$downloads = new Downloads( $this->cloner, null );
+
+		$src1 = 'https://external-source.test/app/uploads/sites/2/2026/08/whim-225x300.jpeg';
+		$src2 = 'https://external-source.test/app/uploads/sites/2/2026/08/screen-300x39.png';
+		$content = '[caption id="attachment_46" align="alignnone" width="225"]' .
+			'<img class="wp-image-46 size-medium" src="' . $src1 . '" alt="" /> first caption[/caption]' . "\n" .
+			'[caption id="attachment_50" align="alignnone" width="300"]' .
+			'<img class="wp-image-50 size-medium" src="' . $src2 . '" alt="" /> second caption[/caption]';
+		$html5 = new \Pressbooks\HtmlParser();
+		$dom = $html5->loadHTML( $content );
+		$imgs = $dom->getElementsByTagName( 'img' );
+
+		$downloads->replaceImage( 191, $src1, $imgs->item( 0 ) );
+		$downloads->replaceImage( 202, $src2, $imgs->item( 1 ) );
+
+		$out = $html5->saveHTML( $dom );
+		$this->assertStringContainsString( 'wp-image-191', $out );
+		$this->assertStringContainsString( 'wp-image-202', $out );
+		$this->assertStringContainsString( 'attachment_191', $out );
+		$this->assertStringContainsString( 'attachment_202', $out );
+		$this->assertStringNotContainsString( 'attachment_46', $out );
+		$this->assertStringNotContainsString( 'attachment_50', $out );
+	}
 }

--- a/tests/test-cloner.php
+++ b/tests/test-cloner.php
@@ -701,17 +701,11 @@ class ClonerTest extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * The wp-image-{id} class must be rewritten to the new attachment id even when the image's
-	 * src is not found in the source book's known media (the filename-preservation guard fails).
-	 * A stale source id here is what makes the editor load the wrong image on a clone.
-	 *
 	 * @group cloner
 	 */
 	public function test_replaceImage_rewrites_stale_wp_image_class_outside_known_media() {
 		$downloads = new Downloads( $this->cloner, null );
 
-		// External host => sameAsSource() is false => the known-media guard is skipped, which is
-		// exactly the failure path where the id used to be left pointing at the source book.
 		$src = 'https://external-source.test/app/uploads/sites/2/2023/01/photo.jpeg';
 		$html5 = new \Pressbooks\HtmlParser();
 		$dom = $html5->loadHTML( '<p><img class="size-medium wp-image-18" src="' . $src . '" alt="" /></p>' );
@@ -724,9 +718,6 @@ class ClonerTest extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * When the image is wrapped in a link, the [caption id="attachment_{id}"] shortcode is a sibling
-	 * of the <a>, not of the <img>. The rewrite must climb past the <a> to reach it.
-	 *
 	 * @group cloner
 	 */
 	public function test_replaceImage_rewrites_linked_caption_attachment_id() {
@@ -750,9 +741,6 @@ class ClonerTest extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * The legacy rendered caption markup wraps the image in <div id="attachment_{id}">. That id must
-	 * also be rewritten to the new attachment id.
-	 *
 	 * @group cloner
 	 */
 	public function test_replaceImage_rewrites_caption_div_attachment_id() {
@@ -775,10 +763,6 @@ class ClonerTest extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * When several captioned images live in the same content, each [caption id="attachment_{id}"]
-	 * must be rewritten to its OWN image's new id. A previous implementation rewrote every caption
-	 * in the container on each image, so they all collapsed to the last processed id.
-	 *
 	 * @group cloner
 	 */
 	public function test_replaceImage_scopes_caption_id_to_its_own_image() {

--- a/tests/test-image.php
+++ b/tests/test-image.php
@@ -81,10 +81,6 @@ class ImageTest extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * A .jpeg intermediate size (e.g. foo-300x225.jpeg) must resolve to its attachment. Regression
-	 * test for a regex that stripped the size suffix from .jpg but not .jpeg, which made cloned
-	 * images keep the source book's wp-image-{id}/attachment_{id} references.
-	 *
 	 * @group media
 	 */
 	public function test_attachment_id_from_url_jpeg() {
@@ -96,11 +92,9 @@ class ImageTest extends \WP_UnitTestCase {
 		);
 		update_post_meta( $id, '_wp_attached_file', '2017/08/foo-bar.jpeg' );
 
-		// Intermediate size: the -300x225 suffix must be stripped before the lookup.
 		$sized = 'https://pressbooks.dev/app/uploads/2017/08/foo-bar-300x225.jpeg';
 		$this->assertSame( $id, \Pressbooks\Image\attachment_id_from_url( $sized ) );
 
-		// Full size resolves too.
 		$full = 'https://pressbooks.dev/app/uploads/2017/08/foo-bar.jpeg';
 		$this->assertSame( $id, \Pressbooks\Image\attachment_id_from_url( $full ) );
 	}

--- a/tests/test-image.php
+++ b/tests/test-image.php
@@ -81,6 +81,31 @@ class ImageTest extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * A .jpeg intermediate size (e.g. foo-300x225.jpeg) must resolve to its attachment. Regression
+	 * test for a regex that stripped the size suffix from .jpg but not .jpeg, which made cloned
+	 * images keep the source book's wp-image-{id}/attachment_{id} references.
+	 *
+	 * @group media
+	 */
+	public function test_attachment_id_from_url_jpeg() {
+		$id = $this->factory()->post->create(
+			[
+				'post_type' => 'attachment',
+				'post_mime_type' => 'image/jpeg',
+			]
+		);
+		update_post_meta( $id, '_wp_attached_file', '2017/08/foo-bar.jpeg' );
+
+		// Intermediate size: the -300x225 suffix must be stripped before the lookup.
+		$sized = 'https://pressbooks.dev/app/uploads/2017/08/foo-bar-300x225.jpeg';
+		$this->assertSame( $id, \Pressbooks\Image\attachment_id_from_url( $sized ) );
+
+		// Full size resolves too.
+		$full = 'https://pressbooks.dev/app/uploads/2017/08/foo-bar.jpeg';
+		$this->assertSame( $id, \Pressbooks\Image\attachment_id_from_url( $full ) );
+	}
+
+	/**
 	 * @group media
 	 */
 	public function test_fudge_factor() {

--- a/tests/test-modules-import.php
+++ b/tests/test-modules-import.php
@@ -197,4 +197,101 @@ class Modules_ImportTest extends \WP_UnitTestCase {
 		$values = $import->searchMultipleContributorValues( 'pb_fail', $post_meta );
 		$this->assertCount(0, $values);
 	}
+
+	/**
+	 * @group import
+	 */
+	public function test_replaceImage_rewrites_stale_wp_image_class_outside_known_media() {
+		$wxr = new Wxr();
+		$wxr->setSourceBookUrl( 'https://pressbooks.com/' );
+		$downloads = new Downloads( $wxr );
+
+		// External host => sameAsSource() is false => the known-media guard is skipped.
+		$src = 'https://external-source.test/app/uploads/sites/2/2026/08/photo.jpeg';
+		$html5 = new \Pressbooks\HtmlParser();
+		$dom = $html5->loadHTML( "<p><img class=\"size-medium wp-image-18\" src=\"{$src}\" alt=\"\" /></p>" );
+		$img = $dom->getElementsByTagName( 'img' )->item( 0 );
+
+		$downloads->replaceImage( 4242, $src, $img );
+
+		$this->assertStringContainsString( 'wp-image-4242', $img->getAttribute( 'class' ) );
+		$this->assertStringNotContainsString( 'wp-image-18', $img->getAttribute( 'class' ) );
+	}
+
+	/**
+	 * @group import
+	 */
+	public function test_replaceImage_rewrites_linked_caption_attachment_id() {
+		$wxr = new Wxr();
+		$wxr->setSourceBookUrl( 'https://pressbooks.com/' );
+		$downloads = new Downloads( $wxr );
+
+		$src = 'https://external-source.test/app/uploads/sites/2/2026/08/photo.jpeg';
+		$content = '<p>[caption id="attachment_18" align="alignnone" width="300"]' .
+			"<a href=\"https://external-source.test/full.jpeg\"><img class=\"wp-image-18 size-medium\" src=\"{$src}\" alt=\"\" width=\"300\" height=\"200\" /></a>" .
+			' This is the caption[/caption]</p>';
+		$html5 = new \Pressbooks\HtmlParser();
+		$dom = $html5->loadHTML( $content );
+		$img = $dom->getElementsByTagName( 'img' )->item( 0 );
+
+		$downloads->replaceImage( 4242, $src, $img );
+
+		$out = $html5->saveHTML( $dom );
+		$this->assertStringContainsString( 'wp-image-4242', $out );
+		$this->assertStringContainsString( 'attachment_4242', $out );
+		$this->assertStringNotContainsString( 'attachment_18', $out );
+		$this->assertStringNotContainsString( 'wp-image-18', $out );
+	}
+
+	/**
+	 * @group import
+	 */
+	public function test_replaceImage_rewrites_caption_div_attachment_id() {
+		$wxr = new Wxr();
+		$wxr->setSourceBookUrl( 'https://pressbooks.com/' );
+		$downloads = new Downloads( $wxr );
+
+		$src = 'https://external-source.test/app/uploads/sites/2/2026/08/photo.jpeg';
+		$content = '<div id="attachment_18" class="wp-caption alignnone" style="width: 310px">' .
+			"<img class=\"size-medium wp-image-18\" src=\"{$src}\" alt=\"\" width=\"300\" height=\"200\" />" .
+			'<p class="wp-caption-text">A caption</p></div>';
+		$html5 = new \Pressbooks\HtmlParser();
+		$dom = $html5->loadHTML( $content );
+		$img = $dom->getElementsByTagName( 'img' )->item( 0 );
+
+		$downloads->replaceImage( 4242, $src, $img );
+
+		$out = $html5->saveHTML( $dom );
+		$this->assertStringContainsString( 'id="attachment_4242"', $out );
+		$this->assertStringContainsString( 'wp-image-4242', $out );
+		$this->assertStringNotContainsString( 'attachment_18', $out );
+	}
+
+	/**
+	 * @group import
+	 */
+	public function test_replaceImage_scopes_caption_id_to_its_own_image() {
+		$wxr = new Wxr();
+		$wxr->setSourceBookUrl( 'https://pressbooks.com/' );
+		$downloads = new Downloads( $wxr );
+
+		$src1 = 'https://external-source.test/app/uploads/sites/2/2026/08/whim-225x300.jpeg';
+		$src2 = 'https://external-source.test/app/uploads/sites/2/2026/08/screen-300x39.png';
+		$content = '[caption id="attachment_46" align="alignnone" width="225"]' .
+			'<img class="wp-image-46 size-medium" src="' . $src1 . '" alt="" /> first caption[/caption]' . "\n" .
+			'[caption id="attachment_50" align="alignnone" width="300"]' .
+			'<img class="wp-image-50 size-medium" src="' . $src2 . '" alt="" /> second caption[/caption]';
+		$html5 = new \Pressbooks\HtmlParser();
+		$dom = $html5->loadHTML( $content );
+		$imgs = $dom->getElementsByTagName( 'img' );
+
+		$downloads->replaceImage( 191, $src1, $imgs->item( 0 ) );
+		$downloads->replaceImage( 202, $src2, $imgs->item( 1 ) );
+
+		$out = $html5->saveHTML( $dom );
+		$this->assertStringContainsString( 'attachment_191', $out );
+		$this->assertStringContainsString( 'attachment_202', $out );
+		$this->assertStringNotContainsString( 'attachment_46', $out );
+		$this->assertStringNotContainsString( 'attachment_50', $out );
+	}
 }


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks/issues/4537

Cloned and imported images could keep the source book's attachment IDs in their markup — the `wp-image-{id}` class, the `attachment_{id}` caption wrapper, and the `[caption id="attachment_{id}"]` shortcode. The visual editor resolves the attachment from that class, so a stale ID made it load the wrong image on the first "Edit" click, and stale caption IDs broke attribution lookups. The same bug affected both the cloner and the WXR importer.
The ID-rewriting code already existed but was trapped inside a guard whose real job was deciding whether to preserve the old filename in the new `src`. When that guard failed — which it did for `.jpeg` intermediate sizes (a regex typo), external/CDN hosts, and a few other cases — the file still downloaded and the `src` updated, but every ID reference kept pointing at the source book. A second bug meant multiple captioned images in one post collapsed to the same caption ID.
### What changed
- The ID rewrites now run for every successfully sideloaded image, independent of the filename-preservation heuristic. That heuristic still controls only the `src` filename, which is all it was ever meant to decide.
- Fixed a regex typo in `attachment_id_from_url()` that stripped size suffixes from `.jpg` but not `.jpeg`, so `.jpeg` intermediate-size URLs never resolved to their attachment — the main trigger for the stale IDs in practice.
- Caption ID rewrites are now scoped to each image's own `[caption]` opening tag (the text node immediately before the image, or before its `<a>` wrapper). Previously a scan of all sibling text nodes made every caption in a post take the last-processed image's ID.
- Linked captioned images (`[caption]<a><img></a>[/caption]`) are handled correctly by climbing past the `<a>` wrapper before locating the caption.
- The same fixes were applied to the WXR importer, which carried an identical copy of the bug.
### How to test
1. In a source book, add images in a few configurations: a `.jpeg` inserted at Medium size, a plain captioned image, a linked captioned image, and two or more captioned images in the same chapter.
2. Clone the book to a new target.
3. In the clone, open the chapter in the visual editor and click "Edit" on each image — the correct image should load on the first click, and the Size dropdown should work.
4. Switch to the code editor and confirm each `wp-image-{id}` class and `[caption id="attachment_{id}"]` matches that image's new attachment ID in the target book's Media Library, and that distinct captions have distinct IDs.
5. Optionally repeat via WXR import to confirm the importer path is also fixed.
6. Run `composer test -- --group cloner,media` — all green (48 tests, 192 assertions).