### PR TITLE
fix: epub validation error display

### DIFF
--- a/inc/modules/export/epub/class-epub.php
+++ b/inc/modules/export/epub/class-epub.php
@@ -2957,132 +2957,13 @@ class Epub extends Export {
 	}
 
 	/**
-	 * Parse an epubcheck validation log into a structured, lossless form.
-	 *
-	 * Handles both literal "\n" separators (as produced by validate()) and real
-	 * newlines. Every FATAL/ERROR/WARNING/INFO/USAGE line is captured with its
-	 * severity, code, file, line, column and verbatim message; lines without a
-	 * recognizable file are grouped under '(package)' so nothing is dropped.
-	 *
-	 * @param string $validation_log Raw validation log string
-	 * @return array{files: array<string, array<int, array{severity: string, code: string, line: int, column: int, message: string}>>, errors: int, warnings: int, files_affected: int}
-	 */
-	protected function parseValidationLog( string $validation_log ): array {
-		$lines = explode( "\n", str_replace( '\n', "\n", $validation_log ) );
-
-		$files = [];
-		$errors = 0;
-		$warnings = 0;
-
-		foreach ( $lines as $line ) {
-			$line = trim( $line );
-			if ( ! preg_match( '/^(FATAL|ERROR|WARNING|INFO|USAGE)\(([A-Z]{3}-\d{3}\w?)\):\s*(.*)$/', $line, $matches ) ) {
-				continue;
-			}
-
-			$severity = $matches[1];
-			$code = $matches[2];
-			$file = '(package)';
-			$line_number = 0;
-			$column = 0;
-			$message = $matches[3];
-
-			if ( preg_match( '/\/([^\/()]+)\((\d+),(\d+)\):\s*(.*)$/', $message, $detail ) ) {
-				$file = $detail[1];
-				$line_number = (int) $detail[2];
-				$column = (int) $detail[3];
-				$message = $detail[4];
-			}
-
-			$files[ $file ][] = [
-				'severity' => $severity,
-				'code' => $code,
-				'line' => $line_number,
-				'column' => $column,
-				'message' => $message,
-			];
-
-			if ( $severity === 'FATAL' || $severity === 'ERROR' ) {
-				++$errors;
-			} elseif ( $severity === 'WARNING' ) {
-				++$warnings;
-			}
-		}
-
-		$files_affected = 0;
-		foreach ( $files as $issues ) {
-			foreach ( $issues as $issue ) {
-				if ( in_array( $issue['severity'], [ 'FATAL', 'ERROR', 'WARNING' ], true ) ) {
-					++$files_affected;
-					break;
-				}
-			}
-		}
-
-		return [
-			'files' => $files,
-			'errors' => $errors,
-			'warnings' => $warnings,
-			'files_affected' => $files_affected,
-		];
-	}
-
-	/**
 	 * Format EPUB validation log into readable sections
 	 *
 	 * @param string $validation_log Raw validation log string
 	 * @return string Formatted log with proper line breaks and grouping
 	 */
 	public function formatValidationLog( string $validation_log ): string {
-		$parsed = $this->parseValidationLog( $validation_log );
-
-		/* translators: "EPUB" is a file format name and should not be translated */
-		$formatted_output = __( 'EPUB VALIDATION REPORT', 'pressbooks' ) . "\n";
-		$formatted_output .= str_repeat( '=', 50 ) . "\n\n";
-
-		foreach ( $parsed['files'] as $file => $issues ) {
-			$file_error_count = 0;
-			$file_warning_count = 0;
-			foreach ( $issues as $issue ) {
-				if ( $issue['severity'] === 'FATAL' || $issue['severity'] === 'ERROR' ) {
-					++$file_error_count;
-				} elseif ( $issue['severity'] === 'WARNING' ) {
-					++$file_warning_count;
-				}
-			}
-
-			if ( $file_error_count + $file_warning_count === 0 ) {
-				continue;
-			}
-
-			$formatted_output .= sprintf( __( 'FILE: %s', 'pressbooks' ), $file ) . "\n";
-			/* translators: 1: number of errors, 2: number of warnings */
-			$formatted_output .= sprintf( __( 'Errors: %1$s | Warnings: %2$s', 'pressbooks' ), $file_error_count, $file_warning_count ) . "\n";
-			$formatted_output .= str_repeat( '-', 40 ) . "\n";
-
-			foreach ( $issues as $issue ) {
-				if ( $issue['line'] > 0 ) {
-					/* translators: 1: line number, 2: column number */
-					$location = ' ' . sprintf( __( 'Line %1$s, Col %2$s', 'pressbooks' ), $issue['line'], $issue['column'] ) . ':';
-				} else {
-					$location = '';
-				}
-				$formatted_output .= "  [{$issue['severity']} {$issue['code']}]{$location} {$issue['message']}\n";
-			}
-
-			$formatted_output .= "\n";
-		}
-
-		$formatted_output .= str_repeat( '=', 50 ) . "\n";
-		$formatted_output .= __( 'SUMMARY', 'pressbooks' ) . "\n";
-		/* translators: %s: number of errors */
-		$formatted_output .= sprintf( __( 'Total Errors: %s', 'pressbooks' ), $parsed['errors'] ) . "\n";
-		/* translators: %s: number of warnings */
-		$formatted_output .= sprintf( __( 'Total Warnings: %s', 'pressbooks' ), $parsed['warnings'] ) . "\n";
-		/* translators: %s: number of files affected */
-		$formatted_output .= sprintf( __( 'Files Affected: %s', 'pressbooks' ), $parsed['files_affected'] ) . "\n";
-
-		return $formatted_output;
+		return ( new EpubcheckLog( $validation_log ) )->report();
 	}
 
 	protected function updateCssFile(): void {
@@ -3108,10 +2989,7 @@ class Epub extends Export {
 	 * @return string
 	 */
 	private function getValidationSummary( string $validation_log ): string {
-		$parsed = $this->parseValidationLog( $validation_log );
-
-		/* translators: 1: number of errors, 2: number of warnings, 3: number of files affected */
-		return sprintf( __( 'Errors: %1$s, Warnings: %2$s, Files affected: %3$s', 'pressbooks' ), $parsed['errors'], $parsed['warnings'], $parsed['files_affected'] );
+		return ( new EpubcheckLog( $validation_log ) )->summary();
 	}
 
 	/**

--- a/inc/modules/export/epub/class-epub.php
+++ b/inc/modules/export/epub/class-epub.php
@@ -2983,16 +2983,6 @@ class Epub extends Export {
 	}
 
 	/**
-	 * Get a brief summary of validation errors for quick reference
-	 *
-	 * @param string $validation_log
-	 * @return string
-	 */
-	private function getValidationSummary( string $validation_log ): string {
-		return ( new EpubcheckLog( $validation_log ) )->summary();
-	}
-
-	/**
 	 * Override logError to format validation logs
 	 */
 	public function logError( string $message, array $more_info = [] ): void {
@@ -3001,10 +2991,9 @@ class Epub extends Export {
 
 			error_log( $message ); // Log raw message for debugging
 
-			$more_info['formatted_validation_report'] = $this->formatValidationLog( $message );
-
-			$error_summary = $this->getValidationSummary( $message );
-			$more_info['validation_summary'] = $error_summary;
+			$log = new EpubcheckLog( $message );
+			$more_info['formatted_validation_report'] = $log->report();
+			$more_info['validation_summary'] = $log->summary();
 
 			$message = __( 'EPUB validation completed with issues. See the validation report above.', 'pressbooks' );
 		}

--- a/inc/modules/export/epub/class-epub.php
+++ b/inc/modules/export/epub/class-epub.php
@@ -2957,141 +2957,130 @@ class Epub extends Export {
 	}
 
 	/**
+	 * Parse an epubcheck validation log into a structured, lossless form.
+	 *
+	 * Handles both literal "\n" separators (as produced by validate()) and real
+	 * newlines. Every FATAL/ERROR/WARNING/INFO/USAGE line is captured with its
+	 * severity, code, file, line, column and verbatim message; lines without a
+	 * recognizable file are grouped under '(package)' so nothing is dropped.
+	 *
+	 * @param string $validation_log Raw validation log string
+	 * @return array{files: array<string, array<int, array{severity: string, code: string, line: int, column: int, message: string}>>, errors: int, warnings: int, files_affected: int}
+	 */
+	protected function parseValidationLog( string $validation_log ): array {
+		$lines = explode( "\n", str_replace( '\n', "\n", $validation_log ) );
+
+		$files = [];
+		$errors = 0;
+		$warnings = 0;
+
+		foreach ( $lines as $line ) {
+			$line = trim( $line );
+			if ( ! preg_match( '/^(FATAL|ERROR|WARNING|INFO|USAGE)\(([A-Z]{3}-\d{3}\w?)\):\s*(.*)$/', $line, $matches ) ) {
+				continue;
+			}
+
+			$severity = $matches[1];
+			$code = $matches[2];
+			$file = '(package)';
+			$line_number = 0;
+			$column = 0;
+			$message = $matches[3];
+
+			if ( preg_match( '/\/([^\/()]+)\((\d+),(\d+)\):\s*(.*)$/', $message, $detail ) ) {
+				$file = $detail[1];
+				$line_number = (int) $detail[2];
+				$column = (int) $detail[3];
+				$message = $detail[4];
+			}
+
+			$files[ $file ][] = [
+				'severity' => $severity,
+				'code' => $code,
+				'line' => $line_number,
+				'column' => $column,
+				'message' => $message,
+			];
+
+			if ( $severity === 'FATAL' || $severity === 'ERROR' ) {
+				++$errors;
+			} elseif ( $severity === 'WARNING' ) {
+				++$warnings;
+			}
+		}
+
+		$files_affected = 0;
+		foreach ( $files as $issues ) {
+			foreach ( $issues as $issue ) {
+				if ( in_array( $issue['severity'], [ 'FATAL', 'ERROR', 'WARNING' ], true ) ) {
+					++$files_affected;
+					break;
+				}
+			}
+		}
+
+		return [
+			'files' => $files,
+			'errors' => $errors,
+			'warnings' => $warnings,
+			'files_affected' => $files_affected,
+		];
+	}
+
+	/**
 	 * Format EPUB validation log into readable sections
 	 *
 	 * @param string $validation_log Raw validation log string
 	 * @return string Formatted log with proper line breaks and grouping
 	 */
 	public function formatValidationLog( string $validation_log ): string {
-		$lines = explode( '\n', $validation_log );
-		$formatted_output = '';
-		$error_groups = [];
+		$parsed = $this->parseValidationLog( $validation_log );
 
-		foreach ( $lines as $line ) {
-			$line = trim( $line );
-
-			if ( empty( $line ) ) {
-				continue;
-			}
-
-			// Extract file path from error (chapter)
-			if ( preg_match( '/\/([^\/]+\.xhtml)/', $line, $matches ) ) {
-				$file = $matches[1];
-
-				if ( ! isset( $error_groups[ $file ] ) ) {
-					$error_groups[ $file ] = [
-						'rsc_005' => [], // Invalid attribute errors
-						'opf_014' => [], // Remote resources errors
-						'rsc_006' => [], // Remote resource reference errors
-						'pkg_022' => [], // File extension warnings
-						'other' => [],
-					];
-				}
-
-				if ( str_contains( $line, 'ERROR(RSC-005)' ) ) {
-					if ( str_contains( $line, 'role" is invalid' ) ) {
-						$error_groups[ $file ]['rsc_005'][] = 'Invalid role attribute';
-					} elseif ( str_contains( $line, 'missing required attribute "aria-checked"' ) ) {
-						$error_groups[ $file ]['rsc_005'][] = 'Missing aria-checked attribute on <li> element';
-					}
-				} elseif ( str_contains( $line, 'ERROR(OPF-014)' ) ) {
-					$error_groups[ $file ]['opf_014'][] = 'Remote resources property not declared in OPF file';
-				} elseif ( str_contains( $line, 'ERROR(RSC-006)' ) ) {
-					$error_groups[ $file ]['rsc_006'][] = 'Remote resource reference not allowed';
-				} elseif ( str_contains( $line, 'WARNING(PKG-022)' ) ) {
-					$error_groups[ $file ]['pkg_022'][] = 'Wrong file extension for image (PNG with .jpg extension)';
-				} else {
-					$error_groups[ $file ]['other'][] = $line;
-				}
-			}
-		}
-
-		$formatted_output .= "EPUB VALIDATION REPORT\n";
+		/* translators: "EPUB" is a file format name and should not be translated */
+		$formatted_output = __( 'EPUB VALIDATION REPORT', 'pressbooks' ) . "\n";
 		$formatted_output .= str_repeat( '=', 50 ) . "\n\n";
 
-		$total_errors = 0;
-		$total_warnings = 0;
-
-		foreach ( $error_groups as $file => $errors ) {
-			$file_has_errors = false;
-			$file_output = '';
-
+		foreach ( $parsed['files'] as $file => $issues ) {
 			$file_error_count = 0;
 			$file_warning_count = 0;
-
-			foreach ( $errors as $error_type => $error_list ) {
-				if ( ! empty( $error_list ) ) {
-					$file_has_errors = true;
-
-					if ( $error_type === 'pkg_022' ) {
-						$file_warning_count += count( $error_list );
-					} else {
-						$file_error_count += count( $error_list );
-					}
+			foreach ( $issues as $issue ) {
+				if ( $issue['severity'] === 'FATAL' || $issue['severity'] === 'ERROR' ) {
+					++$file_error_count;
+				} elseif ( $issue['severity'] === 'WARNING' ) {
+					++$file_warning_count;
 				}
 			}
 
-			if ( ! $file_has_errors ) {
+			if ( $file_error_count + $file_warning_count === 0 ) {
 				continue;
 			}
 
-			$total_errors += $file_error_count;
-			$total_warnings += $file_warning_count;
+			$formatted_output .= sprintf( __( 'FILE: %s', 'pressbooks' ), $file ) . "\n";
+			/* translators: 1: number of errors, 2: number of warnings */
+			$formatted_output .= sprintf( __( 'Errors: %1$s | Warnings: %2$s', 'pressbooks' ), $file_error_count, $file_warning_count ) . "\n";
+			$formatted_output .= str_repeat( '-', 40 ) . "\n";
 
-			$file_output .= 'FILE: ' . $file . "\n";
-			$file_output .= "Errors: {$file_error_count} | Warnings: {$file_warning_count}\n";
-			$file_output .= str_repeat( '-', 40 ) . "\n";
-
-			// RSC-005 errors (Invalid attributes)
-			if ( ! empty( $errors['rsc_005'] ) ) {
-				$file_output .= "• ATTRIBUTE ERRORS (RSC-005):\n";
-				$unique_rsc_errors = array_count_values( $errors['rsc_005'] );
-				foreach ( $unique_rsc_errors as $error => $count ) {
-					$file_output .= "  - {$error} ({$count} occurrence" . ( $count > 1 ? 's' : '' ) . ")\n";
+			foreach ( $issues as $issue ) {
+				if ( $issue['line'] > 0 ) {
+					/* translators: 1: line number, 2: column number */
+					$location = ' ' . sprintf( __( 'Line %1$s, Col %2$s', 'pressbooks' ), $issue['line'], $issue['column'] ) . ':';
+				} else {
+					$location = '';
 				}
-				$file_output .= "\n";
+				$formatted_output .= "  [{$issue['severity']} {$issue['code']}]{$location} {$issue['message']}\n";
 			}
 
-			// OPF-014 errors (Remote resources)
-			if ( ! empty( $errors['opf_014'] ) ) {
-				$file_output .= "• REMOTE RESOURCES ERRORS (OPF-014):\n";
-				$file_output .= "  - Remote resources property not declared in OPF file\n\n";
-			}
-
-			// RSC-006 errors (Remote resource references)
-			if ( ! empty( $errors['rsc_006'] ) ) {
-				$file_output .= "• REMOTE REFERENCE ERRORS (RSC-006):\n";
-				$file_output .= '  - Remote resource references not allowed (' . count( $errors['rsc_006'] ) . " occurrences)\n\n";
-			}
-
-			// PKG-022 warnings (File extension)
-			if ( ! empty( $errors['pkg_022'] ) ) {
-				$file_output .= "• FILE EXTENSION WARNINGS (PKG-022):\n";
-				foreach ( $errors['pkg_022'] as $warning ) {
-					$file_output .= "  - {$warning}\n";
-				}
-				$file_output .= "\n";
-			}
-
-			// Other errors
-			if ( ! empty( $errors['other'] ) ) {
-				$file_output .= "• OTHER ISSUES:\n";
-				foreach ( $errors['other'] as $error ) {
-					$file_output .= "  - {$error}\n";
-				}
-				$file_output .= "\n";
-			}
-
-			$formatted_output .= $file_output . "\n";
+			$formatted_output .= "\n";
 		}
 
 		$formatted_output .= str_repeat( '=', 50 ) . "\n";
-		$formatted_output .= "SUMMARY\n";
-		$formatted_output .= "Total Errors: {$total_errors}\n";
-		$formatted_output .= "Total Warnings: {$total_warnings}\n";
-		$formatted_output .= 'Files Affected: ' . count( array_filter( $error_groups, function ( $errors ) {
-				return ! empty( array_filter( $errors ) );
-		} ) ) . "\n";
+		$formatted_output .= __( 'SUMMARY', 'pressbooks' ) . "\n";
+		/* translators: %s: number of errors */
+		$formatted_output .= sprintf( __( 'Total Errors: %s', 'pressbooks' ), $parsed['errors'] ) . "\n";
+		/* translators: %s: number of warnings */
+		$formatted_output .= sprintf( __( 'Total Warnings: %s', 'pressbooks' ), $parsed['warnings'] ) . "\n";
+		/* translators: %s: number of files affected */
+		$formatted_output .= sprintf( __( 'Files Affected: %s', 'pressbooks' ), $parsed['files_affected'] ) . "\n";
 
 		return $formatted_output;
 	}
@@ -3119,11 +3108,10 @@ class Epub extends Export {
 	 * @return string
 	 */
 	private function getValidationSummary( string $validation_log ): string {
-		$error_count = substr_count( $validation_log, 'ERROR(' );
-		$warning_count = substr_count( $validation_log, 'WARNING(' );
-		$files_affected = count( array_unique( preg_match_all( '/\/([^\/]+\.xhtml)/', $validation_log, $matches ) ? $matches[1] : [] ) );
+		$parsed = $this->parseValidationLog( $validation_log );
 
-		return "Errors: {$error_count}, Warnings: {$warning_count}, Files affected: {$files_affected}";
+		/* translators: 1: number of errors, 2: number of warnings, 3: number of files affected */
+		return sprintf( __( 'Errors: %1$s, Warnings: %2$s, Files affected: %3$s', 'pressbooks' ), $parsed['errors'], $parsed['warnings'], $parsed['files_affected'] );
 	}
 
 	/**
@@ -3131,7 +3119,7 @@ class Epub extends Export {
 	 */
 	public function logError( string $message, array $more_info = [] ): void {
 
-		if ( str_contains( $message, 'EPUB Validation' ) || str_contains( $message, 'ERROR(RSC-' ) ) {
+		if ( str_contains( $message, 'EPUB Validation' ) || preg_match( '/(?:FATAL|ERROR|WARNING)\(/', $message ) ) {
 
 			error_log( $message ); // Log raw message for debugging
 
@@ -3140,7 +3128,7 @@ class Epub extends Export {
 			$error_summary = $this->getValidationSummary( $message );
 			$more_info['validation_summary'] = $error_summary;
 
-			$message = 'EPUB validation completed with issues. See formatted report above.';
+			$message = __( 'EPUB validation completed with issues. See the validation report above.', 'pressbooks' );
 		}
 
 		parent::logError( $message, $more_info );

--- a/inc/modules/export/epub/class-epub.php
+++ b/inc/modules/export/epub/class-epub.php
@@ -2956,16 +2956,6 @@ class Epub extends Export {
 		return $dom;
 	}
 
-	/**
-	 * Format EPUB validation log into readable sections
-	 *
-	 * @param string $validation_log Raw validation log string
-	 * @return string Formatted log with proper line breaks and grouping
-	 */
-	public function formatValidationLog( string $validation_log ): string {
-		return ( new EpubcheckLog( $validation_log ) )->report();
-	}
-
 	protected function updateCssFile(): void {
 		$directory = $this->epubDir;
 		$filename = $this->stylesheet;

--- a/inc/modules/export/epub/class-epubchecklog.php
+++ b/inc/modules/export/epub/class-epubchecklog.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Parses raw epubcheck output and renders it as a human-readable report.
+ *
+ * @package Pressbooks
+ * @author  Pressbooks <code@pressbooks.com>
+ * @license GPLv3 (or any later version)
+ */
+
+namespace Pressbooks\Modules\Export\Epub;
+
+use Illuminate\Support\Collection;
+
+class EpubcheckLog {
+
+	/**
+	 * Matches any epubcheck message line, e.g. `ERROR(RSC-005): <detail>`.
+	 */
+	private const LINE_PATTERN = '/^(FATAL|ERROR|WARNING|INFO|USAGE)\(([A-Z]{3}-\d{3}\w?)\):\s*(.*)$/';
+
+	/**
+	 * Extracts `filename(line,column): message` from a message detail, any file extension.
+	 */
+	private const LOCATION_PATTERN = '/\/([^\/()]+)\((\d+),(\d+)\):\s*(.*)$/';
+
+	private const ERROR_SEVERITIES = [ 'FATAL', 'ERROR' ];
+
+	/**
+	 * Group for messages that carry no file reference, so nothing is ever dropped.
+	 */
+	private const PACKAGE_GROUP = '(package)';
+
+	private Collection $issues;
+
+	/**
+	 * @param string $raw_log Raw epubcheck output, with literal '\n' separators (as produced by Epub::validate()) or real newlines
+	 */
+	public function __construct( string $raw_log ) {
+		$this->issues = collect( explode( "\n", str_replace( '\n', "\n", $raw_log ) ) )
+			->map( fn( string $line ) => $this->parseLine( trim( $line ) ) )
+			->filter()
+			->values();
+	}
+
+	/**
+	 * Full validation report: issues grouped per file, verbatim messages with locations, totals.
+	 */
+	public function report(): string {
+		/* translators: "EPUB" is a file format name and should not be translated */
+		$report = __( 'EPUB VALIDATION REPORT', 'pressbooks' ) . "\n";
+		$report .= str_repeat( '=', 50 ) . "\n\n";
+
+		$report .= $this->issues
+			->groupBy( 'file' )
+			->filter( fn( Collection $issues ) => $issues->some( fn( array $issue ) => $this->isError( $issue ) || $this->isWarning( $issue ) ) )
+			->map( fn( Collection $issues, string $file ) => $this->fileSection( $file, $issues ) )
+			->implode( '' );
+
+		return $report . $this->totals();
+	}
+
+	/**
+	 * One-line summary, guaranteed to match the report totals.
+	 */
+	public function summary(): string {
+		/* translators: 1: number of errors, 2: number of warnings, 3: number of files affected */
+		return sprintf(
+			__( 'Errors: %1$s, Warnings: %2$s, Files affected: %3$s', 'pressbooks' ),
+			$this->errorCount(),
+			$this->warningCount(),
+			$this->affectedFileCount()
+		);
+	}
+
+	/**
+	 * @return array{severity: string, code: string, file: string, line: int, column: int, message: string}|null
+	 */
+	private function parseLine( string $line ): ?array {
+		if ( ! preg_match( self::LINE_PATTERN, $line, $matches ) ) {
+			return null;
+		}
+
+		$issue = [
+			'severity' => $matches[1],
+			'code' => $matches[2],
+			'file' => self::PACKAGE_GROUP,
+			'line' => 0,
+			'column' => 0,
+			'message' => $matches[3],
+		];
+
+		if ( preg_match( self::LOCATION_PATTERN, $issue['message'], $location ) ) {
+			$issue['file'] = $location[1];
+			$issue['line'] = (int) $location[2];
+			$issue['column'] = (int) $location[3];
+			$issue['message'] = $location[4];
+		}
+
+		return $issue;
+	}
+
+	private function isError( array $issue ): bool {
+		return in_array( $issue['severity'], self::ERROR_SEVERITIES, true );
+	}
+
+	private function isWarning( array $issue ): bool {
+		return $issue['severity'] === 'WARNING';
+	}
+
+	private function errorCount(): int {
+		return $this->issues->filter( fn( array $issue ) => $this->isError( $issue ) )->count();
+	}
+
+	private function warningCount(): int {
+		return $this->issues->filter( fn( array $issue ) => $this->isWarning( $issue ) )->count();
+	}
+
+	private function affectedFileCount(): int {
+		return $this->issues
+			->filter( fn( array $issue ) => $this->isError( $issue ) || $this->isWarning( $issue ) )
+			->unique( 'file' )
+			->count();
+	}
+
+	private function fileSection( string $file, Collection $issues ): string {
+		$section = sprintf( __( 'FILE: %s', 'pressbooks' ), $file ) . "\n";
+		/* translators: 1: number of errors, 2: number of warnings */
+		$section .= sprintf(
+			__( 'Errors: %1$s | Warnings: %2$s', 'pressbooks' ),
+			$issues->filter( fn( array $issue ) => $this->isError( $issue ) )->count(),
+			$issues->filter( fn( array $issue ) => $this->isWarning( $issue ) )->count()
+		) . "\n";
+		$section .= str_repeat( '-', 40 ) . "\n";
+		$section .= $issues->map( fn( array $issue ) => $this->issueLine( $issue ) )->implode( '' );
+
+		return $section . "\n";
+	}
+
+	private function issueLine( array $issue ): string {
+		$location = '';
+		if ( $issue['line'] > 0 ) {
+			/* translators: 1: line number, 2: column number */
+			$location = ' ' . sprintf( __( 'Line %1$s, Col %2$s', 'pressbooks' ), $issue['line'], $issue['column'] ) . ':';
+		}
+
+		return "  [{$issue['severity']} {$issue['code']}]{$location} {$issue['message']}\n";
+	}
+
+	private function totals(): string {
+		$totals = str_repeat( '=', 50 ) . "\n";
+		$totals .= __( 'SUMMARY', 'pressbooks' ) . "\n";
+		/* translators: %s: number of errors */
+		$totals .= sprintf( __( 'Total Errors: %s', 'pressbooks' ), $this->errorCount() ) . "\n";
+		/* translators: %s: number of warnings */
+		$totals .= sprintf( __( 'Total Warnings: %s', 'pressbooks' ), $this->warningCount() ) . "\n";
+		/* translators: %s: number of files affected */
+		$totals .= sprintf( __( 'Files Affected: %s', 'pressbooks' ), $this->affectedFileCount() ) . "\n";
+
+		return $totals;
+	}
+}

--- a/tests/test-epub-validation.php
+++ b/tests/test-epub-validation.php
@@ -140,9 +140,18 @@ class Epub_ValidationTest extends \WP_UnitTestCase {
 	 * @group export
 	 * @test
 	 */
-	public function epub_export_delegates_report_formatting(): void {
-		$log = $this->logWithLiteralSeparators();
+	public function log_error_attaches_report_and_summary(): void {
+		$temp = tempnam( sys_get_temp_dir(), 'pb-log' );
+		$previous = ini_set( 'error_log', $temp );
 
-		$this->assertSame( ( new EpubcheckLog( $log ) )->report(), ( new Epub( [] ) )->formatValidationLog( $log ) );
+		( new Epub( [] ) )->logError( $this->logWithLiteralSeparators() );
+
+		ini_set( 'error_log', $previous );
+		$logged = file_get_contents( $temp );
+		unlink( $temp );
+
+		$this->assertStringContainsString( 'EPUB VALIDATION REPORT', $logged );
+		$this->assertStringContainsString( '[ERROR RSC-005] Line 15, Col 1045:', $logged );
+		$this->assertStringContainsString( 'Errors: 3, Warnings: 1, Files affected: 4', $logged );
 	}
 }

--- a/tests/test-epub-validation.php
+++ b/tests/test-epub-validation.php
@@ -1,10 +1,9 @@
 <?php
 
 use Pressbooks\Modules\Export\Epub\Epub;
+use Pressbooks\Modules\Export\Epub\EpubcheckLog;
 
 class Epub_ValidationTest extends \WP_UnitTestCase {
-
-	protected Epub $epub;
 
 	private const VALIDATION_LINES = [
 		'Validating using EPUB version 3.3 rules.',
@@ -16,23 +15,12 @@ class Epub_ValidationTest extends \WP_UnitTestCase {
 		'Messages: 0 fatals / 2 errors / 0 warnings / 0 infos',
 	];
 
-	public function set_up() {
-		parent::set_up();
-		$this->epub = new Epub( [] );
-	}
-
 	private function logWithLiteralSeparators(): string {
 		return 'EPUB Validation Warnings/Errors:' . '\\n' . implode( '\\n', self::VALIDATION_LINES );
 	}
 
 	private function logWithRealNewlines(): string {
 		return 'EPUB Validation Warnings/Errors:' . "\n" . implode( "\n", self::VALIDATION_LINES );
-	}
-
-	private function getValidationSummary( string $validation_log ): string {
-		$method = new ReflectionMethod( Epub::class, 'getValidationSummary' );
-		$method->setAccessible( true );
-		return $method->invoke( $this->epub, $validation_log );
 	}
 
 	private function reportTotals( string $report ): array {
@@ -52,10 +40,10 @@ class Epub_ValidationTest extends \WP_UnitTestCase {
 	 * @test
 	 */
 	public function report_totals_match_summary_counts(): void {
-		$log = $this->logWithLiteralSeparators();
+		$log = new EpubcheckLog( $this->logWithLiteralSeparators() );
 
-		$report_totals = $this->reportTotals( $this->epub->formatValidationLog( $log ) );
-		$summary_totals = $this->summaryTotals( $this->getValidationSummary( $log ) );
+		$report_totals = $this->reportTotals( $log->report() );
+		$summary_totals = $this->summaryTotals( $log->summary() );
 
 		$this->assertSame( $summary_totals, $report_totals );
 		$this->assertSame( [ 3, 1, 4 ], $report_totals );
@@ -66,7 +54,7 @@ class Epub_ValidationTest extends \WP_UnitTestCase {
 	 * @test
 	 */
 	public function verbatim_message_and_location_are_preserved(): void {
-		$report = $this->epub->formatValidationLog( $this->logWithLiteralSeparators() );
+		$report = ( new EpubcheckLog( $this->logWithLiteralSeparators() ) )->report();
 
 		$this->assertStringContainsString( '[ERROR RSC-005] Line 15, Col 1045: Error while parsing file: value of attribute "target" is invalid', $report );
 		$this->assertStringContainsString( '[ERROR RSC-005] Line 19, Col 314773:', $report );
@@ -79,7 +67,7 @@ class Epub_ValidationTest extends \WP_UnitTestCase {
 	 * @test
 	 */
 	public function errors_in_non_xhtml_files_are_reported(): void {
-		$report = $this->epub->formatValidationLog( $this->logWithLiteralSeparators() );
+		$report = ( new EpubcheckLog( $this->logWithLiteralSeparators() ) )->report();
 
 		$this->assertStringContainsString( 'content.opf', $report );
 		$this->assertStringContainsString( '[ERROR OPF-014] Line 2, Col 92:', $report );
@@ -91,11 +79,11 @@ class Epub_ValidationTest extends \WP_UnitTestCase {
 	 * @test
 	 */
 	public function literal_and_real_newline_logs_format_identically(): void {
-		$literal = $this->epub->formatValidationLog( $this->logWithLiteralSeparators() );
-		$real = $this->epub->formatValidationLog( $this->logWithRealNewlines() );
+		$literal = new EpubcheckLog( $this->logWithLiteralSeparators() );
+		$real = new EpubcheckLog( $this->logWithRealNewlines() );
 
-		$this->assertSame( $literal, $real );
-		$this->assertSame( $this->getValidationSummary( $this->logWithLiteralSeparators() ), $this->getValidationSummary( $this->logWithRealNewlines() ) );
+		$this->assertSame( $literal->report(), $real->report() );
+		$this->assertSame( $literal->summary(), $real->summary() );
 	}
 
 	/**
@@ -103,9 +91,9 @@ class Epub_ValidationTest extends \WP_UnitTestCase {
 	 * @test
 	 */
 	public function unknown_codes_and_messages_are_not_dropped(): void {
-		$log = 'EPUB Validation Warnings/Errors:\nERROR(MED-001): ./book.epub/EPUB/chapter-001.xhtml(7,42): some future epubcheck message\nWARNING(ABC-999): package-level warning without a file';
+		$log = new EpubcheckLog( 'EPUB Validation Warnings/Errors:\nERROR(MED-001): ./book.epub/EPUB/chapter-001.xhtml(7,42): some future epubcheck message\nWARNING(ABC-999): package-level warning without a file' );
 
-		$report = $this->epub->formatValidationLog( $log );
+		$report = $log->report();
 
 		$this->assertSame( [ 1, 1, 2 ], $this->reportTotals( $report ) );
 		$this->assertStringContainsString( '[ERROR MED-001] Line 7, Col 42: some future epubcheck message', $report );
@@ -118,10 +106,10 @@ class Epub_ValidationTest extends \WP_UnitTestCase {
 	 * @test
 	 */
 	public function noise_lines_do_not_inflate_counts(): void {
-		$log = "Validating using EPUB version 3.3 rules.\nCheck finished with errors\nMessages: 0 fatals / 2 errors / 0 warnings / 0 infos";
+		$log = new EpubcheckLog( "Validating using EPUB version 3.3 rules.\nCheck finished with errors\nMessages: 0 fatals / 2 errors / 0 warnings / 0 infos" );
 
-		$this->assertSame( [ 0, 0, 0 ], $this->reportTotals( $this->epub->formatValidationLog( $log ) ) );
-		$this->assertSame( 'Errors: 0, Warnings: 0, Files affected: 0', $this->getValidationSummary( $log ) );
+		$this->assertSame( [ 0, 0, 0 ], $this->reportTotals( $log->report() ) );
+		$this->assertSame( 'Errors: 0, Warnings: 0, Files affected: 0', $log->summary() );
 	}
 
 	/**
@@ -129,8 +117,10 @@ class Epub_ValidationTest extends \WP_UnitTestCase {
 	 * @test
 	 */
 	public function empty_log_reports_zero_totals(): void {
-		$this->assertSame( [ 0, 0, 0 ], $this->reportTotals( $this->epub->formatValidationLog( '' ) ) );
-		$this->assertSame( 'Errors: 0, Warnings: 0, Files affected: 0', $this->getValidationSummary( '' ) );
+		$log = new EpubcheckLog( '' );
+
+		$this->assertSame( [ 0, 0, 0 ], $this->reportTotals( $log->report() ) );
+		$this->assertSame( 'Errors: 0, Warnings: 0, Files affected: 0', $log->summary() );
 	}
 
 	/**
@@ -138,11 +128,21 @@ class Epub_ValidationTest extends \WP_UnitTestCase {
 	 * @test
 	 */
 	public function info_only_entries_are_not_counted_as_issues(): void {
-		$log = 'INFO(INF-001): ./book.epub/EPUB/chapter-001.xhtml(1,1): informational message';
+		$log = new EpubcheckLog( 'INFO(INF-001): ./book.epub/EPUB/chapter-001.xhtml(1,1): informational message' );
 
-		$report = $this->epub->formatValidationLog( $log );
+		$report = $log->report();
 
 		$this->assertSame( [ 0, 0, 0 ], $this->reportTotals( $report ) );
 		$this->assertStringNotContainsString( 'INFO', $report );
+	}
+
+	/**
+	 * @group export
+	 * @test
+	 */
+	public function epub_export_delegates_report_formatting(): void {
+		$log = $this->logWithLiteralSeparators();
+
+		$this->assertSame( ( new EpubcheckLog( $log ) )->report(), ( new Epub( [] ) )->formatValidationLog( $log ) );
 	}
 }

--- a/tests/test-epub-validation.php
+++ b/tests/test-epub-validation.php
@@ -1,0 +1,148 @@
+<?php
+
+use Pressbooks\Modules\Export\Epub\Epub;
+
+class Epub_ValidationTest extends \WP_UnitTestCase {
+
+	protected Epub $epub;
+
+	private const VALIDATION_LINES = [
+		'Validating using EPUB version 3.3 rules.',
+		'ERROR(RSC-005): ./Transforming-Healthcare-Through-Data-1785798544.epub/EPUB/copyright.xhtml(15,1045): Error while parsing file: value of attribute "target" is invalid; must be a string matching the regular expression _"()|([^_].*)|(_[bB][lL][aA][nN][kK])|(_[sS][eE][lL][fF])|(_[pP][aA][rR][eE][nN][tT])|(_[tT][oO][pP])"_',
+		'ERROR(RSC-005): ./Transforming-Healthcare-Through-Data-1785798544.epub/EPUB/chapter-008-chapter-08-mapping-the-terrain-domains-and-maturity-in-healthcare-analytics.xhtml(19,314773): Error while parsing file: value of attribute "target" is invalid; must be a string matching the regular expression _"()|([^_].*)|(_[bB][lL][aA][nN][kK])|(_[sS][eE][lL][fF])|(_[pP][aA][rR][eE][nN][tT])|(_[tT][oO][pP])"_',
+		'ERROR(OPF-014): ./Transforming-Healthcare-Through-Data-1785798544.epub/EPUB/content.opf(2,92): element from namespace "http://www.idpf.org/2007/opf" must reference an internal resource',
+		'WARNING(PKG-022): ./Transforming-Healthcare-Through-Data-1785798544.epub/EPUB/assets/cover.jpeg(1,1): filename "cover.jpeg" does not map to its media type "image/png"',
+		'Check finished with errors',
+		'Messages: 0 fatals / 2 errors / 0 warnings / 0 infos',
+	];
+
+	public function set_up() {
+		parent::set_up();
+		$this->epub = new Epub( [] );
+	}
+
+	private function logWithLiteralSeparators(): string {
+		return 'EPUB Validation Warnings/Errors:' . '\\n' . implode( '\\n', self::VALIDATION_LINES );
+	}
+
+	private function logWithRealNewlines(): string {
+		return 'EPUB Validation Warnings/Errors:' . "\n" . implode( "\n", self::VALIDATION_LINES );
+	}
+
+	private function getValidationSummary( string $validation_log ): string {
+		$method = new ReflectionMethod( Epub::class, 'getValidationSummary' );
+		$method->setAccessible( true );
+		return $method->invoke( $this->epub, $validation_log );
+	}
+
+	private function reportTotals( string $report ): array {
+		preg_match( '/Total Errors: (\d+)/', $report, $errors );
+		preg_match( '/Total Warnings: (\d+)/', $report, $warnings );
+		preg_match( '/Files Affected: (\d+)/', $report, $files );
+		return [ (int) $errors[1], (int) $warnings[1], (int) $files[1] ];
+	}
+
+	private function summaryTotals( string $summary ): array {
+		preg_match( '/Errors: (\d+), Warnings: (\d+), Files affected: (\d+)/', $summary, $m );
+		return [ (int) $m[1], (int) $m[2], (int) $m[3] ];
+	}
+
+	/**
+	 * @group export
+	 * @test
+	 */
+	public function report_totals_match_summary_counts(): void {
+		$log = $this->logWithLiteralSeparators();
+
+		$report_totals = $this->reportTotals( $this->epub->formatValidationLog( $log ) );
+		$summary_totals = $this->summaryTotals( $this->getValidationSummary( $log ) );
+
+		$this->assertSame( $summary_totals, $report_totals );
+		$this->assertSame( [ 3, 1, 4 ], $report_totals );
+	}
+
+	/**
+	 * @group export
+	 * @test
+	 */
+	public function verbatim_message_and_location_are_preserved(): void {
+		$report = $this->epub->formatValidationLog( $this->logWithLiteralSeparators() );
+
+		$this->assertStringContainsString( '[ERROR RSC-005] Line 15, Col 1045: Error while parsing file: value of attribute "target" is invalid', $report );
+		$this->assertStringContainsString( '[ERROR RSC-005] Line 19, Col 314773:', $report );
+		$this->assertStringContainsString( 'copyright.xhtml', $report );
+		$this->assertStringContainsString( 'chapter-008-chapter-08-mapping-the-terrain-domains-and-maturity-in-healthcare-analytics.xhtml', $report );
+	}
+
+	/**
+	 * @group export
+	 * @test
+	 */
+	public function errors_in_non_xhtml_files_are_reported(): void {
+		$report = $this->epub->formatValidationLog( $this->logWithLiteralSeparators() );
+
+		$this->assertStringContainsString( 'content.opf', $report );
+		$this->assertStringContainsString( '[ERROR OPF-014] Line 2, Col 92:', $report );
+		$this->assertStringContainsString( '[WARNING PKG-022] Line 1, Col 1:', $report );
+	}
+
+	/**
+	 * @group export
+	 * @test
+	 */
+	public function literal_and_real_newline_logs_format_identically(): void {
+		$literal = $this->epub->formatValidationLog( $this->logWithLiteralSeparators() );
+		$real = $this->epub->formatValidationLog( $this->logWithRealNewlines() );
+
+		$this->assertSame( $literal, $real );
+		$this->assertSame( $this->getValidationSummary( $this->logWithLiteralSeparators() ), $this->getValidationSummary( $this->logWithRealNewlines() ) );
+	}
+
+	/**
+	 * @group export
+	 * @test
+	 */
+	public function unknown_codes_and_messages_are_not_dropped(): void {
+		$log = 'EPUB Validation Warnings/Errors:\nERROR(MED-001): ./book.epub/EPUB/chapter-001.xhtml(7,42): some future epubcheck message\nWARNING(ABC-999): package-level warning without a file';
+
+		$report = $this->epub->formatValidationLog( $log );
+
+		$this->assertSame( [ 1, 1, 2 ], $this->reportTotals( $report ) );
+		$this->assertStringContainsString( '[ERROR MED-001] Line 7, Col 42: some future epubcheck message', $report );
+		$this->assertStringContainsString( '(package)', $report );
+		$this->assertStringContainsString( '[WARNING ABC-999] package-level warning without a file', $report );
+	}
+
+	/**
+	 * @group export
+	 * @test
+	 */
+	public function noise_lines_do_not_inflate_counts(): void {
+		$log = "Validating using EPUB version 3.3 rules.\nCheck finished with errors\nMessages: 0 fatals / 2 errors / 0 warnings / 0 infos";
+
+		$this->assertSame( [ 0, 0, 0 ], $this->reportTotals( $this->epub->formatValidationLog( $log ) ) );
+		$this->assertSame( 'Errors: 0, Warnings: 0, Files affected: 0', $this->getValidationSummary( $log ) );
+	}
+
+	/**
+	 * @group export
+	 * @test
+	 */
+	public function empty_log_reports_zero_totals(): void {
+		$this->assertSame( [ 0, 0, 0 ], $this->reportTotals( $this->epub->formatValidationLog( '' ) ) );
+		$this->assertSame( 'Errors: 0, Warnings: 0, Files affected: 0', $this->getValidationSummary( '' ) );
+	}
+
+	/**
+	 * @group export
+	 * @test
+	 */
+	public function info_only_entries_are_not_counted_as_issues(): void {
+		$log = 'INFO(INF-001): ./book.epub/EPUB/chapter-001.xhtml(1,1): informational message';
+
+		$report = $this->epub->formatValidationLog( $log );
+
+		$this->assertSame( [ 0, 0, 0 ], $this->reportTotals( $report ) );
+		$this->assertStringNotContainsString( 'INFO', $report );
+	}
+}


### PR DESCRIPTION
Issue: https://github.com/pressbooks/pressbooks-lti/issues/485

Authors exporting EPUB sometimes received a contradictory validation email: the summary line reported "Errors: 2, Files affected: 2" while the formatted report below it said "Total Errors: 0 / Files Affected: 0". On top of that, the report replaced real epubcheck messages with canned English strings and threw away the file name, line number, and column — leaving authors with no actionable information to fix their book.

The root cause was two independent parsers that could disagree. The formatted report used a hard-coded whitelist of known error patterns (two specific RSC-005 messages, a handful of other codes), so any unrecognised error — including the `target="_new"` attribute violation that triggered this report — entered the right branch but matched no inner condition, landed in no bucket, and was silently dropped. The summary line counted raw `ERROR(` substrings and
was always right; the report was always wrong for unknown errors.

### What changed

- EPUB validation log parsing and rendering moved into a dedicated `EpubcheckLog` class that recognises any epubcheck severity line (`FATAL`, `ERROR`, `WARNING`, `INFO`, `USAGE`) and preserves the verbatim message, file, line, and column. The report and summary render from the same parsed data, so their numbers can never contradict each other, and nothing is ever silently dropped.
- Both the formatted report and the summary line now derive their numbers from the same parse result, so they can never contradict each other.
- The validation report now shows the real epubcheck output per issue — e.g. `[ERROR RSC-005] Line 15, Col 1045: value of attribute "target" is invalid; must be …` — giving authors what they need to actually fix the book.
- Errors in non-XHTML files (`content.opf`, CSS, etc.) are now visible in the report; previously the file regex was XHTML-only so those errors vanished.
- All report strings are now wrapped in `__()` with the `pressbooks` text domain and translator comments.
- The unused public formatValidationLog() helper was removed; validation reporting now runs entirely through the export's error-logging path.

### How to test

1. Export a book that contains a link with `target="_new"` somewhere in its content (you can add one temporarily to a chapter).
2. After the export, check the validation email that arrives for your user (you can use mailHog in your local, run `lando info` to see where the mailHog host is reachable.
3. Confirm the **Total Errors** count in the formatted report matches the **Errors** figure in the summary line — they should be identical.
4. Confirm the report body shows the actual epubcheck message with a file name, line number, and column number (e.g. `[ERROR RSC-005] Line 15, Col 1045: value of attribute "target" is invalid`), not a generic placeholder string.
5. For a clean book with no validation issues, confirm the email is not sent / the report shows zero across the board.