### PR TITLE
chore: bump wp version to 7.0.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         include:
           - php: 8.3
-            wordpress: 7.0.3
+            wordpress: 7.0.4
             prince: 16.2-1
             epubcheck: 4.2.6
             experimental: false
@@ -24,7 +24,7 @@ jobs:
             epubcheck: 4.2.6
             experimental: true
           - php: 8.4
-            wordpress: 7.0.3
+            wordpress: 7.0.4
             prince: 16.2-1
             epubcheck: 4.2.6
             experimental: true

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Pressbooks
 Contributors: Pressbooks <code@pressbooks.com>
 Tags: ebooks, publishing, webbooks
-Requires at least: 7.03
-Tested up to: 7.0.3
+Requires at least: 7.0.4
+Tested up to: 7.0.4
 <!-- x-release-please-start-version -->
 Stable tag: 6.45.0
 <!-- x-release-please-end -->
@@ -30,7 +30,7 @@ Our webbooks and EPUB/[PDF][pdf] exports are all driven by HTML + CSS. XML outpu
 
 ## Requirements
 
-Pressbooks works with PHP 8.3 and WordPress 7.0.3. Lower versions are not supported.
+Pressbooks works with PHP 8.3 and WordPress 7.0.4. Lower versions are not supported.
 
 ## Installing the Plugin
 

--- a/compatibility.php
+++ b/compatibility.php
@@ -35,7 +35,7 @@ function pb_meets_minimum_requirements() {
 
 	// WordPress Version
 	global $pb_minimum_wp;
-	$pb_minimum_wp = '7.0.3';
+	$pb_minimum_wp = '7.0.4';
 
 	include_once ABSPATH . 'wp-admin/includes/plugin.php';
 	$is_compatible = true;

--- a/inc/admin/metaboxes/namespace.php
+++ b/inc/admin/metaboxes/namespace.php
@@ -77,7 +77,7 @@ function upload_cover_image( $pid, $post, $image = null ) {
 		return; // Bail
 	}
 
-	if ( ! current_user_can_for_blog( get_current_blog_id(), 'upload_files' ) ) {
+	if ( ! current_user_can_for_site( get_current_blog_id(), 'upload_files' ) ) {
 		return; // Bail
 	}
 
@@ -291,7 +291,7 @@ function override_parent_id( $post ) {
  */
 function delete_cover_image() {
 
-	if ( current_user_can_for_blog( get_current_blog_id(), 'upload_files' ) && check_ajax_referer( 'pb-delete-cover-image' ) ) {
+	if ( current_user_can_for_site( get_current_blog_id(), 'upload_files' ) && check_ajax_referer( 'pb-delete-cover-image' ) ) {
 
 		$image_url = $_POST['filename'];
 		$pid = $_POST['pid'];

--- a/inc/class-book.php
+++ b/inc/class-book.php
@@ -818,9 +818,9 @@ class Book {
 			} else {
 				if ( in_array( $order[ $post_id ]['post_status'], [ 'publish', 'web-only' ], true ) ) {
 					break;
-				} elseif ( current_user_can_for_blog( $blog_id, 'read_private_posts' ) ) {
+				} elseif ( current_user_can_for_site( $blog_id, 'read_private_posts' ) ) {
 					break;
-				} elseif ( get_option( 'permissive_private_content' ) && current_user_can_for_blog( $blog_id, 'read' ) ) {
+				} elseif ( get_option( 'permissive_private_content' ) && current_user_can_for_site( $blog_id, 'read' ) ) {
 					break;
 				} else {
 					$what( $pos );
@@ -862,9 +862,9 @@ class Book {
 			} else {
 				if ( in_array( $order[ $first_id ]['post_status'], [ 'publish', 'web-only' ], true ) ) {
 					break;
-				} elseif ( current_user_can_for_blog( $blog_id, 'read_private_posts' ) ) {
+				} elseif ( current_user_can_for_site( $blog_id, 'read_private_posts' ) ) {
 					break;
-				} elseif ( get_option( 'permissive_private_content' ) && current_user_can_for_blog( $blog_id, 'read' ) ) {
+				} elseif ( get_option( 'permissive_private_content' ) && current_user_can_for_site( $blog_id, 'read' ) ) {
 					break;
 				} else {
 					next( $pos );

--- a/inc/class-catalog.php
+++ b/inc/class-catalog.php
@@ -764,7 +764,7 @@ class Catalog {
 		}
 
 		$book = get_active_blog_for_user( $this->userId );
-		if ( ! current_user_can_for_blog( $book->blog_id, 'upload_files' ) ) {
+		if ( ! current_user_can_for_site( $book->blog_id, 'upload_files' ) ) {
 			return; // Bail
 		}
 
@@ -1084,7 +1084,7 @@ class Catalog {
 		$user_id = (int) $_POST['pid'];
 
 		$book = get_active_blog_for_user( $user_id );
-		if ( current_user_can_for_blog( $book->blog_id, 'upload_files' ) ) {
+		if ( current_user_can_for_site( $book->blog_id, 'upload_files' ) ) {
 
 			switch_to_blog( $book->blog_id );
 

--- a/pressbooks.php
+++ b/pressbooks.php
@@ -8,7 +8,7 @@
  * x-release-please-start-version
  * Version: 6.45.0
  * x-release-please-end
- * Requires at least: WordPress 7.0.3
+ * Requires at least: WordPress 7.0.4
  * Requires PHP: 8.3
  * Author: Pressbooks (Book Oven Inc.)
  * Author URI: https://pressbooks.org


### PR DESCRIPTION
## Summary

Bumps the minimum supported WordPress version from **7.0.3 → 7.0.4** across every declaration (including the runtime activation gate and CI), and migrates a WordPress‑deprecated capability function to its current replacement. **PHP requirement is unchanged (8.3).**

#### Deprecation fix: `current_user_can_for_blog()` → `current_user_can_for_site()`

`current_user_can_for_blog()` was deprecated in **WordPress 6.7.0** in favour of `current_user_can_for_site()`. Replaced all 8 call sites:

- `inc/class-book.php` (×4)
- `inc/class-catalog.php` (×2)
- `inc/admin/metaboxes/namespace.php` (×2)

Behaviour‑preserving 1:1 rename — identical `(site_id, capability)` signature; the deprecated function simply delegated to the new one. This clears the findings from the plugin's own `phpcs.wp7-deprecations.xml` audit ruleset.